### PR TITLE
Stack trace printing for WAL-G errors

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"io/ioutil"
 	"log"
+	"fmt"
 )
 
 type NoBackupsFoundError struct {
@@ -16,6 +17,10 @@ type NoBackupsFoundError struct {
 
 func NewNoBackupsFoundError() NoBackupsFoundError {
 	return NoBackupsFoundError{errors.New("No backups found")}
+}
+
+func (err NoBackupsFoundError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // Backup contains information about a valid backup

--- a/bundle.go
+++ b/bundle.go
@@ -29,13 +29,17 @@ func NewTarSizeError(packedFileSize, expectedSize int64) TarSizeError {
 	return TarSizeError{errors.Errorf("packed wrong numbers of bytes %d instead of %d", packedFileSize, expectedSize)}
 }
 
+func (err TarSizeError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 // ExcludedFilenames is a list of excluded members from the bundled backup.
 var ExcludedFilenames = make(map[string]Empty)
 
 func init() {
 	filesToExclude := []string{
-		"pg_log", "pg_xlog", "pg_wal",                                                                        // Directories
-		"pgsql_tmp", "postgresql.auto.conf.tmp", "postmaster.pid", "postmaster.opts", "recovery.conf",        // Files
+		"pg_log", "pg_xlog", "pg_wal", // Directories
+		"pgsql_tmp", "postgresql.auto.conf.tmp", "postmaster.pid", "postmaster.opts", "recovery.conf", // Files
 		"pg_dynshmem", "pg_notify", "pg_replslot", "pg_serial", "pg_stat_tmp", "pg_snapshots", "pg_subtrans", // Directories
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -27,12 +27,20 @@ func NewInvalidWalFileMagicError() InvalidWalFileMagicError {
 	return InvalidWalFileMagicError{errors.New("WAL-G: WAL file magic is invalid ")}
 }
 
+func (err InvalidWalFileMagicError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type CantOverwriteWalFileError struct {
 	error
 }
 
 func NewCantOverwriteWalFileError(walFilePath string) CantOverwriteWalFileError {
 	return CantOverwriteWalFileError{errors.Errorf("WAL file '%s' already archived, contents differ, unable to overwrite\n", walFilePath)}
+}
+
+func (err CantOverwriteWalFileError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 const DefaultDataFolderPath = "/tmp"
@@ -43,6 +51,10 @@ type ArchiveNonExistenceError struct {
 
 func NewArchiveNonExistenceError(archiveName string) ArchiveNonExistenceError {
 	return ArchiveNonExistenceError{errors.Errorf("Archive '%s' does not exist.\n", archiveName)}
+}
+
+func (err ArchiveNonExistenceError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // TODO : unit tests

--- a/compressing_pipe_writer.go
+++ b/compressing_pipe_writer.go
@@ -1,6 +1,7 @@
 package walg
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 	"io"
 )
@@ -14,6 +15,10 @@ type CompressingPipeWriterError struct {
 
 func NewCompressingPipeWriterError(reason string) CompressingPipeWriterError {
 	return CompressingPipeWriterError{errors.New(reason)}
+}
+
+func (err CompressingPipeWriterError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // CompressingPipeWriter allows for flexibility of using compressed output.

--- a/compression.go
+++ b/compression.go
@@ -1,8 +1,9 @@
 package walg
 
 import (
-	"io"
 	"github.com/pkg/errors"
+	"io"
+	"fmt"
 )
 
 const (
@@ -20,12 +21,16 @@ const (
 
 var CompressingAlgorithms = []string{Lz4AlgorithmName, LzmaAlgorithmName, BrotliAlgorithmName}
 
-type UnknownCompressionMethodError struct{
+type UnknownCompressionMethodError struct {
 	error
 }
 
 func NewUnknownCompressionMethodError() UnknownCompressionMethodError {
 	return UnknownCompressionMethodError{errors.Errorf("Unknown compression method, supported methods are: %v", CompressingAlgorithms)}
+}
+
+func (err UnknownCompressionMethodError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type Compressor interface {

--- a/configure.go
+++ b/configure.go
@@ -15,8 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/pkg/errors"
 	"golang.org/x/time/rate"
-	"path/filepath"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -30,6 +30,10 @@ type SseKmsIdNotSetError struct {
 
 func NewSseKmsIdNotSetError() SseKmsIdNotSetError {
 	return SseKmsIdNotSetError{errors.New("Configure: WALG_S3_SSE_KMS_ID must be set if using aws:kms encryption")}
+}
+
+func (err SseKmsIdNotSetError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // MaxRetries limit upload and download retries during interaction with S3
@@ -79,7 +83,7 @@ func Configure(verifyUploads bool) (uploader *Uploader, destinationFolder *S3Fol
 		return nil, nil, errors.Wrapf(err, "Configure: failed to parse url '%s'", waleS3Prefix)
 	}
 	if waleS3Url.Scheme == "" || waleS3Url.Host == "" {
-		return nil, nil, fmt.Errorf("Missing url scheme=%q and/or host=%q", waleS3Url.Scheme, waleS3Url.Host)
+		return nil, nil, fmt.Errorf("missing url scheme=%q and/or host=%q", waleS3Url.Scheme, waleS3Url.Host)
 	}
 
 	bucket := waleS3Url.Host

--- a/crypto.go
+++ b/crypto.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"fmt"
 )
 
 type GpgKeyExportError struct {
@@ -18,6 +19,10 @@ type GpgKeyExportError struct {
 
 func NewGpgKeyExportError(text string) GpgKeyExportError {
 	return GpgKeyExportError{errors.Errorf("Got error while exporting gpg key: '%s'", text)}
+}
+
+func (err GpgKeyExportError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // GetKeyRingId extracts name of a key to use from env variable

--- a/data_folder.go
+++ b/data_folder.go
@@ -1,8 +1,9 @@
 package walg
 
 import (
-	"io"
 	"github.com/pkg/errors"
+	"io"
+	"fmt"
 )
 
 type NoSuchFileError struct {
@@ -11,6 +12,10 @@ type NoSuchFileError struct {
 
 func NewNoSuchFileError(filename string) NoSuchFileError {
 	return NoSuchFileError{errors.Errorf("No file found: %s", filename)}
+}
+
+func (err NoSuchFileError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type DataFolder interface {

--- a/delta_file.go
+++ b/delta_file.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/walparser"
 	"io"
+	"fmt"
 )
 
 type NilWalParserError struct {
@@ -12,6 +13,10 @@ type NilWalParserError struct {
 
 func NewNilWalParserError() NilWalParserError {
 	return NilWalParserError{errors.New("expected to get non nil wal parser, but got nil one")}
+}
+
+func (err NilWalParserError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type DeltaFile struct {

--- a/delta_file_manager.go
+++ b/delta_file_manager.go
@@ -3,9 +3,9 @@ package walg
 import (
 	"bytes"
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/walparser"
 	"sync"
-	"github.com/pkg/errors"
 )
 
 type DeltaFileWriterNotFoundError struct {
@@ -14,6 +14,10 @@ type DeltaFileWriterNotFoundError struct {
 
 func NewDeltaFileWriterNotFoundError(filename string) DeltaFileWriterNotFoundError {
 	return DeltaFileWriterNotFoundError{errors.Errorf("can't file delta file writer for file: '%s'", filename)}
+}
+
+func (err DeltaFileWriterNotFoundError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type DeltaFileManager struct {

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package walg
 
 import (
 	"github.com/pkg/errors"
+	"fmt"
 )
 
 // UnsetEnvVarError is used to indicate required environment
@@ -16,6 +17,10 @@ func NewUnsetEnvVarError(names []string) UnsetEnvVarError {
 		msg = msg + v + "\n"
 	}
 	return UnsetEnvVarError{errors.New(msg)}
+}
+
+func (err UnsetEnvVarError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // UnsupportedFileTypeError is used to signal file types

--- a/extract.go
+++ b/extract.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"sync"
 	"strings"
+	"fmt"
 )
 
 type NoFilesToExtractError struct {
@@ -17,6 +18,10 @@ type NoFilesToExtractError struct {
 
 func NewNoFilesToExtractError() NoFilesToExtractError {
 	return NoFilesToExtractError{errors.New("ExtractAll: did not provide files to extract")}
+}
+
+func (err NoFilesToExtractError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // EmptyWriteIgnorer handles 0 byte write in LZ4 package

--- a/file_system_cleaner.go
+++ b/file_system_cleaner.go
@@ -1,9 +1,9 @@
 package walg
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
-	"fmt"
 )
 
 // FileSystemCleaner actually performs it's functions on file system

--- a/lazy_cache.go
+++ b/lazy_cache.go
@@ -1,8 +1,9 @@
 package walg
 
 import (
-	"sync"
 	"github.com/pkg/errors"
+	"sync"
+	"fmt"
 )
 
 type WrongTypeError struct {
@@ -11,6 +12,10 @@ type WrongTypeError struct {
 
 func NewWrongTypeError(desiredType string) WrongTypeError {
 	return WrongTypeError{errors.Errorf("expected to get '%s', but not found one", desiredType)}
+}
+
+func (err WrongTypeError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type LazyCache struct {

--- a/nop_tarball.go
+++ b/nop_tarball.go
@@ -13,7 +13,7 @@ type NOPTarBall struct {
 }
 
 func (tarBall *NOPTarBall) SetUp(crypter Crypter, params ...string) {}
-func (tarBall *NOPTarBall) CloseTar() error                              { return nil }
+func (tarBall *NOPTarBall) CloseTar() error                         { return nil }
 func (tarBall *NOPTarBall) Finish(sentinelDto *S3TarBallSentinelDto) error {
 	fmt.Printf("NOP: %d files.\n", tarBall.number)
 	return nil

--- a/open_pgp_crypter.go
+++ b/open_pgp_crypter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"golang.org/x/crypto/openpgp"
 	"io"
+	"fmt"
 )
 
 // CrypterUseMischiefError happens when crypter is used before initialization
@@ -13,7 +14,11 @@ type CrypterUseMischiefError struct {
 }
 
 func NewCrypterUseMischiefError() CrypterUseMischiefError {
-	return CrypterUseMischiefError{errors.New("Crypter is not checked before use")}
+	return CrypterUseMischiefError{errors.New("crypter is not checked before use")}
+}
+
+func (err CrypterUseMischiefError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // OpenPGPCrypter incapsulates specific of cypher method

--- a/paged_file_delta_map.go
+++ b/paged_file_delta_map.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"fmt"
 )
 
 const (
@@ -24,12 +25,20 @@ func NewNoBitmapFoundError() NoBitmapFoundError {
 	return NoBitmapFoundError{errors.New("GetDeltaBitmapFor: no bitmap found")}
 }
 
+func (err NoBitmapFoundError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type UnknownTableSpaceError struct {
 	error
 }
 
 func NewUnknownTableSpaceError() UnknownTableSpaceError {
 	return UnknownTableSpaceError{errors.New("GetRelFileNodeFrom: unknown tablespace")}
+}
+
+func (err UnknownTableSpaceError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type PagedFileDeltaMap map[walparser.RelFileNode]*roaring.Bitmap

--- a/pagefile.go
+++ b/pagefile.go
@@ -49,12 +49,20 @@ func NewInvalidBlockError(blockNo uint32) InvalidBlockError {
 	return InvalidBlockError{errors.Errorf("block %d is invalid", blockNo)}
 }
 
+func (err InvalidBlockError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type InvalidIncrementFileHeaderError struct {
 	error
 }
 
 func NewInvalidIncrementFileHeaderError() InvalidIncrementFileHeaderError {
 	return InvalidIncrementFileHeaderError{errors.New("Invalid increment file header")}
+}
+
+func (err InvalidIncrementFileHeaderError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type UnknownIncrementFileHeaderError struct {
@@ -65,12 +73,20 @@ func NewUnknownIncrementFileHeaderError() UnknownIncrementFileHeaderError {
 	return UnknownIncrementFileHeaderError{errors.New("Unknown increment file header")}
 }
 
+func (err UnknownIncrementFileHeaderError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type UnexpectedTarDataError struct {
 	error
 }
 
 func NewUnexpectedTarDataError() UnexpectedTarDataError {
 	return UnexpectedTarDataError{errors.New("Expected end of Tar")}
+}
+
+func (err UnexpectedTarDataError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 var pagedFilenameRegexp *regexp.Regexp

--- a/prefetch.go
+++ b/prefetch.go
@@ -1,19 +1,19 @@
 package walg
 
 import (
+	"archive/tar"
 	"fmt"
+	"github.com/pkg/errors"
+	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
-	"path/filepath"
-	"archive/tar"
-	"github.com/pkg/errors"
-	"io"
-	"io/ioutil"
 )
 
 // TODO : unit tests

--- a/queryRunner.go
+++ b/queryRunner.go
@@ -3,6 +3,7 @@ package walg
 import (
 	"github.com/jackc/pgx"
 	"github.com/pkg/errors"
+	"fmt"
 )
 
 type NoPostgresVersionError struct {
@@ -13,12 +14,20 @@ func NewNoPostgresVersionError() NoPostgresVersionError {
 	return NoPostgresVersionError{errors.New("Postgres version not set, cannot determine backup query")}
 }
 
+func (err NoPostgresVersionError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type UnsupportedPostgresVersionError struct {
 	error
 }
 
 func NewUnsupportedPostgresVersionError(version int) UnsupportedPostgresVersionError {
 	return UnsupportedPostgresVersionError{errors.Errorf("Could not determine backup query for version %d", version)}
+}
+
+func (err UnsupportedPostgresVersionError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 // The QueryRunner interface for controlling database during backup

--- a/s3_tar_ball.go
+++ b/s3_tar_ball.go
@@ -18,6 +18,10 @@ func NewNoSentinelUploadError() NoSentinelUploadError {
 	return NoSentinelUploadError{errors.New("Sentinel was not uploaded due to timeline change during backup")}
 }
 
+func (err NoSentinelUploadError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 // S3TarBall represents a tar file that is
 // going to be uploaded to S3.
 type S3TarBall struct {

--- a/timeline.go
+++ b/timeline.go
@@ -15,12 +15,20 @@ func NewBytesPerWalSegmentError() BytesPerWalSegmentError {
 	return BytesPerWalSegmentError{errors.New("bytes_per_wal_segment of the server does not match expected value")}
 }
 
+func (err BytesPerWalSegmentError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type IncorrectLogSegNoError struct {
 	error
 }
 
 func NewIncorrectLogSegNoError(name string) IncorrectLogSegNoError {
 	return IncorrectLogSegNoError{errors.Errorf("Incorrect logSegNoLo in WAL file name: %s", name)}
+}
+
+func (err IncorrectLogSegNoError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 func readTimeline(conn *pgx.Conn) (timeline uint32, err error) {

--- a/wal_part_recorder.go
+++ b/wal_part_recorder.go
@@ -13,6 +13,10 @@ func NewNotWalFilenameError(filename string) NotWalFilenameError {
 	return NotWalFilenameError{errors.Errorf("expected to get wal filename, but found: '%s'", filename)}
 }
 
+func (err NotWalFilenameError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type WalPartRecorder struct {
 	manager     *DeltaFileManager
 	walFilename string

--- a/walg_test/delete_test.go
+++ b/walg_test/delete_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 )
 
-
 //NB: order will reverse after sorting
 var backup_times1 = []walg.BackupTime{
 	{

--- a/walparser/aligned_reader.go
+++ b/walparser/aligned_reader.go
@@ -1,8 +1,8 @@
 package walparser
 
 import (
-	"io"
 	"github.com/pkg/errors"
+	"io"
 )
 
 type AlignedReader struct {

--- a/walparser/parsing_errors.go
+++ b/walparser/parsing_errors.go
@@ -1,6 +1,7 @@
 package walparser
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 )
 
@@ -12,6 +13,10 @@ func NewInvalidRecordBlockIdError(blockId uint8) InvalidRecordBlockIdError {
 	return InvalidRecordBlockIdError{errors.Errorf("invalid record blockId: %v", blockId)}
 }
 
+func (err InvalidRecordBlockIdError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type OutOfOrderBlockIdError struct {
 	error
 }
@@ -20,12 +25,20 @@ func NewOutOfOrderBlockIdError(actualBlockId int, expectedBlockId int) OutOfOrde
 	return OutOfOrderBlockIdError{errors.Errorf("out of order block id: %v, expected: %v", actualBlockId, expectedBlockId)}
 }
 
+func (err OutOfOrderBlockIdError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type InconsistentBlockDataStateError struct {
 	error
 }
 
-func NewInconsistentBlockDataStateError(hasData    bool, dataLength uint16) InconsistentBlockDataStateError {
+func NewInconsistentBlockDataStateError(hasData bool, dataLength uint16) InconsistentBlockDataStateError {
 	return InconsistentBlockDataStateError{errors.Errorf("block state is inconsistent: hasData is: %v, while dataLength is: %v", hasData, dataLength)}
+}
+
+func (err InconsistentBlockDataStateError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type NoPrevRelFileNodeError struct {
@@ -34,6 +47,10 @@ type NoPrevRelFileNodeError struct {
 
 func NewNoPrevRelFileNodeError() NoPrevRelFileNodeError {
 	return NoPrevRelFileNodeError{errors.New("expected to copy previous rel file node, but not found one")}
+}
+
+func (err NoPrevRelFileNodeError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type ContinuationNotFoundError struct {

--- a/walparser/read_xlog_page.go
+++ b/walparser/read_xlog_page.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/walparser/parsingutil"
 	"io"
+	"fmt"
 )
 
 type ZeroPageHeaderError struct {
@@ -15,12 +16,20 @@ func NewZeroPageHeaderError() error {
 	return ZeroPageHeaderError{errors.New("page header contains only zeroes, maybe it is a part .partial file or this page follow WAL-switch record")}
 }
 
+func (err ZeroPageHeaderError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type InvalidPageHeaderError struct {
 	error
 }
 
 func NewInvalidPageHeaderError() error {
 	return InvalidPageHeaderError{errors.New("invalid page header")}
+}
+
+func (err InvalidPageHeaderError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 func tryReadXLogRecordData(alignedReader *AlignedReader) (data []byte, whole bool, err error) {

--- a/walparser/read_xlog_record.go
+++ b/walparser/read_xlog_record.go
@@ -2,9 +2,9 @@ package walparser
 
 import (
 	"bytes"
+	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/walparser/parsingutil"
 	"io"
-	"github.com/pkg/errors"
 )
 
 func readXLogRecordHeader(reader io.Reader) (*XLogRecordHeader, error) {

--- a/walparser/shrinkable_reader.go
+++ b/walparser/shrinkable_reader.go
@@ -1,16 +1,21 @@
 package walparser
 
 import (
-	"io"
 	"github.com/pkg/errors"
+	"io"
+	"fmt"
 )
 
 type NotEnoughDataToShrinkError struct {
 	error
 }
 
-func NewNotEnoughDataToShrinkError(dataRemained int, toShrink     int) error {
+func NewNotEnoughDataToShrinkError(dataRemained int, toShrink int) error {
 	return NotEnoughDataToShrinkError{errors.Errorf("not enough data to shrink: dataRemained: %v, toShrink: %v", dataRemained, toShrink)}
+}
+
+func (err NotEnoughDataToShrinkError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type ShrinkableReader struct {

--- a/walparser/wal_file_page_reader.go
+++ b/walparser/wal_file_page_reader.go
@@ -1,8 +1,8 @@
 package walparser
 
 import (
-	"io"
 	"github.com/pkg/errors"
+	"io"
 )
 
 type WalPageReader struct {

--- a/walparser/wal_file_page_reader_test.go
+++ b/walparser/wal_file_page_reader_test.go
@@ -2,11 +2,11 @@ package walparser
 
 import (
 	"bytes"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"math/rand"
 	"testing"
-	"github.com/pkg/errors"
 )
 
 func TestWalPageReader_ReadPageData(t *testing.T) {

--- a/walparser/wal_parser.go
+++ b/walparser/wal_parser.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wal-g/wal-g/walparser/parsingutil"
 	"io"
 	"io/ioutil"
+	"fmt"
 )
 
 const (
@@ -23,12 +24,20 @@ func NewZeroPageError() ZeroPageError {
 	return ZeroPageError{errors.New("the whole page consists only of zero bytes")}
 }
 
+func (err ZeroPageError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type PartialPageError struct {
 	error
 }
 
 func NewPartialPageError() PartialPageError {
 	return PartialPageError{errors.New("the page is partial, maybe it is the last non zero page of .partial file")}
+}
+
+func (err PartialPageError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type WalParser struct {

--- a/walparser/xlog_record_block_image_header.go
+++ b/walparser/xlog_record_block_image_header.go
@@ -2,6 +2,7 @@ package walparser
 
 import (
 	"github.com/pkg/errors"
+	"fmt"
 )
 
 const (
@@ -20,12 +21,20 @@ func NewInconsistentBlockImageHoleStateError(holeOffset uint16, holeLength uint1
 		holeOffset, holeLength, imageLength, hasHole)}
 }
 
+func (err InconsistentBlockImageHoleStateError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type InconsistentBlockImageLengthError struct {
 	error
 }
 
 func NewInconsistentBlockImageLengthError(hasHole bool, isCompressed bool, length uint16) InconsistentBlockImageLengthError {
 	return InconsistentBlockImageLengthError{errors.Errorf("block image has invalid state: hasHole: %v, isCompressed: %v, imageLength: %v", hasHole, isCompressed, length)}
+}
+
+func (err InconsistentBlockImageLengthError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 type XLogRecordBlockImageHeader struct {

--- a/walparser/xlog_record_header.go
+++ b/walparser/xlog_record_header.go
@@ -2,6 +2,7 @@ package walparser
 
 import (
 	"github.com/pkg/errors"
+	"fmt"
 )
 
 const (
@@ -23,6 +24,10 @@ func NewInconsistentXLogRecordTotalLengthError(totalRecordLength uint32) Inconsi
 	return InconsistentXLogRecordTotalLengthError{errors.Errorf("total record length is too small: %v, expected at least: %v", totalRecordLength, XLogRecordHeaderSize)}
 }
 
+func (err InconsistentXLogRecordTotalLengthError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type InvalidXLogRecordResourceManagerIDError struct {
 	error
 }
@@ -31,12 +36,20 @@ func NewInvalidXLogRecordResourceManagerIDError(resourceManagerID uint8) Invalid
 	return InvalidXLogRecordResourceManagerIDError{errors.Errorf("resource manager id is invalid: %v, while it should be less then: %v", resourceManagerID, RmNextFreeID)}
 }
 
+func (err InvalidXLogRecordResourceManagerIDError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
+}
+
 type ZeroRecordHeaderError struct {
 	error
 }
 
 func NewZeroRecordHeaderError() ZeroRecordHeaderError {
 	return ZeroRecordHeaderError{errors.New("whole record header is zero, maybe it's parsed from .partial file or after WAL-Switch operation")}
+}
+
+func (err ZeroRecordHeaderError) Error() string {
+	return fmt.Sprintf("%+v", err.error)
 }
 
 /* This struct corresponds to postgres struct XLogRecord.


### PR DESCRIPTION
Currently, it's hard to determine what happened in WAL-G because of sick errors. Stack traces should improve logging to simplify WAL-G debug.