### PR TITLE
fix delete retention length warning

### DIFF
--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -40,7 +40,7 @@ func HandleDeleteRetain(folder storage.Folder, retantionCount int, modifier int,
 	}
 	if modifier == FullDeleteModifier {
 		if len(backups) <= retantionCount {
-			tracelog.WarningLogger.Printf("Have only %v backups.\n", retantionCount)
+			tracelog.WarningLogger.Printf("Have only %v backups.\n", len(backups))
 		}
 		left := retantionCount
 		for _, b := range backups {
@@ -60,7 +60,7 @@ func HandleDeleteRetain(folder storage.Folder, retantionCount int, modifier int,
 		tracelog.WarningLogger.Printf("Scanned all backups but didn't have %v full.", retantionCount)
 	} else {
 		if len(backups) <= retantionCount {
-			tracelog.WarningLogger.Printf("Have only %v backups.\n", retantionCount)
+			tracelog.WarningLogger.Printf("Have only %v backups.\n", len(backups))
 		} else {
 			deleteBeforeTarget(folder, NewBackup(baseBackupFolder, backups[retantionCount-1].BackupName), modifier == FindFullDeleteModifier, dryRun)
 		}


### PR DESCRIPTION
This fixes the help message when deleting backups with `retain`

Prior
```
➜  wal-g git:(master) ✗ wal-g delete retain 1000
WARNING: 2019/03/23 06:30:21.803143 Have only 1000 backups.
```

After
```
➜  wal-g git:(master) ✗ wal-g delete retain 1000
WARNING: 2019/03/23 06:31:32.969621 Have only 3 backups.
```