### PR TITLE
Fix prevent wal overwrite

### DIFF
--- a/internal/wal_push_handler.go
+++ b/internal/wal_push_handler.go
@@ -76,7 +76,7 @@ func UploadWALFile(uploader *Uploader, walFilePath string, preventWalOverwrite b
 
 // TODO : unit tests
 func checkWALOverwrite(uploader *Uploader, walFilePath string) (overwriteAttempt bool, err error) {
-	walFileReader, err := DownloadAndDecompressWALFile(uploader.UploadingFolder, filepath.Base(walFilePath)+"."+uploader.Compressor.FileExtension())
+	walFileReader, err := DownloadAndDecompressWALFile(uploader.UploadingFolder, filepath.Base(walFilePath))
 	if err != nil {
 		if _, ok := err.(ArchiveNonExistenceError); ok {
 			err = nil


### PR DESCRIPTION
As mentioned in https://github.com/wal-g/wal-g/pull/361 I am super keen to see the WAL overwrite bug resolved. This PR fixes it and a few other bit and pieces. Would be great to get feedback and to try to get this in. 

- Fixes some PostgreSQL test related issues
- Fix pushing duplicate named WAL with differing content
- Fix pushing duplicate WAL with equal content again

commit 365741ce44b32dcf886afee8e38ac7d64d8069c0 (HEAD -> fix-prevent-wal-overwrite, 

    Don't push PostgreSQL WAL if already archived

    If we detect that a PostgreSQL WAL file has already been archived, and
    it has equal content, then we don't need to upload it again.

commit 7c95dcf88760ffda9679a940e5b03f6adbc813fa

    Fix WALG_PREVENT_WAL_OVERWRITE

    The compressors file extention was being appended twice preventing us
    from correctly detecting overwrites.

commit 1765778361166df73bda4a7fa4f0bb0a67ff0225

    Add test for PostgreSQL WALG_PREVENT_WAL_OVERWRITE

    This is currently broken so a test for it that fails with the current
    implementation is needed. We can then fix the bahviour and the test
    should pass.
