### PR TITLE
GPG Encryption Fixes

### DIFF
--- a/cmd/wal-g/main.go
+++ b/cmd/wal-g/main.go
@@ -218,7 +218,7 @@ func main() {
 			log.Fatalf("%+v\n", err)
 		}
 
-		var crypter walg.Crypter
+		crypter := walg.OpenPGPCrypter{}
 
 		if exists {
 			arch, err := a.GetArchive()

--- a/crypto.go
+++ b/crypto.go
@@ -164,7 +164,7 @@ func GetPubRingArmour(keyId string) ([]byte, error) {
 		}
 	}
 
-	out, err := exec.Command(gpgBin, "-a", "--export", "-r", "\""+keyId+"\"").Output()
+	out, err := exec.Command(gpgBin, "-a", "--export", keyId).Output()
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func GetPubRingArmour(keyId string) ([]byte, error) {
 }
 
 func GetSecretRingArmour(keyId string) ([]byte, error) {
-	out, err := exec.Command(gpgBin, "-a", "--export-secret-key", "-r", "\""+keyId+"\"").Output()
+	out, err := exec.Command(gpgBin, "-a", "--export-secret-key", keyId).Output()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes two issues I found while trying to use the GPG encryption.

1) The GPG key and secret key exports were malformed, causing GPG to always return the first key in the list. 
2) On wal-fetch, the `OpenPGPCrypter` was not being initialized correctly