### PR TITLE
Changed Log level of message with info about used config file.

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -207,7 +207,7 @@ func InitConfig() {
 	// If a config file is found, read it in.
 	err := viper.ReadInConfig()
 	if err == nil {
-		tracelog.InfoLogger.Println("Using config file:", viper.ConfigFileUsed())
+		tracelog.DebugLogger.Println("Using config file:", viper.ConfigFileUsed())
 	}
 
 	// Сheck allowed settings


### PR DESCRIPTION
I think it will be better to change log level for message about config file path from INFO to DEVEL(or TRACE).
For now a see a lot of same rows in postgres log file.

```
INFO: 2019/10/17 13:09:46.558965 Using config file: /var/lib/postgresql/.walg.json
INFO: 2019/10/17 13:09:46.919855 Using config file: /var/lib/postgresql/.walg.json
INFO: 2019/10/17 13:09:47.426680 Using config file: /var/lib/postgresql/.walg.json
INFO: 2019/10/17 13:09:47.783755 Using config file: /var/lib/postgresql/.walg.json
INFO: 2019/10/17 13:09:48.252553 Using config file: /var/lib/postgresql/.walg.json
INFO: 2019/10/17 13:09:48.829940 Using config file: /var/lib/postgresql/.walg.json
INFO: 2019/10/17 13:09:49.200896 Using config file: /var/lib/postgresql/.walg.json
```