### PR TITLE
Support RIPEMD-160

### DIFF
--- a/internal/crypto/openpgp/crypter.go
+++ b/internal/crypto/openpgp/crypter.go
@@ -12,6 +12,9 @@ import (
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/internal/ioextensions"
 	"golang.org/x/crypto/openpgp"
+
+	//  Support alternative hash function RIPEMD160
+	_ "golang.org/x/crypto/ripemd160"
 )
 
 // Crypter incapsulates specific of cypher method


### PR DESCRIPTION
Consider supporting https://ru.wikipedia.org/wiki/RIPEMD-160
See https://godoc.org/golang.org/x/crypto/ripemd160
It is somewhat deprecated but in some cases PGP needs it.