### PR TITLE
Add wal-show command

### DIFF
--- a/cmd/pg/wal_show.go
+++ b/cmd/pg/wal_show.go
@@ -1,0 +1,49 @@
+package pg
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"os"
+)
+
+const (
+	WalShowUsage            = "wal-show"
+	WalShowShortDescription = "Show storage WAL segments info grouped by timelines."
+	WalShowLongDescription  = "Show information such as missing segments for each timeline found in storage. " +
+		"Optionally, show available backups for each timeline."
+
+	detailedOutputFlag        = "detailed-json"
+	detailedOutputDescription = "Output detailed information in JSON format."
+
+	disableBackupsLookupFlag        = "without-backups"
+	disableBackupsLookupDescription = "Disable backups lookup for each timeline."
+)
+
+var (
+	// walShowCmd represents the walShow command
+	walShowCmd = &cobra.Command{
+		Use:   WalShowUsage,
+		Short: WalShowShortDescription,
+		Long:  WalShowLongDescription,
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			folder, err := internal.ConfigureFolder()
+			tracelog.ErrorLogger.FatalOnError(err)
+			outputType := internal.TableOutput
+			if detailedJsonOutput {
+				outputType = internal.JsonOutput
+			}
+			outputWriter := internal.NewWalShowOutputWriter(outputType, os.Stdout, !disableBackupsLookup)
+			internal.HandleWalShow(folder, !disableBackupsLookup, outputWriter)
+		},
+	}
+	detailedJsonOutput   bool
+	disableBackupsLookup bool
+)
+
+func init() {
+	Cmd.AddCommand(walShowCmd)
+	walShowCmd.Flags().BoolVar(&detailedJsonOutput, detailedOutputFlag, false, detailedOutputDescription)
+	walShowCmd.Flags().BoolVar(&disableBackupsLookup, disableBackupsLookupFlag, false, disableBackupsLookupDescription)
+}

--- a/internal/paged_file_delta_map.go
+++ b/internal/paged_file_delta_map.go
@@ -158,7 +158,7 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromWals(folder storage.Folder, t
 }
 
 func (deltaMap *PagedFileDeltaMap) getLocationsFromWal(folder storage.Folder, filename string, walParser *walparser.WalParser) error {
-	reader, err := DownloadAndDecompressWALFile(folder, filename)
+	reader, err := DownloadAndDecompressStorageFile(folder, filename)
 	if err != nil {
 		return errors.Wrapf(err, "Error during wal segment'%s' downloading.", filename)
 	}
@@ -175,7 +175,7 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromWal(folder storage.Folder, fi
 }
 
 func getDeltaFile(folder storage.Folder, filename string) (*DeltaFile, error) {
-	reader, err := DownloadAndDecompressWALFile(folder, filename)
+	reader, err := DownloadAndDecompressStorageFile(folder, filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error during delta file '%s' downloading.", filename)
 	}

--- a/internal/timeline.go
+++ b/internal/timeline.go
@@ -53,7 +53,8 @@ const (
 	// WalSegmentSize is the size of one WAL file
 	WalSegmentSize = uint64(16 * 1024 * 1024) // xlog.c line 113ß
 
-	walFileFormat         = "%08X%08X%08X"               // xlog_internal.h line 155
+	walFileFormat         = "%08X%08X%08X" // xlog_internal.h line 155
+	walHistoryFileFormat  = "%08X.history"
 	xLogSegmentsPerXLogId = 0x100000000 / WalSegmentSize // xlog_internal.h line 101
 )
 

--- a/internal/timeline_history_record.go
+++ b/internal/timeline_history_record.go
@@ -1,0 +1,105 @@
+package internal
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/jackc/pgx"
+	"github.com/pkg/errors"
+	"github.com/wal-g/storages/storage"
+	"github.com/wal-g/tracelog"
+	"io"
+	"regexp"
+	"strconv"
+)
+
+var walHistoryRecordRegexp *regexp.Regexp
+
+func init() {
+	walHistoryRecordRegexp = regexp.MustCompile("^(\\d+)\\t(.+)\\t(.+)$")
+}
+
+type HistoryFileNotFoundError struct {
+	error
+}
+
+func newHistoryFileNotFoundError(historyFileName string) HistoryFileNotFoundError {
+	return HistoryFileNotFoundError{errors.Errorf("History file '%s' does not exist.\n", historyFileName)}
+}
+
+func (err HistoryFileNotFoundError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}
+
+// TimelineHistoryRecord represents entry in .history file
+type TimelineHistoryRecord struct {
+	timeline uint32
+	lsn      uint64
+	comment  string
+}
+
+func newHistoryRecordFromString(row string) (*TimelineHistoryRecord, error) {
+	matchResult := walHistoryRecordRegexp.FindStringSubmatch(row)
+	if matchResult == nil {
+		return nil, nil
+	}
+	timeline, err := strconv.ParseUint(matchResult[1], 10, sizeofInt32)
+	if err != nil {
+		return nil, err
+	}
+	lsn, err := pgx.ParseLSN(matchResult[2])
+	if err != nil {
+		return nil, err
+	}
+	comment := matchResult[3]
+	return &TimelineHistoryRecord{timeline: uint32(timeline), lsn: lsn, comment: comment}, nil
+}
+
+
+func getTimeLineHistoryRecords(startTimeline uint32, walFolder storage.Folder) ([]*TimelineHistoryRecord, error) {
+	historyReadCloser, err := getHistoryFileFromStorage(startTimeline, walFolder)
+	if err != nil {
+		return nil, err
+	}
+	historyRecords, err := parseHistoryFile(historyReadCloser)
+	if err != nil {
+		return nil, err
+	}
+	err = historyReadCloser.Close()
+	if err != nil {
+		return nil, err
+	}
+	return historyRecords, nil
+}
+
+func parseHistoryFile(historyReader io.Reader) (historyRecords []*TimelineHistoryRecord, err error) {
+	scanner := bufio.NewScanner(historyReader)
+	historyRecords = make([]*TimelineHistoryRecord, 0)
+	for scanner.Scan() {
+		nextRow := scanner.Text()
+		if nextRow == "" {
+			// skip empty rows in .history file
+			continue
+		}
+		record, err := newHistoryRecordFromString(nextRow)
+		if record == nil {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		historyRecords = append(historyRecords, record)
+	}
+	return historyRecords, err
+}
+
+func getHistoryFileFromStorage(timeline uint32, walFolder storage.Folder) (io.ReadCloser, error) {
+	historyFileName := fmt.Sprintf(walHistoryFileFormat, timeline)
+	reader, err := DownloadAndDecompressStorageFile(walFolder, historyFileName)
+	if _, ok := err.(ArchiveNonExistenceError); ok {
+		return nil, newHistoryFileNotFoundError(historyFileName)
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error during .history file '%s' downloading.", historyFileName)
+	}
+	return reader, nil
+}

--- a/internal/timeline_history_record.go
+++ b/internal/timeline_history_record.go
@@ -39,7 +39,7 @@ type TimelineHistoryRecord struct {
 
 func newHistoryRecordFromString(row string) (*TimelineHistoryRecord, error) {
 	matchResult := walHistoryRecordRegexp.FindStringSubmatch(row)
-	if matchResult == nil {
+	if matchResult == nil || len(matchResult) < 4 {
 		return nil, nil
 	}
 	timeline, err := strconv.ParseUint(matchResult[1], 10, sizeofInt32)
@@ -71,9 +71,9 @@ func getTimeLineHistoryRecords(startTimeline uint32, walFolder storage.Folder) (
 	return historyRecords, nil
 }
 
-func parseHistoryFile(historyReader io.Reader) (historyRecords []*TimelineHistoryRecord, err error) {
+func parseHistoryFile(historyReader io.Reader) ([]*TimelineHistoryRecord, error) {
 	scanner := bufio.NewScanner(historyReader)
-	historyRecords = make([]*TimelineHistoryRecord, 0)
+	historyRecords := make([]*TimelineHistoryRecord, 0)
 	for scanner.Scan() {
 		nextRow := scanner.Text()
 		if nextRow == "" {
@@ -81,15 +81,15 @@ func parseHistoryFile(historyReader io.Reader) (historyRecords []*TimelineHistor
 			continue
 		}
 		record, err := newHistoryRecordFromString(nextRow)
-		if record == nil {
-			break
-		}
 		if err != nil {
 			return nil, err
 		}
+		if record == nil {
+			break
+		}
 		historyRecords = append(historyRecords, record)
 	}
-	return historyRecords, err
+	return historyRecords, nil
 }
 
 func getHistoryFileFromStorage(timeline uint32, walFolder storage.Folder) (io.ReadCloser, error) {

--- a/internal/wal_fetch_handler.go
+++ b/internal/wal_fetch_handler.go
@@ -221,9 +221,9 @@ func putCachedDecompressorInFirstPlace(decompressors []compression.Decompressor)
 }
 
 // TODO : unit tests
-func DownloadAndDecompressWALFile(folder storage.Folder, walFileName string) (io.ReadCloser, error) {
+func DownloadAndDecompressStorageFile(folder storage.Folder, fileName string) (io.ReadCloser, error) {
 	for _, decompressor := range putCachedDecompressorInFirstPlace(compression.Decompressors) {
-		archiveReader, exists, err := TryDownloadFile(folder, walFileName+"."+decompressor.FileExtension())
+		archiveReader, exists, err := TryDownloadFile(folder, fileName+"."+decompressor.FileExtension())
 		if err != nil {
 			return nil, err
 		}
@@ -238,13 +238,13 @@ func DownloadAndDecompressWALFile(folder storage.Folder, walFileName string) (io
 		}()
 		return reader, nil
 	}
-	return nil, newArchiveNonExistenceError(walFileName)
+	return nil, newArchiveNonExistenceError(fileName)
 }
 
 // TODO : unit tests
 // downloadWALFileTo downloads a file and writes it to local file
 func DownloadWALFileTo(folder storage.Folder, walFileName string, dstPath string) error {
-	reader, err := DownloadAndDecompressWALFile(folder, walFileName)
+	reader, err := DownloadAndDecompressStorageFile(folder, walFileName)
 	if err != nil {
 		return err
 	}

--- a/internal/wal_fetch_handler_test.go
+++ b/internal/wal_fetch_handler_test.go
@@ -30,7 +30,7 @@ func TestWallFetchCachesLastDecompressor(t *testing.T) {
 		assert.NoError(t, folder.PutObject(walFilename+"."+decompressor.FileExtension(),
 			bytes.NewReader([]byte("test data"))))
 
-		_, err := internal.DownloadAndDecompressWALFile(folder, walFilename)
+		_, err := internal.DownloadAndDecompressStorageFile(folder, walFilename)
 		assert.NoError(t, err)
 
 		last, err := internal.GetLastDecompressor()

--- a/internal/wal_push_handler.go
+++ b/internal/wal_push_handler.go
@@ -78,7 +78,7 @@ func uploadWALFile(uploader *WalUploader, walFilePath string, preventWalOverwrit
 
 // TODO : unit tests
 func checkWALOverwrite(uploader *WalUploader, walFilePath string) (overwriteAttempt bool, err error) {
-	walFileReader, err := DownloadAndDecompressWALFile(uploader.UploadingFolder, filepath.Base(walFilePath))
+	walFileReader, err := DownloadAndDecompressStorageFile(uploader.UploadingFolder, filepath.Base(walFilePath))
 	if err != nil {
 		if _, ok := err.(ArchiveNonExistenceError); ok {
 			err = nil

--- a/internal/wal_segment_runner.go
+++ b/internal/wal_segment_runner.go
@@ -34,12 +34,12 @@ func (err ReachedStopSegmentError) Error() string {
 }
 
 type WalSegmentDescription struct {
-	number   WalSegmentNo
-	timeline uint32
+	Number   WalSegmentNo
+	Timeline uint32
 }
 
 func (desc *WalSegmentDescription) GetFileName() string {
-	return desc.number.getFilename(desc.timeline)
+	return desc.Number.getFilename(desc.Timeline)
 }
 
 // WalSegmentRunner is used for sequential iteration over WAL segments in the storage
@@ -60,7 +60,7 @@ func NewWalSegmentRunner(
 
 // Next tries to get the next segment from storage
 func (r *WalSegmentRunner) Next() (WalSegmentDescription, error) {
-	if r.currentWalSegment.number <= r.stopSegmentNo {
+	if r.currentWalSegment.Number <= r.stopSegmentNo {
 		return WalSegmentDescription{}, newReachedStopSegmentError()
 	}
 	nextSegment := r.getNextSegment()
@@ -79,9 +79,9 @@ func (r *WalSegmentRunner) ForceMoveNext() {
 
 // getNextSegment calculates the next segment
 func (r *WalSegmentRunner) getNextSegment() WalSegmentDescription {
-	nextTimeline := r.currentWalSegment.timeline
-	nextSegmentNo := r.currentWalSegment.number.previous()
-	return WalSegmentDescription{timeline: nextTimeline, number: nextSegmentNo}
+	nextTimeline := r.currentWalSegment.Timeline
+	nextSegmentNo := r.currentWalSegment.Number.previous()
+	return WalSegmentDescription{Timeline: nextTimeline, Number: nextSegmentNo}
 }
 
 // getFolderFilenames returns a set of filenames in provided storage folder
@@ -106,7 +106,7 @@ func getSegmentsFromFiles(filenames []string) map[WalSegmentDescription]bool {
 			// non-wal segment file, skip it
 			continue
 		}
-		segment := WalSegmentDescription{timeline: timeline, number: WalSegmentNo(segmentNo)}
+		segment := WalSegmentDescription{Timeline: timeline, Number: WalSegmentNo(segmentNo)}
 		walSegments[segment] = true
 	}
 	return walSegments

--- a/internal/wal_segment_runner.go
+++ b/internal/wal_segment_runner.go
@@ -58,6 +58,10 @@ func NewWalSegmentRunner(
 		segments, stopSegmentNo}
 }
 
+func (r *WalSegmentRunner) Current() WalSegmentDescription {
+	return r.currentWalSegment
+}
+
 // Next tries to get the next segment from storage
 func (r *WalSegmentRunner) Next() (WalSegmentDescription, error) {
 	if r.currentWalSegment.Number <= r.stopSegmentNo {

--- a/internal/wal_segment_runner.go
+++ b/internal/wal_segment_runner.go
@@ -58,14 +58,13 @@ func NewWalSegmentRunner(
 		segments, stopSegmentNo}
 }
 
-// MoveNext tries to get the next segment from storage
-func (r *WalSegmentRunner) MoveNext() (WalSegmentDescription, error) {
+// Next tries to get the next segment from storage
+func (r *WalSegmentRunner) Next() (WalSegmentDescription, error) {
 	if r.currentWalSegment.number <= r.stopSegmentNo {
 		return WalSegmentDescription{}, newReachedStopSegmentError()
 	}
 	nextSegment := r.getNextSegment()
-	var fileExists bool
-	if _, fileExists = r.walFolderSegments[nextSegment]; !fileExists {
+	if _, fileExists := r.walFolderSegments[nextSegment]; !fileExists {
 		return WalSegmentDescription{}, newWalSegmentNotFoundError(nextSegment.GetFileName())
 	}
 	r.currentWalSegment = nextSegment

--- a/internal/wal_segment_runner.go
+++ b/internal/wal_segment_runner.go
@@ -1,0 +1,114 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/wal-g/storages/storage"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/utility"
+)
+
+type WalSegmentNotFoundError struct {
+	error
+}
+
+func newWalSegmentNotFoundError(segmentFileName string) WalSegmentNotFoundError {
+	return WalSegmentNotFoundError{
+		errors.Errorf("Segment file '%s' does not exist in storage.\n", segmentFileName)}
+}
+
+func (err WalSegmentNotFoundError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}
+
+type ReachedStopSegmentError struct {
+	error
+}
+
+func newReachedStopSegmentError() ReachedStopSegmentError {
+	return ReachedStopSegmentError{errors.Errorf("Reached stop segment.\n")}
+}
+
+func (err ReachedStopSegmentError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}
+
+type WalSegmentDescription struct {
+	number   WalSegmentNo
+	timeline uint32
+}
+
+func (desc *WalSegmentDescription) GetFileName() string {
+	return desc.number.getFilename(desc.timeline)
+}
+
+// WalSegmentRunner is used for sequential iteration over WAL segments in the storage
+type WalSegmentRunner struct {
+	currentWalSegment WalSegmentDescription
+	walFolderSegments map[WalSegmentDescription]bool
+	stopSegmentNo     WalSegmentNo
+}
+
+func NewWalSegmentRunner(
+	startWalSegment WalSegmentDescription,
+	segments map[WalSegmentDescription]bool,
+	stopSegmentNo WalSegmentNo,
+) *WalSegmentRunner {
+	return &WalSegmentRunner{startWalSegment,
+		segments, stopSegmentNo}
+}
+
+// MoveNext tries to get the next segment from storage
+func (r *WalSegmentRunner) MoveNext() (WalSegmentDescription, error) {
+	if r.currentWalSegment.number <= r.stopSegmentNo {
+		return WalSegmentDescription{}, newReachedStopSegmentError()
+	}
+	nextSegment := r.getNextSegment()
+	var fileExists bool
+	if _, fileExists = r.walFolderSegments[nextSegment]; !fileExists {
+		return WalSegmentDescription{}, newWalSegmentNotFoundError(nextSegment.GetFileName())
+	}
+	r.currentWalSegment = nextSegment
+	return r.currentWalSegment, nil
+}
+
+// ForceMoveNext do a force-switch to the next segment without accessing storage
+func (r *WalSegmentRunner) ForceMoveNext() {
+	nextSegment := r.getNextSegment()
+	r.currentWalSegment = nextSegment
+}
+
+// getNextSegment calculates the next segment
+func (r *WalSegmentRunner) getNextSegment() WalSegmentDescription {
+	nextTimeline := r.currentWalSegment.timeline
+	nextSegmentNo := r.currentWalSegment.number.previous()
+	return WalSegmentDescription{timeline: nextTimeline, number: nextSegmentNo}
+}
+
+// getFolderFilenames returns a set of filenames in provided storage folder
+func getFolderFilenames(folder storage.Folder) ([]string, error) {
+	objects, _, err := folder.ListFolder()
+	if err != nil {
+		return nil, err
+	}
+	filenames := make([]string, 0, len(objects))
+	for _, object := range objects {
+		filenames = append(filenames, object.GetName())
+	}
+	return filenames, nil
+}
+
+func getSegmentsFromFiles(filenames []string) map[WalSegmentDescription]bool {
+	walSegments := make(map[WalSegmentDescription]bool)
+	for _, filename := range filenames {
+		baseName := utility.TrimFileExtension(filename)
+		timeline, segmentNo, err := ParseWALFilename(baseName)
+		if _, ok := err.(NotWalFilenameError); ok {
+			// non-wal segment file, skip it
+			continue
+		}
+		segment := WalSegmentDescription{timeline: timeline, number: WalSegmentNo(segmentNo)}
+		walSegments[segment] = true
+	}
+	return walSegments
+}

--- a/internal/wal_segment_runner_test.go
+++ b/internal/wal_segment_runner_test.go
@@ -1,0 +1,92 @@
+package internal_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"testing"
+)
+
+func TestWalSegmentRunner_AllExists(t *testing.T) {
+	timelineId := uint32(1)
+	minSegmentNo := internal.WalSegmentNo(300)
+	maxSegmentNo := internal.WalSegmentNo(600)
+
+	testWalSegmentRunner(t, minSegmentNo, maxSegmentNo, timelineId, make(map[internal.WalSegmentNo]bool))
+}
+
+func TestWalSegmentRunner_MissingSegments(t *testing.T) {
+	timelineId := uint32(1)
+	minSegmentNo := internal.WalSegmentNo(300)
+	maxSegmentNo := internal.WalSegmentNo(400)
+
+	missingSegments := map[internal.WalSegmentNo]bool{
+		301: true,
+		305: true,
+		310: true,
+		311: true,
+		312: true,
+	}
+
+	testWalSegmentRunner(t, minSegmentNo, maxSegmentNo, timelineId, missingSegments)
+}
+
+func TestWalSegmentRunner_AllMissing(t *testing.T) {
+	timelineId := uint32(1)
+	minSegmentNo := internal.WalSegmentNo(1)
+	maxSegmentNo := internal.WalSegmentNo(5)
+
+	missingSegments := map[internal.WalSegmentNo]bool{
+		1: true,
+		2: true,
+		3: true,
+		4: true,
+		5: true,
+	}
+
+	testWalSegmentRunner(t, minSegmentNo, maxSegmentNo, timelineId, missingSegments)
+}
+
+func testWalSegmentRunner(t *testing.T, minSegmentNo, maxSegmentNo internal.WalSegmentNo, timelineId uint32,
+	missingSegmentsNo map[internal.WalSegmentNo]bool) {
+	walSegments := make(map[internal.WalSegmentDescription]bool, 0)
+	for i := minSegmentNo; i <= maxSegmentNo; i++ {
+		// do not add wal segment if it in missing segments set
+		if _, ok := missingSegmentsNo[i]; !ok {
+			segment := internal.WalSegmentDescription{Number: i, Timeline: timelineId}
+			walSegments[segment] = true
+		}
+	}
+	startSegment := internal.WalSegmentDescription{Number: maxSegmentNo, Timeline: timelineId}
+	walSegmentRunner := internal.NewWalSegmentRunner(startSegment, walSegments, minSegmentNo)
+
+	prevSegment := startSegment
+	outputSegments := make(map[internal.WalSegmentDescription]bool)
+SegmentRunnerLoop:
+	for {
+		nextSegment, err := walSegmentRunner.Next()
+		if err != nil {
+			switch err := err.(type) {
+			case internal.WalSegmentNotFoundError:
+				walSegmentRunner.ForceMoveNext()
+				nextSegment = walSegmentRunner.Current()
+				// check that missingSegmentsNo set has this number
+				assert.Contains(t, missingSegmentsNo, nextSegment.Number)
+			case internal.ReachedStopSegmentError:
+				break SegmentRunnerLoop
+			default:
+				assert.FailNow(t, "testWalSegmentRunner: unexpected error %v ", err)
+			}
+		}
+		// make sure we didn't encounter this segment before
+		assert.NotContains(t, outputSegments, nextSegment)
+
+		expectedNext := internal.WalSegmentDescription{Number: prevSegment.Number - 1, Timeline: prevSegment.Timeline}
+		assert.Equal(t, expectedNext, nextSegment)
+
+		outputSegments[nextSegment] = true
+		prevSegment = nextSegment
+	}
+
+	expectedEndSegment := internal.WalSegmentDescription{Number: minSegmentNo, Timeline: timelineId}
+	assert.Equal(t, expectedEndSegment, prevSegment)
+}

--- a/internal/wal_show_handler.go
+++ b/internal/wal_show_handler.go
@@ -90,7 +90,7 @@ func (data *WalSegmentsSequence) AddWalSegmentNo(number WalSegmentNo) {
 }
 
 // FindMissingSegments finds missing segments in range [minSegmentNo, maxSegmentNo]
-func (data *WalSegmentsSequence) FindMissingSegments() ([]*WalSegmentDescription, error) {
+func (data *WalSegmentsSequence) FindMissingSegments() ([]WalSegmentDescription, error) {
 	startWalSegment := WalSegmentDescription{Number: data.maxSegmentNo, Timeline: data.timelineId}
 
 	walSegments := make(map[WalSegmentDescription]bool, len(data.walSegmentNumbers))
@@ -101,14 +101,14 @@ func (data *WalSegmentsSequence) FindMissingSegments() ([]*WalSegmentDescription
 
 	// create WAL segment runner to run on single timeline
 	walSegmentRunner := NewWalSegmentRunner(startWalSegment, walSegments, data.minSegmentNo)
-	missingSegments := make([]*WalSegmentDescription, 0)
+	missingSegments := make([]WalSegmentDescription, 0)
 	for {
 		if _, err := walSegmentRunner.Next(); err != nil {
 			switch err := err.(type) {
 			case WalSegmentNotFoundError:
 				// force switch to the next WAL segment
 				walSegmentRunner.ForceMoveNext()
-				missingSegments = append(missingSegments, &walSegmentRunner.currentWalSegment)
+				missingSegments = append(missingSegments, walSegmentRunner.currentWalSegment)
 			case ReachedStopSegmentError:
 				// Can't continue because reached stop segment, stop at this point
 				return missingSegments, nil

--- a/internal/wal_show_handler.go
+++ b/internal/wal_show_handler.go
@@ -15,14 +15,14 @@ const (
 // TimelineInfo contains information about some timeline in storage
 type TimelineInfo struct {
 	Id               uint32          `json:"id"`
-	ParentId         uint32          `json:"parentId"`
-	SwitchPointLsn   uint64          `json:"switchPointLsn"`
-	StartSegment     string          `json:"startSegment"`
-	EndSegment       string          `json:"endSegment"`
-	SegmentsCount    int             `json:"segmentsCount"`
-	MissingSegments  []string        `json:"missingSegments"`
-	Backups          []*BackupDetail `json:"availableBackups,omitempty"`
-	SegmentRangeSize uint64          `json:"segmentRangeSize"`
+	ParentId         uint32          `json:"parent_id"`
+	SwitchPointLsn   uint64          `json:"switch_point_lsn"`
+	StartSegment     string          `json:"start_segment"`
+	EndSegment       string          `json:"end_segment"`
+	SegmentsCount    int             `json:"segments_count"`
+	MissingSegments  []string        `json:"missing_segments"`
+	Backups          []*BackupDetail `json:"backups,omitempty"`
+	SegmentRangeSize uint64          `json:"segment_range_size"`
 	Status           string          `json:"status"`
 }
 

--- a/internal/wal_show_handler.go
+++ b/internal/wal_show_handler.go
@@ -103,7 +103,7 @@ func (data *WalSegmentsSequence) FindMissingSegments() ([]*WalSegmentDescription
 	walSegmentRunner := NewWalSegmentRunner(startWalSegment, walSegments, data.minSegmentNo)
 	missingSegments := make([]*WalSegmentDescription, 0)
 	for {
-		if _, err := walSegmentRunner.MoveNext(); err != nil {
+		if _, err := walSegmentRunner.Next(); err != nil {
 			switch err := err.(type) {
 			case WalSegmentNotFoundError:
 				// force switch to the next WAL segment

--- a/internal/wal_show_handler.go
+++ b/internal/wal_show_handler.go
@@ -79,28 +79,28 @@ func NewSegmentsSequence(id uint32, segmentNo WalSegmentNo) *WalSegmentsSequence
 }
 
 // AddWalSegmentNo adds the provided segment number to collection
-func (data *WalSegmentsSequence) AddWalSegmentNo(number WalSegmentNo) {
-	data.walSegmentNumbers[number] = true
-	if data.minSegmentNo > number {
-		data.minSegmentNo = number
+func (seq *WalSegmentsSequence) AddWalSegmentNo(number WalSegmentNo) {
+	seq.walSegmentNumbers[number] = true
+	if seq.minSegmentNo > number {
+		seq.minSegmentNo = number
 	}
-	if data.maxSegmentNo < number {
-		data.maxSegmentNo = number
+	if seq.maxSegmentNo < number {
+		seq.maxSegmentNo = number
 	}
 }
 
 // FindMissingSegments finds missing segments in range [minSegmentNo, maxSegmentNo]
-func (data *WalSegmentsSequence) FindMissingSegments() ([]WalSegmentDescription, error) {
-	startWalSegment := WalSegmentDescription{Number: data.maxSegmentNo, Timeline: data.timelineId}
+func (seq *WalSegmentsSequence) FindMissingSegments() ([]WalSegmentDescription, error) {
+	startWalSegment := WalSegmentDescription{Number: seq.maxSegmentNo, Timeline: seq.timelineId}
 
-	walSegments := make(map[WalSegmentDescription]bool, len(data.walSegmentNumbers))
-	for number := range data.walSegmentNumbers {
-		segment := WalSegmentDescription{Number: number, Timeline: data.timelineId}
+	walSegments := make(map[WalSegmentDescription]bool, len(seq.walSegmentNumbers))
+	for number := range seq.walSegmentNumbers {
+		segment := WalSegmentDescription{Number: number, Timeline: seq.timelineId}
 		walSegments[segment] = true
 	}
 
 	// create WAL segment runner to run on single timeline
-	walSegmentRunner := NewWalSegmentRunner(startWalSegment, walSegments, data.minSegmentNo)
+	walSegmentRunner := NewWalSegmentRunner(startWalSegment, walSegments, seq.minSegmentNo)
 	missingSegments := make([]WalSegmentDescription, 0)
 	for {
 		if _, err := walSegmentRunner.Next(); err != nil {

--- a/internal/wal_show_handler.go
+++ b/internal/wal_show_handler.go
@@ -1,0 +1,212 @@
+package internal
+
+import (
+	"github.com/wal-g/storages/storage"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/utility"
+	"sort"
+)
+
+const (
+	TimelineOkStatus          = "OK"
+	TimelineLostSegmentStatus = "LOST_SEGMENTS"
+)
+
+// TimelineInfo contains information about some timeline in storage
+type TimelineInfo struct {
+	Id               uint32          `json:"id"`
+	ParentId         uint32          `json:"parentId"`
+	SwitchPointLsn   uint64          `json:"switchPointLsn"`
+	StartSegment     string          `json:"startSegment"`
+	EndSegment       string          `json:"endSegment"`
+	SegmentsCount    int             `json:"segmentsCount"`
+	MissingSegments  []string        `json:"missingSegments"`
+	Backups          []*BackupDetail `json:"availableBackups,omitempty"`
+	SegmentRangeSize uint64          `json:"segmentRangeSize"`
+	Status           string          `json:"status"`
+}
+
+func NewTimelineInfo(walSegments *WalSegmentsSequence, historyRecords []*TimelineHistoryRecord) (*TimelineInfo, error) {
+	timelineInfo := &TimelineInfo{
+		Id:               walSegments.timelineId,
+		StartSegment:     walSegments.minSegmentNo.getFilename(walSegments.timelineId),
+		EndSegment:       walSegments.maxSegmentNo.getFilename(walSegments.timelineId),
+		SegmentsCount:    len(walSegments.walSegmentNumbers),
+		SegmentRangeSize: uint64(walSegments.maxSegmentNo-walSegments.minSegmentNo) + 1,
+		Status:           TimelineOkStatus,
+	}
+
+	missingSegments, err := walSegments.FindMissingSegments()
+	if err != nil {
+		return nil, err
+	}
+	timelineInfo.MissingSegments = make([]string, 0, len(missingSegments))
+	for _, segment := range missingSegments {
+		timelineInfo.MissingSegments = append(timelineInfo.MissingSegments, segment.GetFileName())
+	}
+
+	if len(timelineInfo.MissingSegments) > 0 {
+		timelineInfo.Status = TimelineLostSegmentStatus
+	}
+
+	// set parent timeline id and timeline switch LSN if have .history record available
+	if len(historyRecords) > 0 {
+		switchHistoryRecord := historyRecords[len(historyRecords)-1]
+		timelineInfo.ParentId = switchHistoryRecord.timeline
+		timelineInfo.SwitchPointLsn = switchHistoryRecord.lsn
+	}
+	return timelineInfo, nil
+}
+
+// WalSegmentsSequence represents some collection of wal segments with the same timeline
+type WalSegmentsSequence struct {
+	timelineId        uint32
+	walSegmentNumbers map[WalSegmentNo]bool
+	minSegmentNo      WalSegmentNo
+	maxSegmentNo      WalSegmentNo
+}
+
+func NewSegmentsSequence(id uint32, segmentNo WalSegmentNo) *WalSegmentsSequence {
+	walSegmentNumbers := make(map[WalSegmentNo]bool)
+	walSegmentNumbers[segmentNo] = true
+
+	return &WalSegmentsSequence{
+		timelineId:        id,
+		walSegmentNumbers: walSegmentNumbers,
+		minSegmentNo:      segmentNo,
+		maxSegmentNo:      segmentNo,
+	}
+}
+
+// AddWalSegmentNo adds the provided segment number to collection
+func (data *WalSegmentsSequence) AddWalSegmentNo(number WalSegmentNo) {
+	data.walSegmentNumbers[number] = true
+	if data.minSegmentNo > number {
+		data.minSegmentNo = number
+	}
+	if data.maxSegmentNo < number {
+		data.maxSegmentNo = number
+	}
+}
+
+// FindMissingSegments finds missing segments in range [minSegmentNo, maxSegmentNo]
+func (data *WalSegmentsSequence) FindMissingSegments() ([]*WalSegmentDescription, error) {
+	startWalSegment := WalSegmentDescription{number: data.maxSegmentNo, timeline: data.timelineId}
+
+	walSegments := make(map[WalSegmentDescription]bool, len(data.walSegmentNumbers))
+	for number := range data.walSegmentNumbers {
+		segment := WalSegmentDescription{number: number, timeline: data.timelineId}
+		walSegments[segment] = true
+	}
+
+	// create WAL segment runner to run on single timeline
+	walSegmentRunner := NewWalSegmentRunner(startWalSegment, walSegments, data.minSegmentNo)
+	missingSegments := make([]*WalSegmentDescription, 0)
+	for {
+		if _, err := walSegmentRunner.MoveNext(); err != nil {
+			switch err := err.(type) {
+			case WalSegmentNotFoundError:
+				// force switch to the next WAL segment
+				walSegmentRunner.ForceMoveNext()
+				missingSegments = append(missingSegments, &walSegmentRunner.currentWalSegment)
+			case ReachedStopSegmentError:
+				// Can't continue because reached stop segment, stop at this point
+				return missingSegments, nil
+			default:
+				return nil, err
+			}
+		}
+	}
+}
+
+// HandleWalShow gets the list of files inside WAL folder, detects the available WAL segments,
+// groups WAL segments by the timeline and shows detailed info about each timeline stored in storage
+func HandleWalShow(rootFolder storage.Folder, showBackups bool, outputWriter WalShowOutputWriter) {
+	walFolder := rootFolder.GetSubFolder(utility.WalPath)
+	filenames, err := getFolderFilenames(walFolder)
+	tracelog.ErrorLogger.FatalfOnError("Failed to get the WAL folder filenames %v\n", err)
+
+	walSegments := getSegmentsFromFiles(filenames)
+	segmentsByTimelines, err := groupSegmentsByTimelines(walSegments)
+	tracelog.ErrorLogger.FatalfOnError("Failed to group WAL segments by timelines %v\n", err)
+
+	timelineInfos := make([]*TimelineInfo, 0, len(segmentsByTimelines))
+	for _, segmentsSequence := range segmentsByTimelines {
+		historyRecords, err := getTimeLineHistoryRecords(segmentsSequence.timelineId, walFolder)
+		if err != nil {
+			if _, ok := err.(HistoryFileNotFoundError); !ok {
+				tracelog.ErrorLogger.Fatalf("Error while loading .history file %v\n", err)
+			}
+		}
+
+		info, err := NewTimelineInfo(segmentsSequence, historyRecords)
+		tracelog.ErrorLogger.FatalfOnError("Error while creating TimeLineInfo %v\n", err)
+		timelineInfos = append(timelineInfos, info)
+	}
+
+	if showBackups {
+		timelineInfos, err = addBackupsInfo(timelineInfos, rootFolder)
+		tracelog.ErrorLogger.FatalfOnError("Failed to add backups info: %v\n", err)
+	}
+
+	// order timelines by ID
+	sort.Slice(timelineInfos, func(i, j int) bool {
+		return timelineInfos[i].Id < timelineInfos[j].Id
+	})
+
+	err = outputWriter.Write(timelineInfos)
+	tracelog.ErrorLogger.FatalfOnError("Error writing output: %v\n", err)
+}
+
+func groupSegmentsByTimelines(segments map[WalSegmentDescription]bool) (map[uint32]*WalSegmentsSequence, error) {
+	segmentsByTimelines := make(map[uint32]*WalSegmentsSequence)
+	for segment := range segments {
+		if timelineInfo, ok := segmentsByTimelines[segment.timeline]; ok {
+			timelineInfo.AddWalSegmentNo(segment.number)
+			continue
+		}
+		segmentsByTimelines[segment.timeline] = NewSegmentsSequence(segment.timeline, segment.number)
+	}
+	return segmentsByTimelines, nil
+}
+
+// addBackupsInfo adds info about available backups for each timeline
+func addBackupsInfo(timelineInfos []*TimelineInfo, rootFolder storage.Folder) ([]*TimelineInfo, error) {
+	backups, err := getBackups(rootFolder)
+	if err != nil {
+		return nil, err
+	}
+	backupDetails, err := getBackupDetails(rootFolder, backups)
+	if err != nil {
+		return nil, err
+	}
+	for _, info := range timelineInfos {
+		info.Backups, err = getBackupsInRange(info.StartSegment, info.EndSegment, info.Id, backupDetails)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return timelineInfos, nil
+}
+
+// getBackupsInRange returns backups taken in range [startSegmentName, endSegmentName]
+func getBackupsInRange(startSegmentName, endSegmentName string, timeline uint32,
+	backups []BackupDetail) ([]*BackupDetail, error) {
+	filteredBackups := make([]*BackupDetail, 0)
+
+	for _, backup := range backups {
+		backupTimeline, _, err := ParseWALFilename(backup.WalFileName)
+		if err != nil {
+			return nil, err
+		}
+		startSegment := newWalSegmentNo(backup.StartLsn).getFilename(backupTimeline)
+		endSegment := newWalSegmentNo(backup.FinishLsn).getFilename(backupTimeline)
+
+		// there we compare segments lexicographically, maybe it is wrong...
+		if timeline == backupTimeline && startSegment >= startSegmentName && endSegment <= endSegmentName {
+			filteredBackup := backup
+			filteredBackups = append(filteredBackups, &filteredBackup)
+		}
+	}
+	return filteredBackups, nil
+}

--- a/internal/wal_show_handler.go
+++ b/internal/wal_show_handler.go
@@ -91,11 +91,11 @@ func (data *WalSegmentsSequence) AddWalSegmentNo(number WalSegmentNo) {
 
 // FindMissingSegments finds missing segments in range [minSegmentNo, maxSegmentNo]
 func (data *WalSegmentsSequence) FindMissingSegments() ([]*WalSegmentDescription, error) {
-	startWalSegment := WalSegmentDescription{number: data.maxSegmentNo, timeline: data.timelineId}
+	startWalSegment := WalSegmentDescription{Number: data.maxSegmentNo, Timeline: data.timelineId}
 
 	walSegments := make(map[WalSegmentDescription]bool, len(data.walSegmentNumbers))
 	for number := range data.walSegmentNumbers {
-		segment := WalSegmentDescription{number: number, timeline: data.timelineId}
+		segment := WalSegmentDescription{Number: number, Timeline: data.timelineId}
 		walSegments[segment] = true
 	}
 
@@ -161,11 +161,11 @@ func HandleWalShow(rootFolder storage.Folder, showBackups bool, outputWriter Wal
 func groupSegmentsByTimelines(segments map[WalSegmentDescription]bool) (map[uint32]*WalSegmentsSequence, error) {
 	segmentsByTimelines := make(map[uint32]*WalSegmentsSequence)
 	for segment := range segments {
-		if timelineInfo, ok := segmentsByTimelines[segment.timeline]; ok {
-			timelineInfo.AddWalSegmentNo(segment.number)
+		if timelineInfo, ok := segmentsByTimelines[segment.Timeline]; ok {
+			timelineInfo.AddWalSegmentNo(segment.Number)
 			continue
 		}
-		segmentsByTimelines[segment.timeline] = NewSegmentsSequence(segment.timeline, segment.number)
+		segmentsByTimelines[segment.Timeline] = NewSegmentsSequence(segment.Timeline, segment.Number)
 	}
 	return segmentsByTimelines, nil
 }

--- a/internal/wal_show_handler_test.go
+++ b/internal/wal_show_handler_test.go
@@ -1,0 +1,375 @@
+package internal_test
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/storages/memory"
+	"github.com/wal-g/storages/storage"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/compression"
+	"github.com/wal-g/wal-g/internal/compression/lz4"
+	"github.com/wal-g/wal-g/utility"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// MockWalShowOutputWriter is used to capture wal-show command output
+type MockWalShowOutputWriter struct {
+	timelineInfos []*internal.TimelineInfo
+}
+
+func (writer *MockWalShowOutputWriter) Write(timelineInfos []*internal.TimelineInfo) error {
+	// append timeline infos in case future implementations will call the Write() multiple times
+	writer.timelineInfos = append(writer.timelineInfos, timelineInfos...)
+	return nil
+}
+
+// TestTimelineSetup holds test setup information about single timeline
+type TestTimelineSetup struct {
+	existSegments       []string
+	missingSegments     []string
+	id                  uint32
+	parentId            uint32
+	switchPointLsn      uint64
+	historyFileContents string
+}
+
+// GetWalFilenames returns slice of existing wal segments filenames
+func (timelineSetup *TestTimelineSetup) GetWalFilenames() []string {
+	walFileSuffix := "." + lz4.FileExtension
+	filenamesWithExtension := make([]string,0, len(timelineSetup.existSegments))
+	for _, name := range timelineSetup.existSegments {
+		filenamesWithExtension = append(filenamesWithExtension, name + walFileSuffix)
+	}
+	return filenamesWithExtension
+}
+
+// GetHistory returns .history file name and compressed contents
+func (timelineSetup *TestTimelineSetup) GetHistory() (string, *bytes.Buffer, error) {
+	compressor := compression.Compressors[lz4.AlgorithmName]
+	var compressedData bytes.Buffer
+	compressingWriter := compressor.NewWriter(&compressedData)
+	_, err := utility.FastCopy(compressingWriter, strings.NewReader(timelineSetup.historyFileContents))
+	if err != nil {
+		return "", nil, err
+	}
+	err = compressingWriter.Close()
+	if err != nil {
+		return "", nil, err
+	}
+
+	return fmt.Sprintf("%08X.history."+lz4.FileExtension, timelineSetup.id), &compressedData, nil
+}
+
+// The following TestSegmentSequence test series are used to test
+// the FindMissingSegments() method of the WalSegmentsSequence
+
+// TestSegmentSequence_SingleElement tests the case when sequence contains only one segment number
+func TestSegmentSequence_SingleElement(t *testing.T) {
+	segmentNo := 5000
+	timelineId := uint32(1)
+
+	segmentSequence := internal.NewSegmentsSequence(timelineId, internal.WalSegmentNo(segmentNo))
+
+	foundMissing, err := segmentSequence.FindMissingSegments()
+	assert.NoError(t, err)
+
+	// check that there are no missing segments found
+	assert.Len(t, foundMissing, 0)
+}
+
+// TestSegmentSequence_NoMissingSegments tests the case when there is no missing elements in sequence
+func TestSegmentSequence_NoMissingSegments(t *testing.T) {
+	minSegmentNo := 5000
+	maxSegmentNo := 5200
+	// no missing segments
+	missingSegments := make(map[internal.WalSegmentNo]bool)
+
+	foundMissing, err := testFindMissingSegments(t, minSegmentNo, maxSegmentNo, missingSegments)
+	assert.NoError(t, err)
+
+	// check that there are no missing segments found
+	assert.Len(t, foundMissing, 0)
+}
+
+// TestSegmentSequence_SearchMissingInRange verifies that FindMissingSegments searches for missing
+// segments only in range [minSegmentNo, maxSegmentNo]
+func TestSegmentSequence_SearchMissingInRange(t *testing.T) {
+	minSegmentNo := 5000
+	maxSegmentNo := 5050
+	missingSegmentsNo := map[internal.WalSegmentNo]bool{
+		5001: true,
+		5003: true,
+		5004: true,
+		5010: true,
+	}
+
+	foundMissing, err := testFindMissingSegments(t, minSegmentNo, maxSegmentNo, missingSegmentsNo)
+	assert.NoError(t, err)
+
+	assert.Equal(t, missingSegmentsNo, foundMissing)
+}
+
+func testFindMissingSegments(t *testing.T, minSegmentNo, maxSegmentNo int,
+	lostSegmentNumbers map[internal.WalSegmentNo]bool) (map[internal.WalSegmentNo]bool, error) {
+	timelineId := uint32(1)
+
+	segmentNumbers := make([]internal.WalSegmentNo, 0)
+	for i := minSegmentNo; i < maxSegmentNo; i++ {
+		newSegmentNo := internal.WalSegmentNo(i)
+		// if this segment number is not in lost set, add it
+		if _, exists := lostSegmentNumbers[newSegmentNo]; !exists {
+			segmentNumbers = append(segmentNumbers, internal.WalSegmentNo(i))
+		}
+	}
+
+	segmentSequence := internal.NewSegmentsSequence(timelineId, segmentNumbers[0])
+	for _, segmentNo := range segmentNumbers[1:] {
+		segmentSequence.AddWalSegmentNo(segmentNo)
+	}
+
+	missingSegments, err := segmentSequence.FindMissingSegments()
+	if err != nil {
+		return nil, err
+	}
+
+	// convert missingSegments list to set
+	missingNumbersSet := make(map[internal.WalSegmentNo]bool)
+	for _, segment := range missingSegments {
+		missingNumbersSet[segment.Number] = true
+	}
+
+	// check that FindMissingSegments() returned only unique elements
+	assert.Len(t, missingNumbersSet, len(missingSegments))
+	return missingNumbersSet, nil
+}
+
+// TestWalShow test series is used to test the HandleWalShow() functionality
+
+func TestWalShow_NoSegmentsInStorage(t *testing.T) {
+	timelineInfos := executeWalShow([]string{}, make(map[string]*bytes.Buffer))
+	assert.Empty(t, timelineInfos)
+}
+
+func TestWalShow_NoMissingSegments(t *testing.T) {
+	timelineSetup := &TestTimelineSetup{
+		existSegments: []string{
+			"000000010000000000000090",
+			"000000010000000000000091",
+			"000000010000000000000092",
+			"000000010000000000000093",
+		},
+		missingSegments: make([]string, 0),
+		id:              1,
+	}
+	testSingleTimeline(t, timelineSetup, make(map[string]*bytes.Buffer))
+}
+
+func TestWalShow_OneSegmentMissing(t *testing.T) {
+	timelineSetup := &TestTimelineSetup{
+		existSegments: []string{
+			"000000010000000000000090",
+			"000000010000000000000092",
+			"000000010000000000000093",
+			"000000010000000000000094",
+		},
+		missingSegments: []string{
+			"000000010000000000000091",
+		},
+		id: 1,
+	}
+	testSingleTimeline(t, timelineSetup, make(map[string]*bytes.Buffer))
+}
+
+func TestWalShow_MultipleSegmentsMissing(t *testing.T) {
+	timelineSetup := &TestTimelineSetup{
+		existSegments: []string{
+			"000000010000000000000090",
+			"000000010000000000000092",
+			"000000010000000000000093",
+			"000000010000000000000095",
+		},
+		missingSegments: []string{
+			"000000010000000000000091",
+			"000000010000000000000094",
+		},
+		id: 1,
+	}
+	testSingleTimeline(t, timelineSetup, make(map[string]*bytes.Buffer))
+}
+
+func TestWalShow_SingleTimelineWithHistory(t *testing.T) {
+	timelineSetup := &TestTimelineSetup{
+		existSegments: []string{
+			"000000020000000000000090",
+			"000000020000000000000091",
+			"000000020000000000000092",
+			"000000020000000000000093",
+		},
+		missingSegments: make([]string, 0),
+		id:              2,
+		// parentId and switch point LSN match the .history file record
+		parentId: 1,
+		// 2420113408 is 0x90400000 (hex)
+		switchPointLsn:      2420113408,
+		historyFileContents: "1\t0/90400000\tbefore 2000-01-01 05:00:00+05\n\n",
+	}
+
+	historyFileName, historyContents, err := timelineSetup.GetHistory()
+	assert.NoError(t, err)
+
+	testSingleTimeline(t, timelineSetup, map[string]*bytes.Buffer{historyFileName: historyContents})
+}
+
+func TestWalShow_TwoTimelinesWithHistory(t *testing.T) {
+	timelineSetups := []*TestTimelineSetup{
+		{
+			existSegments: []string{
+				"00000001000000000000008F",
+				"000000010000000000000090",
+				"000000010000000000000091",
+				"000000010000000000000092",
+			},
+			missingSegments: make([]string, 0),
+			id:              1,
+		},
+		{
+			existSegments: []string{
+				"000000020000000000000090",
+				"000000020000000000000091",
+				"000000020000000000000092",
+			},
+			missingSegments: make([]string, 0),
+			id:              2,
+			// parentId and switch point LSN match the .history file record
+			parentId: 1,
+			// 2420113408 is 0x90400000 (hex)
+			switchPointLsn:      2420113408,
+			historyFileContents: "1\t0/90400000\tbefore 2000-01-01 05:00:00+05\n\n",
+		},
+	}
+
+	historyFileName, historyContents, err := timelineSetups[1].GetHistory()
+	assert.NoError(t, err)
+
+	testMultipleTimelines(t, timelineSetups, map[string]*bytes.Buffer{
+		historyFileName: historyContents,
+	})
+}
+
+func TestWalShow_MultipleTimelines(t *testing.T) {
+	timelineSetups := []*TestTimelineSetup{
+		// first timeline
+		{
+			existSegments: []string{
+				"000000010000000000000090",
+				"000000010000000000000091",
+				"000000010000000000000092",
+				"000000010000000000000093",
+			},
+			id: 1,
+		},
+		// second timeline
+		{
+			existSegments: []string{
+				"000000020000000000000091",
+				"000000020000000000000092",
+			},
+			id: 2,
+		},
+	}
+	testMultipleTimelines(t, timelineSetups, make(map[string]*bytes.Buffer))
+}
+
+// testSingleTimeline is used to test wal-show with only one timeline in WAL storage
+func testSingleTimeline(t *testing.T, setup *TestTimelineSetup, walFolderFiles map[string]*bytes.Buffer) {
+	timelines := executeWalShow(setup.GetWalFilenames(), walFolderFiles)
+	assert.Len(t, timelines, 1)
+
+	verifySingleTimeline(t, setup, timelines[0])
+}
+
+// testMultipleTimelines is used to test wal-show in case of multiple timelines in WAL storage
+func testMultipleTimelines(t *testing.T, timelineSetups []*TestTimelineSetup, walFolderFiles map[string]*bytes.Buffer) {
+	walFilenames := concatWalFilenames(timelineSetups)
+	timelineInfos := executeWalShow(walFilenames, walFolderFiles)
+
+	sort.Slice(timelineInfos, func(i, j int) bool {
+		return timelineInfos[i].Id < timelineInfos[j].Id
+	})
+	sort.Slice(timelineSetups, func(i, j int) bool {
+		return timelineSetups[i].id < timelineSetups[j].id
+	})
+
+	assert.Len(t, timelineInfos, len(timelineSetups))
+
+	for idx, info := range timelineInfos {
+		verifySingleTimeline(t, timelineSetups[idx], info)
+	}
+}
+
+// verifySingleTimeline checks that setup values for timeline matches the output timeline info values
+func verifySingleTimeline(t *testing.T, setup *TestTimelineSetup, timelineInfo *internal.TimelineInfo) {
+	// sort setup.existSegments to pick the correct start and end segment
+	sort.Slice(setup.existSegments, func(i, j int) bool {
+		return setup.existSegments[i] < setup.existSegments[j]
+	})
+
+	expectedStatus := internal.TimelineOkStatus
+	if len(setup.missingSegments) > 0 {
+		expectedStatus = internal.TimelineLostSegmentStatus
+	}
+
+	expectedTimelineInfo := internal.TimelineInfo{
+		Id:               setup.id,
+		ParentId:         setup.parentId,
+		SwitchPointLsn:   setup.switchPointLsn,
+		StartSegment:     setup.existSegments[0],
+		EndSegment:       setup.existSegments[len(setup.existSegments)-1],
+		SegmentsCount:    len(setup.existSegments),
+		MissingSegments:  setup.missingSegments,
+		SegmentRangeSize: uint64(len(setup.existSegments) + len(setup.missingSegments)),
+		Status:           expectedStatus,
+	}
+
+	// check that found missing segments matches with setup values
+	assert.ElementsMatch(t, expectedTimelineInfo.MissingSegments, timelineInfo.MissingSegments)
+
+	// avoid equality errors (we ignore missing segments order and we've checked that MissingSegments match before)
+	expectedTimelineInfo.MissingSegments = timelineInfo.MissingSegments
+	assert.Equal(t, expectedTimelineInfo, *timelineInfo)
+}
+
+// executeWalShow invokes the HandleWalShow() with fake storage filled with
+// provided wal segments and other wal folder files
+func executeWalShow(walFilenames []string, walFolderFiles map[string]*bytes.Buffer) []*internal.TimelineInfo {
+	for _, name := range walFilenames {
+		// we don't use the WAL file contents so let it be it empty inside
+		walFolderFiles[name] = new(bytes.Buffer)
+	}
+	folder := setupTestStorageFolder(walFolderFiles)
+	mockOutputWriter := &MockWalShowOutputWriter{}
+
+	internal.HandleWalShow(folder, false, mockOutputWriter)
+
+	return mockOutputWriter.timelineInfos
+}
+
+func setupTestStorageFolder(walFolderFiles map[string]*bytes.Buffer) storage.Folder {
+	memoryStorage := memory.NewStorage()
+	for name, content := range walFolderFiles {
+		memoryStorage.Store("in_memory/wal_005/"+name, *content)
+	}
+
+	return memory.NewFolder("in_memory/", memoryStorage)
+}
+
+func concatWalFilenames(timelineSetups []*TestTimelineSetup) []string {
+	filenames := make([]string, 0)
+	for _, timelineSetup := range timelineSetups {
+		filenames = append(filenames, timelineSetup.GetWalFilenames()...)
+	}
+	return filenames
+}

--- a/internal/wal_show_output_writer.go
+++ b/internal/wal_show_output_writer.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"encoding/json"
+	"github.com/jedib0t/go-pretty/table"
+	"io"
+)
+
+type WalShowOutputType int
+
+const (
+	TableOutput WalShowOutputType = iota + 1
+	JsonOutput
+)
+
+// WalShowOutputWriter writes the output of wal-show command execution result
+type WalShowOutputWriter interface {
+	Write(timelineInfos []*TimelineInfo) error
+}
+
+// WalShowJsonOutputWriter writes the detailed JSON output
+type WalShowJsonOutputWriter struct {
+	output io.Writer
+}
+
+func (writer *WalShowJsonOutputWriter) Write(timelineInfos []*TimelineInfo) error {
+	bytes, err := json.Marshal(timelineInfos)
+	if err != nil {
+		return err
+	}
+	_, err = writer.output.Write(bytes)
+	return err
+}
+
+// WalShowTableOutputWriter writes the output in compact pretty table
+type WalShowTableOutputWriter struct {
+	output io.Writer
+	includeBackups bool
+}
+
+func (writer *WalShowTableOutputWriter) Write(timelineInfos []*TimelineInfo) error {
+	tableWriter := table.NewWriter()
+	tableWriter.SetOutputMirror(writer.output)
+	defer tableWriter.Render()
+
+	header := table.Row{"TLI", "Parent TLI", "Switchpoint LSN", "Start segment",
+		"End segment", "Segment range", "Segments count", "Status"}
+	if writer.includeBackups {
+		header = append(header, "Backups count")
+	}
+	tableWriter.AppendHeader(header)
+
+	for _, tl := range timelineInfos {
+		row := table.Row{tl.Id, tl.ParentId, tl.SwitchPointLsn, tl.StartSegment,
+			tl.EndSegment, tl.SegmentRangeSize, tl.SegmentsCount, tl.Status}
+		if writer.includeBackups {
+			row = append(row, len(tl.Backups))
+		}
+		tableWriter.AppendRow(row)
+	}
+
+	return nil
+}
+
+func NewWalShowOutputWriter(outputType WalShowOutputType, output io.Writer, includeBackups bool) WalShowOutputWriter {
+	switch outputType {
+	case TableOutput:
+		return &WalShowTableOutputWriter{output: output, includeBackups: includeBackups}
+	case JsonOutput:
+		return &WalShowJsonOutputWriter{output: output}
+	default:
+		return &WalShowTableOutputWriter{output: output, includeBackups: includeBackups}
+	}
+}


### PR DESCRIPTION
Wal-show command is used to get information about WAL storage folder.

It shows missing segments for each timeline found in WAL storage folder. By default, it also shows available backups for each timeline (can be turned off with `--without-backups` flag).

By default, output is pretty tiny table which looks like this:
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/47750602/89738597-710dd100-da93-11ea-8f46-3ed84b419886.png">

But user also can request a detailed JSON with `--detailed-json` flag:
```json
[
   {
      "id":1,
      "parentId":0,
      "switchPointLsn":0,
      "startSegment":"000000010000000000000078",
      "endSegment":"00000001000000010000000B",
      "segmentsCount":80,
      "missingSegments":[
         "000000010000000100000007",
         "000000010000000100000006",
         "000000010000000100000005",
         "000000010000000100000004",
...
         "0000000100000000000000C5",
         "0000000100000000000000B3"
      ],
      "availableBackups":[
         {
            "backup_name":"base_000000010000000100000009",
            "time":"2020-07-26T18:36:36.757Z",
            "wal_file_name":"000000010000000100000009",
            "start_time":"2020-07-26T18:30:59.892342Z",
            "finish_time":"2020-07-26T18:36:31.852791Z",
            "date_fmt":"%Y-%m-%dT%H:%M:%S.%fZ",
            "hostname":"MacBook-Pro.local",
            "data_dir":"SOMEDATADIR",
            "pg_version":120002,
            "start_lsn":4445962336,
            "finish_lsn":4462739536,
            "is_permanent":false,
            "system_identifier":6847498813832237599,
            "uncompressed_size":834620740,
            "compressed_size":160905595
         }
      ],
      "segmentRangeSize":148,
      "status":"LOST_SEG"
   },
   {
      "id":2,
      "parentId":1,
      "switchPointLsn":4496293888,
      "startSegment":"00000002000000010000000C",
      "endSegment":"00000002000000010000002D",
      "segmentsCount":34,
      "missingSegments":[

      ],
      "segmentRangeSize":34,
      "status":"OK"
   },
   {
      "id":3,
      "parentId":2,
      "switchPointLsn":4945750496,
      "startSegment":"000000030000000100000026",
      "endSegment":"000000030000000200000003",
      "segmentsCount":220,
      "missingSegments":[
         "0000000300000001000000E6",
         "0000000300000001000000BB"
      ],
      "availableBackups":[
         {
            "backup_name":"base_0000000300000001000000FB_D_0000000300000001000000E4",
            "time":"2020-08-03T20:55:00.277Z",
            "wal_file_name":"0000000300000001000000FB",
            "start_time":"2020-08-03T20:54:58.073709Z",
            "finish_time":"2020-08-03T20:55:00.135621Z",
            "date_fmt":"%Y-%m-%dT%H:%M:%S.%fZ",
            "hostname":"MacBook-Pro.local",
            "data_dir":"SOMEDATADIR",
            "pg_version":120002,
            "start_lsn":8506048552,
            "finish_lsn":8506048768,
            "is_permanent":false,
            "system_identifier":6847498813832237599,
            "uncompressed_size":712048,
            "compressed_size":182810
         },
         {
            "backup_name":"base_0000000300000001000000E4_D_0000000300000001000000DA",
            "time":"2020-08-01T20:06:11.535Z",
            "wal_file_name":"0000000300000001000000E4",
            "start_time":"2020-08-01T20:06:09.303919Z",
            "finish_time":"2020-08-01T20:06:11.273686Z",
            "date_fmt":"%Y-%m-%dT%H:%M:%S.%fZ",
            "hostname":"MacBook-Pro.local",
            "data_dir":"SOMEDATADIR",
            "pg_version":120002,
            "start_lsn":8120172584,
            "finish_lsn":8120172800,
            "is_permanent":false,
            "system_identifier":6847498813832237599,
            "uncompressed_size":0,
            "compressed_size":4179
         },
         {
            "backup_name":"base_0000000300000001000000DA_D_0000000300000001000000CA",
            "time":"2020-08-01T18:13:18.758Z",
            "wal_file_name":"0000000300000001000000DA",
            "start_time":"2020-08-01T18:13:16.397234Z",
            "finish_time":"2020-08-01T18:13:18.591066Z",
            "date_fmt":"%Y-%m-%dT%H:%M:%S.%fZ",
            "hostname":"MacBook-Pro.local",
            "data_dir":"SOMEDATADIR",
            "pg_version":120002,
            "start_lsn":7952400424,
            "finish_lsn":7952400640,
            "is_permanent":false,
            "system_identifier":6847498813832237599,
            "uncompressed_size":0,
            "compressed_size":181860
         },
         {
            "backup_name":"base_0000000300000001000000CA_D_000000010000000100000009",
            "time":"2020-07-30T12:14:34.565Z",
            "wal_file_name":"0000000300000001000000CA",
            "start_time":"2020-07-30T12:14:01.026327Z",
            "finish_time":"2020-07-30T12:14:34.31232Z",
            "date_fmt":"%Y-%m-%dT%H:%M:%S.%fZ",
            "hostname":"MacBook-Pro.local",
            "data_dir":"SOMEDATADIR",
            "pg_version":120002,
            "start_lsn":7683964968,
            "finish_lsn":7683965240,
            "is_permanent":false,
            "system_identifier":6847498813832237599,
            "uncompressed_size":0,
            "compressed_size":117878634
         }
      ],
      "segmentRangeSize":222,
      "status":"LOST_SEG"
   }
]
```