### PR TITLE
fix wal-g delete and no backups found exit code

### DIFF
--- a/internal/backup_fetch_handler.go
+++ b/internal/backup_fetch_handler.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/internal/storages/storage"
 	"github.com/wal-g/wal-g/internal/tracelog"

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -2,24 +2,25 @@ package internal
 
 import (
 	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/wal-g/wal-g/internal/storages/storage"
 	"github.com/wal-g/wal-g/internal/tracelog"
 	"github.com/wal-g/wal-g/utility"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const (
 	NoDeleteModifier = iota
 	FullDeleteModifier
 	FindFullDeleteModifier
-	ConfirmFlag = "confirm"
+	ConfirmFlag            = "confirm"
 	DeleteShortDescription = "Clears old backups and WALs"
-
 
 	DeleteRetainExamples = `  retain 5                      keep 5 backups
   retain FULL 5                 keep 5 full backups and all deltas of them
@@ -160,7 +161,7 @@ func FindTarget(folder storage.Folder,
 			return object, nil
 		}
 	}
-	return nil, BackupNonExistenceError{}
+	return nil, nil
 }
 
 func GetBeforeChoiceFunc(name string, modifier int,
@@ -247,6 +248,10 @@ func HandleDeleteBefore(folder storage.Folder, args []string, confirmed bool,
 	if err != nil {
 		tracelog.ErrorLogger.FatalError(err)
 	}
+	if target == nil {
+		tracelog.InfoLogger.Printf("No backup found for deletion")
+		os.Exit(0)
+	}
 	err = DeleteBeforeTarget(folder, target, confirmed, isFullBackup, less)
 	if err != nil {
 		tracelog.ErrorLogger.FatalError(err)
@@ -266,6 +271,10 @@ func HandleDeleteRetain(folder storage.Folder, args []string, confirmed bool,
 	target, err := FindTargetRetain(folder, retentionCount, modifier, isFullBackup, greater)
 	if err != nil {
 		tracelog.ErrorLogger.FatalError(err)
+	}
+	if target == nil {
+		tracelog.InfoLogger.Printf("No backup found for deletion")
+		os.Exit(0)
 	}
 	err = DeleteBeforeTarget(folder, target, confirmed, isFullBackup, less)
 	if err != nil {


### PR DESCRIPTION
When `WAL-G DELETE <options>` is called and no backup matches the delete criteria nothing gets deleted but WAL-G returns with **exit code 1** and "nil" in the output

In order to distinguish these "nothing to delete errors" from real errors WAL-G should return in this situation with **exit code 0** and some proper INFO output instead

```
wal-g backup-list
name                          last_modified        wal_segment_backup_start
base_000000010000000000000008 2019-05-27T09:21:33Z 000000010000000000000008
base_00000001000000000000000A 2019-05-27T09:23:25Z 00000001000000000000000A
base_00000001000000000000000E 2019-05-27T09:49:47Z 00000001000000000000000E

wal-g delete retain FULL 5
INFO: 2019/05/27 15:20:17.155260 No backup found for deletion
echo $? 
0

```