### PR TITLE
Refactoring for reverse delta unpack

### DIFF
--- a/internal/catchup_file_unwrapper.go
+++ b/internal/catchup_file_unwrapper.go
@@ -14,7 +14,11 @@ type CatchupFileUnwrapper struct {
 
 func (u *CatchupFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Header, file *os.File) error {
 	if u.options.isIncremented {
-		err := CreateFileFromIncrement(reader, file)
+		fileInfo, err := file.Stat()
+		if err != nil {
+			return err
+		}
+		err = CreateFileFromIncrement(reader, NewReadWriterAtFrom(file, fileInfo))
 		return errors.Wrapf(err, "Interpret: failed to create file from increment '%s'", file.Name())
 	}
 
@@ -23,7 +27,11 @@ func (u *CatchupFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Heade
 
 func (u *CatchupFileUnwrapper) UnwrapExistingFile(reader io.Reader, header *tar.Header, file *os.File) error {
 	if u.options.isIncremented {
-		err := WritePagesFromIncrement(reader, file, true)
+		fileInfo, err := file.Stat()
+		if err != nil {
+			return err
+		}
+		err = WritePagesFromIncrement(reader, NewReadWriterAtFrom(file, fileInfo), true)
 		return errors.Wrapf(err, "Interpret: failed to write increment to file '%s'", file.Name())
 	}
 

--- a/internal/catchup_file_unwrapper.go
+++ b/internal/catchup_file_unwrapper.go
@@ -1,0 +1,37 @@
+package internal
+
+import (
+	"archive/tar"
+	"github.com/pkg/errors"
+	"io"
+	"os"
+)
+
+// CatchupFileUnwrapper is used for catchup (catchup-push) backups
+type CatchupFileUnwrapper struct {
+	BackupFileUnwrapper
+}
+
+func (u *CatchupFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Header, file *os.File) error {
+	if u.options.isIncremented {
+		err := CreateFileFromIncrement(reader, file)
+		return errors.Wrapf(err, "Interpret: failed to create file from increment '%s'", file.Name())
+	}
+
+	return u.writeLocalFile(reader, header, file)
+}
+
+func (u *CatchupFileUnwrapper) UnwrapExistingFile(reader io.Reader, header *tar.Header, file *os.File) error {
+	if u.options.isIncremented {
+		err := WritePagesFromIncrement(reader, file, true)
+		return errors.Wrapf(err, "Interpret: failed to write increment to file '%s'", file.Name())
+	}
+
+	// clear the local file because there is a newer version for it
+	err := u.clearLocalFile(file)
+	if err != nil {
+		return err
+	}
+
+	return u.writeLocalFile(reader, header, file)
+}

--- a/internal/catchup_file_unwrapper.go
+++ b/internal/catchup_file_unwrapper.go
@@ -14,11 +14,11 @@ type CatchupFileUnwrapper struct {
 
 func (u *CatchupFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Header, file *os.File) error {
 	if u.options.isIncremented {
-		fileInfo, err := file.Stat()
+		targetReadWriterAt, err := NewReadWriterAtFrom(file)
 		if err != nil {
 			return err
 		}
-		err = CreateFileFromIncrement(reader, NewReadWriterAtFrom(file, fileInfo))
+		err = CreateFileFromIncrement(reader, targetReadWriterAt)
 		return errors.Wrapf(err, "Interpret: failed to create file from increment '%s'", file.Name())
 	}
 
@@ -27,11 +27,11 @@ func (u *CatchupFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Heade
 
 func (u *CatchupFileUnwrapper) UnwrapExistingFile(reader io.Reader, header *tar.Header, file *os.File) error {
 	if u.options.isIncremented {
-		fileInfo, err := file.Stat()
+		targetReadWriterAt, err := NewReadWriterAtFrom(file)
 		if err != nil {
 			return err
 		}
-		err = WritePagesFromIncrement(reader, NewReadWriterAtFrom(file, fileInfo), true)
+		err = WritePagesFromIncrement(reader, targetReadWriterAt, true)
 		return errors.Wrapf(err, "Interpret: failed to write increment to file '%s'", file.Name())
 	}
 

--- a/internal/default_file_unwrapper.go
+++ b/internal/default_file_unwrapper.go
@@ -1,0 +1,37 @@
+package internal
+
+import (
+	"archive/tar"
+	"github.com/pkg/errors"
+	"io"
+	"os"
+)
+
+// DefaultFileUnwrapper is used for default (backup-push) backups
+type DefaultFileUnwrapper struct {
+	BackupFileUnwrapper
+}
+
+func (u *DefaultFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Header, file *os.File) error {
+	if u.options.isIncremented {
+		err := CreateFileFromIncrement(reader, file)
+		return errors.Wrapf(err, "Interpret: failed to create file from increment '%s'", file.Name())
+	}
+
+	return u.writeLocalFile(reader, header, file)
+}
+
+func (u *DefaultFileUnwrapper) UnwrapExistingFile(reader io.Reader, header *tar.Header, file *os.File) error {
+	if u.options.isIncremented {
+		err := WritePagesFromIncrement(reader, file, false)
+		return errors.Wrapf(err, "Interpret: failed to write increment to file '%s'", file.Name())
+	}
+
+	if u.options.isPageFile {
+		err := RestoreMissingPages(reader, file)
+		return errors.Wrapf(err, "Interpret: failed to restore pages for file '%s'", file.Name())
+	}
+
+	// skip the non-page file because newer version is already on the disk
+	return nil
+}

--- a/internal/default_file_unwrapper.go
+++ b/internal/default_file_unwrapper.go
@@ -14,11 +14,11 @@ type DefaultFileUnwrapper struct {
 
 func (u *DefaultFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Header, file *os.File) error {
 	if u.options.isIncremented {
-		fileInfo, err := file.Stat()
+		targetReadWriterAt, err := NewReadWriterAtFrom(file)
 		if err != nil {
 			return err
 		}
-		err = CreateFileFromIncrement(reader, NewReadWriterAtFrom(file, fileInfo))
+		err = CreateFileFromIncrement(reader, targetReadWriterAt)
 		return errors.Wrapf(err, "Interpret: failed to create file from increment '%s'", file.Name())
 	}
 
@@ -26,17 +26,17 @@ func (u *DefaultFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Heade
 }
 
 func (u *DefaultFileUnwrapper) UnwrapExistingFile(reader io.Reader, header *tar.Header, file *os.File) error {
-	fileInfo, err := file.Stat()
+	targetReadWriterAt, err := NewReadWriterAtFrom(file)
 	if err != nil {
 		return err
 	}
 	if u.options.isIncremented {
-		err := WritePagesFromIncrement(reader, NewReadWriterAtFrom(file, fileInfo), false)
+		err := WritePagesFromIncrement(reader, targetReadWriterAt, false)
 		return errors.Wrapf(err, "Interpret: failed to write increment to file '%s'", file.Name())
 	}
 
 	if u.options.isPageFile {
-		err := RestoreMissingPages(reader, NewReadWriterAtFrom(file, fileInfo))
+		err := RestoreMissingPages(reader, targetReadWriterAt)
 		return errors.Wrapf(err, "Interpret: failed to restore pages for file '%s'", file.Name())
 	}
 

--- a/internal/file_unwrapper.go
+++ b/internal/file_unwrapper.go
@@ -1,0 +1,77 @@
+package internal
+
+import (
+	"archive/tar"
+	"github.com/pkg/errors"
+	"github.com/wal-g/tracelog"
+	"io"
+	"os"
+)
+
+type FileUnwrapperType int
+
+const (
+	DefaultBackupFileUnwrapper FileUnwrapperType = iota + 1
+	CatchupBackupFileUnwrapper
+)
+
+func NewFileUnwrapper(unwrapperType FileUnwrapperType, options *BackupFileOptions) IBackupFileUnwrapper {
+	switch unwrapperType {
+	case DefaultBackupFileUnwrapper:
+		return &DefaultFileUnwrapper{BackupFileUnwrapper{options}}
+	case CatchupBackupFileUnwrapper:
+		return &CatchupFileUnwrapper{BackupFileUnwrapper{options}}
+	default:
+		return &DefaultFileUnwrapper{BackupFileUnwrapper{options}}
+	}
+}
+
+type BackupFileOptions struct {
+	isIncremented bool
+	isPageFile    bool
+}
+
+type IBackupFileUnwrapper interface {
+	UnwrapNewFile(reader io.Reader, header *tar.Header, file *os.File) error
+	UnwrapExistingFile(reader io.Reader, header *tar.Header, file *os.File) error
+}
+
+type BackupFileUnwrapper struct {
+	options *BackupFileOptions
+}
+
+// truncate local file and set reader offset to zero
+func (u *BackupFileUnwrapper) clearLocalFile(file *os.File) error {
+	err := file.Truncate(0)
+	if err != nil {
+		return err
+	}
+	_, err = file.Seek(0, 0)
+	return err
+}
+
+// write file from reader to local file
+func (u *BackupFileUnwrapper) writeLocalFile(fileReader io.Reader, header *tar.Header, localFile *os.File) error {
+	_, err := io.Copy(localFile, fileReader)
+	if err != nil {
+		err1 := localFile.Close()
+		if err1 != nil {
+			tracelog.ErrorLogger.Printf("Interpret: failed to close localFile '%s' because of error: %v",
+				localFile.Name(), err1)
+		}
+		err1 = os.Remove(localFile.Name())
+		if err1 != nil {
+			tracelog.ErrorLogger.Fatalf("Interpret: failed to remove localFile '%s' because of error: %v",
+				localFile.Name(), err1)
+		}
+		return errors.Wrap(err, "Interpret: copy failed")
+	}
+
+	mode := os.FileMode(header.Mode)
+	if err = os.Chmod(localFile.Name(), mode); err != nil {
+		return errors.Wrap(err, "Interpret: chmod failed")
+	}
+
+	err = localFile.Sync()
+	return errors.Wrap(err, "Interpret: fsync failed")
+}

--- a/internal/pagefile_new.go
+++ b/internal/pagefile_new.go
@@ -21,9 +21,13 @@ type ReadWriterAt interface {
 	Name() string
 }
 
-func NewReadWriterAtFrom(file *os.File, info os.FileInfo) ReadWriterAt {
-	size := info.Size()
-	return &ReadWriterAtFileImpl{file, size}
+func NewReadWriterAtFrom(file *os.File) (ReadWriterAt, error) {
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := fileInfo.Size()
+	return &ReadWriterAtFileImpl{file, size}, nil
 }
 
 type ReadWriterAtFileImpl struct {


### PR DESCRIPTION
Since the implementation of reverse delta unpacking, the unpack logic for default backups (backup-push) and for catchup backups (catchup-push) began to differ even more.

To improve the code readability and maintainability I propose dividing the catchup backup and default backup unwrap logic. I created an interface and added two implementations for backup file unwrap: one for default backup, one for catchup backup.