### PR TITLE
Add export CGO_LDFLAGS='-no-pie' to PostgreSQL.md

### DIFF
--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -6,6 +6,12 @@ Development
 -----------
 ### Installing
 
+Prepare on Ubuntu:
+```
+sudo apt-get install liblzo2-dev
+export CGO_LDFLAGS='-no-pie'
+```
+
 To compile and build the binary for Postgres:
 
 (To build with libsodium, just set `USE_LIBSODIUM` environment variable)


### PR DESCRIPTION
Fix relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIC