### PR TITLE
Check WAL file existence before upload

### DIFF
--- a/bguploader_test.go
+++ b/bguploader_test.go
@@ -1,9 +1,11 @@
 package walg_test
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/wal-g/wal-g"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -14,59 +16,32 @@ import (
 // We expect that background worker will upload 100 files.
 // But we have no guaranties for this
 func TestBackgroundWALUpload(t *testing.T) {
-	cwd, err := filepath.Abs("./")
-	if err != nil {
-		t.Log(err)
-	}
-
-	//Create temp directory.
-	dir, err := ioutil.TempDir(cwd, "data")
-	if err != nil {
-		t.Log(err)
-	}
-
-	err = os.MkdirAll(filepath.Join(dir, "archive_status"), 0700)
-	if err != nil {
-		t.Log(err)
-	}
-
-	a := filepath.Join(dir, "A")
-	file, err := os.Create(a)
-	if err != nil {
-		t.Log(err)
-	}
-	file.Close()
-
+	dir, a := setupArchiveStatus(t, "")
 	for i := 0; i < 100; i++ {
-		bname := "B" + strconv.Itoa(i)
-		b := filepath.Join(dir, bname)
-		file, err = os.Create(b)
-		if err != nil {
-			t.Log(err)
-		}
-		file.Close()
-
-		br := filepath.Join(dir, "archive_status", bname+".ready")
-		file, err = os.Create(br)
-		if err != nil {
-			t.Log(err)
-		}
-		file.Close()
+		addTestDataFile(t, dir, i)
 	}
 
 	// Re-use generated data to test uploading WAL.
 	tu := walg.NewLz4MockTarUploader()
 	tu.UploaderApi = &mockS3Uploader{}
+	pre := &walg.S3Prefix{
+		Svc: &mockS3Client{
+			err:      true,
+			notFound: true,
+		},
+		Bucket: aws.String("mock bucket"),
+		Server: aws.String("mock server"),
+	}
 	bu := walg.BgUploader{}
 	// Look for new WALs while doing main upload
-	bu.Start(a, 16, tu, nil, false)
+	bu.Start(a, 16, tu, pre, false)
 	time.Sleep(time.Second) //time to spin up new uploaders
 	bu.Stop()
 
 	for i := 0; i < 100; i++ {
 		bname := "B" + strconv.Itoa(i)
 		bd := filepath.Join(dir, "archive_status", bname+".done")
-		_, err = os.Stat(bd)
+		_, err := os.Stat(bd)
 		if os.IsNotExist(err) {
 			t.Error(bname + ".done was not created")
 		}
@@ -78,7 +53,116 @@ func TestBackgroundWALUpload(t *testing.T) {
 		}
 	}
 
-	err = os.RemoveAll(dir)
+	cleanup(t, dir)
+}
+
+func TestBackgroundNoOverwriteWALUpload(t *testing.T) {
+	var overwriteDir = "overwritetestdata"
+	if os.Getenv("NO_OVERWRITE_TEST") == "1" {
+		_, a := setupArchiveStatus(t, overwriteDir)
+
+		addTestDataFile(t, overwriteDir, 0)
+
+		// Re-use generated data to test uploading WAL.
+		tu := walg.NewLz4MockTarUploader()
+		tu.UploaderApi = &mockS3Uploader{}
+		pre := &walg.S3Prefix{
+			Svc: &mockS3Client{
+				err:      false,
+				notFound: false,
+			},
+			Bucket: aws.String("mock bucket"),
+			Server: aws.String("mock server"),
+		}
+		bu := walg.BgUploader{}
+
+		// Look for new WALs while doing main upload
+		bu.Start(a, 16, tu, pre, false)
+		time.Sleep(time.Second) //time to spin up new uploaders
+		bu.Stop()
+
+		t.Error("did not exit from not overwriting")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestBackgroundNoOverwriteWALUpload")
+	cmd.Env = append(os.Environ(), "NO_OVERWRITE_TEST=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		bname := "B0"
+		bd := filepath.Join(overwriteDir, "archive_status", bname+".ready")
+		_, err := os.Stat(bd)
+		if os.IsNotExist(err) {
+			t.Error(bname + ".ready was deleted")
+		}
+
+		cleanup(t, overwriteDir)
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
+}
+
+func setupArchiveStatus(t *testing.T, dir string) (string, string) {
+	cwd, err := filepath.Abs("./")
+	if err != nil {
+		t.Log(err)
+	}
+
+	var testDir = dir
+	if dir != "" {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			err := os.Mkdir(dir, 0700)
+			if err != nil {
+				t.Log(err)
+			}
+		}
+	} else {
+		//Create temp directory.
+		tmpDir, err := ioutil.TempDir(cwd, "data")
+		testDir = tmpDir
+		if err != nil {
+			t.Log(err)
+		}
+	}
+
+	err = os.MkdirAll(filepath.Join(testDir, "archive_status"), 0700)
+	if err != nil {
+		t.Log(err)
+	}
+
+	a := filepath.Join(testDir, "A")
+	file, err := os.Create(a)
+	if err != nil {
+		t.Log(err)
+	}
+	file.Close()
+
+	return testDir, a
+}
+
+func addTestDataFile(t *testing.T, dir string, i int) {
+	bname := "B" + strconv.Itoa(i)
+	b := filepath.Join(dir, bname)
+
+	if _, err := os.Stat(b); os.IsNotExist(err) {
+		file, err := os.Create(b)
+		if err != nil {
+			t.Log(err)
+		}
+		file.Close()
+	}
+
+	br := filepath.Join(dir, "archive_status", bname+".ready")
+	if _, err := os.Stat(br); os.IsNotExist(err) {
+		file, err := os.Create(br)
+		if err != nil {
+			t.Log(err)
+		}
+		file.Close()
+	}
+}
+
+func cleanup(t *testing.T, dir string) {
+	err := os.RemoveAll(dir)
 	if err != nil {
 		t.Log("temporary data directory was not deleted ", err)
 	}

--- a/commands.go
+++ b/commands.go
@@ -604,6 +604,19 @@ func HandleWALPush(tarUploader *TarUploader, dirArc string, pre *S3Prefix, verif
 
 // UploadWALFile from FS to the cloud
 func UploadWALFile(tarUploader *TarUploader, dirArc string, pre *S3Prefix, verify bool) {
+	archive := &Archive{
+		Prefix:  pre,
+		Archive: aws.String(sanitizePath(tarUploader.server + WalPath + filepath.Base(dirArc) + "." + tarUploader.compressor.FileExtension())),
+	}
+
+	exists, err := archive.CheckExistence()
+	if err != nil {
+		log.Fatalf("FATAL %+v\n", err)
+	}
+	if exists {
+		log.Fatalf("FATAL WAL file '%s' already archived, not overwriting", dirArc)
+	}
+
 	path, err := tarUploader.UploadWal(dirArc, pre, verify)
 	if re, ok := err.(CompressingPipeWriterError); ok {
 		log.Fatalf("FATAL: could not upload '%s' due to compression error.\n%+v\n", path, re)


### PR DESCRIPTION
Issue: https://github.com/wal-g/wal-g/issues/104

A first pass attempt at not overwriting WAL files.

I did not see any way to set up unit tests for this. The `commands_test.go` file looked to just do parsing tests.

Manually building this and testing it did work though.

```
$ wal-g wal-push /var/lib/postgresql/10/main/pg_wal/000000010000000000000001
BUCKET: mybucket
SERVER: myserver
WAL PATH: myserver/wal_005/000000010000000000000001.lz4
$ wal-g wal-push /var/lib/postgresql/10/main/pg_wal/000000010000000000000001
BUCKET: mybucket
SERVER: myserver
2018/07/24 21:47:03 WAL file '/var/lib/postgresql/10/main/pg_wal/000000010000000000000001' already archived, not overwriting
```