### PR TITLE
Wal delta fetch fix

### DIFF
--- a/internal/delta_map_downloader.go
+++ b/internal/delta_map_downloader.go
@@ -26,7 +26,7 @@ func getDeltaMap(folder storage.Folder, timeline uint32, firstUsedLSN, firstNotU
 	deltaMap.AddLocationsToDelta(lastDeltaFile.Locations)
 
 	firstUsedWalSegmentNo, firstNotUsedWalSegmentNo := getWalSegmentRange(firstNotUsedDeltaNo, firstNotUsedLSN)
-	// we handle WAL files from [firstUsedWalSegmentNo, lastUsedWalSegmentNo]
+	// we handle WAL files from [firstUsedWalSegmentNo, firstNotUsedWalSegmentNo)
 	err = deltaMap.getLocationsFromWals(folder, timeline, firstUsedWalSegmentNo, firstNotUsedWalSegmentNo, lastDeltaFile.WalParser)
 	if err != nil {
 		return deltaMap, errors.Wrapf(err, "Error during fetch locations from wal segments.\n")
@@ -42,7 +42,6 @@ func getDeltaRange(firstUsedLsn, firstNotUsedLsn uint64) (DeltaNo, DeltaNo) {
 
 func getWalSegmentRange(firstNotUsedDeltaNo DeltaNo, firstNotUsedLsn uint64) (WalSegmentNo, WalSegmentNo) {
 	firstUsedWalSegmentNo := firstNotUsedDeltaNo.firstWalSegmentNo()
-	lastUsedLsn := firstNotUsedLsn - 1
-	lastUsedWalSegmentNo := newWalSegmentNo(lastUsedLsn)
-	return firstUsedWalSegmentNo, lastUsedWalSegmentNo.next()
+	firstNotUsedWalSegmentNo := newWalSegmentNo(firstNotUsedLsn)
+	return firstUsedWalSegmentNo, firstNotUsedWalSegmentNo
 }


### PR DESCRIPTION
This PR contains two potential fixes for initialization of delta map from wal deltas.

Let's suppose that we are creating delta backup.
Let the **A** be the LSN of previous backup start and **B** be the LSN of current backup start.
Then, lets say that **aSegment** is the wal segment which contains log record with LSN A, **bSegment** - segment which contains the log record with LSN B.

So, in order to build a delta map for this backup, in theory, we should get all WAL segments (or deltas) in range **[aSegment, bSegment)**

If the previous thesis is correct, I see two issues with the current implementation of delta map initialization and propose solutions to them.

**First issue**
WAL-G tries to download the wal segment which is created after the pg_start_backup() call (**bSegment**), and it results in crash of delta map initialization because the **bSegment** is not finished yet and not uploaded to S3.

Some people say that the **bSegment** is not actually needed for delta map initialization because it is created after pg_start_backup(). 
So we may actually need to download WAL segments only in range **[aSegment, bSegment)** because there is a WAL switch on pg_start_backup() call. Also, there is a fragment in the Postgres source code which speaks in favor of this opinion.
Excerpt from Postgres source code https://doxygen.postgresql.org/xlog_8c_source.html#l10595

* Force an XLOG file switch before the checkpoint, to ensure that the
* WAL segment the checkpoint is written to doesn't contain pages with
* old timeline IDs.  That would otherwise happen if you called
* pg_start_backup() right after restoring from a PITR archive: the
* first WAL segment containing the startup checkpoint has pages in
* the beginning with the old timeline ID.  That can cause trouble at
* recovery: we won't have a history file covering the old timeline if
* pg_wal directory was not included in the base backup and the WAL
* archive was cleared too before starting the backup.

Also, I asked the pgsql-hackers mailing list about the WAL-switch on pg_start_backup() but did not receive any feedback so far, will update the PR if there will be some new information from them.

@g0djan and @x4m said that there was previously an issue in this place with data loss in this place. I look forward to test the proposed approach to test if it is legit or not.

**Second issue**
In order to initialize the delta map from WALs we should do two sequential steps:
1. Download a couple of WAL deltas at first
2. Download some WAL segments in range [firstNotUsedDeltaNo.firstWalSegmentNo(), **bSegment**).

In cases when the window between **A** and **B** is relatively small, there is no WAL deltas to fetch at all, so we are executing only step 2. But in this case, the range of WAL segments to be downloaded may be incorrect because the first WAL segment of the first unused WAL delta is before **A** so in this case we incorrectly download some extra WAL segments before the **aSegment**.

So I propose in this case just download the WAL segments from range **[aSegment, bSegment)**