### PR TITLE
Move WAL overwrite under switch and add precaution checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ To configure how many concurrency streams are reading disk during ```backup-push
 
 * `WALG_SENTINEL_USER_DATA`
 
-This setting allows backup automation tools to add extra information to JSON sentinel file during ```backup-push```.
+This setting allows backup automation tools to add extra information to JSON sentinel file during ```backup-push```. This setting can be used e.g. to give user-defined names to backups.
+
+* `WALG_PREVENT_WAL_OVERWRITE`
+
+If this setting is specified, during ```wal-push``` WAL-G will check the existence of WAL before uploading it. If the different file is already archived under the same name, WAL-G will return the non-zero exit code to prevent PostgreSQL from removing WAL.
 
 * `AWS_ENDPOINT`
 

--- a/bguploader.go
+++ b/bguploader.go
@@ -116,7 +116,7 @@ func haveNoSlots(u *BgUploader) bool {
 // Upload one WAL file
 func (uploader *BgUploader) Upload(info os.FileInfo) {
 	walfilename := strings.TrimSuffix(info.Name(), readySuffix)
-	UploadWALFile(uploader.tarUploader.Clone(), filepath.Join(uploader.dir, walfilename), uploader.pre, uploader.verify)
+	UploadWALFile(uploader.tarUploader.Clone(), filepath.Join(uploader.dir, walfilename), uploader.pre, uploader.verify, true)
 
 	ready := filepath.Join(uploader.dir, archiveStatus, info.Name())
 	done := filepath.Join(uploader.dir, archiveStatus, walfilename+done)

--- a/compression.go
+++ b/compression.go
@@ -45,3 +45,13 @@ var Decompressors = []Decompressor{
 	ZstdDecompressor{},
 	LzmaDecompressor{},
 }
+
+func getDecompressorByCompressor(compressor Compressor) Decompressor {
+	extension := compressor.FileExtension()
+	for _,d:=range Decompressors{
+		if d.FileExtension() == extension {
+			return d
+		}
+	}
+	return nil
+}

--- a/s3_prefix.go
+++ b/s3_prefix.go
@@ -4,7 +4,8 @@ import "github.com/aws/aws-sdk-go/service/s3/s3iface"
 
 // S3Prefix contains the S3 service client, bucket and string.
 type S3Prefix struct {
-	Svc    s3iface.S3API
-	Bucket *string
-	Server *string
+	Svc                 s3iface.S3API
+	Bucket              *string
+	Server              *string
+	PreventWalOverwrite bool
 }

--- a/upload.go
+++ b/upload.go
@@ -93,7 +93,7 @@ func Configure() (*TarUploader, *S3Prefix, error) {
 	if len(s3ForcePathStyleStr) > 0 {
 		s3ForcePathStyle, err := strconv.ParseBool(s3ForcePathStyleStr)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "Configure: failed parse AWS_S3_FORCE_PATH_STYLE")
+			return nil, nil, errors.Wrap(err, "Configure: failed to parse AWS_S3_FORCE_PATH_STYLE")
 		}
 		config.S3ForcePathStyle = aws.Bool(s3ForcePathStyle)
 	}
@@ -118,6 +118,15 @@ func Configure() (*TarUploader, *S3Prefix, error) {
 	pre := &S3Prefix{
 		Bucket: aws.String(bucket),
 		Server: aws.String(server),
+	}
+
+	preventWalOverwriteStr := os.Getenv("WALG_PREVENT_WAL_OVERWRITE")
+	if len(preventWalOverwriteStr) > 0 {
+		preventWalOverwrite, err := strconv.ParseBool(preventWalOverwriteStr)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "Configure: failed to parse WALG_PREVENT_WAL_OVERWRITE")
+		}
+		pre.PreventWalOverwrite = preventWalOverwrite
 	}
 
 	diskLimitStr := os.Getenv("WALG_DISK_RATE_LIMIT")


### PR DESCRIPTION
@DustinChaloupka, @fdr plz review this PR, mainly design decisions. I'll add docs later.

Here we check WAL contents if WAL-G tries to overwrite WAL.

I've tried MD5==ETag thing, it does not work for gpg-encrypted files, because the file is different each time.