### PR TITLE
Build alpine image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-cmd/wal-g/wal-g
+bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: go
 go:
   - 1.8.x
+services:
+  - docker
 before_deploy:
-  - tar -zcf wal-g.linux-amd64.tar.gz -C cmd/wal-g/ wal-g
+  - tar -zcf wal-g.linux-amd64.tar.gz  -C bin/linux-amd64/ wal-g
+  - tar -zcf wal-g.alpine-amd64.tar.gz -C bin/alpine-amd64/ wal-g
 deploy:
   provider: releases
   api_key:
     secure: nRVV5uKaBdCi/J/sLP7+c/shuDEaSeMiapEsro5gp4gr8n/QMgGm5AHNZhkfQVBmhmaKNB7dDzg34RVD2qacVpeZQTTUWetorBiwWvSjf+mlVcmBPKOIivamqetIdMEPgGQ0vudDADMpYiiqWBV893vAg1w0x02Cz7yvduzKEDyVttH+P4A7MPZ9tPtwLyMoOKjxe7Z0IOp82DK0rj+2KXQYe+El9Ipya+2WB88NBuRn2dJSfsAx9VI+5VmUz0waB1lP3ityjgQpaL13QEV6qsCXl+ntb4vGACbPYoPt0pgesq/zkL2ScFKTbzSSo6yByf3zHhV+elZ2sXnK/UYrqe4erC3qkG5qiTuy+uzPKg0pOVdqI1kDtMNoIanCjSVblXXsR+vz0UVHbzOmTMm7ckpnMB1nxsSyaQfs1C2e42SCgIB57RJsWUSsRx/Uq9iJS32ab/8pSnzJ2dZLNo4BxNHJDgKpmfj6ZKhBne+JUcfBsx2DOXs1ad9s0+ahpnlLiijhQQ5ZxGTfzYcXjijtAOyN2Y42wU6YI3L7ezsZTw+AoJeBMdc2MM8yy1CI/PM0x5IL+e9cZ+LoL87f0WZFxMd0KYblEeQzL+yRv0M5cRf4GPgqgEFsYUU4WXAH6Fnah2dailOvkfV1ygbaTxjvrSiIDnk0DKls3y8QLwSJPLw=
   skip_cleanup: true
-  file: wal-g.linux-amd64.tar.gz
+  file:
+  - wal-g.linux-amd64.tar.gz
+  - wal-g.alpine-amd64.tar.gz
   on:
     repo: wal-g/wal-g
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
+PKG  := github.com/wal-g/wal-g
 CMD_FILES = $(wildcard cmd/wal-g/*.go)
 PKG_FILES = $(wildcard *.go)
 
-.PHONY : fmt test install all clean
+.PHONY : fmt test install all clean build
 
-test: cmd/wal-g/wal-g
+test: build
 	go list ./... | grep -v 'vendor/' | xargs go vet
 	go test -v
 
 fmt: $(CMD_FILES) $(PKG_FILES)
 	gofmt -s -w $(CMD_FILES) $(PKG_FILES)
 
-all: cmd/wal-g/wal-g
+all: build
 
 install:
 	(cd cmd/wal-g && go install)
@@ -19,6 +20,22 @@ clean:
 	rm -r extracted compressed $(wildcard data*)
 	go clean
 	(cd cmd/wal-g && go clean)
+	rm -rf bin
 
-cmd/wal-g/wal-g: $(CMD_FILES) $(PKG_FILES)
-	(cd cmd/wal-g && go build)
+build: bin/linux-amd64 bin/alpine-amd64
+
+bin/linux-amd64: $(CMD_FILES) $(PKG_FILES)
+	(GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/linux-amd64/wal-g cmd/wal-g/*.go)
+
+bin/alpine-amd64: $(CMD_FILES) $(PKG_FILES)
+	docker run                                                              \
+	    --rm                                                                \
+	    -u $$(id -u):$$(id -g)                                              \
+	    -v /tmp:/.cache                                                     \
+	    -v "$$(pwd):/go/src/$(PKG)"                                         \
+	    -w /go/src/$(PKG)                                                   \
+	    -e GOOS=linux                                                       \
+	    -e GOARCH=amd64                                                     \
+	    -e CGO_ENABLED=0                                                    \
+	    golang:1.10.0-alpine                                                \
+	    go build -o bin/alpine-amd64/wal-g cmd/wal-g/*.go


### PR DESCRIPTION
- builds static binary
- builds separate binary for alpine. The linux-amd64 binary does not work in alpine docker images.