### PR TITLE
Workaround for mysqlbinlog problem

### DIFF
--- a/internal/backup_fetch_handler.go
+++ b/internal/backup_fetch_handler.go
@@ -91,13 +91,13 @@ func GetStreamFetcher(writeCloser io.WriteCloser) func(folder storage.Folder, ba
 
 func GetCommandStreamFetcher(cmd *exec.Cmd) func(folder storage.Folder, backup Backup) {
 	return func(folder storage.Folder, backup Backup) {
-		writer, err := cmd.StdinPipe()
+		stdin, err := cmd.StdinPipe()
 		tracelog.ErrorLogger.FatalfOnError("Failed to fetch backup: %v\n", err)
 		stderr := &bytes.Buffer{}
 		cmd.Stderr = stderr
 		err = cmd.Start()
 		tracelog.ErrorLogger.FatalfOnError("Failed to start restore command: %v\n", err)
-		err = downloadAndDecompressStream(&backup, writer)
+		err = downloadAndDecompressStream(&backup, stdin)
 		cmdErr := cmd.Wait()
 		if cmdErr != nil {
 			tracelog.ErrorLogger.Printf("Restore command output:\n%s", stderr.String())

--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -109,9 +109,6 @@ func (bl *BinlogReader) readEvent(buf []byte) (int, error) {
 
 func (bl *BinlogReader) Read(buf []byte) (int, error) {
 	blen := len(buf)
-	if blen < 4 {
-		panic("incoming buffer is too small") // for magic
-	}
 	// save magic and first event (aka header) into the temporary buffer
 	// and keep them until first appropriate event
 	if !bl.headerSaved {
@@ -133,10 +130,12 @@ func (bl *BinlogReader) Read(buf []byte) (int, error) {
 			}
 		}
 		// pass next event to client
-		read, err := bl.readEvent(buf[offset:])
-		offset += read
-		if err != nil || bl.tail > 0 {
-			return offset, err
+		if bl.tail > 0 {
+			read, err := bl.readEvent(buf[offset:])
+			offset += read
+			if err != nil || bl.tail > 0 {
+				return offset, err
+			}
 		}
 		// parse next event
 		hbuf, err := bl.reader.Peek(BinlogEventHeaderSize)

--- a/internal/databases/mysql/mysql_binlog_test.go
+++ b/internal/databases/mysql/mysql_binlog_test.go
@@ -139,7 +139,7 @@ func TestReadWholeBinlogWithDifferentChunks(t *testing.T) {
 		t.Errorf("failed to read data exapmple: %v", err)
 	}
 	// read binlog through binlog reader with different input and output chunk combinations
-	variants := []int{5, 13, 967, 11087}
+	variants := []int{3, 13, 967, 11087}
 	for _, underChunk := range variants {
 		for _, overChunk := range variants {
 			_, err = binlog.Seek(0, 0)


### PR DESCRIPTION
Mysqlbinlog have a bug reading binlog from pipe in case
when binlog written to pipe via small chunks.
It can be reproduced even without wal-g
cat any_binlog_file | buffer -b1 -s1024 | mysqlbinlog -v - > /dev/null

Writing using large buffers solves this issue.