### PR TITLE
Reimplement BgUploader and fix tests

### DIFF
--- a/internal/archive_status_manager_fake.go
+++ b/internal/archive_status_manager_fake.go
@@ -1,0 +1,42 @@
+package internal
+
+import "sync"
+
+type FakeASM struct {
+	uploaded map[string]bool
+	mutex    sync.Mutex
+}
+
+var _ ArchiveStatusManager = &FakeASM{}
+
+func NewFakeASM() *FakeASM {
+	return &FakeASM{
+		uploaded: make(map[string]bool),
+	}
+}
+
+func (asm *FakeASM) isWalAlreadyUploaded(walFilePath string) bool {
+	asm.mutex.Lock()
+	defer asm.mutex.Unlock()
+	isUploaded, ok := asm.uploaded[walFilePath]
+	return ok && isUploaded
+}
+
+// IsWalAlreadyUploaded is used for testing
+func (asm *FakeASM) IsWalAlreadyUploaded(walFilePath string) bool {
+	return asm.isWalAlreadyUploaded(walFilePath)
+}
+
+func (asm *FakeASM) markWalUploaded(walFilePath string) error {
+	asm.mutex.Lock()
+	defer asm.mutex.Unlock()
+	asm.uploaded[walFilePath] = true
+	return nil
+}
+
+func (asm *FakeASM) unmarkWalFile(walFilePath string) error {
+	asm.mutex.Lock()
+	defer asm.mutex.Unlock()
+	asm.uploaded[walFilePath] = false
+	return nil
+}

--- a/internal/bguploader.go
+++ b/internal/bguploader.go
@@ -63,8 +63,9 @@ func NewBgUploader(walFilePath string, maxParallelWorkers int32, maxNumUploaded 
 
 // Start up checking what's inside archive_status
 func (b *BgUploader) Start() {
-	if b.maxParallelWorkers < 1 {
-		return // Nothing to start
+	// Exit early if BgUploader is effectively disabled
+	if b.maxParallelWorkers < 1 || b.maxNumUploaded < 1 {
+		return
 	}
 
 	go b.scanFiles()

--- a/internal/bguploader.go
+++ b/internal/bguploader.go
@@ -22,9 +22,9 @@ const (
 	// segments
 	archiveStatusDir = "archive_status"
 
-	// pollPause defines the amount of time to pause before scanning the
+	// pollPauseDuration defines the amount of time to pause before scanning the
 	// filesystem again to find WAL segments
-	pollPause = 5 * time.Second
+	pollPauseDuration = 100 * time.Millisecond
 )
 
 // BgUploader represents the state of concurrent WAL upload
@@ -129,7 +129,7 @@ func (b *BgUploader) scanAndProcessFiles() {
 		select {
 		case <-b.ctx.Done():
 			return
-		case <-time.After(pollPause):
+		case <-time.After(pollPauseDuration):
 		}
 	}
 

--- a/internal/bguploader_test.go
+++ b/internal/bguploader_test.go
@@ -43,9 +43,16 @@ func TestBackgroundWALUpload(t *testing.T) {
 		{
 			name:                 "parallelism=1 with lots of files",
 			maxParallelism:       1,
-			numFilesOnDisk:       100,
+			numFilesOnDisk:       200,
 			maxNumFilesUploaded:  32,
 			wantNumFilesUploaded: 32,
+		},
+		{
+			name:                 "parallelism=3 with lots of files",
+			maxParallelism:       3,
+			numFilesOnDisk:       200,
+			maxNumFilesUploaded:  150,
+			wantNumFilesUploaded: 150,
 		},
 		{
 			name:                 "parallelism=10",

--- a/internal/bguploader_test.go
+++ b/internal/bguploader_test.go
@@ -36,6 +36,8 @@ func TestBackgroundWALUpload(t *testing.T) {
 
 	// Re-use generated data to test uploading WAL.
 	tu := testtools.NewMockWalUploader(false, false)
+	fakeASM := internal.NewFakeASM()
+	tu.ArchiveStatusManager = fakeASM
 	bu := internal.NewBgUploader(a, 16, tu, false)
 	// Look for new WALs while doing main upload
 	bu.Start()
@@ -46,9 +48,8 @@ func TestBackgroundWALUpload(t *testing.T) {
 
 	for i := 0; i < int(numBgUploadFiles); i++ {
 		bname := "B" + strconv.Itoa(i)
-		bd := filepath.Join(walgDataDir, "walg_archive_status", bname)
-		_, err := os.Stat(bd)
-		assert.Falsef(t, os.IsNotExist(err), bname+" status file was not created")
+		wasUploaded := fakeASM.IsWalAlreadyUploaded(bname)
+		assert.True(t, wasUploaded, bname+" was not marked as uploaded")
 	}
 
 	cleanup(t, dir)

--- a/internal/bguploader_test.go
+++ b/internal/bguploader_test.go
@@ -15,85 +15,93 @@ import (
 	"github.com/wal-g/wal-g/testtools"
 )
 
-// This test has known race condition. We expect that background worker will
-// upload 32 files. But we have no guarantees for this.
+// This test has known race condition. Since we cannot directly control
+// BgUploader's internals, the test will wait for 1 second to allow BgUploader
+// to run.
 func TestBackgroundWALUpload(t *testing.T) {
 	tests := []struct {
 		name                 string
+		maxParallelism       int
 		numFilesOnDisk       int
 		maxNumFilesUploaded  int
-		maxParallelism       int
-		wantNumFilesUploaded int
+		wantNumFilesUploaded int // This is more of a minimum. BgUploader may actually upload more files.
 	}{
 		{
-			name:                 "parallelism=1",
+			name:                 "parallelism=0 no-op",
+			maxParallelism:       0,
+			numFilesOnDisk:       10,
+			maxNumFilesUploaded:  32,
+			wantNumFilesUploaded: 0,
+		},
+		{
+			name:                 "parallelism=1 with a few files",
+			maxParallelism:       1,
+			numFilesOnDisk:       3,
+			maxNumFilesUploaded:  32,
+			wantNumFilesUploaded: 3,
+		},
+		{
+			name:                 "parallelism=1 with lots of files",
+			maxParallelism:       1,
 			numFilesOnDisk:       100,
 			maxNumFilesUploaded:  32,
-			maxParallelism:       1,
 			wantNumFilesUploaded: 32,
 		},
 		{
 			name:                 "parallelism=10",
+			maxParallelism:       10,
 			numFilesOnDisk:       100,
 			maxNumFilesUploaded:  32,
-			maxParallelism:       10,
 			wantNumFilesUploaded: 32,
 		},
 		{
 			name:                 "parallelism=100 and fewer files on disk",
+			maxParallelism:       100,
 			numFilesOnDisk:       16,
 			maxNumFilesUploaded:  32,
-			maxParallelism:       100,
 			wantNumFilesUploaded: 16,
 		},
 		{
 			name:                 "parallelism=100 and extra files on disk",
+			maxParallelism:       100,
 			numFilesOnDisk:       100,
 			maxNumFilesUploaded:  32,
-			maxParallelism:       100,
 			wantNumFilesUploaded: 32,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			internal.InitConfig()
-			totalBgUploadedLimitStr, ok := internal.GetSetting(internal.TotalBgUploadedLimit)
-			if !ok {
-				t.Fatalf("failed to get setting for %s", internal.TotalBgUploadedLimit)
-			}
-			numBgUploadFiles, err := strconv.Atoi(totalBgUploadedLimitStr)
-			if err != nil {
-				t.Fatalf("failed to parse setting for %s: %v", internal.TotalBgUploadedLimit, err)
-			}
+			defer cleanup(t, internal.GetDataFolderPath())
 
+			// Use generated data to test uploading WAL.
 			dir, a := setupArchiveStatus(t, "")
-			// create more files than the TotalBgUploadedLimit
 			for i := 0; i < tt.numFilesOnDisk; i++ {
 				addTestDataFile(t, dir, i)
 			}
+			defer cleanup(t, dir)
 
-			// Re-use generated data to test uploading WAL.
+			// Setup BgUploader
 			tu := testtools.NewMockWalUploader(false, false)
 			fakeASM := internal.NewFakeASM()
 			tu.ArchiveStatusManager = fakeASM
-			bu := internal.NewBgUploader(a, int32(tt.maxParallelism), int32(numBgUploadFiles), tu, false)
+			bu := internal.NewBgUploader(a, int32(tt.maxParallelism), int32(tt.maxNumFilesUploaded), tu, false)
 
-			// Look for new WALs while doing main upload
+			// Run BgUploader and wait 1 second before stopping
 			bu.Start()
-			time.Sleep(time.Second) // time to spin up new uploaders
+			// KLUDGE If maxParallelism=0, we expect to do no work. Therefore, do not wait.
+			if tt.maxParallelism > 0 {
+				time.Sleep(time.Second) // time to spin up new uploaders
+			}
 			bu.Stop()
 
-			walgDataDir := internal.GetDataFolderPath()
-
+			// Check that at least the expected number of files were created
 			for i := 0; i < tt.wantNumFilesUploaded; i++ {
 				bname := testFilename(i)
 				wasUploaded := fakeASM.IsWalAlreadyUploaded(bname)
 				assert.True(t, wasUploaded, bname+" was not marked as uploaded")
 			}
 
-			cleanup(t, dir)
-			cleanup(t, walgDataDir)
 		})
 	}
 }

--- a/internal/wal_push_handler.go
+++ b/internal/wal_push_handler.go
@@ -42,9 +42,10 @@ func HandleWALPush(uploader *WalUploader, walFilePath string) {
 	concurrency, err := getMaxUploadConcurrency()
 	tracelog.ErrorLogger.FatalOnError(err)
 
+	totalBgUploadedLimit := viper.GetInt32(TotalBgUploadedLimit)
 	preventWalOverwrite := viper.GetBool(PreventWalOverwriteSetting)
 
-	bgUploader := NewBgUploader(walFilePath, int32(concurrency-1), uploader, preventWalOverwrite)
+	bgUploader := NewBgUploader(walFilePath, int32(concurrency-1), totalBgUploadedLimit-1, uploader, preventWalOverwrite)
 	// Look for new WALs while doing main upload
 	bgUploader.Start()
 	err = uploadWALFile(uploader, walFilePath, bgUploader.preventWalOverwrite)


### PR DESCRIPTION
Individual commits are relatively self-contained and reviewable.

This PR
1. Fixes and extends test coverage for BgUploader. Previously the tests were completely broken and didn't run at all.
2. Re-implements a large portion of BgUploader, specifically targeting concurrency controls. My goal was to simplify the logic and it more easily understood.