### PR TITLE
Add extract function.

### DIFF
--- a/cmd/wal-g/main.go
+++ b/cmd/wal-g/main.go
@@ -18,6 +18,7 @@ var helpMsg = "  backup-fetch\tfetch a backup from S3\n" +
 	"  backup-list\tprints available backups\n" +
 	"  wal-fetch\tfetch a WAL file from S3\n" +
 	"  wal-push\tupload a WAL file to S3\n" +
+	"  extract\textract a local WAL file\n" +
 	"  delete\tclear old backups and WALs\n"
 
 func init() {
@@ -65,6 +66,8 @@ func main() {
 		case "wal-push":
 			fmt.Printf("usage:\twal-g wal-push archive_path\n\n")
 			os.Exit(0)
+		case "extract":
+			fmt.Printf("usage:\twal-g extract file_to_extract extract_to\n\n")
 		default:
 			l.Fatalf("Command '%s' is unsupported by WAL-G.\n\n", command)
 		}
@@ -109,6 +112,8 @@ func main() {
 		walg.HandleBackupFetch(backupName, pre, firstArgument, mem)
 	} else if command == "backup-list" {
 		walg.HandleBackupList(pre)
+	} else if command == "extract" {
+		walg.HandleExtract(firstArgument, backupName)
 	} else if command == "delete" {
 		walg.HandleDelete(pre, all)
 	} else {

--- a/commands.go
+++ b/commands.go
@@ -786,3 +786,33 @@ func UploadWALFile(tu *TarUploader, dirArc string) {
 		log.Fatalf("FATAL%+v\n", err)
 	}
 }
+
+func HandleExtract(path string, location string) {
+	var f io.ReadCloser
+	f, err := os.Open(path)
+	if err != nil {
+		log.Fatalf("UploadWal: failed to open file %s\n", path)
+		return
+	}
+
+	var crypter = OpenPGPCrypter{}
+	if crypter.IsUsed() {
+		var reader io.Reader
+		reader, err = crypter.Decrypt(f)
+		if err != nil {
+			log.Fatalf("%v\n", err)
+		}
+		f = ReadCascadeClose{reader, f}
+	}
+
+	f2, err := os.Create(location)
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+
+	_, err = DecompressLz4(f2, f)
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+	f.Close()
+}


### PR DESCRIPTION
Adds a command to extract a file created by `wal-g`. I've noticed that while `wal-fetch` works correctly, if I try to decrypt + decompress one of the `.lz4` files manually, the decompression fails with an error: 

```
Error 77 : Decoding Failed ! Corrupted input detected !
```