### PR TITLE
Fix AWS_SECURITY_TOKEN vs AWS_SESSION_TOKEN thinko

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To connect to Amazon S3, WAL-G requires that this variable be set:
 
 * `WALG_S3_PREFIX` (eg. `s3://bucket/path/to/folder`) (alternative form `WALE_S3_PREFIX`)
 
-WAL-G determines AWS credentials [like other AWS tools](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence). You can set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (optionally with `AWS_SECURITY_TOKEN`), or `~/.aws/credentials` (optionally with `AWS_PROFILE`), or you can set nothing to automatically fetch credentials from the EC2 metadata service.
+WAL-G determines AWS credentials [like other AWS tools](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence). You can set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (optionally with `AWS_SESSION_TOKEN`), or `~/.aws/credentials` (optionally with `AWS_PROFILE`), or you can set nothing to automatically fetch credentials from the EC2 metadata service.
 
 
 To store backups in Google Cloud Storage, WAL-G requires that this variable be set:

--- a/internal/upload_test.go
+++ b/internal/upload_test.go
@@ -45,7 +45,7 @@ func doConfigureWithBucketPath(t *testing.T, bucketPath string, expectedServer s
 	internal.Configure()
 	viper.Set("AWS_ACCESS_KEY_ID", "aws_access_key_id")
 	viper.Set("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key")
-	viper.Set("AWS_SECURITY_TOKEN", "aws_security_token")
+	viper.Set("AWS_SESSION_TOKEN", "aws_session_token")
 	viper.Set("WALE_S3_PREFIX", "gs://abc.com")
 	viper.Set("AWS_ENDPOINT", "http://127.0.0.1:9000")
 	viper.Set("AWS_REGION", "")


### PR DESCRIPTION
The naming of AWS_SECURITY_TOKEN was an educated guess in the WAL-E
era, but it was wrong: more references began to appear that preferred
AWS_SESSION_TOKEN. And indeed, WAL-G *only* respects the latter as-is,
for that reason:

    $ git grep AWS_SESSION_TOKEN internal/
    internal/storages/s3/folder.go: SessionTokenSetting      = "AWS_SESSION_TOKEN"

Rectify the documentation and one other reference.
