### PR TITLE
Fix backup name extraction in fetch LATEST

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -85,21 +85,24 @@ func (b *Backup) GetLatest() (string, error) {
 
 	count := len(backups.Contents)
 
-	if count==0 {
+	if count == 0 {
 		return "", LatestNotFound
 	}
 
-	sortTimes := make([]BackupTime, count)
+	sortTimes := GetBackupTimeSlices(backups)
 
+	return sortTimes[0].Name, nil
+}
+func GetBackupTimeSlices(backups *s3.ListObjectsV2Output) []BackupTime {
+	sortTimes := make([]BackupTime, len(backups.Contents))
 	for i, ob := range backups.Contents {
 		key := *ob.Key
 		time := *ob.LastModified
 		sortTimes[i] = BackupTime{stripNameBackup(key), time}
 	}
-
-	sort.Sort(TimeSlice(sortTimes))
-
-	return sortTimes[0].Name, nil
+	slice := TimeSlice(sortTimes)
+	sort.Sort(slice)
+	return slice
 }
 
 // Strips the backup key and returns it in its base form `base_...`.

--- a/backup.go
+++ b/backup.go
@@ -105,7 +105,7 @@ func (b *Backup) GetLatest() (string, error) {
 // Strips the backup key and returns it in its base form `base_...`.
 func stripNameBackup(key string) string {
 	all := strings.SplitAfter(key, "/")
-	name := strings.Split(all[2], "_backup")[0]
+	name := strings.Split(all[len(all)-1], "_backup")[0]
 	return name
 }
 

--- a/upload.go
+++ b/upload.go
@@ -74,7 +74,11 @@ func Configure() (*TarUploader, *Prefix, error) {
 	}
 
 	bucket := u.Host
-	server := u.Path[1:]
+	var server = ""
+	if len(u.Path) > 0 {
+		// TODO: Unchecked assertion: first char is '/'
+		server = u.Path[1:]
+	}
 
 	config := defaults.Get().Config
 


### PR DESCRIPTION
Currently name is extracted from backup path so that backup can only reside in one subdir inside bucket.
This fix allows deeper nesting.