### PR TITLE
Fixed cracked payload in integration tests

### DIFF
--- a/docker/pg/delta_backup_fullscan_test.sh
+++ b/docker/pg/delta_backup_fullscan_test.sh
@@ -10,7 +10,8 @@ pgbench -i -s 10 postgres
 wal-g backup-push $PGDATA
 pgbench -i -s 20 postgres
 pg_dumpall -f /tmp/dump1
-pgbench -c 2 -j -T 100000000&
+pgbench -c 2 -T 100000000 -S &
+sleep 1
 wal-g backup-push $PGDATA
 pkill -9 postgres
 rm -rf $PGDATA

--- a/docker/pg/delta_backup_wal_delta_test.sh
+++ b/docker/pg/delta_backup_wal_delta_test.sh
@@ -11,7 +11,8 @@ pgbench -i -s 30 postgres
 wal-g backup-push $PGDATA
 pgbench -i -s 40 postgres
 pg_dumpall -f /tmp/dump1
-pgbench -c 2 -j -T 100000000&
+pgbench -c 2 -T 100000000 -S &
+sleep 1
 wal-g backup-push $PGDATA
 pkill -9 postgres
 rm -rf $PGDATA

--- a/docker/pg/full_backup_test.sh
+++ b/docker/pg/full_backup_test.sh
@@ -8,7 +8,8 @@ echo "archive_timeout = 600" >> /var/lib/postgresql/10/main/postgresql.conf
 /usr/lib/postgresql/10/bin/pg_ctl -D $PGDATA -w start
 pgbench -i -s 10 postgres
 pg_dumpall -f /tmp/dump1
-pgbench -c 2 -j -T 100000000&
+pgbench -c 2 -T 100000000 -S &
+sleep 1
 wal-g backup-push $PGDATA
 pkill -9 postgres
 rm -rf $PGDATA


### PR DESCRIPTION
Payload didn't work during integration tests, because of a typo in command. This commit fixes it.