### PR TITLE
Add many-delta fetches to integration tests

### DIFF
--- a/docker/pg/scripts/delta_backup_fullscan_test.sh
+++ b/docker/pg/scripts/delta_backup_fullscan_test.sh
@@ -13,8 +13,12 @@ echo "archive_timeout = 600" >> /var/lib/postgresql/10/main/postgresql.conf
 
 pgbench -i -s 10 postgres
 wal-g backup-push ${PGDATA}
+pgbench -T 3 postgres
+wal-g backup-push ${PGDATA}
+pgbench -T 3 postgres
+wal-g backup-push ${PGDATA}
 
-pgbench -i -s 20 postgres
+pgbench -T 3 postgres
 pg_dumpall -f /tmp/dump1
 pgbench -c 2 -T 100000000 -S &
 sleep 1

--- a/docker/pg/scripts/delta_backup_wal_delta_test.sh
+++ b/docker/pg/scripts/delta_backup_wal_delta_test.sh
@@ -12,13 +12,19 @@ echo "archive_timeout = 600" >> /var/lib/postgresql/10/main/postgresql.conf
 
 /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA} -w start
 
-pgbench -i -s 30 postgres
+pgbench -i -s 40 postgres
+wal-g backup-push ${PGDATA}
+pgbench -T 3 postgres
+wal-g backup-push ${PGDATA}
+pgbench -T 3 postgres
 wal-g backup-push ${PGDATA}
 
-pgbench -i -s 40 postgres
+pgbench -T 3 postgres
 pg_dumpall -f /tmp/dump1
 pgbench -c 2 -T 100000000 -S &
 sleep 1
+wal-g backup-push ${PGDATA}
+wal-g backup-push ${PGDATA}
 wal-g backup-push ${PGDATA}
 
 pkill -9 postgres


### PR DESCRIPTION
Wa are not checking man-level deltas in integration tests. This PR adds two more steps.