### PR TITLE
Let the GCS client library handle authentication.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@ Johan Hernandez <im@bithavoc.io>
 Patrick Figel <patrick@figel.email>
 Vladimir Leskov <vladimirlesk@yandex-team.ru>
 Will Glynn <will@willglynn.com>
+Dario Nieuwenhuis <dirbaio@dirbaio.net>

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ To connect to Amazon S3, WAL-G requires that this variable be set:
 WAL-G determines AWS credentials [like other AWS tools](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence). You can set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (optionally with `AWS_SECURITY_TOKEN`), or `~/.aws/credentials` (optionally with `AWS_PROFILE`), or you can set nothing to automatically fetch credentials from the EC2 metadata service.
 
 
-To store backups in Google Cloud Storage, WAL-G requires that these variables be set:
+To store backups in Google Cloud Storage, WAL-G requires that this variable be set:
 
 * `WALG_GS_PREFIX` to specify where to store backups (eg. `gs://x4m-test-bucket/walg-folder`) 
 
-* `GOOGLE_APPLICATION_CREDENTIALS` must point to authentication json file given by GCP
+WAL-G determines Google Cloud credentials using [application-default credentials](https://cloud.google.com/docs/authentication/production) like other GCP tools. You can set `GOOGLE_APPLICATION_CREDENTIALS` to point to a service account json key from GCP. If you set nothing, WAL-G will attempt to fetch credentials from the GCE/GKE metadata service.
 
 
 To store backups on files system, WAL-G requires that these variables be set:

--- a/internal/config.go
+++ b/internal/config.go
@@ -2,45 +2,45 @@ package internal
 
 import (
 	"encoding/json"
-	"github.com/go-yaml/yaml"
-	"github.com/wal-g/wal-g/internal/tracelog"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
 	"strings"
+
+	"github.com/go-yaml/yaml"
+	"github.com/wal-g/wal-g/internal/tracelog"
 )
 
 var (
 	WalgConfig        *map[string]string
 	allowedConfigKeys = map[string]*string{
-		"WALG_S3_PREFIX":                 nil,
-		"WALE_S3_PREFIX":                 nil,
-		"WALG_FILE_PREFIX":               nil,
-		"WALE_FILE_PREFIX":               nil,
-		"WALG_GS_PREFIX":                 nil,
-		"WALE_GS_PREFIX":                 nil,
-		"GOOGLE_APPLICATION_CREDENTIALS": nil,
-		"AWS_REGION":                     nil,
-		"WALG_DOWNLOAD_CONCURRENCY":      nil,
-		"WALG_UPLOAD_CONCURRENCY":        nil,
-		"WALG_UPLOAD_DISK_CONCURRENCY":   nil,
-		"WALG_SENTINEL_USER_DATA":        nil,
-		"WALG_PREVENT_WAL_OVERWRITE":     nil,
-		"AWS_ENDPOINT":                   nil,
-		"AWS_S3_FORCE_PATH_STYLE":        nil,
-		"WALG_S3_STORAGE_CLASS":          nil,
-		"WALG_S3_SSE":                    nil,
-		"WALG_S3_SSE_KMS_ID":             nil,
-		"WALG_GPG_KEY_ID":                nil,
-		"WALE_GPG_KEY_ID":                nil,
-		"WALG_DELTA_MAX_STEPS":           nil,
-		"WALG_DELTA_ORIGIN":              nil,
-		"WALG_COMPRESSION_METHOD":        nil,
-		"WALG_DISK_RATE_LIMIT":           nil,
-		"WALG_NETWORK_RATE_LIMIT":        nil,
-		"WALG_USE_WAL_DELTA":             nil,
-		"WALG_LOG_LEVEL":                 nil,
+		"WALG_S3_PREFIX":               nil,
+		"WALE_S3_PREFIX":               nil,
+		"WALG_FILE_PREFIX":             nil,
+		"WALE_FILE_PREFIX":             nil,
+		"WALG_GS_PREFIX":               nil,
+		"WALE_GS_PREFIX":               nil,
+		"AWS_REGION":                   nil,
+		"WALG_DOWNLOAD_CONCURRENCY":    nil,
+		"WALG_UPLOAD_CONCURRENCY":      nil,
+		"WALG_UPLOAD_DISK_CONCURRENCY": nil,
+		"WALG_SENTINEL_USER_DATA":      nil,
+		"WALG_PREVENT_WAL_OVERWRITE":   nil,
+		"AWS_ENDPOINT":                 nil,
+		"AWS_S3_FORCE_PATH_STYLE":      nil,
+		"WALG_S3_STORAGE_CLASS":        nil,
+		"WALG_S3_SSE":                  nil,
+		"WALG_S3_SSE_KMS_ID":           nil,
+		"WALG_GPG_KEY_ID":              nil,
+		"WALE_GPG_KEY_ID":              nil,
+		"WALG_DELTA_MAX_STEPS":         nil,
+		"WALG_DELTA_ORIGIN":            nil,
+		"WALG_COMPRESSION_METHOD":      nil,
+		"WALG_DISK_RATE_LIMIT":         nil,
+		"WALG_NETWORK_RATE_LIMIT":      nil,
+		"WALG_USE_WAL_DELTA":           nil,
+		"WALG_LOG_LEVEL":               nil,
 	}
 )
 

--- a/internal/gcs_folder.go
+++ b/internal/gcs_folder.go
@@ -1,16 +1,16 @@
 package internal
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/wal-g/wal-g/internal/tracelog"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 	"io"
 	"io/ioutil"
 	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal/tracelog"
+	"google.golang.org/api/iterator"
 )
 
 type GSFolderError struct {
@@ -30,14 +30,9 @@ func NewGSFolder(bucket *storage.BucketHandle, path string) *GSFolder {
 }
 
 func ConfigureGSFolder(prefix string) (StorageFolder, error) {
-	credentials := getSettingValue("GOOGLE_APPLICATION_CREDENTIALS")
-	if credentials == "" {
-		return nil, NewUnsetEnvVarError([]string{"GOOGLE_APPLICATION_CREDENTIALS"})
-	}
-
 	ctx := context.Background()
 
-	client, err := storage.NewClient(ctx, option.WithCredentialsFile(credentials))
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return nil, NewGSFolderError(err, "Unable to create GS Client")
 	}

--- a/test/gcs_folder_test.go
+++ b/test/gcs_folder_test.go
@@ -1,16 +1,15 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
-	"os"
-	"testing"
 )
 
 func TestGSFolder(t *testing.T) {
 	t.Skip("Credentials needed to run GCP tests")
 
-	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/Users/x4mmm/Downloads/mdb-tests-d0uble-0b98813b622b.json")
 	storageFolder, err := internal.ConfigureGSFolder("gs://x4m-test/walg-bucket")
 
 	assert.NoError(t, err)


### PR DESCRIPTION
Follow up to #163.

This allows using other forms of application-default credentials
other than GOOGLE_APPLICATION_CREDENTIALS, such as getting them
from the metadata service.

Things: 
- My editor runs goimports on save so some imports are switched around. If this is a problem, I can resend the PR without the changes. Ideally all the code should be formatted according to goimports though :) 
- For the test to continue working in your local machine, you can do `gcloud auth application-default login`, and wal-g will pick up that auth.