### PR TITLE
Added possibility to dump compiled ENV vars

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -173,6 +173,12 @@ func Configure() {
 		tracelog.ErrorLogger.FatalError(err)
 	}
 
+	// Show all ENV vars in DEVEL Logging Mode
+	tracelog.DebugLogger.Println("--- COMPILED ENVIRONMENT VARS ---")
+	for _, pair := range os.Environ() {
+		tracelog.DebugLogger.Println(pair)
+	}
+
 	ConfigureLimiters()
 
 	for _, adapter := range StorageAdapters {


### PR DESCRIPTION
Dump all ENV vars of wal-g runtime when DEVEL log level is set.
Can be useful in case of configuration problems in config file/env.