### PR TITLE
Update wal-g/storages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,9 +52,9 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
-	github.com/tinsane/tracelog v0.0.0-20190824100002-0ab2b054ff30 // indirect
+	github.com/tinsane/tracelog v0.0.0-20190824100002-0ab2b054ff30
 	github.com/ulikunitz/xz v0.5.6
-	github.com/wal-g/storages v0.0.0-20200123152726-d4de6f533d23
+	github.com/wal-g/storages v0.0.0-20200511083259-4a94923055a1
 	github.com/wal-g/tracelog v0.0.0-20190824100002-0ab2b054ff30
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.1-0.20180714160509-73f8eece6fdc // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/wal-g/storages v0.0.0-20200123152726-d4de6f533d23 h1:mC+qJZc0FHIIjG/0QIvrSh17iKxZLcICXX9wDiyvkOY=
-github.com/wal-g/storages v0.0.0-20200123152726-d4de6f533d23/go.mod h1:t5AGFPrx4TEY8B3N2cbpsRKRi59N+habZHV2/tJgDbE=
+github.com/wal-g/storages v0.0.0-20200511083259-4a94923055a1 h1:3VxvHMolqIpZo1fhiNiY4vf4GtetiNvKbTWnZWZiNXw=
+github.com/wal-g/storages v0.0.0-20200511083259-4a94923055a1/go.mod h1:t5AGFPrx4TEY8B3N2cbpsRKRi59N+habZHV2/tJgDbE=
 github.com/wal-g/tracelog v0.0.0-20190824100002-0ab2b054ff30 h1:LoTfXAgZzRKuYVjWhP8dTDLBX+EUiMeRrdF7MynJ1RU=
 github.com/wal-g/tracelog v0.0.0-20190824100002-0ab2b054ff30/go.mod h1:onYsyKxs/aN2SHYnSw/ciYSGOPPYNHxJjxKNRVzLwNY=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=


### PR DESCRIPTION
I want to incorporate https://github.com/wal-g/storages/commit/4a94923055a146f86d375b2c99b4e5c8058e8090 into wal-g

To do this, I ran
1. `go get -u github.com/wal-g/storages`
2. `go tidy`

and then discarded all changes unrelated to the upgrade.

Side note: there seem to be a bunch of cruft in the `go.mod` and `go.sum` files. Running `go mod tidy` on master generates a non-zero diff for me (which I find surprising).