### PR TITLE
Update Readme for PostgreSQL

### DIFF
--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -45,11 +45,11 @@ Concurrency values can be configured using:
 
 * `WALG_DOWNLOAD_CONCURRENCY`
 
-To configure how many goroutines to use during backup-fetch  and wal-push, use `WALG_DOWNLOAD_CONCURRENCY`. By default, WAL-G uses the minimum of the number of files to extract and 10.
+To configure how many goroutines to use during backup-fetch and wal-fetch, use `WALG_DOWNLOAD_CONCURRENCY`. By default, WAL-G uses the minimum of the number of files to extract and 10.
 
 * `WALG_UPLOAD_CONCURRENCY`
 
-To configure how many concurrency streams to use during backup uploading, use `WALG_UPLOAD_CONCURRENCY`. By default, WAL-G uses 10 streams.
+To configure how many concurrency streams to use during backup uploading, use `WALG_UPLOAD_CONCURRENCY`. By default, WAL-G uses 16 streams.
 
 * `WALG_UPLOAD_DISK_CONCURRENCY`
 


### PR DESCRIPTION
* Minor fixes in Readme for PostgreSQL.
* Update the default value of `WALG_UPLOAD_CONCURRENCY`.
According to `UploadConcurrencySetting` in [internal/config.go](https://github.com/wal-g/wal-g/blob/master/internal/config.go#L40) default value is 16 instead of specified 10 streams.