### PR TITLE
crypto: return an error if `gpg -a --export <key-id>` silenty fails

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,7 @@
-Patrick Figel <patrick@figel.email>
-Will Glynn <will@willglynn.com>
-Johan Hernandez <im@bithavoc.io>
+Adam Shannon <adamkshannon@gmail.com>
 Andrey Borodin <amborodin@acm.org>
 Cory Stephenson <aevin@me.com>
 Jarred Nicholls <jarred.nicholls@gmail.com>
+Johan Hernandez <im@bithavoc.io>
+Patrick Figel <patrick@figel.email>
+Will Glynn <will@willglynn.com>


### PR DESCRIPTION
I ran into a situation where gpg -a --export <key-id> was failing and
gpg was printing an error to stderr. This resulted in an empty body
being stored in the cache and empty slice returned.

```
$ gpg -a --export D22173AC > /dev/null
gpg: WARNING: nothing exported

$ echo $?
0
```