### PR TITLE
Fixed parsing of XLOG record split by three parts

### DIFF
--- a/internal/delta_file_manager.go
+++ b/internal/delta_file_manager.go
@@ -137,7 +137,7 @@ func (manager *DeltaFileManager) FlushPartFiles() (completedPartFiles map[string
 			err := manager.CombinePartFile(deltaFilename, partFile)
 			if err != nil {
 				manager.CanceledDeltaFiles[deltaFilename] = true
-				tracelog.WarningLogger.Printf("Canceled delta file writing because of error: %v\n", err)
+				tracelog.WarningLogger.Printf("Canceled delta file writing because of error: "+tracelog.GetErrorFormatter()+"\n", err)
 			}
 		} else {
 			err := saveToDataFolder(partFile, partFilename, manager.dataFolder)
@@ -220,7 +220,7 @@ func (manager *DeltaFileManager) CombinePartFile(deltaFilename string, partFile 
 		return NewDeltaFileWriterNotFoundError(deltaFilename)
 	}
 	deltaFileWriter := deltaFileWriterInterface.(*DeltaFileChanWriter)
-	deltaFileWriter.DeltaFile.WalParser = walparser.LoadWalParserFromCurrentRecordData(partFile.WalHeads[WalFileInDelta-1])
+	deltaFileWriter.DeltaFile.WalParser = walparser.LoadWalParserFromCurrentRecordHead(partFile.WalHeads[WalFileInDelta-1])
 	records, err := partFile.CombineRecords()
 	if err != nil {
 		return err

--- a/internal/walparser/wal_parser_test.go
+++ b/internal/walparser/wal_parser_test.go
@@ -14,7 +14,7 @@ const SmallPartialTestPath = "./testdata/small_partial_test"
 
 func TestZeroPageParsing(t *testing.T) {
 	zeroPage := make([]byte, WalPageSize)
-	parser := WalParser{}
+	parser := NewWalParser()
 	_, pageData, err := parser.ParseRecordsFromPage(bytes.NewReader(zeroPage))
 	assert.Nilf(t, pageData, "not nil pageData")
 	assert.IsType(t, err, ZeroPageError{})
@@ -45,9 +45,9 @@ func parsingTestCase(t *testing.T, filename string, doTesting func(*testing.T, W
 	defer walFile.Close()
 	assert.NoError(t, err)
 	pageReader := WalPageReader{walFileReader: walFile}
-	parser := WalParser{}
+	parser := NewWalParser()
 
-	doTesting(t, pageReader, parser)
+	doTesting(t, pageReader, *parser)
 }
 
 func TestParsing(t *testing.T) {
@@ -58,7 +58,7 @@ func TestParsing(t *testing.T) {
 }
 
 func TestSaveLoadWalParser(t *testing.T) {
-	walParser := &WalParser{[]byte{1, 2, 3, 4, 5, 6}}
+	walParser := LoadWalParserFromCurrentRecordHead([]byte{1, 2, 3, 4, 5, 6})
 
 	var walParserData bytes.Buffer
 	err := walParser.Save(&walParserData)


### PR DESCRIPTION
There was a bug related to this case.