### PR TITLE
Fix possible deadlock in background WAL uploader

### DIFF
--- a/internal/bguploader.go
+++ b/internal/bguploader.go
@@ -70,8 +70,10 @@ func (bgUploader *BgUploader) Stop() {
 	} // Wait until no one works
 
 	bgUploader.mutex.Lock()
-	defer bgUploader.mutex.Unlock()
+	// We have to do this under mutex to exclude interference with shouldKeepScanning() branch
 	atomic.StoreInt32(&bgUploader.maxParallelWorkers, 0) // stop new jobs
+	bgUploader.mutex.Unlock()
+
 	bgUploader.running.Wait()                            // wait again for those who jumped to the closing door
 }
 


### PR DESCRIPTION
Stop() of background uploader was acquiring upload scan mutex. Under
this mutex, it was disallowing new uploads and awaits finish of all
spawned uploads. But scan process has to acquire that mutex too.
In various race outcomes, upload could deadlock with Stop().

Now Stop() awaits for finished uploads with the released mutex.
Mutex guards that upload is not started if Stop() in progress.

With current mutex guards, we could relax all atomic operations
with bgUploader.parallelWorkers, but this requires extra refactoring,
now we should just fix the bug.

This should fix #222 