### PR TITLE
[fdb] improve integration tests

### DIFF
--- a/docker/fdb_tests/Dockerfile
+++ b/docker/fdb_tests/Dockerfile
@@ -13,6 +13,11 @@ COPY main/ main/
 COPY utility/ utility/
 COPY Makefile Makefile
 
+RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
+        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
+    cd main/fdb && \
+    go build -mod vendor -tags brotli -race -o wal-g -ldflags "-s -w -X main.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+    
 RUN make fdb_build
 
 FROM foundationdb/foundationdb:latest

--- a/docker/fdb_tests/scripts/tests/full_backup_test.sh
+++ b/docker/fdb_tests/scripts/tests/full_backup_test.sh
@@ -11,13 +11,17 @@ mkdir $WALG_FILE_PREFIX
 
 wal-g backup-push
 
-fdbcli -C /var/fdb/fdb.cluster --exec 'writemode on; clearrange "" \xFF'
+expected_output=$(fdbcli -C /var/fdb/fdb.cluster --exec 'getrange "" "\xFF" 10000')
+
+fdbcli -C /var/fdb/fdb.cluster --exec 'writemode on; clearrange "" "\xFF"'
 
 wal-g backup-fetch LATEST
 
-actual_output=$(fdbcli -C /var/fdb/fdb.cluster --exec 'get test_key')
+actual_output=$(fdbcli -C /var/fdb/fdb.cluster --exec 'getrange "" "\xFF" 10000')
 
-if [ "$actual_output" != "\`test_key' is \`test_value'" ]; then
-  echo "Unexpected output: $actual_output"
+if [ "$actual_output" != "$expected_output" ]; then
+  echo "Error: actual output doesn't match expected output"
+  echo "Expected output: $expected_output"
+  echo "Actual output: $actual_output"
   exit 1
 fi

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
-	github.com/tinsane/tracelog v0.0.0-20190824100002-0ab2b054ff30
+	github.com/tinsane/tracelog v0.0.0-20190824100002-0ab2b054ff30 // indirect
 	github.com/ulikunitz/xz v0.5.6
 	github.com/wal-g/storages v0.0.0-20200511083259-4a94923055a1
 	github.com/wal-g/tracelog v0.0.0-20190824100002-0ab2b054ff30

--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,7 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191112182307-2180aed22343 h1:00ohfJ4K98s3m6BGUoBd8nyfp4Yl0GoIKvw5abItTjI=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=


### PR DESCRIPTION
Generalize backup restoration checking: instead of checking inserted key-value pair check the whole logical backup.
Additionally, fix tests failing because of compilation issues