### PR TITLE
Add environment variables for reverse unpack

### DIFF
--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -129,8 +129,11 @@ WAL-G can also fetch the latest backup using:
 wal-g backup-fetch ~/extract/to/here LATEST
 ```
 
-Beta feature: WAL-G can unpack delta backups in reverse order to improve fetch efficiency. To activate this feature, add the --reverse-unpack flag:
+Beta feature: WAL-G can unpack delta backups in reverse order to improve fetch efficiency. 
+To activate this feature, do one of the following:
 
+* set the `WALG_USE_REVERSE_UNPACK`environment variable
+* add the --reverse-unpack flag
 ```
 wal-g backup-fetch ~/extract/to/here LATEST --reverse-unpack
 ```

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/wal-g/storages/storage"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -29,7 +30,8 @@ var backupFetchCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		var pgFetcher func(folder storage.Folder, backup internal.Backup)
-		if reverseDeltaUnpack {
+		useReverseUnpackEnv := viper.GetBool(internal.UseReverseUnpackSetting)
+		if reverseDeltaUnpack || useReverseUnpackEnv {
 			pgFetcher = internal.GetPgFetcherNew(args[0], fileMask, restoreSpec)
 		} else {
 			pgFetcher = internal.GetPgFetcherOld(args[0], fileMask, restoreSpec)

--- a/internal/config.go
+++ b/internal/config.go
@@ -27,6 +27,7 @@ const (
 	DiskRateLimitSetting         = "WALG_DISK_RATE_LIMIT"
 	NetworkRateLimitSetting      = "WALG_NETWORK_RATE_LIMIT"
 	UseWalDeltaSetting           = "WALG_USE_WAL_DELTA"
+	UseReverseUnpackSetting      = "WALG_USE_REVERSE_UNPACK"
 	LogLevelSetting              = "WALG_LOG_LEVEL"
 	TarSizeThresholdSetting      = "WALG_TAR_SIZE_THRESHOLD"
 	CseKmsIDSetting              = "WALG_CSE_KMS_ID"
@@ -76,6 +77,7 @@ var (
 		UseWalDeltaSetting:           "false",
 		TarSizeThresholdSetting:      "1073741823", // (1 << 30) - 1
 		TotalBgUploadedLimit:         "32",
+		UseReverseUnpackSetting:      "false",
 
 		OplogArchiveTimeoutSetting:    "60",
 		OplogArchiveAfterSize:         "16777216", // 32 << (10 * 2)
@@ -106,6 +108,7 @@ var (
 		TotalBgUploadedLimit:         true,
 		NameStreamCreateCmd:          true,
 		NameStreamRestoreCmd:         true,
+		UseReverseUnpackSetting:      true,
 
 		// Postgres
 		PgPortSetting:     true,


### PR DESCRIPTION
Reverse unpack now can be turned on using `WALG_USE_REVERSE_UNPACK` environment variable