### PR TITLE
Fix WALG_GPG_KEY_ID env variable usage

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,7 @@
 Adam Shannon <adamkshannon@gmail.com>
 Andrey Borodin <amborodin@acm.org>
 Barthelemy Dagenais <barthelemy@infobart.com>
+Alexander Demyanenko <>
 Cory Stephenson <aevin@me.com>
 David Fetter <david@fetter.org>
 Dustin Chaloupka <dustin.chaloupka@banno.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,7 +1,7 @@
 Adam Shannon <adamkshannon@gmail.com>
 Andrey Borodin <amborodin@acm.org>
 Barthelemy Dagenais <barthelemy@infobart.com>
-Alexander Demyanenko <>
+Alexander Demyanenko <gblacknoir@gmail.com>
 Cory Stephenson <aevin@me.com>
 David Fetter <david@fetter.org>
 Dustin Chaloupka <dustin.chaloupka@banno.com>

--- a/internal/crypto.go
+++ b/internal/crypto.go
@@ -28,7 +28,11 @@ func (err GpgKeyExportError) Error() string {
 
 // GetKeyRingId extracts name of a key to use from env variable
 func GetKeyRingId() string {
-	return os.Getenv("WALE_GPG_KEY_ID")
+	gpgKeyRingId := os.Getenv("WALG_GPG_KEY_ID")
+	if gpgKeyRingId == "" {
+		gpgKeyRingId = os.Getenv("WALE_GPG_KEY_ID")
+	}
+	return gpgKeyRingId
 }
 
 const GpgBin = "gpg"

--- a/internal/crypto.go
+++ b/internal/crypto.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/internal/tracelog"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
@@ -28,11 +27,7 @@ func (err GpgKeyExportError) Error() string {
 
 // GetKeyRingId extracts name of a key to use from env variable
 func GetKeyRingId() string {
-	gpgKeyRingId := os.Getenv("WALG_GPG_KEY_ID")
-	if gpgKeyRingId == "" {
-		gpgKeyRingId = os.Getenv("WALE_GPG_KEY_ID")
-	}
-	return gpgKeyRingId
+	return getSettingValue("WALG_GPG_KEY_ID")
 }
 
 const GpgBin = "gpg"

--- a/internal/crypto.go
+++ b/internal/crypto.go
@@ -27,7 +27,7 @@ func (err GpgKeyExportError) Error() string {
 
 // GetKeyRingId extracts name of a key to use from env variable
 func GetKeyRingId() string {
-	return getSettingValue("WALG_GPG_KEY_ID")
+	return getSettingValue("WALE_GPG_KEY_ID")
 }
 
 const GpgBin = "gpg"


### PR DESCRIPTION
WAL-G will use both WALG_GPG_KEY_ID and WALE_GPG_KEY_ID env variables for gpg key id now.