### PR TITLE
Fixed failure while unable to use delta data folder

### DIFF
--- a/configure.go
+++ b/configure.go
@@ -217,6 +217,7 @@ func configureWalDeltaUsage() (useWalDelta bool, deltaDataFolder DataFolder, err
 		useWalDelta = false
 		tracelog.WarningLogger.Printf("can't use wal delta feature because can't open delta data folder '%s'"+
 			" due to error: '%v'\n", dataFolderPath, err)
+		err = nil
 	}
 	return
 }


### PR DESCRIPTION
Now WAL-G fatals when it's unable to initialize correct delta data folder. But the warning about the absent folder is better because currently, it's only an experimental feature.