### PR TITLE
Link statically with liblzo2.a

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ go:
 services:
   - docker
 
-matrix:
-  include:
-    - env: TEST_MODIFIER=-race GOTAGS= BINSUFFIX=
-      addons:
-        apt:
-          packages: [liblzo2-dev]
+env:
+  global:
+  - TEST_MODIFIER=-race
+
+addons:
+  apt:
+    packages: [liblzo2-dev]
 
 jobs:
   include:
@@ -39,14 +40,14 @@ notifications:
   email: false
 
 before_deploy:
-  - tar -zcf wal-g.linux-amd64$BINSUFFIX.tar.gz -C main/pg wal-g
+  - tar -zcf wal-g.linux-amd64.tar.gz -C main/pg wal-g
 
 deploy:
   provider: releases
   api_key:
     secure: nRVV5uKaBdCi/J/sLP7+c/shuDEaSeMiapEsro5gp4gr8n/QMgGm5AHNZhkfQVBmhmaKNB7dDzg34RVD2qacVpeZQTTUWetorBiwWvSjf+mlVcmBPKOIivamqetIdMEPgGQ0vudDADMpYiiqWBV893vAg1w0x02Cz7yvduzKEDyVttH+P4A7MPZ9tPtwLyMoOKjxe7Z0IOp82DK0rj+2KXQYe+El9Ipya+2WB88NBuRn2dJSfsAx9VI+5VmUz0waB1lP3ityjgQpaL13QEV6qsCXl+ntb4vGACbPYoPt0pgesq/zkL2ScFKTbzSSo6yByf3zHhV+elZ2sXnK/UYrqe4erC3qkG5qiTuy+uzPKg0pOVdqI1kDtMNoIanCjSVblXXsR+vz0UVHbzOmTMm7ckpnMB1nxsSyaQfs1C2e42SCgIB57RJsWUSsRx/Uq9iJS32ab/8pSnzJ2dZLNo4BxNHJDgKpmfj6ZKhBne+JUcfBsx2DOXs1ad9s0+ahpnlLiijhQQ5ZxGTfzYcXjijtAOyN2Y42wU6YI3L7ezsZTw+AoJeBMdc2MM8yy1CI/PM0x5IL+e9cZ+LoL87f0WZFxMd0KYblEeQzL+yRv0M5cRf4GPgqgEFsYUU4WXAH6Fnah2dailOvkfV1ygbaTxjvrSiIDnk0DKls3y8QLwSJPLw=
   skip_cleanup: true
-  file: wal-g.linux-amd64$BINSUFFIX.tar.gz
+  file: wal-g.linux-amd64.tar.gz
   on:
     repo: wal-g/wal-g
     tags: true

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,12 @@ COVERAGE_FILE := coverage.out
 
 .PHONY: unittest fmt lint install clean
 
-ifdef GOTAGS
-override GOTAGS := -tags $(GOTAGS)
-endif
-
 test: install deps lint unittest pg_build mysql_build redis_build mongo_build unlink_brotli pg_integration_test mysql_integration_test redis_integration_test mongo_integration_test
 
 pg_test: install deps pg_build lint unlink_brotli pg_integration_test
 
 pg_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_PG_PATH) && go build -o wal-g $(GOTAGS) -ldflags "-s -w -X github.com/wal-g/wal-g/cmd.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd.GitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd.WalgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_PG_PATH) && go build -o wal-g -tags lzo -ldflags "-s -w -X github.com/wal-g/wal-g/cmd.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd.GitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd.WalgVersion=`git tag -l --points-at HEAD`")
 
 pg_integration_test:
 	docker-compose build $(DOCKER_COMMON) pg pg_tests
@@ -46,7 +42,7 @@ pg_install: pg_build
 mysql_test: install deps mysql_build lint unlink_brotli mysql_integration_test
 
 mysql_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_MYSQL_PATH) && go build -o wal-g $(GOTAGS) -ldflags "-s -w -X github.com/wal-g/wal-g/cmd.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd.GitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd.WalgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_MYSQL_PATH) && go build -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd.GitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd.WalgVersion=`git tag -l --points-at HEAD`")
 
 mysql_integration_test:
 	docker-compose build $(DOCKER_COMMON) mysql mysql_tests
@@ -62,7 +58,7 @@ mysql_install: mysql_build
 mongo_test: install deps mongo_build lint unlink_brotli mongo_integration_test
 
 mongo_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_MONGO_PATH) && go build -o wal-g $(GOTAGS) -ldflags "-s -w -X github.com/wal-g/wal-g/cmd.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd.GitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd.WalgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_MONGO_PATH) && go build -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd.GitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd.WalgVersion=`git tag -l --points-at HEAD`")
 
 mongo_install: mongo_build
 	mv $(MAIN_MONGO_PATH)/wal-g $(GOBIN)/wal-g
@@ -74,7 +70,7 @@ mongo_integration_test:
 redis_test: install deps redis_build lint unlink_brotli redis_integration_test
 
 redis_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_REDIS_PATH) && go build -o wal-g $(GOTAGS) -ldflags "-s -w -X github.com/wal-g/wal-g/cmd.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd.GitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd.WalgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_REDIS_PATH) && go build -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd.GitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd.WalgVersion=`git tag -l --points-at HEAD`")
 
 redis_integration_test:
 	docker-compose build $(DOCKER_COMMON) redis redis_tests
@@ -116,6 +112,7 @@ lint: $(CMD_FILES) $(PKG_FILES) $(TEST_FILES)
 deps:
 	git submodule update --init
 	dep ensure
+	sed -i 's|\(#cgo LDFLAGS:\) .*|\1 -Wl,-Bstatic -llzo2 -Wl,-Bdynamic|' vendor/github.com/cyberdelia/lzo/lzo.go
 	./link_brotli.sh
 
 install:

--- a/docker/mongo_tests/Dockerfile
+++ b/docker/mongo_tests/Dockerfile
@@ -11,7 +11,9 @@ COPY cmd/ cmd/
 COPY main/ main/
 COPY utility/ utility/
 
-RUN cd main/mongo && \
+RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
+        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
+    cd main/mongo && \
     go build -race -o wal-g -ldflags "-s -w -X main.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
 
 FROM wal-g/mongo:latest

--- a/docker/mysql_tests/Dockerfile
+++ b/docker/mysql_tests/Dockerfile
@@ -11,7 +11,9 @@ COPY cmd/ cmd/
 COPY main/ main/
 COPY utility/ utility/
 
-RUN cd main/mysql && \
+RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
+        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
+    cd main/mysql && \
     go build -race -o wal-g -ldflags "-s -w -X main.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
 
 FROM wal-g/mysql:latest

--- a/docker/pg_tests/Dockerfile_prefix
+++ b/docker/pg_tests/Dockerfile_prefix
@@ -12,7 +12,11 @@ COPY cmd/ cmd/
 COPY main/ main/
 COPY utility/ utility/
 
-RUN cd main/pg && \
+RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
+        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
+    sed -i 's|\(#cgo LDFLAGS:\) .*|\1 -Wl,-Bstatic -llzo2 -Wl,-Bdynamic|' \
+        vendor/github.com/cyberdelia/lzo/lzo.go && \
+    cd main/pg && \
     go build -race -o wal-g -tags lzo -ldflags "-s -w -X main.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
 
 FROM wal-g/pg:latest

--- a/docker/redis_tests/Dockerfile
+++ b/docker/redis_tests/Dockerfile
@@ -11,7 +11,9 @@ COPY cmd/ cmd/
 COPY main/ main/
 COPY utility/ utility/
 
-RUN cd main/redis && \
+RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
+        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
+    cd main/redis && \
     go build -race -o wal-g -ldflags "-s -w -X main.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
 
 FROM wal-g/redis:latest


### PR DESCRIPTION
It adds only 40kb to the binary but allows to get rid from liblzo2 dependency.
In addition to that, execute tests against binary statically linked with liblzo2 and libbrotli.