### PR TITLE
Set compiled config to ENV

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -3,7 +3,9 @@ package internal
 import (
 	"github.com/spf13/viper"
 	"github.com/tinsane/tracelog"
+	"os"
 	"os/user"
+	"strings"
 )
 
 const (
@@ -114,5 +116,17 @@ func InitConfig() {
 	err := viper.ReadInConfig()
 	if err == nil {
 		tracelog.InfoLogger.Println("Using config file:", viper.ConfigFileUsed())
+	}
+
+	// Set compiled config to ENV.
+	// Applicable for Swift/Postgres/etc libs that waiting config paramenters only from ENV.
+	for k, v := range viper.AllSettings() {
+		val, ok := v.(string)
+		if ok {
+			if err := os.Setenv(strings.ToUpper(k), val); err != nil {
+				tracelog.ErrorLogger.Println("failed to bind config to env variable", err.Error())
+				os.Exit(1)
+			}
+		}
 	}
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -81,6 +81,8 @@ var (
 		"PGUSER":     true,
 		"PGHOST":     true,
 		"PGPASSWORD": true,
+		"PGDATABASE": true,
+		"PGSSLMODE":  true,
 
 		// Swift
 		"WALG_SWIFT_PREFIX": true,
@@ -200,7 +202,8 @@ func InitConfig() {
 	// Сheck allowed settings
 	foundNotAllowed := false
 	for k := range viper.AllSettings() {
-		if !IsAllowedSetting(strings.ToUpper(k), AllowedSettings) {
+		k = strings.ToUpper(k)
+		if !IsAllowedSetting(k, AllowedSettings) {
 			tracelog.WarningLogger.Println(k + " is unknown")
 			foundNotAllowed = true
 		}

--- a/internal/config.go
+++ b/internal/config.go
@@ -29,11 +29,14 @@ const (
 	PgpKeySetting                = "WALG_PGP_KEY"
 	PgpKeyPathSetting            = "WALG_PGP_KEY_PATH"
 	PgpKeyPassphraseSetting      = "WALG_PGP_KEY_PASSPHRASE"
-	PgDataSetting                = "PGDATA" // TODO : do something with it
-	UserSetting                  = "USER"   // TODO : do something with it
-	PgPortSetting                = "PGPORT" // TODO : do something with it
-	PgUserSetting                = "PGUSER" // TODO : do something with it
-	PgHostSetting                = "PGHOST" // TODO : do something with it
+	PgDataSetting                = "PGDATA"
+	UserSetting                  = "USER" // TODO : do something with it
+	PgPortSetting                = "PGPORT"
+	PgUserSetting                = "PGUSER"
+	PgHostSetting                = "PGHOST"
+	PgPasswordSetting            = "PGPASSWORD"
+	PgDatabaseSetting            = "PGDATABASE"
+	PgSslModeSetting             = "PGSSLMODE"
 	TotalBgUploadedLimit         = "TOTAL_BG_UPLOADED_LIMIT"
 	NameStreamCreateCmd          = "WALG_STREAM_CREATE_COMMAND"
 )
@@ -55,34 +58,35 @@ var (
 
 	AllowedSettings = map[string]bool{
 		// WAL-G core
-		"WALG_DOWNLOAD_CONCURRENCY":    true,
-		"WALG_UPLOAD_CONCURRENCY":      true,
-		"WALG_UPLOAD_DISK_CONCURRENCY": true,
-		"WALG_UPLOAD_QUEUE":            true,
-		"WALG_SENTINEL_USER_DATA":      true,
-		"WALG_PREVENT_WAL_OVERWRITE":   true,
-		"WALG_DELTA_MAX_STEPS":         true,
-		"WALG_DELTA_ORIGIN":            true,
-		"WALG_COMPRESSION_METHOD":      true,
-		"WALG_DISK_RATE_LIMIT":         true,
-		"WALG_NETWORK_RATE_LIMIT":      true,
-		"WALG_USE_WAL_DELTA":           true,
-		"WALG_LOG_LEVEL":               true,
-		"WALG_TAR_SIZE_THRESHOLD":      true,
-		"GPG_KEY_ID":                   true,
-		"WALG_PGP_KEY":                 true,
-		"WALG_PGP_KEY_PATH":            true,
-		"WALG_PGP_KEY_PASSPHRASE":      true,
-		"TOTAL_BG_UPLOADED_LIMIT":      true,
-		"WALG_STREAM_CREATE_COMMAND":   true,
+		DownloadConcurrencySetting:   true,
+		UploadConcurrencySetting:     true,
+		UploadDiskConcurrencySetting: true,
+		UploadQueueSetting:           true,
+		SentinelUserDataSetting:      true,
+		PreventWalOverwriteSetting:   true,
+		DeltaMaxStepsSetting:         true,
+		DeltaOriginSetting:           true,
+		CompressionMethodSetting:     true,
+		DiskRateLimitSetting:         true,
+		NetworkRateLimitSetting:      true,
+		UseWalDeltaSetting:           true,
+		LogLevelSetting:              true,
+		TarSizeThresholdSetting:      true,
+		"WALG_" + GpgKeyIDSetting:    true,
+		"WALE_" + GpgKeyIDSetting:    true,
+		PgpKeySetting:                true,
+		PgpKeyPathSetting:            true,
+		PgpKeyPassphraseSetting:      true,
+		TotalBgUploadedLimit:         true,
+		NameStreamCreateCmd:          true,
 
 		// Postgres
-		"PGPORT":     true,
-		"PGUSER":     true,
-		"PGHOST":     true,
-		"PGPASSWORD": true,
-		"PGDATABASE": true,
-		"PGSSLMODE":  true,
+		PgPortSetting:     true,
+		PgUserSetting:     true,
+		PgHostSetting:     true,
+		PgPasswordSetting: true,
+		PgDatabaseSetting: true,
+		PgSslModeSetting:  true,
 
 		// Swift
 		"WALG_SWIFT_PREFIX": true,
@@ -170,6 +174,13 @@ func Configure() {
 	}
 
 	ConfigureLimiters()
+
+	for _, adapter := range StorageAdapters {
+		for _,setting :=  range adapter.settingNames {
+			AllowedSettings[setting] = true
+		}
+		AllowedSettings["WALG_" + adapter.prefixName] = true
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/internal/config.go
+++ b/internal/config.go
@@ -52,7 +52,86 @@ var (
 		TarSizeThresholdSetting:      "1073741823", // (1 << 30) - 1
 		TotalBgUploadedLimit:         "32",
 	}
+
+	AllowedSettings = map[string]bool{
+		// WAL-G core
+		"WALG_DOWNLOAD_CONCURRENCY":    true,
+		"WALG_UPLOAD_CONCURRENCY":      true,
+		"WALG_UPLOAD_DISK_CONCURRENCY": true,
+		"WALG_UPLOAD_QUEUE":            true,
+		"WALG_SENTINEL_USER_DATA":      true,
+		"WALG_PREVENT_WAL_OVERWRITE":   true,
+		"WALG_DELTA_MAX_STEPS":         true,
+		"WALG_DELTA_ORIGIN":            true,
+		"WALG_COMPRESSION_METHOD":      true,
+		"WALG_DISK_RATE_LIMIT":         true,
+		"WALG_NETWORK_RATE_LIMIT":      true,
+		"WALG_USE_WAL_DELTA":           true,
+		"WALG_LOG_LEVEL":               true,
+		"WALG_TAR_SIZE_THRESHOLD":      true,
+		"GPG_KEY_ID":                   true,
+		"WALG_PGP_KEY":                 true,
+		"WALG_PGP_KEY_PATH":            true,
+		"WALG_PGP_KEY_PASSPHRASE":      true,
+		"TOTAL_BG_UPLOADED_LIMIT":      true,
+		"WALG_STREAM_CREATE_COMMAND":   true,
+
+		// Postgres
+		"PGPORT":     true,
+		"PGUSER":     true,
+		"PGHOST":     true,
+		"PGPASSWORD": true,
+
+		// Swift
+		"WALG_SWIFT_PREFIX": true,
+		"OS_AUTH_URL":       true,
+		"OS_USERNAME":       true,
+		"OS_PASSWORD":       true,
+		"OS_TENANT_NAME":    true,
+		"OS_REGION_NAME":    true,
+
+		// AWS s3
+		"WALE_S3_PREFIX":              true,
+		"AWS_ACCESS_KEY_ID":           true,
+		"AWS_SECRET_ACCESS_KEY":       true,
+		"AWS_SESSION_TOKEN":           true,
+		"AWS_DEFAULT_REGION":          true,
+		"AWS_DEFAULT_OUTPUT":          true,
+		"AWS_PROFILE":                 true,
+		"AWS_ROLE_SESSION_NAME":       true,
+		"AWS_CA_BUNDLE":               true,
+		"AWS_SHARED_CREDENTIALS_FILE": true,
+		"AWS_CONFIG_FILE":             true,
+		"AWS_REGION":                  true,
+		"AWS_ENDPOINT":                true,
+		"AWS_S3_FORCE_PATH_STYLE":     true,
+		"WALG_S3_CA_CERT_FILE":        true,
+		"WALG_S3_STORAGE_CLASS":       true,
+		"WALG_S3_SSE":                 true,
+		"WALG_S3_SSE_KMS_ID":          true,
+		"WALG_CSE_KMS_ID":             true,
+		"WALG_CSE_KMS_REGION":         true,
+
+		// Azure
+		"WALG_AZ_PREFIX":         true,
+		"AZURE_STORAGE_ACCOUNT":  true,
+		"AZURE_STORAGE_KEY":      true,
+		"WALG_AZURE_BUFFER_SIZE": true,
+		"WALG_AZURE_MAX_BUFFERS": true,
+
+		// GS
+		"WALG_GS_PREFIX":                 true,
+		"GOOGLE_APPLICATION_CREDENTIALS": true,
+
+		//File
+		"WALG_FILE_PREFIX": true,
+	}
 )
+
+func IsAllowedSetting(setting string, AllowedSettings map[string]bool) (exists bool) {
+	_, exists = AllowedSettings[setting]
+	return
+}
 
 func GetSetting(key string) (value string, ok bool) {
 	if viper.IsSet(key) {
@@ -116,6 +195,22 @@ func InitConfig() {
 	err := viper.ReadInConfig()
 	if err == nil {
 		tracelog.InfoLogger.Println("Using config file:", viper.ConfigFileUsed())
+	}
+
+	// Сheck allowed settings
+	foundNotAllowed := false
+	for k := range viper.AllSettings() {
+		if !IsAllowedSetting(strings.ToUpper(k), AllowedSettings) {
+			tracelog.WarningLogger.Println(k + " is unknown")
+			foundNotAllowed = true
+		}
+	}
+
+	// TODO delete in the future
+	// Message for the first time.
+	if foundNotAllowed {
+		tracelog.WarningLogger.Println("We found that some variables in your config file detected as 'Unknown'. \n  " +
+			"If this is not right, please create issue https://github.com/wal-g/wal-g/issues/new")
 	}
 
 	// Set compiled config to ENV.


### PR DESCRIPTION
Main problem that wal-g can't work with config file only. It still needed some ENV vars for swift/pg/etc.

This change set compiled config to ENV variables to have transparent config for all libs in wal-g.
And for now wal-g can work even only config file available, without ENV.