### PR TITLE
add --detail switch to backup-list to print meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Lists names and creation time of available backups.
 
 ``--json`` flag prints list in json format, pretty-printed if combined with ``--pretty`` 
 
+``--detail`` flag prints extra backup details, pretty-printed if combined with ``--pretty`` , json-encoded if combined with ``--json`` 
+
 * ``delete``
 
 Is used to delete backups and WALs before them. By default ``delete`` will perform dry run. If you want to execute deletion you have to add ``--confirm`` flag at the end of the command.

--- a/cmd/pg/backup_list.go
+++ b/cmd/pg/backup_list.go
@@ -10,6 +10,7 @@ const (
 	BackupListShortDescription = "Prints available backups"
 	PrettyFlag                 = "pretty"
 	JsonFlag                   = "json"
+	DetailFlag                 = "detail"
 )
 
 var (
@@ -23,8 +24,8 @@ var (
 			if err != nil {
 				tracelog.ErrorLogger.FatalError(err)
 			}
-			if pretty || json {
-				internal.HandleBackupListWithFlags(folder, pretty, json)
+			if pretty || json || detail {
+				internal.HandleBackupListWithFlags(folder, pretty, json, detail)
 			} else {
 				internal.HandleBackupList(folder)
 			}
@@ -32,6 +33,7 @@ var (
 	}
 	pretty = false
 	json   = false
+	detail = false
 )
 
 func init() {
@@ -39,4 +41,5 @@ func init() {
 
 	backupListCmd.Flags().BoolVar(&pretty, PrettyFlag, false, "Prints more readable output")
 	backupListCmd.Flags().BoolVar(&json, JsonFlag, false, "Prints output in json format")
+	backupListCmd.Flags().BoolVar(&detail, DetailFlag, false, "Prints extra backup details")
 }

--- a/internal/backup_detail.go
+++ b/internal/backup_detail.go
@@ -1,0 +1,25 @@
+package internal
+
+// BackupDetails is used to append ExtendedMetadataDto details to BackupTime struct
+type BackupDetail struct {
+	BackupTime
+	ExtendedMetadataDto
+}
+
+// writeBackupTime sets matching elements in BackupDetail with values from BackupTime
+func (backupDetail *BackupDetail) writeBackupTime(backupTime BackupTime) {
+	backupDetail.BackupName = backupTime.BackupName
+	backupDetail.Time = backupTime.Time
+	backupDetail.WalFileName = backupTime.WalFileName
+}
+
+// writeExtendedMetadataDto sets matching elements in BackupDetail with values from ExtendedMetadataDto
+func (backupDetail *BackupDetail) writeExtendedMetadataDto(extendedMetadataDto ExtendedMetadataDto) {
+	backupDetail.DataDir = extendedMetadataDto.DataDir
+	backupDetail.FinishLsn = extendedMetadataDto.FinishLsn
+	backupDetail.FinishTime = extendedMetadataDto.FinishTime
+	backupDetail.Hostname = extendedMetadataDto.Hostname
+	backupDetail.PgVersion = extendedMetadataDto.PgVersion
+	backupDetail.StartLsn = extendedMetadataDto.StartLsn
+	backupDetail.StartTime = extendedMetadataDto.StartTime
+}

--- a/internal/backup_detail.go
+++ b/internal/backup_detail.go
@@ -5,21 +5,3 @@ type BackupDetail struct {
 	BackupTime
 	ExtendedMetadataDto
 }
-
-// writeBackupTime sets matching elements in BackupDetail with values from BackupTime
-func (backupDetail *BackupDetail) writeBackupTime(backupTime BackupTime) {
-	backupDetail.BackupName = backupTime.BackupName
-	backupDetail.Time = backupTime.Time
-	backupDetail.WalFileName = backupTime.WalFileName
-}
-
-// writeExtendedMetadataDto sets matching elements in BackupDetail with values from ExtendedMetadataDto
-func (backupDetail *BackupDetail) writeExtendedMetadataDto(extendedMetadataDto ExtendedMetadataDto) {
-	backupDetail.DataDir = extendedMetadataDto.DataDir
-	backupDetail.FinishLsn = extendedMetadataDto.FinishLsn
-	backupDetail.FinishTime = extendedMetadataDto.FinishTime
-	backupDetail.Hostname = extendedMetadataDto.Hostname
-	backupDetail.PgVersion = extendedMetadataDto.PgVersion
-	backupDetail.StartLsn = extendedMetadataDto.StartLsn
-	backupDetail.StartTime = extendedMetadataDto.StartTime
-}

--- a/internal/backup_list_handler.go
+++ b/internal/backup_list_handler.go
@@ -3,13 +3,14 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jedib0t/go-pretty/table"
-	"github.com/wal-g/wal-g/internal/storages/storage"
-	"github.com/wal-g/wal-g/internal/tracelog"
 	"io"
 	"os"
 	"text/tabwriter"
 	"time"
+
+	"github.com/jedib0t/go-pretty/table"
+	"github.com/wal-g/wal-g/internal/storages/storage"
+	"github.com/wal-g/wal-g/internal/tracelog"
 )
 
 // TODO : unit tests
@@ -24,18 +25,42 @@ func HandleBackupList(folder storage.Folder) {
 }
 
 // TODO : unit tests
-func HandleBackupListWithFlags(folder storage.Folder, pretty bool, json bool) {
+func HandleBackupListWithFlags(folder storage.Folder, pretty bool, json bool, detail bool) {
 	backups, err := getBackups(folder)
 	if err != nil {
 		tracelog.ErrorLogger.FatalError(err)
 	}
-
-	if json {
-		WriteBackupListAsJson(backups, os.Stdout, pretty)
-	} else if pretty {
-		WritePrettyBackupList(backups, os.Stdout)
+	// if details are requested we append content of metadata.json to each line
+	backupDetails := make([]BackupDetail, len(backups))
+	if detail {
+		for i := len(backups) - 1; i >= 0; i-- {
+			backup, err := GetBackupByName(backups[i].BackupName, folder)
+			if err != nil {
+				tracelog.ErrorLogger.FatalError(err)
+			} else {
+				metaData, err := backup.FetchMeta()
+				if err != nil {
+					tracelog.ErrorLogger.FatalError(err)
+				}
+				backupDetails[i].writeBackupTime(backups[i])
+				backupDetails[i].writeExtendedMetadataDto(metaData)
+			}
+		}
+		if json {
+			WriteBackupListDetailsAsJson(backupDetails, os.Stdout, pretty)
+		} else if pretty {
+			WritePrettyBackupListDetails(backupDetails, os.Stdout)
+		} else {
+			WriteBackupListDetails(backupDetails, os.Stdout)
+		}
 	} else {
-		WriteBackupList(backups, os.Stdout)
+		if json {
+			WriteBackupListAsJson(backups, os.Stdout, pretty)
+		} else if pretty {
+			WritePrettyBackupList(backups, os.Stdout)
+		} else {
+			WriteBackupList(backups, os.Stdout)
+		}
 	}
 }
 
@@ -51,6 +76,17 @@ func WriteBackupList(backups []BackupTime, output io.Writer) {
 }
 
 // TODO : unit tests
+func WriteBackupListDetails(backupDetails []BackupDetail, output io.Writer) {
+	writer := tabwriter.NewWriter(output, 0, 0, 1, ' ', 0)
+	defer writer.Flush()
+	fmt.Fprintln(writer, "name\tlast_modified\twal_segment_backup_start\tstart_time\tfinish_time\thostname\tdata_dir\tpg_version\tstart_lsn\tfinish_lsn")
+	for i := len(backupDetails) - 1; i >= 0; i-- {
+		b := backupDetails[i]
+		fmt.Fprintln(writer, fmt.Sprintf("%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v", b.BackupName, b.Time.Format(time.RFC3339), b.WalFileName, b.StartTime.Format(time.RFC850), b.FinishTime.Format(time.RFC850), b.Hostname, b.DataDir, b.PgVersion, b.StartLsn, b.FinishLsn))
+	}
+}
+
+// TODO : unit tests
 func WritePrettyBackupList(backups []BackupTime, output io.Writer) {
 	writer := table.NewWriter()
 	writer.SetOutputMirror(output)
@@ -62,6 +98,17 @@ func WritePrettyBackupList(backups []BackupTime, output io.Writer) {
 }
 
 // TODO : unit tests
+func WritePrettyBackupListDetails(backupDetails []BackupDetail, output io.Writer) {
+	writer := table.NewWriter()
+	writer.SetOutputMirror(output)
+	defer writer.Render()
+	writer.AppendHeader(table.Row{"#", "Name", "Last modified", "WAL segment backup start", "Start time", "Finish time", "Hostname", "Datadir", "PG Version", "Start LSN", "Finish LSN"})
+	for i, b := range backupDetails {
+		writer.AppendRow(table.Row{i, b.BackupName, b.Time.Format(time.RFC850), b.WalFileName, b.StartTime.Format(time.RFC850), b.FinishTime.Format(time.RFC850), b.Hostname, b.DataDir, b.PgVersion, b.StartLsn, b.FinishLsn})
+	}
+}
+
+// TODO : unit tests
 func WriteBackupListAsJson(backups []BackupTime, output io.Writer, pretty bool) {
 	var bytes []byte
 	var _ error
@@ -69,6 +116,18 @@ func WriteBackupListAsJson(backups []BackupTime, output io.Writer, pretty bool) 
 		bytes, _ = json.MarshalIndent(backups, "", "    ")
 	} else {
 		bytes, _ = json.Marshal(backups)
+	}
+	output.Write(bytes)
+}
+
+// TODO : unit tests
+func WriteBackupListDetailsAsJson(backupDetails []BackupDetail, output io.Writer, pretty bool) {
+	var bytes []byte
+	var _ error
+	if pretty {
+		bytes, _ = json.MarshalIndent(backupDetails, "", "    ")
+	} else {
+		bytes, _ = json.Marshal(backupDetails)
 	}
 	output.Write(bytes)
 }

--- a/internal/backup_list_handler.go
+++ b/internal/backup_list_handler.go
@@ -42,8 +42,7 @@ func HandleBackupListWithFlags(folder storage.Folder, pretty bool, json bool, de
 				if err != nil {
 					tracelog.ErrorLogger.FatalError(err)
 				}
-				backupDetails[i].writeBackupTime(backups[i])
-				backupDetails[i].writeExtendedMetadataDto(metaData)
+				backupDetails[i] = BackupDetail{backups[i], metaData}
 			}
 		}
 		if json {

--- a/test/backup_list_test.go
+++ b/test/backup_list_test.go
@@ -3,10 +3,11 @@ package test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"github.com/wal-g/wal-g/internal"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
 )
 
 func TestBackupListFindsBackups(t *testing.T) {
@@ -16,7 +17,7 @@ func TestBackupListFindsBackups(t *testing.T) {
 
 func TestBackupListFlagsFindsBackups(t *testing.T) {
 	folder := createMockStorageFolder()
-	internal.HandleBackupListWithFlags(folder, true, false)
+	internal.HandleBackupListWithFlags(folder, true, false, false)
 }
 
 var backups = []internal.BackupTime{


### PR DESCRIPTION
WAL-G creates and saves a metadata.json file during each `backup-push operation` 
The metadata file contains lots of valuable data that can be used by e.g. external automation of backup/restore processes.

This PR should add the functionality to retrieve this metadata during a `backup-list` operation 

For this purpose a new flag `--detail` is added to the signature of backup-list
It supports existing flags `--pretty` and `--json` to control the output style

In this way e.g. the retrieval of the PostgreSQL version of a backup from a shell script will be  possible (with a little help from jq command line util)

wal-g backup-list --detail --json | jq '.[] | select( .backup_name == "<some backupname>" ) | .pg_version  '
