### PR TITLE
Set swift settings as env variables for swift client

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,3 +18,4 @@ Reshke Kirill <reshke@yandex-team.ru>
 Rezoan Tamal <rezoan@appscode.com>
 Vladimir Leskov <vladimirlesk@yandex-team.ru>
 Will Glynn <will@willglynn.com>
+Andrey Dudin <dudin.andrey@gmail.com>

--- a/internal/storages/swift/folder.go
+++ b/internal/storages/swift/folder.go
@@ -5,6 +5,7 @@ import (
 	"github.com/wal-g/wal-g/internal/storages/storage"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/ncw/swift"
@@ -29,6 +30,10 @@ func NewFolder(connection *swift.Connection, container swift.Container, path str
 
 func ConfigureFolder(prefix string, settings map[string]string) (storage.Folder, error) {
 	connection := new(swift.Connection)
+	//Set settings as env variables
+	for prop,value := range settings {
+		os.Setenv(prop,value)
+	}	
 	//users must set conventional openStack environment variables: username, key, auth-url, tenantName, region etc
 	err := connection.ApplyEnvironment()
 	if err != nil {

--- a/internal/storages/swift/swift_folder_test.go
+++ b/internal/storages/swift/swift_folder_test.go
@@ -7,18 +7,30 @@ import (
 	"testing"
 )
 
-func TestSwiftFolder(t *testing.T) {
+var settings = map[string]string{
+	"OS_USERNAME":    "",
+	"OS_PASSWORD":    "",
+	"OS_AUTH_URL":    "",
+	"OS_TENANT_NAME": "",
+	"OS_REGION_NAME": "",
+}
+
+func TestSwiftFolderUsingConfigFile(t *testing.T) {
 	t.Skip("Credentials needed to run Swift Storage tests")
 
-	os.Setenv("OS_USERNAME", "")
-	os.Setenv("OS_PASSWORD", "")
-	os.Setenv("OS_AUTH_URL", "")
-	os.Setenv("OS_TENANT_NAME", "")
-	os.Setenv("OS_REGION_NAME", "")
-
-	storageFolder, err := ConfigureFolder("swift://test-container/wal-g-test-folder/sub0", nil)
-
+	storageFolderUsingConfigFile, err := ConfigureFolder("swift://test-container/wal-g-test-folder/sub0", settings)
 	assert.NoError(t, err)
+	storage.RunFolderTest(storageFolderUsingConfigFile, t)
+}
 
-	storage.RunFolderTest(storageFolder, t)
+func TestSwiftFolderUsingEnvVariables(t *testing.T) {
+	t.Skip("Credentials needed to run Swift Storage tests")
+
+	for prop, value := range settings {
+		os.Setenv(prop, value)
+	}
+
+	storageFolderUsingEnvVars, err := ConfigureFolder("swift://test-container/wal-g-test-folder/sub0", nil)
+	assert.NoError(t, err)
+	storage.RunFolderTest(storageFolderUsingEnvVars, t)
 }


### PR DESCRIPTION
We add swift settings to ENV as swift client should read these parameters from environment variables.

Should help with #274