### PR TITLE
Fix incorrect wal-g binlog fetching

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       &&  mkdir -p /export/mysqlbinlogpushbucket
       &&  mkdir -p /export/mysqldeleteendtoendbucket
       &&  mkdir -p /export/mysqlbinlogapplyuntilbucket
+      &&  mkdir -p /export/mysqlbinlogpushwhiles3downbucket
       &&  mkdir -p /export/mongostreampushbucket
       &&  mkdir -p /export/mongooplogpushbucket
       &&  mkdir -p /export/mongodeletebeforebucket

--- a/docker/mysql_tests/scripts/tests/binlog_push_while_s3_down_test.sh
+++ b/docker/mysql_tests/scripts/tests/binlog_push_while_s3_down_test.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+export WALE_S3_PREFIX=s3://mysqlbinlogpushwhiles3downbucket
+export WALG_COMPRESSION_METHOD=lz4
+
+export WALG_STREAM_RESTORE_COMMAND="xtrabackup --prepare --target-dir=${MYSQLDATA}"
+export WALG_LOG_APPLY_COMMAND=/root/testtools/test_apply.sh
+
+add_test_data() {
+  mysql -u sbtest -h localhost -e "
+  USE sbtest;
+  CREATE TABLE example ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );
+  INSERT INTO example ( id, name ) VALUES ( null, 'Sample data' );
+  "
+}
+
+check_test_additional_data() {
+  if [ -z "$(mysql -u sbtest -h localhost -e "USE sbtest; SHOW TABLES like 'example';")" ]; then
+    echo no data!!!
+    return 1
+  fi;
+  return 0
+}
+
+mysqld --initialize --init-file=/etc/mysql/init.sql
+
+service mysql start
+wal-g backup-push
+
+mysql -u sbtest -h localhost -e "FLUSH LOGS";
+add_test_data
+sleep 10
+mysql -u sbtest -h localhost -e "FLUSH LOGS" && sleep 10
+
+export UNTILL=$(date "+%Y-%m-%dT%H:%M:%S") && export WALG_MYSQL_BINLOG_END_TS=$(date --rfc-3339=ns | sed 's/ /T/') && sleep 20 && wal-g binlog-push  && kill_mysql_and_cleanup_data
+
+mkdir "${MYSQLDATA}"
+wal-g backup-fetch LATEST | xbstream -x -C "${MYSQLDATA}"
+
+
+# start mysql && try to apply binlogs
+chown -R mysql:mysql "${MYSQLDATA}"
+service mysql start && wal-g binlog-fetch --since LATEST --until "${WALG_MYSQL_BINLOG_END_TS}" --apply
+
+check_test_additional_data
+

--- a/internal/databases/mysql/binlog_fetch_handler_test.go
+++ b/internal/databases/mysql/binlog_fetch_handler_test.go
@@ -27,9 +27,7 @@ type TestBinlogHandlers struct {
 
 func (t TestBinlogHandlers) FetchLog(storage.Folder, string) (needAbortFetch bool, err error) {
 	tm, _ := parseFirstTimestampFromHeader(t.readSeekCloser)
-
 	return isBinlogCreatedAfterEndTs(time.Unix(int64(tm), 0), t.endTS), nil
-
 }
 
 func (t TestBinlogHandlers) HandleAbortFetch(logFilePath string) error {
@@ -108,16 +106,16 @@ func TestFetchBinlogs(t *testing.T) {
 
 func fillTestStorage() (*memory.Storage, time.Time) {
 	storage_ := memory.NewStorage()
-	storage_.Store(filepath.Join(BinlogPath, "mysql-bin-log.000017.lz4"), *bytes.NewBuffer([]byte{0x01, 0x00, 0x00, 0x00}))
-	storage_.Store(filepath.Join(BinlogPath, "mysql-bin-log.000018.lz4"), *bytes.NewBuffer([]byte{0x02, 0x00, 0x00, 0x00}))
+	storage_.Store(filepath.Join(BinlogPath, "mysql-bin-log.000017.lz4"), *bytes.NewBuffer([]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}))
+	storage_.Store(filepath.Join(BinlogPath, "mysql-bin-log.000018.lz4"), *bytes.NewBuffer([]byte{0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00}))
 	cutPoint := utility.TimeNowCrossPlatformUTC()
 	time.Sleep(time.Millisecond * 20)
 	// this binlog will be uploaded to storage too late (in terms of GetLastModified() func)
-	storage_.Store(filepath.Join(BinlogPath, "mysql-bin-log.000019.lz4"), *bytes.NewBuffer([]byte{0x03, 0x00, 0x00, 0x00}))
+	storage_.Store(filepath.Join(BinlogPath, "mysql-bin-log.000019.lz4"), *bytes.NewBuffer([]byte{0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00}))
 	time.Sleep(time.Millisecond * 20)
 
 	// we will parse 2 ** 31 - 1 from header - binlog will be too old
-	storage_.Store(filepath.Join(BinlogPath, "mysql-bin-log.000020.lz4"), *bytes.NewBuffer([]byte{0xFF, 0xFF, 0xFF, 0x7F}))
+	storage_.Store(filepath.Join(BinlogPath, "mysql-bin-log.000020.lz4"), *bytes.NewBuffer([]byte{0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0x7F}))
 
 	return storage_, cutPoint
 }

--- a/internal/start_command.go
+++ b/internal/start_command.go
@@ -41,6 +41,7 @@ func ApplyCommand(command []string, stdin io.Reader) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		tracelog.ErrorLogger.Printf("cmd.Run() failed with %s\n", err)
+		tracelog.InfoLogger.Printf("combined out:\n%s\n", string(out))
 		return err
 	}
 	tracelog.InfoLogger.Printf("combined out:\n%s\n", string(out))


### PR DESCRIPTION
Suppose s3 was unavailable from t1 to t2. If we try to push some binlogs while s3 is unavalable and then perform PITR on t3 such that t1 < t3 < t2,we will fail, because of incorrect condition in func logFileShouldBeFetched (let's not pay attention to end Timestamp - parse binlog first TS from binlog header is enough)