### PR TITLE
Mariadb full backup tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,12 @@ mysql_clean:
 mysql_install: mysql_build
 	mv $(MAIN_MYSQL_PATH)/wal-g $(GOBIN)/wal-g
 
+mariadb_test: install deps mysql_build lint unlink_brotli mariadb_integration_test
+
+mariadb_integration_test: load_docker_common
+	docker-compose build mariadb mariadb_tests
+	docker-compose up --exit-code-from mariadb_tests mariadb_tests
+
 mongo_test: install deps mongo_build lint unlink_brotli
 
 mongo_build: $(CMD_FILES) $(PKG_FILES)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       &&  mkdir -p /export/mysqlbinlogreplaybucket
       &&  mkdir -p /export/mysqlpitrxtrabackupbucket
       &&  mkdir -p /export/mysqlpitrmysqldumpbucket
+      &&  mkdir -p /export/mariadbfullmysqldumpbucket
+      &&  mkdir -p /export/mariadbfullmariabackupbucket
       &&  mkdir -p /export/mongostreampushbucket
       &&  mkdir -p /export/mongooplogpushbucket
       &&  mkdir -p /export/mongodeletebeforebucket
@@ -356,6 +358,28 @@ services:
       - seccomp:unconfined
     image: wal-g/mysql_tests
     container_name: wal-g_mysql_tests
+    env_file:
+      - docker/common/common_walg.env
+    depends_on:
+      - s3
+    links:
+      - s3
+
+  mariadb:
+    build:
+      dockerfile: docker/mariadb/Dockerfile
+      context: .
+    image: wal-g/mariadb
+    container_name: wal-g_mariadb
+
+  mariadb_tests:
+    build:
+      dockerfile: docker/mariadb_tests/Dockerfile
+      context: .
+    security_opt:
+      - seccomp:unconfined
+    image: wal-g/mariadb_tests
+    container_name: wal-g_mariadb_tests
     env_file:
       - docker/common/common_walg.env
     depends_on:

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -1,0 +1,26 @@
+FROM wal-g/ubuntu:latest
+
+# mb not another path
+ENV MYSQLDATA /var/lib/mysql
+
+# fixme: the package of MariaDB 10.4 doesn't work in this environement because it's not being added to the services.
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends --no-install-suggests software-properties-common dirmngr gnupg2 curl && \
+    curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | /bin/bash -s -- --mariadb-server-version="mariadb-10.3" && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+    mariadb-server \
+    mariadb-client \
+    mariadb-backup
+
+RUN curl -s https://packagecloud.io/install/repositories/akopytov/sysbench/script.deb.sh | bash && apt -y install sysbench
+RUN rm -rf $MYSQLDATA
+
+COPY docker/mariadb/client.cnf /root/.my.cnf
+COPY docker/mariadb/client.cnf /etc/mysql/debian.cnf
+COPY docker/mariadb/init.sql /etc/mysql/init.sql
+COPY docker/mariadb/export_common.sh /usr/local/export_common.sh
+
+# append
+COPY docker/mariadb/my.cnf /tmp/my.cnf
+RUN cat /tmp/my.cnf >> /etc/mysql/my.cnf; rm /tmp/my.cnf

--- a/docker/mariadb/client.cnf
+++ b/docker/mariadb/client.cnf
@@ -1,0 +1,11 @@
+[client]
+user = sbtest
+host = localhost
+port = 3306
+protocol = tcp
+
+[mysqldump]
+user = sbtest
+host = localhost
+port = 3306
+comments = OFF

--- a/docker/mariadb/export_common.sh
+++ b/docker/mariadb/export_common.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# common wal-g settings
+export WALG_MYSQL_DATASOURCE_NAME=sbtest:@/sbtest
+export WALG_STREAM_CREATE_COMMAND="mariabackup --backup --stream=xbstream --user=sbtest --host=localhost --datadir=${MYSQLDATA}"
+export WALG_STREAM_RESTORE_COMMAND="mbstream -x -C ${MYSQLDATA}"
+export WALG_MYSQL_BACKUP_PREPARE_COMMAND="mariabackup --prepare --target-dir=${MYSQLDATA}"
+
+
+# test tools
+mariadb_kill_and_clean_data() {
+    kill -9 `pidof mysqld` || true
+    rm -rf "${MYSQLDATA}"/*
+    rm -rf /root/.walg_mysql_binlogs_cache
+}
+
+sysbench() {
+    # shellcheck disable=SC2068
+    /usr/bin/sysbench --db-driver=mysql --verbosity=0 /usr/share/sysbench/oltp_insert.lua $@
+}
+
+date3339() {
+    date --rfc-3339=ns | sed 's/ /T/'
+}

--- a/docker/mariadb/init.sql
+++ b/docker/mariadb/init.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE sbtest;
+CREATE USER sbtest@localhost;
+GRANT ALL PRIVILEGES ON *.* TO sbtest@localhost WITH GRANT OPTION;

--- a/docker/mariadb/my.cnf
+++ b/docker/mariadb/my.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+datadir = /var/lib/mysql
+init_file = /etc/mysql/init.sql
+server_id = 1
+binlog_format = ROW
+log_bin = mysql-bin
+log_bin_index = /var/lib/mysql/mysql-bin.index
+
+[mariadb]
+log_error=/var/log/mysql/error.log

--- a/docker/mariadb_tests/Dockerfile
+++ b/docker/mariadb_tests/Dockerfile
@@ -1,0 +1,27 @@
+FROM wal-g/golang:latest as build
+
+WORKDIR /go/src/github.com/wal-g/wal-g
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends --no-install-suggests
+
+COPY go.mod go.mod
+COPY vendor/ vendor/
+COPY internal/ internal/
+COPY cmd/ cmd/
+COPY main/ main/
+COPY utility/ utility/
+
+RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
+        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
+    cd main/mysql && \
+    go build -mod vendor -tags brotli -race -o wal-g -ldflags "-s -w -X main.BuildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+
+FROM wal-g/mariadb:latest
+COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin
+
+RUN mkdir /root/testtools
+
+COPY docker/mariadb_tests/scripts/ /tmp
+
+CMD /tmp/run_integration_tests.sh

--- a/docker/mariadb_tests/scripts/run_integration_tests.sh
+++ b/docker/mariadb_tests/scripts/run_integration_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+. /usr/local/export_common.sh
+
+for i in /tmp/tests/*; do
+  echo
+  echo "===== RUNNING $i ====="
+  set -x
+  "$i"
+  set +x
+  echo "===== SUCCESS $i ====="
+  echo
+  mariadb_kill_and_clean_data
+done

--- a/docker/mariadb_tests/scripts/tests/full_mariabackup_test.sh
+++ b/docker/mariadb_tests/scripts/tests/full_mariabackup_test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mariadbfullmariabackupbucket
+
+
+mysql_install_db > /dev/null
+service mysql start
+
+sysbench --table-size=10 prepare
+
+sysbench --time=5 run
+
+mysql -e 'FLUSH LOGS'
+
+mysqldump sbtest > /tmp/dump_before_backup
+
+wal-g backup-push
+
+mariadb_kill_and_clean_data
+
+wal-g backup-fetch LATEST
+
+chown -R mysql:mysql $MYSQLDATA
+
+mysql_install_db > /dev/null
+service mysql start || (cat /var/log/mysql/error.log && false)
+
+mysqldump sbtest > /tmp/dump_after_restore
+
+diff /tmp/dump_before_backup /tmp/dump_after_restore

--- a/docker/mariadb_tests/scripts/tests/full_mysqldump_test.sh
+++ b/docker/mariadb_tests/scripts/tests/full_mysqldump_test.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mariadbfullmysqldumpbucket
+export WALG_STREAM_CREATE_COMMAND="mysqldump --all-databases --single-transaction"
+export WALG_STREAM_RESTORE_COMMAND="mysql"
+export WALG_MYSQL_BACKUP_PREPARE_COMMAND=
+
+
+mysql_install_db > /dev/null
+service mysql start
+
+sysbench --table-size=10 prepare
+
+sysbench --time=5 run
+
+mysql -e 'FLUSH LOGS'
+
+mysqldump sbtest > /tmp/dump_before_backup
+
+wal-g backup-push
+
+
+ps aux | grep mysqld_safe
+
+mariadb_kill_and_clean_data
+
+mysql_install_db > /dev/null
+service mysql start
+
+wal-g backup-fetch LATEST
+
+mysqldump sbtest > /tmp/dump_after_restore
+
+diff /tmp/dump_before_backup /tmp/dump_after_restore


### PR DESCRIPTION
As it was said [here](https://github.com/wal-g/wal-g/pull/638) by @pushrbx the full backup logic is exactly the same as MySQL, but with different create/restore/prepare commands setup. As for PITR:
The logic should also be similar, despite the fact that there is no documentation. I was able to contact with Geoff Montee from MariaDB corp and talk about PITR with mysqlbinlog. He confirmed that there are no differences, except things like [this](https://github.com/wal-g/wal-g/blob/7201ce0765ac2f0dec2828065c05adfd9e34bfad/docker/mysql/export_common.sh#L26), but this is not related to implementation.

But for some reason can't achieve a successful test for PITR with mysqlbinlog. Still working on it