### PR TITLE
Place UserData into metadata file too

### DIFF
--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -197,6 +197,7 @@ func UploadMetadata(uploader *Uploader, sentinelDto *BackupSentinelDto, backupNa
 	meta.StartLsn = *sentinelDto.BackupStartLSN
 	meta.FinishLsn = *sentinelDto.BackupFinishLSN
 	meta.PgVersion = sentinelDto.PgVersion
+	meta.UserData = sentinelDto.UserData;
 
 	metaFile := storage.JoinPath(backupName, utility.MetadataFileName)
 	dtoBody, err := json.Marshal(meta)

--- a/internal/backup_sentinel_dto.go
+++ b/internal/backup_sentinel_dto.go
@@ -33,6 +33,8 @@ type ExtendedMetadataDto struct {
 	StartLsn       uint64    `json:"start_lsn"`
 	FinishLsn      uint64    `json:"finish_lsn"`
 	IsPermanent    bool      `json:"is_permanent"`
+
+	UserData interface{} `json:"UserData,omitempty"`
 }
 
 func (dto *BackupSentinelDto) setFiles(p *sync.Map) {


### PR DESCRIPTION
I think we should add a lot to metadata, like size of the db, size of backup, approx size of WAL. And fetch metadata on backup-list --json --detail.

This is the first step towards it.