### PR TITLE
Sustain high-parallelism in wal-push during archive lag

### DIFF
--- a/internal/bguploader.go
+++ b/internal/bguploader.go
@@ -166,7 +166,8 @@ func (b *BgUploader) speculativelyGenerateNextWalFilenames(ctx context.Context, 
 	for i := 0; i < 100*int(b.maxNumUploaded); i++ {
 		nextWalSegment, err := GetNextWalFilename(walSegment)
 		if err != nil {
-			tracelog.InfoLogger.Printf("failed to parse %s as wal segment name: %v", walSegment, err)
+			// couldn't generate next WAL segment name, stop try to
+			// guess next WAL
 			return
 		}
 

--- a/internal/bguploader_test.go
+++ b/internal/bguploader_test.go
@@ -2,7 +2,6 @@ package internal_test
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -244,10 +243,7 @@ type stallableDataFolder struct {
 func (s *stallableDataFolder) ListFilenames() ([]string, error) {
 	select {
 	case <-s.ctx.Done():
-		return nil, fmt.Errorf(
-			"fake dir reader was cancelled before wait completed: %v",
-			s.ctx.Err(),
-		)
+		return []string{}, nil
 	case <-time.After(s.waitDuration):
 	}
 

--- a/internal/data_folder.go
+++ b/internal/data_folder.go
@@ -21,6 +21,8 @@ func (err NoSuchFileError) Error() string {
 }
 
 type DataFolder interface {
+	// ListFilenames returns a list of sorted filenames
+	ListFilenames() (filenames []string, err error)
 	// OpenReadonlyFile should return NoSuchFileError if it cannot find desired file
 	OpenReadonlyFile(filename string) (io.ReadCloser, error)
 	OpenWriteOnlyFile(filename string) (io.WriteCloser, error)

--- a/internal/disk_data_folder.go
+++ b/internal/disk_data_folder.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -16,6 +17,18 @@ func newDiskDataFolder(folderPath string) (*DiskDataFolder, error) {
 		return nil, err
 	}
 	return &DiskDataFolder{folderPath}, nil
+}
+
+func (folder *DiskDataFolder) ListFilenames() ([]string, error) {
+	files, err := ioutil.ReadDir(folder.path)
+	if err != nil {
+		return nil, err
+	}
+	filenames := []string{}
+	for _, file := range files {
+		filenames = append(filenames, file.Name())
+	}
+	return filenames, nil
 }
 
 func (folder *DiskDataFolder) OpenReadonlyFile(filename string) (io.ReadCloser, error) {

--- a/internal/timeline.go
+++ b/internal/timeline.go
@@ -68,7 +68,8 @@ func getWalFilename(lsn uint64, conn *pgx.Conn) (walFilename string, timeline ui
 	return walSegmentNo.getFilename(timeline), timeline, nil
 }
 
-func formatWALFileName(timeline uint32, logSegNo uint64) string {
+// FormatWALFilename returns the filename which corresponds to a given WAL segment.
+func FormatWALFilename(timeline uint32, logSegNo uint64) string {
 	return fmt.Sprintf(walFileFormat, timeline, logSegNo/xLogSegmentsPerXLogId, logSegNo%xLogSegmentsPerXLogId)
 }
 
@@ -115,7 +116,7 @@ func GetNextWalFilename(name string) (string, error) {
 		return "", err
 	}
 	logSegNo++
-	return formatWALFileName(uint32(timelineId), logSegNo), nil
+	return FormatWALFilename(uint32(timelineId), logSegNo), nil
 }
 
 func shouldPrefault(name string) (lsn uint64, shouldPrefault bool, timelineId uint32, err error) {

--- a/internal/wal_delta_util.go
+++ b/internal/wal_delta_util.go
@@ -28,7 +28,7 @@ func GetDeltaFilenameFor(walFilename string) (string, error) {
 		return "", err
 	}
 	deltaSegNo := logSegNo - (logSegNo % WalFileInDelta)
-	return toDeltaFilename(formatWALFileName(timeline, deltaSegNo)), nil
+	return toDeltaFilename(FormatWALFilename(timeline, deltaSegNo)), nil
 }
 
 func GetPositionInDelta(walFilename string) int {

--- a/testtools/mock_data_folder.go
+++ b/testtools/mock_data_folder.go
@@ -4,11 +4,26 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"sort"
 
 	"github.com/wal-g/wal-g/internal"
 )
 
 type MockDataFolder map[string]*bytes.Buffer
+
+func NewMockDataFolder() *MockDataFolder {
+	dataFolder := MockDataFolder(make(map[string]*bytes.Buffer))
+	return &dataFolder
+}
+
+func (folder *MockDataFolder) ListFilenames() ([]string, error) {
+	filenames := []string{}
+	for filename, _ := range *folder {
+		filenames = append(filenames, filename)
+	}
+	sort.Strings(filenames)
+	return filenames, nil
+}
 
 func (folder *MockDataFolder) FileExists(filename string) bool {
 	_, ok := (*folder)[filename]
@@ -27,11 +42,6 @@ func (folder *MockDataFolder) CreateFile(filename string) error {
 
 func (folder *MockDataFolder) CleanFolder() error {
 	return nil
-}
-
-func NewMockDataFolder() *MockDataFolder {
-	dataFolder := MockDataFolder(make(map[string]*bytes.Buffer))
-	return &dataFolder
 }
 
 func (folder *MockDataFolder) IsEmpty() bool {


### PR DESCRIPTION
This PR implements a lightweight performance optimization which should help sustain high wal-push concurrency even when WAL archiving falls behind.

When WAL archiving lags significantly and `pg_wal` grows very large (in my experience: >500GB), this can reduce the actual parallelism of wal-push. Before, BgUploader solely used `ioutil.ReadDir` to find other WAL files to upload while the "main" WAL file is being uploaded. When the main upload is complete, BgUploader is stopped - all running uploads are allowed to complete but no new files are enqueued. If `ioutil.ReadDir` is very slow (worst case: slower than main WAL upload), this can cause BgUploader to exit before it even uploads any WALs. This effectively reduces wal-push parallelism.

This PR adds "speculative WAL filename generation" which effectively short-circuits the filesystem scan (which finds actual WAL files on disk) and guesses for subsequent WAL files which are expected to exist given the main WAL filename. This process races against `ioutil.ReadDir` and is stopped as soon as the filesystem scan returns successfully (or a maximum number of guesses have been made, which ever comes first).

Test coverage in BgUploader has been extended to simulate a slow filesystem scan. The individual commits should be reviewable.