### PR TITLE
Fix lz4 backward compatibility

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,7 +55,7 @@
 
 [[constraint]]
   name = "github.com/pierrec/lz4"
-  version = "2.0.7"
+  revision = "5a3d2245f97fc249850e7802e3c01fad02a1c316"
 
 [[constraint]]
   name = "github.com/pkg/errors"


### PR DESCRIPTION
Latest versions of lz4 are unable to read compressed data produced by older lz4 versions. I'll try to fix this in lz4, but for now, revert lz4 version to proven one.