### PR TITLE
Refactoring of tests

### DIFF
--- a/internal/compression/compression_test.go
+++ b/internal/compression/compression_test.go
@@ -9,13 +9,6 @@ import (
 	"testing"
 )
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 type BiasedRandomReader struct{}
 
 func NewBiasedRandomReader() *BiasedRandomReader {
@@ -24,7 +17,7 @@ func NewBiasedRandomReader() *BiasedRandomReader {
 
 func (reader *BiasedRandomReader) Read(p []byte) (n int, err error) {
 	for i := 0; i < len(p); i++ {
-		p[i] = byte(min(10, rand.Int()%256))
+		p[i] = byte(utility.Min(10, rand.Int()%256))
 	}
 	return len(p), nil
 }

--- a/internal/storages/s3/folder.go
+++ b/internal/storages/s3/folder.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/internal/storages/storage"
-	"github.com/wal-g/wal-g/utility"
 	"io"
 	"strings"
 )
@@ -202,7 +201,7 @@ func (folder *Folder) partitionToObjects(keys []string) []*s3.ObjectIdentifier {
 
 func isAwsNotExist(err error) bool {
 	if awsErr, ok := err.(awserr.Error); ok {
-		if awsErr.Code() == utility.NotFoundAWSErrorCode || awsErr.Code() == NoSuchKeyAWSErrorCode {
+		if awsErr.Code() == NotFoundAWSErrorCode || awsErr.Code() == NoSuchKeyAWSErrorCode {
 			return true
 		}
 	}

--- a/test/backup_fetch_handler_test.go
+++ b/test/backup_fetch_handler_test.go
@@ -3,39 +3,40 @@ package test
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
 	"testing"
 )
 
 func TestGetRestoredBackupFilesToUnwrap_SimpleFile(t *testing.T) {
 	sentinelDto := internal.BackupSentinelDto{
-		Files: NewBackupFileListBuilder().WithSimple().Build(),
+		Files: testtools.NewBackupFileListBuilder().WithSimple().Build(),
 	}
 
 	files := internal.GetRestoredBackupFilesToUnwrap(sentinelDto)
-	assert.Contains(t, files, SimplePath)
+	assert.Contains(t, files, testtools.SimplePath)
 }
 
 func TestGetRestoredBackupFilesToUnwrap_IncrementedFile(t *testing.T) {
 	sentinelDto := internal.BackupSentinelDto{
-		Files: NewBackupFileListBuilder().WithIncremented().Build(),
+		Files: testtools.NewBackupFileListBuilder().WithIncremented().Build(),
 	}
 
 	files := internal.GetRestoredBackupFilesToUnwrap(sentinelDto)
-	assert.Contains(t, files, IncrementedPath)
+	assert.Contains(t, files, testtools.IncrementedPath)
 }
 
 func TestGetRestoredBackupFilesToUnwrap_SkippedFile(t *testing.T) {
 	sentinelDto := internal.BackupSentinelDto{
-		Files: NewBackupFileListBuilder().WithSkipped().Build(),
+		Files: testtools.NewBackupFileListBuilder().WithSkipped().Build(),
 	}
 
 	files := internal.GetRestoredBackupFilesToUnwrap(sentinelDto)
-	assert.Contains(t, files, SkippedPath)
+	assert.Contains(t, files, testtools.SkippedPath)
 }
 
 func TestGetRestoredBackupFilesToUnwrap_UtilityFiles(t *testing.T) {
 	sentinelDto := internal.BackupSentinelDto{
-		Files: NewBackupFileListBuilder().Build(),
+		Files: testtools.NewBackupFileListBuilder().Build(),
 	}
 
 	files := internal.GetRestoredBackupFilesToUnwrap(sentinelDto)
@@ -44,14 +45,14 @@ func TestGetRestoredBackupFilesToUnwrap_UtilityFiles(t *testing.T) {
 
 func TestGetRestoredBackupFilesToUnwrap_NoMoreFiles(t *testing.T) {
 	sentinelDto := internal.BackupSentinelDto{
-		Files: NewBackupFileListBuilder().WithSimple().WithIncremented().WithSkipped().Build(),
+		Files: testtools.NewBackupFileListBuilder().WithSimple().WithIncremented().WithSkipped().Build(),
 	}
 
 	files := internal.GetRestoredBackupFilesToUnwrap(sentinelDto)
 	expected := map[string]bool{
-		SimplePath:      true,
-		IncrementedPath: true,
-		SkippedPath:     true,
+		testtools.SimplePath:      true,
+		testtools.IncrementedPath: true,
+		testtools.SkippedPath:     true,
 	}
 	for utilityPath := range internal.UtilityFilePaths {
 		expected[utilityPath] = true
@@ -60,9 +61,9 @@ func TestGetRestoredBackupFilesToUnwrap_NoMoreFiles(t *testing.T) {
 }
 
 func TestGetBaseFilesToUnwrap_SimpleFile(t *testing.T) {
-	fileStates := NewBackupFileListBuilder().WithSimple().Build()
+	fileStates := testtools.NewBackupFileListBuilder().WithSimple().Build()
 	currentToUnwrap := map[string]bool{
-		SimplePath: true,
+		testtools.SimplePath: true,
 	}
 	baseToUnwrap, err := internal.GetBaseFilesToUnwrap(fileStates, currentToUnwrap)
 	assert.NoError(t, err)
@@ -70,9 +71,9 @@ func TestGetBaseFilesToUnwrap_SimpleFile(t *testing.T) {
 }
 
 func TestGetBaseFilesToUnwrap_IncrementedFile(t *testing.T) {
-	fileStates := NewBackupFileListBuilder().WithIncremented().Build()
+	fileStates := testtools.NewBackupFileListBuilder().WithIncremented().Build()
 	currentToUnwrap := map[string]bool{
-		IncrementedPath: true,
+		testtools.IncrementedPath: true,
 	}
 	baseToUnwrap, err := internal.GetBaseFilesToUnwrap(fileStates, currentToUnwrap)
 	assert.NoError(t, err)
@@ -80,9 +81,9 @@ func TestGetBaseFilesToUnwrap_IncrementedFile(t *testing.T) {
 }
 
 func TestGetBaseFilesToUnwrap_SkippedFile(t *testing.T) {
-	fileStates := NewBackupFileListBuilder().WithSkipped().Build()
+	fileStates := testtools.NewBackupFileListBuilder().WithSkipped().Build()
 	currentToUnwrap := map[string]bool{
-		SkippedPath: true,
+		testtools.SkippedPath: true,
 	}
 	baseToUnwrap, err := internal.GetBaseFilesToUnwrap(fileStates, currentToUnwrap)
 	assert.NoError(t, err)

--- a/test/backup_fetch_test.go
+++ b/test/backup_fetch_test.go
@@ -4,30 +4,13 @@ import (
 	"bytes"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
-	"github.com/wal-g/wal-g/internal/storages/storage"
 	"github.com/wal-g/wal-g/testtools"
 	"github.com/wal-g/wal-g/utility"
-	"strings"
 	"testing"
 )
 
-func createMockStorageFolder() storage.Folder {
-	var folder = testtools.MakeDefaultInMemoryStorageFolder()
-	subFolder := folder.GetSubFolder(utility.BaseBackupPath)
-	subFolder.PutObject("base_123_backup_stop_sentinel.json", &bytes.Buffer{})
-	subFolder.PutObject("base_456_backup_stop_sentinel.json", strings.NewReader("{}"))
-	subFolder.PutObject("base_000_backup_stop_sentinel.json", &bytes.Buffer{}) // last put
-	subFolder.PutObject("base_123312", &bytes.Buffer{})                        // not a sentinel
-	subFolder.PutObject("base_321/nop", &bytes.Buffer{})
-	subFolder.PutObject("folder123/nop", &bytes.Buffer{})
-	subFolder.PutObject("base_456/tar_partitions/1", &bytes.Buffer{})
-	subFolder.PutObject("base_456/tar_partitions/2", &bytes.Buffer{})
-	subFolder.PutObject("base_456/tar_partitions/3", &bytes.Buffer{})
-	return folder
-}
-
 func TestGetBackupByName_Latest(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup, err := internal.GetBackupByName(internal.LatestString, folder)
 	assert.NoError(t, err)
 	assert.Equal(t, folder.GetSubFolder(utility.BaseBackupPath), backup.BaseBackupFolder)
@@ -43,7 +26,7 @@ func TestGetBackupByName_LatestNoBackups(t *testing.T) {
 }
 
 func TestGetBackupByName_Exists(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup, err := internal.GetBackupByName("base_123", folder)
 	assert.NoError(t, err)
 	assert.Equal(t, folder.GetSubFolder(utility.BaseBackupPath), backup.BaseBackupFolder)
@@ -51,7 +34,7 @@ func TestGetBackupByName_Exists(t *testing.T) {
 }
 
 func TestGetBackupByName_NotExists(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	_, err := internal.GetBackupByName("base_321", folder)
 	assert.Error(t, err)
 	assert.IsType(t, internal.NewBackupNonExistenceError(""), err)

--- a/test/backup_list_test.go
+++ b/test/backup_list_test.go
@@ -8,15 +8,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
 )
 
 func TestBackupListFindsBackups(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	internal.HandleBackupList(folder)
 }
 
 func TestBackupListFlagsFindsBackups(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	internal.HandleBackupListWithFlags(folder, true, false, false)
 }
 

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
 	"github.com/wal-g/wal-g/utility"
 	"testing"
 )
 
 func TestCheckExistenceWhenBackupExists(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup := internal.NewBackup(folder.GetSubFolder(utility.BaseBackupPath), "base_000")
 	exists, err := backup.CheckExistence()
 	assert.NoError(t, err)
@@ -18,7 +19,7 @@ func TestCheckExistenceWhenBackupExists(t *testing.T) {
 }
 
 func TestCheckExistenceWhenBackupNotExists(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup := internal.NewBackup(folder.GetSubFolder(utility.BaseBackupPath), "base_321")
 	exists, err := backup.CheckExistence()
 	assert.NoError(t, err)
@@ -26,7 +27,7 @@ func TestCheckExistenceWhenBackupNotExists(t *testing.T) {
 }
 
 func TestGetTarNames(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup := internal.NewBackup(folder.GetSubFolder(utility.BaseBackupPath), "base_456")
 	tarNames, err := backup.GetTarNames()
 	assert.NoError(t, err)
@@ -34,7 +35,7 @@ func TestGetTarNames(t *testing.T) {
 }
 
 func TestIsPgControlRequired(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup := internal.NewBackup(folder.GetSubFolder(utility.BaseBackupPath), "base_456")
 	dto, err := backup.FetchSentinel()
 	assert.NoError(t, err)
@@ -42,13 +43,13 @@ func TestIsPgControlRequired(t *testing.T) {
 }
 
 func TestIsPgControlNotRequiredForWALEBackups(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup := internal.NewBackup(folder.GetSubFolder(utility.BaseBackupPath), "base_000000010000DD170000000C_00743784")
 	assert.False(t, internal.IsPgControlRequired(backup, internal.BackupSentinelDto{}))
 }
 
 func TestFetchSentinel(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	expectedSentinel := internal.BackupSentinelDto{}
 	expectedSentinelJson, _ := json.Marshal(expectedSentinel)
 	folder.PutObject("base_789454598_backup_stop_sentinel.json", bytes.NewReader(expectedSentinelJson))
@@ -61,7 +62,7 @@ func TestFetchSentinel(t *testing.T) {
 }
 
 func TestFetchSentinelReturnErrorWhenSentinelNotExist(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup := internal.NewBackup(folder.GetSubFolder(utility.BaseBackupPath), "base_78934085033849")
 
 	_, err := backup.FetchSentinel()
@@ -70,7 +71,7 @@ func TestFetchSentinelReturnErrorWhenSentinelNotExist(t *testing.T) {
 }
 
 func TestFetchSentinelReturnErrorWhenSentinelUnmarshallable(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	backup := internal.NewBackup(folder.GetSubFolder(utility.BaseBackupPath), "base_000")
 	errorMessage := "failed to unmarshal sentinel"
 

--- a/test/block_locations_util_test.go
+++ b/test/block_locations_util_test.go
@@ -4,11 +4,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/walparser"
+	"github.com/wal-g/wal-g/testtools"
 	"testing"
 )
 
 func TestExtractBlockLocations(t *testing.T) {
-	record, _ := GetXLogRecordData()
+	record, _ := testtools.GetXLogRecordData()
 	expectedLocations := []walparser.BlockLocation{record.Blocks[0].Header.BlockLocation}
 	actualLocations := internal.ExtractBlockLocations([]walparser.XLogRecord{record})
 	assert.Equal(t, expectedLocations, actualLocations)

--- a/test/bundle_test.go
+++ b/test/bundle_test.go
@@ -171,7 +171,7 @@ func fillStorageWithMockDeltas(storage *memory.Storage) error {
 	if err != nil {
 		return err
 	}
-	err = putWalIntoStorage(storage, createWalPageWithContinuation(), "000000010000000000000090")
+	err = putWalIntoStorage(storage, testtools.CreateWalPageWithContinuation(), "000000010000000000000090")
 	return err
 }
 

--- a/test/compression_structures_test.go
+++ b/test/compression_structures_test.go
@@ -7,43 +7,12 @@ import (
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/compression"
 	"github.com/wal-g/wal-g/internal/compression/lz4"
+	"github.com/wal-g/wal-g/testtools"
 	"io"
 	"io/ioutil"
 	"math/rand"
 	"testing"
 )
-
-var MockCloseError = errors.New("mock close: close error")
-var MockReadError = errors.New("mock reader: read error")
-var MockWriteError = errors.New("mock writer: write error")
-
-type BufCloser struct {
-	*bytes.Buffer
-	err bool
-}
-
-func (w *BufCloser) Close() error {
-	if w.err {
-		return MockCloseError
-	}
-	return nil
-}
-
-type ErrorWriteCloser struct{}
-
-func (ew ErrorWriteCloser) Write(p []byte) (int, error) {
-	return -1, MockWriteError
-}
-
-func (ew ErrorWriteCloser) Close() error {
-	return MockCloseError
-}
-
-type ErrorReader struct{}
-
-func (er ErrorReader) Read(p []byte) (int, error) {
-	return -1, MockReadError
-}
 
 func GetLz4Compressor() compression.Compressor {
 	return compression.Compressors[lz4.AlgorithmName]
@@ -59,7 +28,7 @@ var tests = []struct {
 
 func TestCascadeFileCloser(t *testing.T) {
 	for _, tt := range tests {
-		b := &BufCloser{bytes.NewBufferString(tt.testString), false}
+		b := &testtools.BufCloser{bytes.NewBufferString(tt.testString), false}
 		lz := &internal.CascadeWriteCloser{
 			WriteCloser: GetLz4Compressor().NewWriter(b),
 			Underlying:  b,
@@ -78,7 +47,7 @@ func TestCascadeFileCloser(t *testing.T) {
 		err = lz.Close()
 		assert.NoErrorf(t, err, "compress: CascadeWriteCloser expected `<nil>` but got %v", err)
 
-		b.err = true
+		b.Err = true
 
 		err = lz.Close()
 		assert.Errorf(t, err, "compress: Underlying writer expected to close with error but got `<nil>`")
@@ -87,7 +56,7 @@ func TestCascadeFileCloser(t *testing.T) {
 }
 
 func TestCascadeFileCloserError(t *testing.T) {
-	mock := &ErrorWriteCloser{}
+	mock := &testtools.ErrorWriteCloser{}
 	lz := &internal.CascadeWriteCloser{
 		WriteCloser: GetLz4Compressor().NewWriter(mock),
 		Underlying:  mock,
@@ -102,11 +71,11 @@ func TestCascadeFileCloserError(t *testing.T) {
 
 func TestCompressAndEncrypt(t *testing.T) {
 	for _, tt := range tests {
-		in := &BufCloser{bytes.NewBufferString(tt.testString), false}
+		in := &testtools.BufCloser{bytes.NewBufferString(tt.testString), false}
 		compressor := GetLz4Compressor()
 		compressed := internal.CompressAndEncrypt(in, compressor, nil)
 
-		decompressed := &BufCloser{&bytes.Buffer{}, false}
+		decompressed := &testtools.BufCloser{&bytes.Buffer{}, false}
 		decompressor := compression.GetDecompressorByCompressor(compressor)
 		err := decompressor.Decompress(decompressed, compressed)
 		if err != nil {
@@ -122,12 +91,12 @@ func TestCompressAndEncryptBigChunk(t *testing.T) {
 	L := 1024 * 1024 // 1Mb
 	b := make([]byte, L)
 	rand.Read(b)
-	in := &BufCloser{bytes.NewBuffer(b), false}
+	in := &testtools.BufCloser{bytes.NewBuffer(b), false}
 
 	compressor := GetLz4Compressor()
 	compressed := internal.CompressAndEncrypt(in, compressor, nil)
 
-	decompressed := &BufCloser{&bytes.Buffer{}, false}
+	decompressed := &testtools.BufCloser{&bytes.Buffer{}, false}
 	decompressor := compression.GetDecompressorByCompressor(compressor)
 	err := decompressor.Decompress(decompressed, compressed)
 	if err != nil {
@@ -160,11 +129,11 @@ func testCompressAndEncryptErrorPropagation(compressor compression.Compressor, t
 	L := 1 << 20
 	b := make([]byte, L)
 	rand.Read(b)
-	in := &BufCloser{bytes.NewBuffer(b), false}
+	in := &testtools.BufCloser{bytes.NewBuffer(b), false}
 
 	compressed := internal.CompressAndEncrypt(in, compressor, nil)
 
-	decompressed := &BufCloser{&bytes.Buffer{}, false}
+	decompressed := &testtools.BufCloser{&bytes.Buffer{}, false}
 	decompressor := compression.GetDecompressorByCompressor(compressor)
 	err := decompressor.Decompress(decompressed, &DelayedErrorReader{compressed, L})
 	assert.Errorf(t, err, "%v did not propagate error of the buffer", compressor.FileExtension())
@@ -178,7 +147,7 @@ func TestCompressAndEncryptErrorPropagation(t *testing.T) {
 
 func TestCompressAndEncryptError(t *testing.T) {
 	compressor := GetLz4Compressor()
-	compressed := internal.CompressAndEncrypt(&ErrorReader{}, compressor, nil)
+	compressed := internal.CompressAndEncrypt(&testtools.ErrorReader{}, compressor, nil)
 
 	_, err := ioutil.ReadAll(compressed)
 	assert.Errorf(t, err, "compress: CompressingPipeWriter expected error but got `<nil>`")

--- a/test/compression_structures_test.go
+++ b/test/compression_structures_test.go
@@ -28,7 +28,7 @@ var tests = []struct {
 
 func TestCascadeFileCloser(t *testing.T) {
 	for _, tt := range tests {
-		b := &testtools.BufCloser{bytes.NewBufferString(tt.testString), false}
+		b := &testtools.BufCloser{Buffer: bytes.NewBufferString(tt.testString), Err: false}
 		lz := &internal.CascadeWriteCloser{
 			WriteCloser: GetLz4Compressor().NewWriter(b),
 			Underlying:  b,
@@ -71,11 +71,11 @@ func TestCascadeFileCloserError(t *testing.T) {
 
 func TestCompressAndEncrypt(t *testing.T) {
 	for _, tt := range tests {
-		in := &testtools.BufCloser{bytes.NewBufferString(tt.testString), false}
+		in := &testtools.BufCloser{Buffer: bytes.NewBufferString(tt.testString), Err: false}
 		compressor := GetLz4Compressor()
 		compressed := internal.CompressAndEncrypt(in, compressor, nil)
 
-		decompressed := &testtools.BufCloser{&bytes.Buffer{}, false}
+		decompressed := &testtools.BufCloser{Buffer: &bytes.Buffer{}, Err: false}
 		decompressor := compression.GetDecompressorByCompressor(compressor)
 		err := decompressor.Decompress(decompressed, compressed)
 		if err != nil {
@@ -91,12 +91,12 @@ func TestCompressAndEncryptBigChunk(t *testing.T) {
 	L := 1024 * 1024 // 1Mb
 	b := make([]byte, L)
 	rand.Read(b)
-	in := &testtools.BufCloser{bytes.NewBuffer(b), false}
+	in := &testtools.BufCloser{Buffer: bytes.NewBuffer(b), Err: false}
 
 	compressor := GetLz4Compressor()
 	compressed := internal.CompressAndEncrypt(in, compressor, nil)
 
-	decompressed := &testtools.BufCloser{&bytes.Buffer{}, false}
+	decompressed := &testtools.BufCloser{Buffer: &bytes.Buffer{}, Err: false}
 	decompressor := compression.GetDecompressorByCompressor(compressor)
 	err := decompressor.Decompress(decompressed, compressed)
 	if err != nil {
@@ -129,11 +129,11 @@ func testCompressAndEncryptErrorPropagation(compressor compression.Compressor, t
 	L := 1 << 20
 	b := make([]byte, L)
 	rand.Read(b)
-	in := &testtools.BufCloser{bytes.NewBuffer(b), false}
+	in := &testtools.BufCloser{Buffer: bytes.NewBuffer(b), Err: false}
 
 	compressed := internal.CompressAndEncrypt(in, compressor, nil)
 
-	decompressed := &testtools.BufCloser{&bytes.Buffer{}, false}
+	decompressed := &testtools.BufCloser{Buffer: &bytes.Buffer{}, Err: false}
 	decompressor := compression.GetDecompressorByCompressor(compressor)
 	err := decompressor.Decompress(decompressed, &DelayedErrorReader{compressed, L})
 	assert.Errorf(t, err, "%v did not propagate error of the buffer", compressor.FileExtension())

--- a/test/delta_file_manager_test.go
+++ b/test/delta_file_manager_test.go
@@ -12,13 +12,6 @@ import (
 	"testing"
 )
 
-func concatByteSlices(a []byte, b []byte) []byte {
-	result := make([]byte, len(a)+len(b))
-	copy(result, a)
-	copy(result[len(a):], b)
-	return result
-}
-
 func GetXLogRecordData() (walparser.XLogRecord, []byte) {
 	imageData := []byte{
 		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
@@ -35,7 +28,7 @@ func GetXLogRecordData() (walparser.XLogRecord, []byte) {
 		0x00, 0x00, 0x15, 0x40, 0x00, 0x00, 0xe4, 0x18, 0x00, 0x00,
 		0xff, 0x04,
 	}
-	data = concatByteSlices(concatByteSlices(concatByteSlices(data, imageData), blockData), mainData)
+	data = utility.ConcatByteSlices(utility.ConcatByteSlices(utility.ConcatByteSlices(data, imageData), blockData), mainData)
 	recordHeader := walparser.XLogRecordHeader{
 		TotalRecordLength: uint32(walparser.XLogRecordHeaderSize + len(data)),
 		XactID:            0x00000243,
@@ -52,7 +45,7 @@ func GetXLogRecordData() (walparser.XLogRecord, []byte) {
 	recordHeaderData.Write(utility.ToBytes(&recordHeader.ResourceManagerID))
 	recordHeaderData.Write([]byte{0, 0})
 	recordHeaderData.Write(utility.ToBytes(&recordHeader.Crc32Hash))
-	recordData := concatByteSlices(recordHeaderData.Bytes(), data)
+	recordData := utility.ConcatByteSlices(recordHeaderData.Bytes(), data)
 	record, _ := walparser.ParseXLogRecordFromBytes(recordData)
 	return *record, recordData
 }

--- a/test/delta_file_manager_test.go
+++ b/test/delta_file_manager_test.go
@@ -1,54 +1,14 @@
 package test
 
 import (
-	"bytes"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/storages/memory"
 	"github.com/wal-g/wal-g/internal/walparser"
 	"github.com/wal-g/wal-g/testtools"
-	"github.com/wal-g/wal-g/utility"
 	"sync"
 	"testing"
 )
-
-func GetXLogRecordData() (walparser.XLogRecord, []byte) {
-	imageData := []byte{
-		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
-	}
-	blockData := []byte{
-		0x0a, 0x0b, 0x0c,
-	}
-	mainData := []byte{
-		0x0d, 0x0e, 0x0f, 0x10,
-	}
-	data := []byte{ // block header data
-		0xfd, 0x01, 0xfe,
-		0x00, 0x30, 0x03, 0x00, 0x0a, 0x00, 0xd4, 0x05, 0x05, 0x7f, 0x06, 0x00, 0x00, 0x00, 0x40,
-		0x00, 0x00, 0x15, 0x40, 0x00, 0x00, 0xe4, 0x18, 0x00, 0x00,
-		0xff, 0x04,
-	}
-	data = utility.ConcatByteSlices(utility.ConcatByteSlices(utility.ConcatByteSlices(data, imageData), blockData), mainData)
-	recordHeader := walparser.XLogRecordHeader{
-		TotalRecordLength: uint32(walparser.XLogRecordHeaderSize + len(data)),
-		XactID:            0x00000243,
-		PrevRecordPtr:     0x000000002affedc8,
-		Info:              0xb0,
-		ResourceManagerID: 0x00,
-		Crc32Hash:         0xecf5203c,
-	}
-	var recordHeaderData bytes.Buffer
-	recordHeaderData.Write(utility.ToBytes(&recordHeader.TotalRecordLength))
-	recordHeaderData.Write(utility.ToBytes(&recordHeader.XactID))
-	recordHeaderData.Write(utility.ToBytes(&recordHeader.PrevRecordPtr))
-	recordHeaderData.Write(utility.ToBytes(&recordHeader.Info))
-	recordHeaderData.Write(utility.ToBytes(&recordHeader.ResourceManagerID))
-	recordHeaderData.Write([]byte{0, 0})
-	recordHeaderData.Write(utility.ToBytes(&recordHeader.Crc32Hash))
-	recordData := utility.ConcatByteSlices(recordHeaderData.Bytes(), data)
-	record, _ := walparser.ParseXLogRecordFromBytes(recordData)
-	return *record, recordData
-}
 
 func TestGetCanceledDeltaFiles_MidWalFile(t *testing.T) {
 	manager := internal.NewDeltaFileManager(testtools.NewMockDataFolder())
@@ -180,7 +140,7 @@ func TestFlushPartFiles_CanceledFile(t *testing.T) {
 
 func TestFlushPartFiles_CompleteFile(t *testing.T) {
 	partFile := internal.NewWalPartFile()
-	xLogRecord, xLogRecordData := GetXLogRecordData()
+	xLogRecord, xLogRecordData := testtools.GetXLogRecordData()
 	for i := 0; i < int(internal.WalFileInDelta); i++ {
 		partFile.WalTails[i] = make([]byte, 0)
 		partFile.WalHeads[i] = make([]byte, 0)
@@ -274,7 +234,7 @@ func TestFlushDeltaFiles_PartialFile(t *testing.T) {
 
 func TestCombinePartFile(t *testing.T) {
 	partFile := internal.NewWalPartFile()
-	xLogRecord, xLogRecordData := GetXLogRecordData()
+	xLogRecord, xLogRecordData := testtools.GetXLogRecordData()
 	for i := 0; i < int(internal.WalFileInDelta); i++ {
 		partFile.WalTails[i] = make([]byte, 0)
 		partFile.WalHeads[i] = make([]byte, 0)

--- a/test/folder_test.go
+++ b/test/folder_test.go
@@ -35,7 +35,7 @@ func TestListFolderRecursively(t *testing.T) {
 }
 
 func TestDeleteOldObjects(t *testing.T) {
-	folder := createMockStorageFolder()
+	folder := testtools.CreateMockStorageFolder()
 	expectedOnlyOneSavedObjectName := "basebackups_005/base_123312"
 	filter := func(object storage.Object) bool {
 		return object.GetName() != expectedOnlyOneSavedObjectName

--- a/test/wal_delta_recording_reader_test.go
+++ b/test/wal_delta_recording_reader_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/walparser"
@@ -18,25 +17,8 @@ var WalFilePath = path.Join(WalgTestDataFolderPath, WalFilename)
 var DeltaFilePath = path.Join(WalgTestDataFolderPath, DeltaFilename)
 var RealLocation = *walparser.NewBlockLocation(internal.DefaultSpcNode, 16384, 16397, 2062)
 
-func createWalPageWithContinuation() []byte {
-	pageHeader := walparser.XLogPageHeader{
-		Info:             walparser.XlpFirstIsContRecord,
-		RemainingDataLen: 12312,
-	}
-	data := make([]byte, 20)
-	binary.LittleEndian.PutUint16(data, pageHeader.Magic)
-	binary.LittleEndian.PutUint16(data, pageHeader.Info)
-	binary.LittleEndian.PutUint32(data, uint32(pageHeader.TimeLineID))
-	binary.LittleEndian.PutUint64(data, uint64(pageHeader.PageAddress))
-	binary.LittleEndian.PutUint32(data, pageHeader.RemainingDataLen)
-	for len(data) < int(walparser.WalPageSize) {
-		data = append(data, 2)
-	}
-	return data
-}
-
 func createWalParser() (*walparser.WalParser, error) {
-	data := createWalPageWithContinuation()
+	data := testtools.CreateWalPageWithContinuation()
 
 	walParser := walparser.NewWalParser()
 	_, _, err := walParser.ParseRecordsFromPage(bytes.NewReader(data)) // initializing parsing

--- a/test/wal_part_file_test.go
+++ b/test/wal_part_file_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/walparser"
+	"github.com/wal-g/wal-g/testtools"
 	"testing"
 )
 
@@ -61,7 +62,7 @@ func TestSaveLoadWalPartFile(t *testing.T) {
 
 func TestCombineRecords(t *testing.T) {
 	partFile := internal.NewWalPartFile()
-	xLogRecord, recordData := GetXLogRecordData()
+	xLogRecord, recordData := testtools.GetXLogRecordData()
 	partFile.WalHeads[1] = recordData[:16]
 	partFile.WalTails[2] = recordData[16:]
 

--- a/testtools/backup_file_list_builder.go
+++ b/testtools/backup_file_list_builder.go
@@ -1,4 +1,4 @@
-package test
+package testtools
 
 import (
 	"github.com/wal-g/wal-g/internal"

--- a/testtools/mock_s3_client.go
+++ b/testtools/mock_s3_client.go
@@ -5,7 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/wal-g/wal-g/utility"
+	walgs3 "github.com/wal-g/wal-g/internal/storages/s3"
 	"io/ioutil"
 	"strings"
 	"time"
@@ -56,7 +56,7 @@ func (client *mockS3Client) HeadObject(input *s3.HeadObjectInput) (*s3.HeadObjec
 	if client.err {
 		return nil, awserr.New("MockHeadObject", "mock HeadObject error", nil)
 	} else if client.notFound {
-		return nil, awserr.New(utility.NotFoundAWSErrorCode, "mock HeadObject error", nil)
+		return nil, awserr.New(walgs3.NotFoundAWSErrorCode, "mock HeadObject error", nil)
 	}
 
 	return &s3.HeadObjectOutput{}, nil

--- a/testtools/util.go
+++ b/testtools/util.go
@@ -1,8 +1,12 @@
 package testtools
 
 import (
+	"bytes"
 	"errors"
+	"github.com/wal-g/wal-g/internal/storages/storage"
+	"github.com/wal-g/wal-g/utility"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
@@ -35,6 +39,21 @@ func NewStoringMockUploader(storage *memory.Storage, deltaDataFolder internal.Da
 		memory.NewFolder("in_memory/", storage),
 		nil,
 	)
+}
+
+func CreateMockStorageFolder() storage.Folder {
+	var folder = MakeDefaultInMemoryStorageFolder()
+	subFolder := folder.GetSubFolder(utility.BaseBackupPath)
+	subFolder.PutObject("base_123_backup_stop_sentinel.json", &bytes.Buffer{})
+	subFolder.PutObject("base_456_backup_stop_sentinel.json", strings.NewReader("{}"))
+	subFolder.PutObject("base_000_backup_stop_sentinel.json", &bytes.Buffer{}) // last put
+	subFolder.PutObject("base_123312", &bytes.Buffer{})                        // not a sentinel
+	subFolder.PutObject("base_321/nop", &bytes.Buffer{})
+	subFolder.PutObject("folder123/nop", &bytes.Buffer{})
+	subFolder.PutObject("base_456/tar_partitions/1", &bytes.Buffer{})
+	subFolder.PutObject("base_456/tar_partitions/2", &bytes.Buffer{})
+	subFolder.PutObject("base_456/tar_partitions/3", &bytes.Buffer{})
+	return folder
 }
 
 type ReadWriteNopCloser struct {

--- a/testtools/util.go
+++ b/testtools/util.go
@@ -103,12 +103,16 @@ func (seeker *NopSeeker) Seek(offset int64, whence int) (int64, error) {
 	return 0, nil
 }
 
+var MockCloseError = errors.New("mock close: close error")
+var MockReadError = errors.New("mock reader: read error")
+var MockWriteError = errors.New("mock writer: write error")
+
 //ErrorWriter struct implements io.Writer interface.
 //Its Write method returns zero and non-nil error on every call
 type ErrorWriter struct{}
 
 func (w ErrorWriter) Write(b []byte) (int, error) {
-	return 0, errors.New("expected writing error")
+	return 0, MockWriteError
 }
 
 //ErrorReader struct implements io.Reader interface.
@@ -116,5 +120,27 @@ func (w ErrorWriter) Write(b []byte) (int, error) {
 type ErrorReader struct{}
 
 func (r ErrorReader) Read(b []byte) (int, error) {
-	return 0, errors.New("expected reading error")
+	return 0, MockReadError
+}
+
+type BufCloser struct {
+	*bytes.Buffer
+	Err bool
+}
+
+func (w *BufCloser) Close() error {
+	if w.Err {
+		return MockCloseError
+	}
+	return nil
+}
+
+type ErrorWriteCloser struct{}
+
+func (ew ErrorWriteCloser) Write(p []byte) (int, error) {
+	return -1, MockWriteError
+}
+
+func (ew ErrorWriteCloser) Close() error {
+	return MockCloseError
 }

--- a/testtools/util.go
+++ b/testtools/util.go
@@ -2,6 +2,7 @@ package testtools
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"github.com/wal-g/wal-g/internal/storages/storage"
 	"github.com/wal-g/wal-g/internal/walparser"
@@ -55,6 +56,24 @@ func CreateMockStorageFolder() storage.Folder {
 	subFolder.PutObject("base_456/tar_partitions/2", &bytes.Buffer{})
 	subFolder.PutObject("base_456/tar_partitions/3", &bytes.Buffer{})
 	return folder
+}
+
+
+func CreateWalPageWithContinuation() []byte {
+	pageHeader := walparser.XLogPageHeader{
+		Info:             walparser.XlpFirstIsContRecord,
+		RemainingDataLen: 12312,
+	}
+	data := make([]byte, 20)
+	binary.LittleEndian.PutUint16(data, pageHeader.Magic)
+	binary.LittleEndian.PutUint16(data, pageHeader.Info)
+	binary.LittleEndian.PutUint32(data, uint32(pageHeader.TimeLineID))
+	binary.LittleEndian.PutUint64(data, uint64(pageHeader.PageAddress))
+	binary.LittleEndian.PutUint32(data, pageHeader.RemainingDataLen)
+	for len(data) < int(walparser.WalPageSize) {
+		data = append(data, 2)
+	}
+	return data
 }
 
 func GetXLogRecordData() (walparser.XLogRecord, []byte) {

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -36,7 +36,6 @@ const (
 	SentinelSuffix         = "_backup_stop_sentinel.json"
 	CompressedBlockMaxSize = 20 << 20
 	CopiedBlockMaxSize     = CompressedBlockMaxSize
-	NotFoundAWSErrorCode   = "NotFound"
 	MetadataFileName       = "metadata.json"
 )
 

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -169,3 +169,10 @@ func TimeNowCrossPlatformUTC() time.Time {
 func TimeNowCrossPlatformLocal() time.Time {
 	return CeilTimeUpToMicroseconds(time.Now())
 }
+
+func ConcatByteSlices(a []byte, b []byte) []byte {
+	result := make([]byte, len(a)+len(b))
+	copy(result, a)
+	copy(result[len(a):], b)
+	return result
+}


### PR DESCRIPTION
Made a refactoring of tests, namely:
- moved some general functionality from test package to testtools or utility
- deleted duplicate code (such as function `Min` and struct `ErrorReader`)

I've made this PR because I want to fix coverage for tests (now coverage described in README doesn't work). It will be simpler for you to review (and merge) this two PRs separetely.
My next PR will contain only changes regarding that fix.