### PR TITLE
Add unit-tests for utility.FastCopy

### DIFF
--- a/test/utility_test.go
+++ b/test/utility_test.go
@@ -195,7 +195,7 @@ func TestFastCopy_ReturnsError_WhenReaderFails(t *testing.T) {
 
 func TestFastCopy_ReturnsError_WhenWriterFails(t *testing.T) {
 	reader := strings.NewReader("data")
-	writer := new(testtools.WriterError)
+	writer := new(testtools.ErrorWriter)
 	_, err := utility.FastCopy(writer, reader)
 	assert.Error(t, err)
 }

--- a/testtools/util.go
+++ b/testtools/util.go
@@ -1,13 +1,15 @@
 package testtools
 
 import (
+	"errors"
+	"io"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/storages/memory"
 	"github.com/wal-g/wal-g/internal/storages/s3"
-	"io"
-	"testing"
 )
 
 func MakeDefaultInMemoryStorageFolder() *memory.Folder {
@@ -80,4 +82,20 @@ type NopSeeker struct{}
 
 func (seeker *NopSeeker) Seek(offset int64, whence int) (int64, error) {
 	return 0, nil
+}
+
+//ErrorWriter struct implements io.Writer interface.
+//Its Write method returns zero and non-nil error on every call
+type ErrorWriter struct{}
+
+func (w ErrorWriter) Write(b []byte) (int, error) {
+	return 0, errors.New("expected writing error")
+}
+
+//ErrorReader struct implements io.Reader interface.
+//Its Read method returns zero and non-nil error on every call
+type ErrorReader struct{}
+
+func (r ErrorReader) Read(b []byte) (int, error) {
+	return 0, errors.New("expected reading error")
 }

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -99,7 +99,6 @@ func GetFileRelativePath(fileAbsPath string, directoryPath string) string {
 	return strings.TrimPrefix(fileAbsPath, directoryPath)
 }
 
-// TODO : unit tests
 //FastCopy copies data from src to dst in blocks of CopiedBlockMaxSize bytes
 func FastCopy(dst io.Writer, src io.Reader) (int64, error) {
 	n := int64(0)

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/wal-g/wal-g/internal/tracelog"
 	"io"
 	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal/tracelog"
 )
 
 // TODO : unit tests
@@ -34,6 +35,7 @@ const (
 	// utility.SentinelSuffix is a suffix of backup finish sentinel file
 	SentinelSuffix         = "_backup_stop_sentinel.json"
 	CompressedBlockMaxSize = 20 << 20
+	CopiedBlockMaxSize     = CompressedBlockMaxSize
 	NotFoundAWSErrorCode   = "NotFound"
 	MetadataFileName       = "metadata.json"
 )
@@ -98,9 +100,10 @@ func GetFileRelativePath(fileAbsPath string, directoryPath string) string {
 }
 
 // TODO : unit tests
+//FastCopy copies data from src to dst in blocks of CopiedBlockMaxSize bytes
 func FastCopy(dst io.Writer, src io.Reader) (int64, error) {
 	n := int64(0)
-	buf := make([]byte, CompressedBlockMaxSize)
+	buf := make([]byte, CopiedBlockMaxSize)
 	for {
 		m, readingErr := src.Read(buf)
 		if readingErr != nil && readingErr != io.EOF {


### PR DESCRIPTION
Add unit-tests for FastCopy method in utility package. Add auxiliary structs (ErrorWriter and ErrorReader) into testtools package for this purpose.
Also apply some refactoring in utility package: use CopiedBlockMaxSize const instead of CompressedBlockMaxSize in FastCopy method.