### PR TITLE
Implement parallel backup-push

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ To configure how many goroutines to use during backup-fetch  and wal-push, use `
 
 To configure how many concurrency streams to use during backup uploading, use `WALG_UPLOAD_CONCURRENCY`. By default, WAL-G uses 10 streams.
 
+* `WALG_UPLOAD_DISK_CONCURRENCY`
+
+To configure how many concurrency streams are reading disk during ```backup-push```. By default, WAL-G uses 1 stream.
+
 * `AWS_ENDPOINT`
 
 Overrides the default hostname to connect to an S3-compatible service. i.e, `http://s3-like-service:9000`

--- a/commands.go
+++ b/commands.go
@@ -388,13 +388,14 @@ func HandleBackupPush(dirArc string, tu *TarUploader, pre *Prefix) {
 		IncrementFromLsn: dto.LSN,
 		IncrementFrom:    latest,
 	}
-	bundle.NewTarBall()
+
+	bundle.StartQueue()
 	fmt.Println("Walking ...")
 	err = filepath.Walk(dirArc, bundle.TarWalker)
 	if err != nil {
 		log.Fatalf("%+v\n", err)
 	}
-	err = bundle.Tb.CloseTar()
+	err = bundle.FinishQueue()
 	if err != nil {
 		log.Fatalf("%+v\n", err)
 	}

--- a/connect.go
+++ b/connect.go
@@ -65,10 +65,10 @@ func (b *Bundle) StartBackup(conn *pgx.Conn, backup string) (backupName string, 
 	}
 	name, lsnStr, b.Replica, err = queryRunner.StartBackup(backup)
 
-	lsn, err = ParseLsn(lsnStr)
 	if err != nil {
 		return "", 0, queryRunner.Version, err
 	}
+	lsn, err = ParseLsn(lsnStr)
 
 	if b.Replica {
 		name, b.Timeline, err = WALFileName(lsn, conn)

--- a/extract.go
+++ b/extract.go
@@ -121,7 +121,7 @@ func ExtractAll(ti TarInterpreter, files []ReaderMaker) error {
 	}()
 
 	// Set maximum number of goroutines spun off by ExtractAll
-	var con = getMaxDownloadConcurrency(len(files))
+	var con = getMaxDownloadConcurrency(min(len(files), 10))
 
 	concurrent := make(chan Empty, con)
 	for i := 0; i < con; i++ {

--- a/make.go
+++ b/make.go
@@ -3,7 +3,7 @@ package walg
 // TarBallMaker is used to allow for
 // flexible creation of different TarBalls.
 type TarBallMaker interface {
-	Make() TarBall
+	Make(inheritState bool) TarBall
 }
 
 // S3TarBallMaker creates tarballs that are uploaded to S3.
@@ -21,15 +21,19 @@ type S3TarBallMaker struct {
 }
 
 // Make returns a tarball with required S3 fields.
-func (s *S3TarBallMaker) Make() TarBall {
+func (s *S3TarBallMaker) Make(inheritState bool) TarBall {
 	s.number++
+	uploader := s.Tu
+	if !inheritState {
+		uploader = uploader.Clone()
+	}
 	return &S3TarBall{
 		number:           s.number,
 		size:             s.size,
 		baseDir:          s.BaseDir,
 		trim:             s.Trim,
 		bkupName:         s.BkupName,
-		tu:               s.Tu,
+		tu:               uploader,
 		Lsn:              s.Lsn,
 		IncrementFromLsn: s.IncrementFromLsn,
 		IncrementFrom:    s.IncrementFrom,

--- a/make.go
+++ b/make.go
@@ -3,7 +3,7 @@ package walg
 // TarBallMaker is used to allow for
 // flexible creation of different TarBalls.
 type TarBallMaker interface {
-	Make(inheritState bool) TarBall
+	Make(newUploader bool) TarBall
 }
 
 // S3TarBallMaker creates tarballs that are uploaded to S3.
@@ -21,10 +21,10 @@ type S3TarBallMaker struct {
 }
 
 // Make returns a tarball with required S3 fields.
-func (s *S3TarBallMaker) Make(inheritState bool) TarBall {
+func (s *S3TarBallMaker) Make(newUploader bool) TarBall {
 	s.number++
 	uploader := s.Tu
-	if !inheritState {
+	if newUploader {
 		uploader = uploader.Clone()
 	}
 	return &S3TarBall{

--- a/structs_test.go
+++ b/structs_test.go
@@ -20,9 +20,10 @@ func TestS3TarBall(t *testing.T) {
 		BaseDir:  "tmp",
 		Trim:     "/usr/local",
 		BkupName: "test",
+		Tu:       walg.NewTarUploader(&mockS3Client{}, "bucket", "server", "region"),
 	}
 
-	bundle.NewTarBall(true)
+	bundle.NewTarBall(bundle.Tb)
 	tarBallCounter += 1
 
 	if bundle.Tb == nil {
@@ -62,7 +63,7 @@ func TestS3TarBall(t *testing.T) {
 		t.Errorf("make: Tarball writer should not be set up without calling SetUp()")
 	}
 
-	bundle.NewTarBall(true)
+	bundle.NewTarBall(bundle.Tb)
 	tarBallCounter += 1
 
 	if tarBall == bundle.Tb {
@@ -92,7 +93,7 @@ func TestS3DependentFunctions(t *testing.T) {
 		Tu:       tu,
 	}
 
-	bundle.NewTarBall(true)
+	bundle.NewTarBall(bundle.Tb)
 	tarBall := bundle.Tb
 	tarBall.SetUp(walg.MockArmedCrypter())
 	tarWriter := tarBall.Tw()
@@ -129,7 +130,7 @@ func TestS3DependentFunctions(t *testing.T) {
 	}
 
 	// Test naming property of SetUp().
-	bundle.NewTarBall(true)
+	bundle.NewTarBall(bundle.Tb)
 	tarBall = bundle.Tb
 	tarBall.SetUp(walg.MockArmedCrypter(), "mockTarball")
 	tarBall.CloseTar()
@@ -207,23 +208,25 @@ func queueTest(t *testing.T) {
 
 	bundle.StartQueue()
 
+	a := bundle.Deque()
 	go func() {
-		a := bundle.Deque()
-		time.Sleep(10*time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		bundle.EnqueueBack(a, &tr)
-		time.Sleep(10*time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		bundle.EnqueueBack(a, &f)
 	}()
 
+
+	c := bundle.Deque()
 	go func() {
-		c := bundle.Deque()
-		time.Sleep(10*time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		bundle.CheckSizeAndEnqueueBack(c)
 	}()
 
+
+	b := bundle.Deque()
 	go func() {
-		b := bundle.Deque()
-		time.Sleep(10*time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 		bundle.EnqueueBack(b, &f)
 	}()
 

--- a/structs_test.go
+++ b/structs_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/wal-g/wal-g"
+	"os"
+	"time"
 )
 
 // Tests S3 get and set methods.
@@ -20,7 +22,7 @@ func TestS3TarBall(t *testing.T) {
 		BkupName: "test",
 	}
 
-	bundle.NewTarBall()
+	bundle.NewTarBall(true)
 	tarBallCounter += 1
 
 	if bundle.Tb == nil {
@@ -60,7 +62,7 @@ func TestS3TarBall(t *testing.T) {
 		t.Errorf("make: Tarball writer should not be set up without calling SetUp()")
 	}
 
-	bundle.NewTarBall()
+	bundle.NewTarBall(true)
 	tarBallCounter += 1
 
 	if tarBall == bundle.Tb {
@@ -90,7 +92,7 @@ func TestS3DependentFunctions(t *testing.T) {
 		Tu:       tu,
 	}
 
-	bundle.NewTarBall()
+	bundle.NewTarBall(true)
 	tarBall := bundle.Tb
 	tarBall.SetUp(walg.MockArmedCrypter())
 	tarWriter := tarBall.Tw()
@@ -127,7 +129,7 @@ func TestS3DependentFunctions(t *testing.T) {
 	}
 
 	// Test naming property of SetUp().
-	bundle.NewTarBall()
+	bundle.NewTarBall(true)
 	tarBall = bundle.Tb
 	tarBall.SetUp(walg.MockArmedCrypter(), "mockTarball")
 	tarBall.CloseTar()
@@ -136,4 +138,97 @@ func TestS3DependentFunctions(t *testing.T) {
 		t.Errorf("structs: tarball did not finish correctly with error %s", err)
 	}
 
+}
+
+func TestEmptyBundleQueue(t *testing.T) {
+
+	bundle := &walg.Bundle{
+		MinSize: 100,
+	}
+
+	tu := walg.NewTarUploader(&mockS3Client{}, "bucket", "server", "region")
+	tu.Upl = &mockS3Uploader{}
+
+	bundle.Tbm = &walg.S3TarBallMaker{
+		BaseDir:  "mockDirectory",
+		Trim:     "",
+		BkupName: "mockBackup",
+		Tu:       tu,
+	}
+
+	bundle.StartQueue()
+
+	err := bundle.FinishQueue()
+	if err != nil {
+		t.Log(err)
+	}
+}
+
+func TestBundleQueue(t *testing.T) {
+
+	queueTest(t)
+
+}
+
+func TestBundleQueueHC(t *testing.T) {
+
+	os.Setenv("WALG_UPLOAD_CONCURRENCY", "100")
+
+	queueTest(t)
+
+	os.Unsetenv("WALG_UPLOAD_CONCURRENCY")
+}
+
+func TestBundleQueueLC(t *testing.T) {
+
+	os.Setenv("WALG_UPLOAD_CONCURRENCY", "1")
+
+	queueTest(t)
+
+	os.Unsetenv("WALG_UPLOAD_CONCURRENCY")
+}
+
+func queueTest(t *testing.T) {
+	bundle := &walg.Bundle{
+		MinSize: 100,
+	}
+	tu := walg.NewTarUploader(&mockS3Client{}, "bucket", "server", "region")
+	tu.Upl = &mockS3Uploader{}
+	bundle.Tbm = &walg.S3TarBallMaker{
+		BaseDir:  "mockDirectory",
+		Trim:     "",
+		BkupName: "mockBackup",
+		Tu:       tu,
+	}
+
+	f := false
+	tr := true
+	// For tests there must be at leaest 3 workers
+
+	bundle.StartQueue()
+
+	go func() {
+		a := bundle.Deque()
+		time.Sleep(10*time.Millisecond)
+		bundle.EnqueueBack(a, &tr)
+		time.Sleep(10*time.Millisecond)
+		bundle.EnqueueBack(a, &f)
+	}()
+
+	go func() {
+		c := bundle.Deque()
+		time.Sleep(10*time.Millisecond)
+		bundle.CheckSizeAndEnqueueBack(c)
+	}()
+
+	go func() {
+		b := bundle.Deque()
+		time.Sleep(10*time.Millisecond)
+		bundle.EnqueueBack(b, &f)
+	}()
+
+	err := bundle.FinishQueue()
+	if err != nil {
+		t.Log(err)
+	}
 }

--- a/test_tools/cmd/compress/main.go
+++ b/test_tools/cmd/compress/main.go
@@ -96,19 +96,19 @@ func main() {
 			Tu:       tu,
 		}
 
-		bundle.NewTarBall()
+		bundle.NewTarBall(true)
 		bundle.HandleLabelFiles(c)
 
 	}
 
-	bundle.NewTarBall()
+	bundle.StartQueue()
 	defer tools.TimeTrack(time.Now(), "MAIN")
 	fmt.Println("Walking ...")
 	err = filepath.Walk(in, bundle.TarWalker)
 	if err != nil {
 		panic(err)
 	}
-	err = bundle.Tb.CloseTar()
+	err = bundle.FinishQueue()
 	if err != nil {
 		panic(err)
 	}

--- a/test_tools/cmd/compress/main.go
+++ b/test_tools/cmd/compress/main.go
@@ -96,7 +96,7 @@ func main() {
 			Tu:       tu,
 		}
 
-		bundle.NewTarBall(true)
+		bundle.NewTarBall(bundle.Tb)
 		bundle.HandleLabelFiles(c)
 
 	}

--- a/test_tools/tarballMaker.go
+++ b/test_tools/tarballMaker.go
@@ -16,7 +16,7 @@ type FileTarBallMaker struct {
 }
 
 // Make creates a new FileTarBall.
-func (f *FileTarBallMaker) Make() walg.TarBall {
+func (f *FileTarBallMaker) Make(inheritState bool) walg.TarBall {
 	f.number++
 	return &FileTarBall{
 		number:  f.number,
@@ -38,7 +38,7 @@ type NOPTarBallMaker struct {
 }
 
 // Make creates a new NOPTarBall.
-func (n *NOPTarBallMaker) Make() walg.TarBall {
+func (n *NOPTarBallMaker) Make(inheritState bool) walg.TarBall {
 	n.number++
 	return &NOPTarBall{
 		number:  n.number,

--- a/test_tools/tarballs.go
+++ b/test_tools/tarballs.go
@@ -88,6 +88,7 @@ func (b *FileTarBall) AppendIncrementalFile(filePath ...string) {}
 func (b *FileTarBall) GetIncrementalFiles() []string            { return nil }
 func (b *FileTarBall) SetFiles(files walg.BackupFileList)       {}
 func (b *FileTarBall) GetFiles() walg.BackupFileList            { return make(walg.BackupFileList) }
+func (b *FileTarBall) AwaitUploads()                            {}
 
 // NOPTarBall mocks a tarball. Used for testing purposes.
 type NOPTarBall struct {
@@ -116,3 +117,4 @@ func (n *NOPTarBall) Tw() *tar.Writer { return n.tw }
 
 func (b *NOPTarBall) SetFiles(files walg.BackupFileList) {}
 func (b *NOPTarBall) GetFiles() walg.BackupFileList      { return make(walg.BackupFileList) }
+func (b *NOPTarBall) AwaitUploads()                      {}

--- a/upload.go
+++ b/upload.go
@@ -282,7 +282,7 @@ func (bundle *Bundle) HandleSentinel() error {
 	info := bundle.Sen.Info
 	path := bundle.Sen.path
 
-	bundle.NewTarBall()
+	bundle.NewTarBall(true)
 	tarBall := bundle.Tb
 	tarBall.SetUp(&bundle.Crypter, "pg_control.tar.lz4")
 	tarWriter := tarBall.Tw()
@@ -353,7 +353,7 @@ func (bundle *Bundle) HandleLabelFiles(conn *pgx.Conn) (uint64, error) {
 		return lsn, nil
 	}
 
-	bundle.NewTarBall()
+	bundle.NewTarBall(true)
 	tarBall := bundle.Tb
 	tarBall.SetUp(&bundle.Crypter)
 	tarWriter := tarBall.Tw()

--- a/upload.go
+++ b/upload.go
@@ -282,7 +282,7 @@ func (bundle *Bundle) HandleSentinel() error {
 	info := bundle.Sen.Info
 	path := bundle.Sen.path
 
-	bundle.NewTarBall(true)
+	bundle.NewTarBall(bundle.Tb)
 	tarBall := bundle.Tb
 	tarBall.SetUp(&bundle.Crypter, "pg_control.tar.lz4")
 	tarWriter := tarBall.Tw()
@@ -353,7 +353,7 @@ func (bundle *Bundle) HandleLabelFiles(conn *pgx.Conn) (uint64, error) {
 		return lsn, nil
 	}
 
-	bundle.NewTarBall(true)
+	bundle.NewTarBall(bundle.Tb)
 	tarBall := bundle.Tb
 	tarBall.SetUp(&bundle.Crypter)
 	tarWriter := tarBall.Tw()

--- a/upload_test.go
+++ b/upload_test.go
@@ -169,7 +169,7 @@ func TestUploadError(t *testing.T) {
 		Tu:       tu,
 	}
 
-	tarBall := maker.Make()
+	tarBall := maker.Make(true)
 	tarBall.SetUp(walg.MockArmedCrypter())
 
 	tarBall.Finish(&walg.S3TarBallSentinelDto{})
@@ -181,7 +181,7 @@ func TestUploadError(t *testing.T) {
 		multierr: true,
 	}
 
-	tarBall = maker.Make()
+	tarBall = maker.Make(true)
 	tarBall.SetUp(walg.MockArmedCrypter())
 	tarBall.Finish(&walg.S3TarBallSentinelDto{})
 	if tu.Success {

--- a/utility.go
+++ b/utility.go
@@ -73,15 +73,25 @@ func ResolveSymlink(path string) string {
 	return resolve
 }
 
-func getMaxDownloadConcurrency(reasonableMaximum int) int {
-	return getMaxConcurrency("WALG_DOWNLOAD_CONCURRENCY", reasonableMaximum)
+func getMaxDownloadConcurrency(default_value int) int {
+	return getMaxConcurrency("WALG_DOWNLOAD_CONCURRENCY", default_value)
 }
 
-func getMaxUploadConcurrency(reasonableMaximum int) int {
-	return getMaxConcurrency("WALG_UPLOAD_CONCURRENCY", reasonableMaximum)
+func getMaxUploadConcurrency(default_value int) int {
+	return getMaxConcurrency("WALG_UPLOAD_CONCURRENCY", default_value)
 }
 
-func getMaxConcurrency(key string, reasonableMaximum int) int {
+// This setting is intentially undocumented in README. Effectively, this configures how many prepared tar files there
+// may be in uploading state during backup-push.
+func getMaxUploadQueue() int {
+	return getMaxConcurrency("WALG_UPLOAD_QUEUE", 2)
+}
+
+func getMaxUploadDiskConcurrency() int {
+	return getMaxConcurrency("WALG_UPLOAD_DISK_CONCURRENCY", 1)
+}
+
+func getMaxConcurrency(key string, default_value int) int {
 	var con int
 	var err error
 	conc, ok := os.LookupEnv(key)
@@ -92,10 +102,10 @@ func getMaxConcurrency(key string, reasonableMaximum int) int {
 			log.Panic("Unknown concurrency number ", err)
 		}
 	} else {
-		if reasonableMaximum > 0 {
-			con = min(10, reasonableMaximum)
+		if default_value > 0 {
+			con = default_value
 		} else {
-			return 10
+			con = 10
 		}
 	}
 	return max(con, 1)

--- a/utility.go
+++ b/utility.go
@@ -74,25 +74,17 @@ func ResolveSymlink(path string) string {
 }
 
 func getMaxDownloadConcurrency(reasonableMaximum int) int {
-	var con int
-	var err error
-	conc, ok := os.LookupEnv("WALG_DOWNLOAD_CONCURRENCY")
-	if ok {
-		con, err = strconv.Atoi(conc)
-
-		if err != nil {
-			log.Panic("Unknown concurrency number ", err)
-		}
-	} else {
-		con = min(10, reasonableMaximum)
-	}
-	return max(con, 1)
+	return getMaxConcurrency("WALG_DOWNLOAD_CONCURRENCY", reasonableMaximum)
 }
 
 func getMaxUploadConcurrency(reasonableMaximum int) int {
+	return getMaxConcurrency("WALG_UPLOAD_CONCURRENCY", reasonableMaximum)
+}
+
+func getMaxConcurrency(key string, reasonableMaximum int) int {
 	var con int
 	var err error
-	conc, ok := os.LookupEnv("WALG_UPLOAD_CONCURRENCY")
+	conc, ok := os.LookupEnv(key)
 	if ok {
 		con, err = strconv.Atoi(conc)
 
@@ -100,7 +92,11 @@ func getMaxUploadConcurrency(reasonableMaximum int) int {
 			log.Panic("Unknown concurrency number ", err)
 		}
 	} else {
-		con = min(10, reasonableMaximum)
+		if reasonableMaximum > 0 {
+			con = min(10, reasonableMaximum)
+		} else {
+			return 10
+		}
 	}
 	return max(con, 1)
 }

--- a/walk_test.go
+++ b/walk_test.go
@@ -337,17 +337,18 @@ func TestWalk(t *testing.T) {
 		t.Log(err)
 	}
 
-	bundle.NewTarBall()
+	bundle.StartQueue()
 	fmt.Println("Walking ...")
 	err = filepath.Walk(data, bundle.TarWalker)
 	if err != nil {
 		t.Log(err)
 	}
 
-	err = bundle.Tb.CloseTar()
+	err = bundle.FinishQueue()
 	if err != nil {
 		t.Log(err)
 	}
+
 	err = bundle.Tb.Finish(&walg.S3TarBallSentinelDto{})
 	if err != nil {
 		t.Log(err)


### PR DESCRIPTION
Currently, backup-push uses only one goroutine to read from disk. This PR solves this problem and makes backup-push 1.5x faster according to my load tests.
But I have two concerns about it:
1. Each pipeline consumes ~400MB of RAM. So, with default WALG_MAX_UPLOAD_CONCURRENCY RAM usages is increased by the factor of 10, this seems unacceptable.
2. @Aevin1387 discovered some bugs #82. I suspect that these bugs manifest on PG versions before 9.6 but further investigation is necessary
3. This PR makes disk throttling a necessary feature because it somewhat guarantees exhausting either disk io throughput or network throughput.

I plan to make this parallelism controllable by some env switch and make it off by default.