### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/open_pgp_crypter.go
+++ b/internal/open_pgp_crypter.go
@@ -65,7 +65,7 @@ func (crypter *OpenPGPCrypter) IsUsed() bool {
 	return crypter.IsArmed()
 }
 
-// OpenPGPCrypter internal initialization
+// ConfigurePGPCrypter internal initialization
 func (crypter *OpenPGPCrypter) ConfigurePGPCrypter() {
 	crypter.Configured = true
 

--- a/internal/walparser/wal_file_page_reader.go
+++ b/internal/walparser/wal_file_page_reader.go
@@ -13,7 +13,7 @@ func NewWalPageReader(walFileReader io.Reader) *WalPageReader {
 	return &WalPageReader{walFileReader}
 }
 
-// reads data corresponding to one page
+// ReadPageData reads data corresponding to one page
 func (reader *WalPageReader) ReadPageData() ([]byte, error) {
 	page := make([]byte, WalPageSize)
 	_, err := io.ReadFull(reader.walFileReader, page)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?