### PR TITLE
Upload metadata file with backup

### DIFF
--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -185,8 +185,12 @@ func HandleBackupPush(uploader *Uploader, archiveDirectory string) {
 	currentBackupSentinelDto.BackupFinishLSN = &finishLsn
 	currentBackupSentinelDto.UserData = GetSentinelUserData()
 
+	err = UploadMetadata(uploader, currentBackupSentinelDto, backupName, meta)
+	if err != nil {
+		tracelog.ErrorLogger.Printf("Failed to upload metadata file for backup: %s %v", backupName, err)
+	}
 	// If other parts are successful in uploading, upload json file.
-	err = UploadSentinel(uploader, currentBackupSentinelDto, backupName, meta)
+	err = UploadSentinel(uploader, currentBackupSentinelDto, backupName)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("Failed to upload sentinel file for backup: %s", backupName)
 		tracelog.ErrorLogger.FatalError(err)
@@ -194,7 +198,9 @@ func HandleBackupPush(uploader *Uploader, archiveDirectory string) {
 }
 
 // TODO : unit tests
-func UploadSentinel(uploader *Uploader, sentinelDto *BackupSentinelDto, backupName string, meta ExtendedMetadataDto) error {
+func UploadMetadata(uploader *Uploader, sentinelDto *BackupSentinelDto, backupName string, meta ExtendedMetadataDto) error {
+	// BackupSentinelDto struct allows nil field for backward compatiobility
+	// We do not expect here nil dto since it is new dto to upload
 	meta.FinishTime = time.Now()
 	meta.StartLsn = *sentinelDto.BackupStartLSN
 	meta.FinishLsn = *sentinelDto.BackupFinishLSN
@@ -206,14 +212,14 @@ func UploadSentinel(uploader *Uploader, sentinelDto *BackupSentinelDto, backupNa
 		return NewSentinelMarshallingError(metaFile, err)
 	}
 
-	err = uploader.Upload(metaFile, bytes.NewReader(dtoBody))
-	if err != nil {
-		return err
-	}
+	return uploader.Upload(metaFile, bytes.NewReader(dtoBody))
+}
 
+// TODO : unit tests
+func UploadSentinel(uploader *Uploader, sentinelDto *BackupSentinelDto, backupName string) error {
 	sentinelName := backupName + SentinelSuffix
 
-	dtoBody, err = json.Marshal(*sentinelDto)
+	dtoBody, err := json.Marshal(*sentinelDto)
 	if err != nil {
 		return NewSentinelMarshallingError(sentinelName, err)
 	}

--- a/internal/backup_sentinel_dto.go
+++ b/internal/backup_sentinel_dto.go
@@ -1,6 +1,9 @@
 package internal
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 // BackupSentinelDto describes file structure of json sentinel
 type BackupSentinelDto struct {
@@ -16,6 +19,17 @@ type BackupSentinelDto struct {
 	BackupFinishLSN *uint64 `json:"FinishLSN"`
 
 	UserData interface{} `json:"UserData,omitempty"`
+}
+
+// Extended metadata should describe backup in more details, but be small enough to be downloaded often
+type ExtendedMetadataDto struct {
+	StartTime  time.Time `json:"start_time"`
+	FinishTime time.Time `json:"finish_time"`
+	Hostname   string    `json:"hostname"`
+	DataDir    string    `json:"data_dir"`
+	PgVersion  int       `json:"pg_version"`
+	StartLsn   uint64    `json:"start_lsn"`
+	FinishLsn  uint64    `json:"finish_lsn"`
 }
 
 func (dto *BackupSentinelDto) setFiles(p *sync.Map) {

--- a/internal/utility.go
+++ b/internal/utility.go
@@ -25,6 +25,7 @@ const (
 	SentinelSuffix         = "_backup_stop_sentinel.json"
 	CompressedBlockMaxSize = 20 << 20
 	NotFoundAWSErrorCode   = "NotFound"
+	MetadataFileName       = "metadata.json"
 )
 
 // Empty is used for channel signaling.


### PR DESCRIPTION
We store json sentinel, which is functional now and is under quite
hard requirements. Usually it is big, maybe few MB or so. In
metadata file we want to have easily retrivable, frequently used
information.