### PR TITLE
Fix region handling and make it optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,16 @@ Configuration
 To connect to Amazon S3, WAL-G requires that these variables be set:
 
 * `WALE_S3_PREFIX` (eg. `s3://bucket/path/to/folder`)
-* `AWS_REGION`(eg. `us-west-2`)
-* `AWS_ACCESS_KEY_ID`
-* `AWS_SECRET_ACCESS_KEY`
+
+WAL-G determines AWS credentials [like other AWS tools](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence). You can set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (optionally with `AWS_SECURITY_TOKEN`), or `~/.aws/credentials` (optionally with `AWS_PROFILE`), or you can set nothing to automatically fetch credentials from the EC2 metadata service.
 
 WAL-G uses [the usual PostgreSQL environment variables](https://www.postgresql.org/docs/current/static/libpq-envars.html) to configure its connection, especially including `PGHOST`, `PGPORT`, `PGUSER`, and `PGPASSWORD`/`PGPASSFILE`/`~/.pgpass`.
 
 **Optional**
 
-Required if using AWS STS:
+WAL-G can automatically determine the S3 bucket's region using `s3:GetBucketLocation`, but if you wish to avoid this API call or forbid it from the applicable IAM policy, specify:
 
-* `AWS_SESSION_TOKEN`
+* `AWS_REGION`(eg. `us-west-2`)
 
 Concurrency values can be configured using:
 

--- a/cmd/wal-g/main.go
+++ b/cmd/wal-g/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/wal-g/wal-g"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime/pprof"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/wal-g/wal-g"
 )
 
 var profile bool


### PR DESCRIPTION
I was going to open a PR per my suggestion in #6 anyway, and this seems as good a time as any. 

I believe 68f31ea9aeab73235224f8dbd4396c63cba97818 broke `AWS_REGION`, entirely removing its effect on the AWS configuration. This commit a) restores `AWS_REGION` and b) makes it optional, falling back to `s3:GetBucketLocation` if it is unspecified.

@fdr didn't like this idea because it's an extra API call that might fail, but I insist that there's no downside. If the user specifies `AWS_REGION`, it'll get used, period. If the user doesn't specify `AWS_REGION`, WAL-G can call `s3:GetBucketLocation`. If that fails too, WAL-G terminates -- which is what it does now. If it succeeds, WAL-G can proceed without requiring the user to specify `AWS_REGION`. This change adds another _success_ mode, not another failure mode.