### PR TITLE
Fix base-backups on Postgres 9.0-9.5

### DIFF
--- a/upload.go
+++ b/upload.go
@@ -352,6 +352,10 @@ func (bundle *Bundle) HandleLabelFiles(conn *pgx.Conn) (uint64, error) {
 		return 0, errors.Wrap(err, "HandleLabelFiles: failed to parse finish LSN")
 	}
 
+	if queryRunner.Version < 90600 {
+		return lsn, nil
+	}
+
 	bundle.NewTarBall()
 	tarBall := bundle.Tb
 	tarBall.SetUp(&bundle.Crypter)


### PR DESCRIPTION
Fixes base-backups on Postgres 9.0-9.5 by skipping the steps to write the BackupLabel and tablespace map. The backup_label is written automatically, and tablespace map does not exist in < 9.6. This got dropped in the refactor of https://github.com/wal-g/wal-g/pull/38 and I forgot to re-test restoring the backup (I only tested generation)