### PR TITLE
add pg_stop/start_backup INFO to backup-push

### DIFF
--- a/internal/queryRunner.go
+++ b/internal/queryRunner.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/jackc/pgx"
 	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/internal/tracelog"
@@ -103,6 +104,7 @@ func (queryRunner *PgQueryRunner) getVersion() (err error) {
 
 // StartBackup informs the database that we are starting copy of cluster contents
 func (queryRunner *PgQueryRunner) StartBackup(backup string) (backupName string, lsnString string, inRecovery bool, dataDir string, err error) {
+	tracelog.InfoLogger.Println("Calling pg_start_backup()")
 	startBackupQuery, err := queryRunner.BuildStartBackup()
 	conn := queryRunner.connection
 	if err != nil {
@@ -117,11 +119,12 @@ func (queryRunner *PgQueryRunner) StartBackup(backup string) (backupName string,
 		return "", "", false, "", errors.Wrap(err, "QueryRunner StartBackup: show data_directory failed")
 	}
 
-	return backupName, lsnString, inRecovery, dataDir,nil
+	return backupName, lsnString, inRecovery, dataDir, nil
 }
 
 // StopBackup informs the database that copy is over
 func (queryRunner *PgQueryRunner) StopBackup() (label string, offsetMap string, lsnStr string, err error) {
+	tracelog.InfoLogger.Println("Calling pg_stop_backup()")
 	conn := queryRunner.connection
 
 	tx, err := conn.Begin()


### PR DESCRIPTION
Currently `wal-g backup-push <folder>` might hang during execution at the stage where it tries to execute a pg_stop_backup() operation which might hang forever due to missing or non working wal shipping configuration inside PostgreSQL db. 

In order to make it easier to find reason for hanging wal-g extra INFO output was added before each pg_start_backup() / pg_stop_backup() operation:

INFO: 2019/05/27 11:49:41.892949 Using config file: /root/.walg.json
INFO: 2019/05/27 11:49:41.894844 Doing full backup.
**INFO: 2019/05/27 11:49:41.925332 Calling pg_start_backup()**
INFO: 2019/05/27 11:49:42.074234 Walking ...
INFO: 2019/05/27 11:49:42.074495 Starting part 1 ...
INFO: 2019/05/27 11:49:45.352699 Finished writing part 1.
INFO: 2019/05/27 11:49:46.126640 Starting part 2 ...
INFO: 2019/05/27 11:49:46.127894 /global/pg_control
INFO: 2019/05/27 11:49:46.132088 Finished writing part 2.
**INFO: 2019/05/27 11:49:46.140268 Calling pg_stop_backup()**
INFO: 2019/05/27 11:49:47.167025 Starting part 3 ..
INFO: 2019/05/27 11:49:47.171256 backup_label
INFO: 2019/05/27 11:49:47.175569 tablespace_map
INFO: 2019/05/27 11:49:47.176982 Finished writing part 3.
INFO: 2019/05/27 11:49:47.564437 Wrote backup with name base_00000001000000000000000E
