### PR TITLE
Ignore deleted files during incremental backup

### DIFF
--- a/internal/bundle.go
+++ b/internal/bundle.go
@@ -536,7 +536,7 @@ func (bundle *Bundle) packFileIntoTar(path string, info os.FileInfo, fileInfoHea
 		}
 		fileReader, fileInfoHeader.Size, err = ReadIncrementalFile(path, info.Size(), *incrementBaseLsn, bitmap)
 		if os.IsNotExist(err) { // File was deleted before opening
-			bundle.skipFile(fileInfoHeader, info)
+			// We should ignore file here as if it did not exist.
 			return nil
 		}
 		switch err.(type) {


### PR DESCRIPTION
Recent fix in this area added those files to deleted list.
This can cause gargbae files in restored backup.
To prevent it, consider deleted file nonexistent.