### PR TITLE
Fix upload race condition with high disk concurrency

### DIFF
--- a/internal/bundle.go
+++ b/internal/bundle.go
@@ -125,15 +125,6 @@ func (bundle *Bundle) FinishQueue() error {
 	}
 	bundle.started = false
 
-	// At this point no new tarballs should be put into uploadQueue
-	for len(bundle.uploadQueue) > 0 {
-		select {
-		case otb := <-bundle.uploadQueue:
-			otb.AwaitUploads()
-		default:
-		}
-	}
-
 	// We have to deque exactly this count of workers
 	for i := 0; i < bundle.parallelTarballs; i++ {
 		tarBall := <-bundle.tarballQueue
@@ -147,6 +138,16 @@ func (bundle *Bundle) FinishQueue() error {
 		}
 		tarBall.AwaitUploads()
 	}
+
+	// At this point no new tarballs should be put into uploadQueue
+	for len(bundle.uploadQueue) > 0 {
+		select {
+		case otb := <-bundle.uploadQueue:
+			otb.AwaitUploads()
+		default:
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
I run wal-g with `WALG_UPLOAD_DISK_CONCURRENCY=4` and a few times noticed that backup was corrupted due to one of the "part_*" files missing on S3.

All the times it was the file from the last "batch" (example):
```
INFO: 2019/03/03 21:16:36.592108 Starting part 1347 ...
INFO: 2019/03/03 21:16:45.294903 Finished writing part 1344.
INFO: 2019/03/03 21:16:45.294936 Starting part 1348 ...
INFO: 2019/03/03 21:16:46.985147 Finished writing part 1345.
INFO: 2019/03/03 21:16:46.985188 Starting part 1349 ...
INFO: 2019/03/03 21:16:48.893276 Finished writing part 1349.
INFO: 2019/03/03 21:16:51.970783 Finished writing part 1348.
INFO: 2019/03/03 21:16:53.015073 Finished writing part 1346.
INFO: 2019/03/03 21:16:54.020712 Finished writing part 1347.
INFO: 2019/03/03 21:16:54.020751 Starting part 1352 ...
INFO: 2019/03/03 21:16:54.020770 /global/pg_control
INFO: 2019/03/03 21:16:54.023284 Finished writing part 1352.
INFO: 2019/03/03 21:16:54.101148 Starting part 1353 ...
INFO: 2019/03/03 21:16:54.101274 backup_label
INFO: 2019/03/03 21:16:54.101310 tablespace_map
INFO: 2019/03/03 21:16:54.105245 Finished writing part 1353.
INFO: 2019/03/03 21:16:54.332386 Uploaded 1353 compressed tar Files.
```

But meanwhile, on S3 we see a different picture:
```
2019-03-03 21:16:30  362601757 part_1344.tar.br
2019-03-03 21:16:32  363139933 part_1345.tar.br
2019-03-03 21:16:37  364695121 part_1346.tar.br
2019-03-03 21:16:47   63188496 part_1348.tar.br
2019-03-03 21:16:49   31750001 part_1349.tar.br
2019-03-03 21:16:55        277 part_1353.tar.br
2019-03-03 21:16:55        283 pg_control.tar.br
```

`part_1347.tar.br` is missing there despite the "success" in the log.