### PR TITLE
Add option to set path to gpg command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ To configure GPG key for encryption and decryption. By default, no encryption is
 
  To configure base for next delta backup (only if `WALG_DELTA_MAX_STEPS` is not exceeded). `WALG_DELTA_ORIGIN` can be LATEST (chaining increments), LATEST_FULL (for bases where volatile part is compact and chaining has no meaning - deltas overwrite each other). Defaults to LATEST.
 
+* `GPG_BIN_PATH`
+
+To configure the path to the `gpg` command. If not set, it defaults to `gpg` and is assumed to be on the PATH.
 
 Usage
 -----

--- a/crypto.go
+++ b/crypto.go
@@ -139,7 +139,16 @@ func GetKeyRingId() string {
 	return os.Getenv("WALE_GPG_KEY_ID")
 }
 
-const gpgBin = "gpg"
+func GetGpgBinPath() string {
+	gpgBinPath := os.Getenv("GPG_BIN_PATH")
+	if gpgBinPath == "" {
+		return "gpg"
+	}
+
+	return gpgBinPath
+}
+
+var gpgBin = GetGpgBinPath()
 
 type CachedKey struct {
 	KeyId string `json:"keyId"`


### PR DESCRIPTION
For some reason, Postgres wasn't finding `gpg` on my `PATH` during a restore, even though I could see it was there for the postgres user. This just lets the user set an explicit `gpg` path as an environment variable. If it's not set, it just falls back to the original `gpg` with no explicit path set.