### PR TITLE
Fixed invalid error suppression

### DIFF
--- a/internal/limited/reader.go
+++ b/internal/limited/reader.go
@@ -2,6 +2,8 @@ package limited
 
 import (
 	"context"
+	"github.com/wal-g/wal-g/internal/tracelog"
+	"github.com/wal-g/wal-g/utility"
 	"golang.org/x/time/rate"
 	"io"
 )
@@ -17,7 +19,12 @@ func NewReader(reader io.Reader, limiter *rate.Limiter) *Reader {
 
 func (r *Reader) Read(buf []byte) (int, error) {
 	n, err := r.reader.Read(buf)
-	if n <= 0 {
+
+	if err != nil {
+		limiterErr := r.limiter.WaitN(context.TODO(), utility.Max(n, 0))
+		if limiterErr != nil {
+			tracelog.ErrorLogger.Printf("Error happened while limiting: %+v\n", limiterErr)
+		}
 		return n, err
 	}
 


### PR DESCRIPTION
We can suppress error that we shouldn't in limited reader. This commit fixes it.