### PR TITLE
Use newer pip for fixing build

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
     lzop \
     libbrotli1 && \
     rm -rf /var/lib/apt/lists/* && \
+    pip3 install --upgrade pip && \
     pip3 install git+https://github.com/wal-e/wal-e.git && \
     pip3 install boto
 


### PR DESCRIPTION
I don't know why, but newer pip uses whl, so we don't need to install python3-wheel, python3-dev, gcc, etc. to build wheel from source