### PR TITLE
README: describe new GCS variables. Typos, grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Build Status](https://travis-ci.org/wal-g/wal-g.svg?branch=master)](https://travis-ci.org/wal-g/wal-g)
 [![Go Report Card](https://goreportcard.com/badge/github.com/wal-g/wal-g)](https://goreportcard.com/report/github.com/wal-g/wal-g)
 
-WAL-G is an archival restoration tool for Postgres(beta for MySQL, MongoDB and Redis)
+WAL-G is an archival restoration tool for Postgres(beta for MySQL, MongoDB, and Redis)
 
-WAL-G is the successor of WAL-E with a number of key differences. WAL-G uses LZ4, LZMA or Brotli compression, multiple processors and non-exclusive base backups for Postgres. More information on the design and implementation of WAL-G can be found on the Citus Data blog post ["Introducing WAL-G by Citus: Faster Disaster Recovery for Postgres"](https://www.citusdata.com/blog/2017/08/18/introducing-wal-g-faster-restores-for-postgres/).
+WAL-G is the successor of WAL-E with a number of key differences. WAL-G uses LZ4, LZMA, or Brotli compression, multiple processors, and non-exclusive base backups for Postgres. More information on the design and implementation of WAL-G can be found on the Citus Data blog post ["Introducing WAL-G by Citus: Faster Disaster Recovery for Postgres"](https://www.citusdata.com/blog/2017/08/18/introducing-wal-g-faster-restores-for-postgres/).
 
 **Table of Contents**
 - [Installation](#installation)
@@ -38,43 +38,43 @@ Configuration
 
 To connect to Amazon S3, WAL-G requires that this variable be set:
 
-* `WALG_S3_PREFIX` (eg. `s3://bucket/path/to/folder`) (alternative form `WALE_S3_PREFIX`)
+* `WALG_S3_PREFIX` (e.g. `s3://bucket/path/to/folder`) (alternative form `WALE_S3_PREFIX`)
 
-WAL-G determines AWS credentials [like other AWS tools](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence). You can set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (optionally with `AWS_SESSION_TOKEN`), or `~/.aws/credentials` (optionally with `AWS_PROFILE`), or you can set nothing to automatically fetch credentials from the EC2 metadata service.
+WAL-G determines AWS credentials [like other AWS tools](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence). You can set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (optionally with `AWS_SESSION_TOKEN`), or `~/.aws/credentials` (optionally with `AWS_PROFILE`), or you can set nothing to fetch credentials from the EC2 metadata service automatically.
 
 
 To store backups in Google Cloud Storage, WAL-G requires that this variable be set:
 
-* `WALG_GS_PREFIX` to specify where to store backups (eg. `gs://x4m-test-bucket/walg-folder`) 
+* `WALG_GS_PREFIX` to specify where to store backups (e.g. `gs://x4m-test-bucket/walg-folder`) 
 
 WAL-G determines Google Cloud credentials using [application-default credentials](https://cloud.google.com/docs/authentication/production) like other GCP tools. You can set `GOOGLE_APPLICATION_CREDENTIALS` to point to a service account json key from GCP. If you set nothing, WAL-G will attempt to fetch credentials from the GCE/GKE metadata service.
 
 
 To store backups in Azure Storage, WAL-G requires that this variable be set:
 
-* `WALG_AZ_PREFIX` to specify where to store backups in Azure storage (eg. `azure://test-container/walg-folder`)
+* `WALG_AZ_PREFIX` to specify where to store backups in Azure storage (e.g. `azure://test-container/walg-folder`)
 
 WAL-G determines Azure Storage credentials using [azure default credentials](https://docs.microsoft.com/en-us/azure/storage/common/storage-azure-cli#azure-cli-sample-script). You can set `AZURE_STORAGE_ACCOUNT`, `AZURE_STORAGE_ACCESS_KEY` to provide azure storage credentials.
 
-WAL-G sets default upload buffer size to 64 Megabytes, and uses 3 buffers by default. However, users can choose to override these values by setting optional environment variables.
+WAL-G sets default upload buffer size to 64 Megabytes and uses 3 buffers by default. However, users can choose to override these values by setting optional environment variables.
 
 
 To store backups in Swift object storage, WAL-G requires that this variable be set:
 
-* `WALG_SWIFT_PREFIX` to specify where to store backups in Swift object storage (eg. `swift://test-container/walg-folder`)
+* `WALG_SWIFT_PREFIX` to specify where to store backups in Swift object storage (e.g. `swift://test-container/walg-folder`)
 
 WAL-G determines Swift object storage credentials using [openStack default credentials](https://www.swiftstack.com/docs/cookbooks/swift_usage/auth.html). You can use any of V1, V2, V3 of the SwiftStack Auth middleware to provide Swift object storage credentials.
 
 
 To store backups on files system, WAL-G requires that these variables be set:
 
-* `WALG_FILE_PREFIX` (eg. `/tmp/wal-g-test-data`)
+* `WALG_FILE_PREFIX` (e.g. `/tmp/wal-g-test-data`)
 
 Please, keep in mind that by default storing backups on disk along with database is not safe. Do not use it as a disaster recovery plan.
 
 **Optional variables**
 
-* `AWS_REGION`(eg. `us-west-2`)
+* `AWS_REGION`(e.g. `us-west-2`)
 
 WAL-G can automatically determine the S3 bucket's region using `s3:GetBucketLocation`, but if you wish to avoid this API call or forbid it from the applicable IAM policy, specify this variable.
 
@@ -84,18 +84,26 @@ Overrides the default hostname to connect to an S3-compatible service. i.e, `htt
 
 * `AWS_S3_FORCE_PATH_STYLE`
 
-To enable path-style addressing(i.e., `http://s3.amazonaws.com/BUCKET/KEY`) when connecting to an S3-compatible service that lack of support for sub-domain style bucket URLs (i.e., `http://BUCKET.s3.amazonaws.com/KEY`). Defaults to `false`.
+To enable path-style addressing (i.e., `http://s3.amazonaws.com/BUCKET/KEY`) when connecting to an S3-compatible service that lack of support for sub-domain style bucket URLs (i.e., `http://BUCKET.s3.amazonaws.com/KEY`). Defaults to `false`.
 
-* `WALG_AZURE_BUFFER_SIZE` (eg. `33554432`)
+* `GCS_CONTEXT_TIMEOUT`
+
+Default: 1 hour.
+
+* `GCS_NORMALIZE_PREFIX`
+
+Controls the trimming of extra slashes in paths. The default is `true`. To allow restoring from WAL-E archives on GCS, set it to `false` and keep double slashes in `WALG_GS_PREFIX` values.
+
+* `WALG_AZURE_BUFFER_SIZE` (e.g. `33554432`)
 
 Overrides the default `upload buffer size` of 67108864 bytes (64 MB). Note that the size of the buffer must be specified in bytes. Therefore, to use 32 MB sized buffers, this variable should be set to 33554432 bytes.
 
-* `WALG_AZURE_MAX_BUFFERS` (eg. `5`)
+* `WALG_AZURE_MAX_BUFFERS` (e.g. `5`)
 
 Overrides the default `maximum number of upload buffers`. By default, at most 3 buffers are used concurrently.
 
-* `TOTAL_BG_UPLOADED_LIMIT` (eg. `1024`)
-Overrides the default `number of WAL files to upload during one scan`. By default, at most 32 wal files will be uploaded.
+* `TOTAL_BG_UPLOADED_LIMIT` (e.g. `1024`)
+Overrides the default `number of WAL files to upload during one scan`. By default, at most 32 WAL files will be uploaded.
 
 ***Example: Using Minio.io S3-compatible storage***
 
@@ -123,18 +131,18 @@ If using S3 server-side encryption with `aws:kms`, the KMS Key ID to use for obj
 
 * `WALG_CSE_KMS_ID`
 
-To configure AWS KMS key for client side encryption and decryption. By default, no encryption is used. (AWS_REGION or WALG_CSE_KMS_REGION required to be set when using AWS KMS key client side encryption)
+To configure AWS KMS key for client-side encryption and decryption. By default, no encryption is used. (AWS_REGION or WALG_CSE_KMS_REGION required to be set when using AWS KMS key client-side encryption)
 
 * `WALG_CSE_KMS_REGION`
 
-To configure AWS KMS key region for client side encryption and decryption (i.e., `eu-west-1`).
+To configure AWS KMS key region for client-side encryption and decryption (i.e., `eu-west-1`).
 
 * `WALG_COMPRESSION_METHOD`
 
-To configure compression method used for backups. Possible options are: `lz4`, 'lzma', 'brotli'. Default method is `lz4`. LZ4 is the fastest method, but compression ratio is bad.
-LZMA is way much slower, however it compresses backups about 6 times better than LZ4. Brotli is a good trade-off between speed and compression ratio which is about 3 times better than LZ4.
+To configure the compression method used for backups. Possible options are: `lz4`, 'lzma', 'brotli'. The default method is `lz4`. LZ4 is the fastest method, but the compression ratio is bad.
+LZMA is way much slower. However, it compresses backups about 6 times better than LZ4. Brotli is a good trade-off between speed and compression ratio, which is about 3 times better than LZ4.
 
-**More options are available for chosen database. See it in [Databases](#databases)**
+**More options are available for the chosen database. See it in [Databases](#databases)**
 
 Usage
 -----
@@ -147,13 +155,13 @@ Lists names and creation time of available backups.
 
 ``--pretty``  flag prints list in a table
 
-``--json`` flag prints list in json format, pretty-printed if combined with ``--pretty`` 
+``--json`` flag prints list in JSON format, pretty-printed if combined with ``--pretty`` 
 
 ``--detail`` flag prints extra backup details, pretty-printed if combined with ``--pretty`` , json-encoded if combined with ``--json`` 
 
 * ``delete``
 
-Is used to delete backups and WALs before them. By default ``delete`` will perform dry run. If you want to execute deletion you have to add ``--confirm`` flag at the end of the command. Backups marked as permanent will not be deleted.
+Is used to delete backups and WALs before them. By default ``delete`` will perform a dry run. If you want to execute deletion, you have to add ``--confirm`` flag at the end of the command. Backups marked as permanent will not be deleted.
 
 ``delete`` can operate in three modes: ``retain``, ``before`` and ``everything``.
 
@@ -163,13 +171,13 @@ if FULL is specified keep 5 full backups and everything in the middle
 
 ``before`` [FIND_FULL] %name%
 
-if FIND_FULL is specified WAL-G will calculate minimum backup needed to keep all deltas alive. If FIND_FULL is not specified and call can produce orphaned deltas - call will fail with the list.
+If `FIND_FULL` is specified, WAL-G will calculate minimum backup needed to keep all deltas alive. If FIND_FULL is not specified and call can produce orphaned deltas - the call will fail with the list.
 
 ``everything`` [FORCE]
 
 Examples: 
 
-``everything`` all backups will be deleted (if there is no permanent backups)
+``everything`` all backups will be deleted (if there are no permanent backups)
 
 ``everything FORCE`` all backups, include permanent, will be deleted
 
@@ -179,11 +187,11 @@ Examples:
 
 ``retain FIND_FULL`` will find necessary full for 5th
 
-``before base_000010000123123123`` will fail if base_000010000123123123 is delta
+``before base_000010000123123123`` will fail if `base_000010000123123123` is delta
 
 ``before FIND_FULL base_000010000123123123`` will keep everything after base of base_000010000123123123
 
-**More commands are available for chosen database. See it in [Databases](#databases)**
+**More commands are available for the chosen database engine. See it in [Databases](#databases)**
 
 Databases
 -----------
@@ -209,7 +217,7 @@ make unittest
 ```
 For more information on testing, please consult [test](test), [testtools](testtools) and `unittest` section in [Makefile](Makefile).
 
-WAL-G will perform a round-trip compression/decompression test that generates a directory for data (eg. data...), compressed files (eg. compressed), and extracted files (eg. extracted). These directories will only get cleaned up if the files in the original data directory match the files in the extracted one.
+WAL-G will perform a round-trip compression/decompression test that generates a directory for data (e.g. data...), compressed files (e.g. compressed), and extracted files (e.g. extracted). These directories will only get cleaned up if the files in the original data directory match the files in the extracted one.
 
 Test coverage can be obtained using:
 ```
@@ -234,11 +242,11 @@ License
 
 This project is licensed under the Apache License, Version 2.0, but the lzo support is licensed under GPL 3.0+. Please refer to the [LICENSE.md](LICENSE.md) file for more details.
 
-Acknowledgements
+Acknowledgments
 ----------------
 WAL-G would not have happened without the support of [Citus Data](https://www.citusdata.com/)
 
-WAL-G came into existence as a result of the collaboration between a summer engineering intern at Citus, Katie Li, and Daniel Farina, the original author of WAL-E who currently serves as a principal engineer on the Citus Cloud team. Citus Data also has an [open source extension to Postgres](https://github.com/citusdata) that distributes database queries horizontally to deliver scale and performance.
+WAL-G came into existence as a result of the collaboration between a summer engineering intern at Citus, Katie Li, and Daniel Farina, the original author of WAL-E, who currently serves as a principal engineer on the Citus Cloud team. Citus Data also has an [open source extension to Postgres](https://github.com/citusdata) that distributes database queries horizontally to deliver scale and performance.
 
 WAL-G development is supported by [Yandex Cloud](https://cloud.yandex.com)
 


### PR DESCRIPTION
- Mention `GCS_CONTEXT_TIMEOUT` and `GCS_NORMALIZE_PREFIX`
- Various typos and grammar fixes