### PR TITLE
add delete prevention

### DIFF
--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -112,6 +112,7 @@ func HandleBackupPush(uploader *Uploader, archiveDirectory string) {
 	var meta ExtendedMetadataDto
 	meta.StartTime = time.Now()
 	meta.Hostname, _ = os.Hostname()
+	meta.IsPermanent = false // TODO: add permanent command flag
 
 	// Connect to postgres and start/finish a nonexclusive backup.
 	conn, err := Connect()

--- a/internal/backup_sentinel_dto.go
+++ b/internal/backup_sentinel_dto.go
@@ -23,13 +23,14 @@ type BackupSentinelDto struct {
 
 // Extended metadata should describe backup in more details, but be small enough to be downloaded often
 type ExtendedMetadataDto struct {
-	StartTime  time.Time `json:"start_time"`
-	FinishTime time.Time `json:"finish_time"`
-	Hostname   string    `json:"hostname"`
-	DataDir    string    `json:"data_dir"`
-	PgVersion  int       `json:"pg_version"`
-	StartLsn   uint64    `json:"start_lsn"`
-	FinishLsn  uint64    `json:"finish_lsn"`
+	StartTime   time.Time `json:"start_time"`
+	FinishTime  time.Time `json:"finish_time"`
+	Hostname    string    `json:"hostname"`
+	DataDir     string    `json:"data_dir"`
+	PgVersion   int       `json:"pg_version"`
+	StartLsn    uint64    `json:"start_lsn"`
+	FinishLsn   uint64    `json:"finish_lsn"`
+	IsPermanent bool      `json:"is_permanent"`
 }
 
 func (dto *BackupSentinelDto) setFiles(p *sync.Map) {

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -244,10 +244,12 @@ func getPermanentBackupNames(folder storage.Folder) (backupNames []string) {
 	for _, backupTime := range backupTimes {
 		backup, err := GetBackupByName(backupTime.BackupName, folder)
 		if err != nil {
+			tracelog.ErrorLogger.Printf("failed to get backup by name with error %s, ignoring...", err.Error())
 			continue
 		}
 		meta, err := backup.FetchMeta()
 		if err != nil {
+			tracelog.ErrorLogger.Printf("failed to fetch backup meta for backup %s with error %s, ignoring...", backupTime.BackupName, err.Error())
 			continue
 		}
 		if meta.IsPermanent {

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -225,9 +225,43 @@ func DeleteBeforeTarget(folder storage.Folder, target storage.Object,
 		return utility.NewForbiddenActionError(fmt.Sprintf(errorMessage, target.GetName()))
 	}
 	tracelog.InfoLogger.Println("Start delete")
+	permanentBackupNames := getPermanentBackupNames(folder)
+	if len(permanentBackupNames) > 0 {
+		tracelog.InfoLogger.Println("Found permanent backups: " + strings.Join(permanentBackupNames, ","))
+	}
 	return storage.DeleteObjectsWhere(folder, confirmed, func(object storage.Object) bool {
-		return less(object, target)
+		return less(object, target) && !anyContains(object.GetName(), permanentBackupNames)
 	})
+}
+
+func getPermanentBackupNames(folder storage.Folder) (backupNames []string) {
+	backupTimes, err := getBackups(folder)
+	if err != nil {
+		return nil
+	}
+	for _, backupTime := range backupTimes {
+		backup, err := GetBackupByName(backupTime.BackupName, folder)
+		if err != nil {
+			continue
+		}
+		meta, err := backup.FetchMeta()
+		if err != nil {
+			continue
+		}
+		if meta.IsPermanent {
+			backupNames = append(backupNames, backupTime.BackupName)
+		}
+	}
+	return
+}
+
+func anyContains(str string, substrs []string) bool {
+	for _, substr := range substrs {
+		if strings.Contains(str, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func HandleDeleteBefore(folder storage.Folder, args []string, confirmed bool,

--- a/test/delete_test.go
+++ b/test/delete_test.go
@@ -94,6 +94,29 @@ func testFindTargetBeforeTime(t *testing.T, minute int, modifier int) (storage.O
 	return internal.FindTargetBeforeTime(mockFolder, timeLine, modifier, isFullBackup, lessByTime)
 }
 
+func TestDeleteBeforeTarget_WithPermanentBackups(t *testing.T) {
+	folder := createMockStorageFolderWithPermanentBackups(t)
+	subFolder := folder.GetSubFolder(utility.BaseBackupPath)
+	expectExistAfterDelete := map[string]bool{
+		"base_000000010000000000000003": false,
+		"base_000000010000000000000005": true,
+		"base_000000010000000000000007": false,
+	}
+	for backupName, _ := range expectExistAfterDelete {
+		exists, err := subFolder.Exists(backupName + "/" + utility.MetadataFileName)
+		assert.NoError(t, err)
+		assert.True(t, exists, "expected backup "+backupName+" to exist")
+	}
+	target := storage.NewLocalObject("", utility.TimeNowCrossPlatformLocal().Add(time.Duration(1*int(time.Minute))))
+	err := internal.DeleteBeforeTarget(folder, target, true, isFullBackup, lessByTime)
+	assert.NoError(t, err)
+	for backupName, expect := range expectExistAfterDelete {
+		exists, err := subFolder.Exists(backupName + "/" + utility.MetadataFileName)
+		assert.NoError(t, err)
+		assert.Equal(t, expect, exists, "expected backup "+backupName+" to exist")
+	}
+}
+
 func createMockFolderWithTime(t *testing.T, baseTime time.Time) *mocks.MockFolder {
 	baseNamePrefix := "base_"
 	deltaMark := "_D_"
@@ -168,6 +191,40 @@ func createMockStorageFolderWithDeltaBackups(t *testing.T) storage.Folder {
 		assert.NoError(t, err)
 		sentinelString := string(bytesSentinel)
 		err = subFolder.PutObject(backupName+utility.SentinelSuffix, strings.NewReader(sentinelString))
+		assert.NoError(t, err)
+	}
+	return folder
+}
+
+func createMockStorageFolderWithPermanentBackups(t *testing.T) storage.Folder {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	subFolder := folder.GetSubFolder(utility.BaseBackupPath)
+	emptyData := map[string]interface{}{}
+	permanentMetadata := map[string]interface{}{
+		"start_time":   utility.TimeNowCrossPlatformLocal().Format(time.RFC3339),
+		"finish_time":  utility.TimeNowCrossPlatformLocal().Format(time.RFC3339),
+		"hostname":     "",
+		"data_dir":     "",
+		"pg_version":   0,
+		"start_lsn":    0,
+		"finish_lsn":   1,
+		"is_permanent": true,
+	}
+	backupNames := map[string]interface{}{
+		"base_000000010000000000000003": emptyData,
+		"base_000000010000000000000005": permanentMetadata,
+		"base_000000010000000000000007": emptyData,
+	}
+	for backupName, metadata := range backupNames {
+		bytesSentinel, err := json.Marshal(&emptyData)
+		assert.NoError(t, err)
+		sentinelString := string(bytesSentinel)
+		err = subFolder.PutObject(backupName+utility.SentinelSuffix, strings.NewReader(sentinelString))
+		assert.NoError(t, err)
+		bytesMetadata, err := json.Marshal(&metadata)
+		assert.NoError(t, err)
+		metadataString := string(bytesMetadata)
+		err = subFolder.PutObject(backupName+"/"+utility.MetadataFileName, strings.NewReader(metadataString))
 		assert.NoError(t, err)
 	}
 	return folder


### PR DESCRIPTION
This adds a new field `isPermanent` to `metadata` (which for now can be manually edited), and avoids deleting permanent backups in `DeleteBeforeTarget`

Permanent backups will show up on the log and skipped
```
INFO: 2019/05/29 00:11:07.254100 Start delete
INFO: 2019/05/29 00:11:07.254744 Found permanent backups: base_00000001000000000000000F
INFO: 2019/05/29 00:11:07.256589 Objects in folder:
...
INFO: 2019/05/29 00:11:07.256847        will be deleted: basebackups_005/base_00000001000000000000000D/tar_partitions/part_001.tar.lz4
INFO: 2019/05/29 00:11:07.256861        will be deleted: basebackups_005/base_00000001000000000000000D/tar_partitions/part_003.tar.lz4
INFO: 2019/05/29 00:11:07.256873        will be deleted: basebackups_005/base_00000001000000000000000D/tar_partitions/pg_control.tar.lz4
INFO: 2019/05/29 00:11:07.256883        skipped: basebackups_005/base_00000001000000000000000F/tar_partitions/part_001.tar.lz4
INFO: 2019/05/29 00:11:07.256892        skipped: basebackups_005/base_00000001000000000000000F/tar_partitions/part_003.tar.lz4
INFO: 2019/05/29 00:11:07.256901        skipped: basebackups_005/base_00000001000000000000000F/tar_partitions/pg_control.tar.lz4
INFO: 2019/05/29 00:11:07.256911        will be deleted: basebackups_005/base_000000010000000000000011/tar_partitions/part_001.tar.lz4
INFO: 2019/05/29 00:11:07.256920        will be deleted: basebackups_005/base_000000010000000000000011/tar_partitions/part_003.tar.lz4
INFO: 2019/05/29 00:11:07.256929        will be deleted: basebackups_005/base_000000010000000000000011/tar_partitions/pg_control.tar.lz4
```