### PR TITLE
Inform user about error during parsing config file

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -379,6 +379,11 @@ func ReadConfigFromFile(config *viper.Viper, configFile string) {
 	err := config.ReadInConfig()
 	if err == nil {
 		tracelog.DebugLogger.Println("Using config file:", config.ConfigFileUsed())
+	} else {
+		if config.ConfigFileUsed() != "" {
+			// Config file is found, but parsing failed
+			tracelog.WarningLogger.Printf("Failed to parse config file %s. %s.", config.ConfigFileUsed(), err)
+		}
 	}
 }
 


### PR DESCRIPTION
Should solve #630 

Log if file is invalid
```
WARNING: 2020/08/15 20:52:23.806309 Failed to parse config file /home/defntvdm/.walg.json. While parsing config: invalid character '}' looking for beginning of object key string. Only environment variables are used.
ERROR: 2020/08/15 20:52:23.806869 Failed to find any configured storage
```

Log if file is correct, but variable is wrong
```
ERROR: 2020/08/15 20:52:57.187181 FS error : Folder not exists or is inaccessible: stat /var/lib/pgsql/backup-from-s3: no such file or directory
```