### PR TITLE
IO limiter fix for low limits

### DIFF
--- a/internal/limited/reader.go
+++ b/internal/limited/reader.go
@@ -19,7 +19,11 @@ func NewReader(reader io.Reader, limiter *rate.Limiter) *Reader {
 }
 
 func (r *Reader) Read(buf []byte) (int, error) {
-	n, err := r.reader.Read(buf)
+	end := len(buf)
+	if r.limiter.Burst() < end {
+		end = r.limiter.Burst()
+	}
+	n, err := r.reader.Read(buf[:end])
 
 	if err != nil {
 		limiterErr := r.limiter.WaitN(context.TODO(), utility.Max(n, 0))


### PR DESCRIPTION
When IO limit is lower than IO buffer
the first read operation may exceed limiter burst causing error