### PR TITLE
Add rating tar ball composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,9 @@ jobs:
     - script: make TEST="pg_full_backup_test" pg_integration_test
       workspaces:
         use: image_cache
+    - script: make TEST="pg_full_backup_rating_composer_test" pg_integration_test
+      workspaces:
+        use: image_cache
     - script: make TEST="pg_delete_before_name_find_full_test" pg_integration_test
       workspaces:
         use: image_cache

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -14,10 +14,12 @@ const (
 	FullBackupFlag                 = "full"
 	VerifyPagesFlag                = "verify"
 	StoreAllCorruptBlocksFlag      = "store-all-corrupt"
+	UseRatingComposer              = "rating-composer"
 	PermanentShorthand             = "p"
 	FullBackupShorthand            = "f"
 	VerifyPagesShorthand           = "v"
 	StoreAllCorruptBlocksShorthand = "s"
+	UseRatingComposerShortHand     = "r"
 )
 
 var (
@@ -31,13 +33,14 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 			verifyPageChecksums = verifyPageChecksums || viper.GetBool(internal.VerifyPageChecksumsSetting)
 			storeAllCorruptBlocks = storeAllCorruptBlocks || viper.GetBool(internal.StoreAllCorruptBlocksSetting)
-			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums, storeAllCorruptBlocks)
+			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums, storeAllCorruptBlocks, useRatingComposer)
 		},
 	}
 	permanent             = false
 	fullBackup            = false
 	verifyPageChecksums   = false
 	storeAllCorruptBlocks = false
+	useRatingComposer     = false
 )
 
 func init() {
@@ -48,4 +51,5 @@ func init() {
 	backupPushCmd.Flags().BoolVarP(&verifyPageChecksums, VerifyPagesFlag, VerifyPagesShorthand, false, "Verify page checksums")
 	backupPushCmd.Flags().BoolVarP(&storeAllCorruptBlocks, StoreAllCorruptBlocksFlag, StoreAllCorruptBlocksShorthand,
 		false, "Store all corrupt blocks found during page checksum verification")
+	backupPushCmd.Flags().BoolVarP(&useRatingComposer, UseRatingComposer, UseRatingComposerShortHand, false, "Use rating tar composer (beta)")
 }

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -34,6 +34,7 @@ var (
 			verifyPageChecksums = verifyPageChecksums || viper.GetBool(internal.VerifyPageChecksumsSetting)
 			storeAllCorruptBlocks = storeAllCorruptBlocks || viper.GetBool(internal.StoreAllCorruptBlocksSetting)
 			tarBallComposerType := internal.RegularComposer
+			useRatingComposer = useRatingComposer || viper.GetBool(internal.UseRatingComposerSetting)
 			if useRatingComposer {
 				tarBallComposerType = internal.RatingComposer
 			}

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -33,7 +33,11 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 			verifyPageChecksums = verifyPageChecksums || viper.GetBool(internal.VerifyPageChecksumsSetting)
 			storeAllCorruptBlocks = storeAllCorruptBlocks || viper.GetBool(internal.StoreAllCorruptBlocksSetting)
-			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums, storeAllCorruptBlocks, useRatingComposer)
+			tarBallComposerType := internal.RegularComposer
+			if useRatingComposer {
+				tarBallComposerType = internal.RatingComposer
+			}
+			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums, storeAllCorruptBlocks, tarBallComposerType)
 		},
 	}
 	permanent             = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     entrypoint: sh
     command: >
       -c 'mkdir -p /export/fullbucket
+      &&  mkdir -p /export/fullratingcomposerbucket
       &&  mkdir -p /export/fullscandeltabucket
       &&  mkdir -p /export/cryptobucket
       &&  mkdir -p /export/waldeltabucket
@@ -181,6 +182,17 @@ services:
       context: .
     image: wal-g/full_backup_test
     container_name: wal-g_pg_full_backup_test
+    depends_on:
+      - s3
+    links:
+      - s3
+
+  pg_full_backup_rating_composer_test:
+    build:
+      dockerfile: docker/pg_tests/Dockerfile_full_backup_rating_composer_test
+      context: .
+    image: wal-g/full_backup_rating_composer_test
+    container_name: wal-g_pg_full_backup_rating_composer_test
     depends_on:
       - s3
     links:

--- a/docker/pg_tests/Dockerfile_full_backup_rating_composer_test
+++ b/docker/pg_tests/Dockerfile_full_backup_rating_composer_test
@@ -1,0 +1,3 @@
+FROM wal-g/docker_prefix:latest
+
+CMD su postgres -c "/tmp/tests/full_backup_rating_composer_test.sh"

--- a/docker/pg_tests/scripts/configs/full_backup_rating_composer_test_config.json
+++ b/docker/pg_tests/scripts/configs/full_backup_rating_composer_test_config.json
@@ -1,0 +1,4 @@
+"WALE_S3_PREFIX": "s3://fullratingcomposerbucket",
+"WALG_DELTA_MAX_STEPS": "6",
+"WALG_PGP_KEY_PATH": "/tmp/PGP_KEY",
+"WALG_USE_RATING_COMPOSER": "true"

--- a/docker/pg_tests/scripts/run_integration_tests.sh
+++ b/docker/pg_tests/scripts/run_integration_tests.sh
@@ -2,5 +2,5 @@
 set -e -x
 
 pushd /tmp
-for i in tests/*; do ./$i; done
+for i in tests/*.sh; do ./$i; done
 popd

--- a/docker/pg_tests/scripts/tests/full_backup_rating_composer_test.sh
+++ b/docker/pg_tests/scripts/tests/full_backup_rating_composer_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e -x
-CONFIG_FILE="/tmp/configs/full_backup_test_config.json"
+CONFIG_FILE="/tmp/configs/full_backup_rating_composer_test_config.json"
 COMMON_CONFIG="/tmp/configs/common_config.json"
 TMP_CONFIG="/tmp/configs/tmp_config.json"
 cat ${CONFIG_FILE} > ${TMP_CONFIG}

--- a/docker/pg_tests/scripts/tests/test_functions/test_full_backup.sh
+++ b/docker/pg_tests/scripts/tests/test_functions/test_full_backup.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+test_full_backup()
+{
+  TMP_CONFIG=$1
+  /usr/lib/postgresql/10/bin/initdb ${PGDATA}
+
+  echo "archive_mode = on" >> /var/lib/postgresql/10/main/postgresql.conf
+  echo "archive_command = '/usr/bin/timeout 600 /usr/bin/wal-g --config=${TMP_CONFIG} wal-push %p'" >> /var/lib/postgresql/10/main/postgresql.conf
+  echo "archive_timeout = 600" >> /var/lib/postgresql/10/main/postgresql.conf
+
+  /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA} -w start
+
+  /tmp/scripts/wait_while_pg_not_ready.sh
+
+  wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+  pgbench -i -s 5 postgres
+  pg_dumpall -f /tmp/dump1
+  pgbench -c 2 -T 100000000 -S &
+  sleep 1
+  wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+  /tmp/scripts/drop_pg.sh
+
+  wal-g --config=${TMP_CONFIG} backup-fetch ${PGDATA} LATEST
+
+  echo "restore_command = 'echo \"WAL file restoration: %f, %p\"&& /usr/bin/wal-g --config=${TMP_CONFIG} wal-fetch \"%f\" \"%p\"'" > ${PGDATA}/recovery.conf
+
+  /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA} -w start
+  /tmp/scripts/wait_while_pg_not_ready.sh
+  pg_dumpall -f /tmp/dump2
+
+  diff /tmp/dump1 /tmp/dump2
+
+  psql -f /tmp/scripts/amcheck.sql -v "ON_ERROR_STOP=1" postgres
+
+  echo "Full backup success!!!!!!"
+
+  # Also we test here WAL overwrite prevention as a part of regular backup functionality
+
+  export WALG_PREVENT_WAL_OVERWRITE=true
+
+  echo test > ${PGDATA}/pg_wal/test_file
+  wal-g --config=${TMP_CONFIG} wal-push ${PGDATA}/pg_wal/test_file
+  wal-g --config=${TMP_CONFIG} wal-push ${PGDATA}/pg_wal/test_file
+
+  echo test1 > ${PGDATA}/pg_wal/test_file
+  wal-g --config=${TMP_CONFIG} wal-push ${PGDATA}/pg_wal/test_file && EXIT_STATUS=$? || EXIT_STATUS=$?
+
+  if [ "$EXIT_STATUS" -eq 0 ] ; then
+      echo "Error: Duplicate WAL with different content was pushed"
+      exit 1
+  fi
+
+  /tmp/scripts/drop_pg.sh
+  rm ${TMP_CONFIG}
+
+  echo "Prevent WAL overwrite success!!!!!!"
+}

--- a/internal/backup_file_description.go
+++ b/internal/backup_file_description.go
@@ -12,10 +12,11 @@ type BackupFileDescription struct {
 	IsSkipped     bool
 	MTime         time.Time
 	CorruptBlocks *CorruptBlocksInfo `json:",omitempty"`
+	UpdatesCount  uint64
 }
 
 func NewBackupFileDescription(isIncremented, isSkipped bool, modTime time.Time) *BackupFileDescription {
-	return &BackupFileDescription{isIncremented, isSkipped, modTime, nil}
+	return &BackupFileDescription{isIncremented, isSkipped, modTime, nil, 0}
 }
 
 type CorruptBlocksInfo struct {

--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -76,7 +76,7 @@ func createAndPushBackup(
 	isPermanent, forceIncremental bool,
 	incrementCount int,
 	verifyPageChecksums, storeAllCorruptBlocks bool,
-	useRatingComposer bool,
+	tarBallComposerType TarBallComposerType,
 ) {
 	folder := uploader.UploadingFolder
 	uploader.UploadingFolder = folder.GetSubFolder(backupsFolder) // TODO: AB: this subfolder switch look ugly. I think typed storage folders could be better (i.e. interface BasebackupStorageFolder, WalStorageFolder etc)
@@ -123,7 +123,10 @@ func createAndPushBackup(
 	// Start a new tar bundle, walk the archiveDirectory and upload everything there.
 	err = bundle.StartQueue(NewStorageTarBallMaker(backupName, uploader.Uploader))
 	tracelog.ErrorLogger.FatalOnError(err)
-	err = bundle.SetupComposer(NewTarBallFilePackerOptions(verifyPageChecksums, storeAllCorruptBlocks), conn)
+	tarBallComposerMaker, err := NewTarBallComposerMaker(tarBallComposerType, conn,
+		NewTarBallFilePackerOptions(verifyPageChecksums, storeAllCorruptBlocks))
+	tracelog.ErrorLogger.FatalOnError(err)
+	err = bundle.SetupComposer(tarBallComposerMaker)
 	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.InfoLogger.Println("Walking ...")
 	err = filepath.Walk(archiveDirectory, bundle.HandleWalkedFSObject)
@@ -202,7 +205,7 @@ func createAndPushBackup(
 // TODO : unit tests
 // HandleBackupPush is invoked to perform a wal-g backup-push
 func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanent, isFullBackup,
-	verifyPageChecksums, storeAllCorruptBlocks, useRatingComposer bool) {
+	verifyPageChecksums, storeAllCorruptBlocks bool, tarBallComposerType TarBallComposerType) {
 	archiveDirectory = utility.ResolveSymlink(archiveDirectory)
 	maxDeltas, fromFull := getDeltaConfig()
 	checkPgVersionAndPgControl(archiveDirectory)
@@ -254,7 +257,8 @@ func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanen
 	}
 
 	createAndPushBackup(uploader, archiveDirectory, utility.BaseBackupPath, previousBackupName,
-		previousBackupSentinelDto, isPermanent, false, incrementCount, verifyPageChecksums, storeAllCorruptBlocks, useRatingComposer)
+		previousBackupSentinelDto, isPermanent, false, incrementCount, verifyPageChecksums,
+		storeAllCorruptBlocks, tarBallComposerType)
 }
 
 // TODO : unit tests

--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -76,6 +76,7 @@ func createAndPushBackup(
 	isPermanent, forceIncremental bool,
 	incrementCount int,
 	verifyPageChecksums, storeAllCorruptBlocks bool,
+	useRatingComposer bool,
 ) {
 	folder := uploader.UploadingFolder
 	uploader.UploadingFolder = folder.GetSubFolder(backupsFolder) // TODO: AB: this subfolder switch look ugly. I think typed storage folders could be better (i.e. interface BasebackupStorageFolder, WalStorageFolder etc)
@@ -122,7 +123,7 @@ func createAndPushBackup(
 	// Start a new tar bundle, walk the archiveDirectory and upload everything there.
 	err = bundle.StartQueue(NewStorageTarBallMaker(backupName, uploader.Uploader))
 	tracelog.ErrorLogger.FatalOnError(err)
-	err = bundle.SetupComposer(NewTarBallFilePackerOptions(verifyPageChecksums, storeAllCorruptBlocks))
+	err = bundle.SetupComposer(NewTarBallFilePackerOptions(verifyPageChecksums, storeAllCorruptBlocks), conn)
 	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.InfoLogger.Println("Walking ...")
 	err = filepath.Walk(archiveDirectory, bundle.HandleWalkedFSObject)
@@ -201,7 +202,7 @@ func createAndPushBackup(
 // TODO : unit tests
 // HandleBackupPush is invoked to perform a wal-g backup-push
 func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanent, isFullBackup,
-	verifyPageChecksums, storeAllCorruptBlocks bool) {
+	verifyPageChecksums, storeAllCorruptBlocks, useRatingComposer bool) {
 	archiveDirectory = utility.ResolveSymlink(archiveDirectory)
 	maxDeltas, fromFull := getDeltaConfig()
 	checkPgVersionAndPgControl(archiveDirectory)
@@ -253,7 +254,7 @@ func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanen
 	}
 
 	createAndPushBackup(uploader, archiveDirectory, utility.BaseBackupPath, previousBackupName,
-		previousBackupSentinelDto, isPermanent, false, incrementCount, verifyPageChecksums, storeAllCorruptBlocks)
+		previousBackupSentinelDto, isPermanent, false, incrementCount, verifyPageChecksums, storeAllCorruptBlocks, useRatingComposer)
 }
 
 // TODO : unit tests

--- a/internal/bundle.go
+++ b/internal/bundle.go
@@ -103,8 +103,8 @@ func (bundle *Bundle) StartQueue(tarBallMaker TarBallMaker) error {
 	return bundle.TarBallQueue.StartQueue()
 }
 
-func (bundle *Bundle) SetupComposer(filePackOptions TarBallFilePackerOptions) (err error) {
-	bundle.TarBallComposer, err = NewTarBallComposer(RegularComposer, bundle, filePackOptions)
+func (bundle *Bundle) SetupComposer(filePackOptions TarBallFilePackerOptions, conn *pgx.Conn) (err error) {
+	bundle.TarBallComposer, err = NewTarBallComposer(RegularComposer, bundle, filePackOptions, conn)
 	return err
 }
 

--- a/internal/bundle.go
+++ b/internal/bundle.go
@@ -103,9 +103,13 @@ func (bundle *Bundle) StartQueue(tarBallMaker TarBallMaker) error {
 	return bundle.TarBallQueue.StartQueue()
 }
 
-func (bundle *Bundle) SetupComposer(filePackOptions TarBallFilePackerOptions, conn *pgx.Conn) (err error) {
-	bundle.TarBallComposer, err = NewTarBallComposer(RegularComposer, bundle, filePackOptions, conn)
-	return err
+func (bundle *Bundle) SetupComposer(composerMaker TarBallComposerMaker) (err error) {
+	tarBallComposer, err := composerMaker.Make(bundle)
+	if err != nil {
+		return err
+	}
+	bundle.TarBallComposer = tarBallComposer
+	return nil
 }
 
 func (bundle *Bundle) FinishQueue() error {

--- a/internal/bundle_files.go
+++ b/internal/bundle_files.go
@@ -2,6 +2,10 @@ package internal
 
 import (
 	"archive/tar"
+	"github.com/jackc/pgx"
+	"github.com/pkg/errors"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/walparser"
 	"os"
 	"sync"
 )
@@ -38,4 +42,94 @@ func (files *RegularBundleFiles) AddFileWithCorruptBlocks(tarHeader *tar.Header,
 
 func (files *RegularBundleFiles) GetUnderlyingMap() *sync.Map {
 	return &files.Map
+}
+
+func newStatBundleFiles(fileStat RelFileStatistics) *StatBundleFiles {
+	return &StatBundleFiles{fileStats: fileStat}
+}
+
+// StatBundleFiles contains the bundle files.
+// Additionally, it calculates and stores the updates count for each added file
+type StatBundleFiles struct {
+	sync.Map
+	fileStats RelFileStatistics
+}
+
+func (files *StatBundleFiles) AddSkippedFile(tarHeader *tar.Header, fileInfo os.FileInfo) {
+	updatesCount := files.fileStats.getFileUpdateCount(tarHeader.Name)
+	files.Store(tarHeader.Name,
+		BackupFileDescription{IsSkipped: true, IsIncremented: false,
+			MTime: fileInfo.ModTime(), UpdatesCount: updatesCount})
+}
+
+func (files *StatBundleFiles) AddFile(tarHeader *tar.Header, fileInfo os.FileInfo, isIncremented bool) {
+	updatesCount := files.fileStats.getFileUpdateCount(tarHeader.Name)
+	files.Store(tarHeader.Name,
+		BackupFileDescription{IsSkipped: false, IsIncremented: isIncremented,
+			MTime: fileInfo.ModTime(), UpdatesCount: updatesCount})
+}
+
+func (files *StatBundleFiles) GetUnderlyingMap() *sync.Map {
+	return &files.Map
+}
+
+type RelFileStatistics map[walparser.RelFileNode]PgRelationStat
+
+func (relStat *RelFileStatistics) getFileUpdateCount(filePath string) uint64 {
+	if relStat == nil {
+		return 0
+	}
+	relFileNode, err := GetRelFileNodeFrom(filePath)
+	if err != nil {
+		return 0
+	}
+	fileStat, ok := (*relStat)[*relFileNode]
+	if !ok {
+		return 0
+	}
+	return fileStat.deletedTuplesCount + fileStat.updatedTuplesCount + fileStat.insertedTuplesCount
+}
+
+func newRelFileStatistics(conn *pgx.Conn) (RelFileStatistics, error) {
+	databases, err := getDatabaseInfos(conn)
+	if err != nil {
+		return nil, errors.Wrap(err, "CollectStatistics: Failed to get db names.")
+	}
+
+	result := make(map[walparser.RelFileNode]PgRelationStat)
+	// CollectStatistics collects statistics for each relFileNode
+	for _, db := range databases {
+		databaseOption := func(c *pgx.ConnConfig) error {
+			c.Database = db.name
+			return nil
+		}
+		dbConn, err := Connect(databaseOption)
+		if err != nil {
+			tracelog.WarningLogger.Printf("Failed to collect statistics for database: %s\n'%v'\n", db.name, err)
+			continue
+		}
+
+		queryRunner, err := newPgQueryRunner(dbConn)
+		if err != nil {
+			return nil, errors.Wrap(err, "CollectStatistics: Failed to build query runner.")
+		}
+		pgStatRows, err := queryRunner.getStatistics(&db)
+		if err != nil {
+			return nil, errors.Wrap(err, "CollectStatistics: Failed to collect statistics.")
+		}
+		for relFileNode, statRow := range pgStatRows {
+			result[relFileNode] = statRow
+		}
+		err = dbConn.Close()
+		tracelog.WarningLogger.PrintOnError(err)
+	}
+	return result, nil
+}
+
+func getDatabaseInfos(conn *pgx.Conn) ([]PgDatabaseInfo, error) {
+	queryRunner, err := newPgQueryRunner(conn)
+	if err != nil {
+		return nil, errors.Wrap(err, "getDatabaseInfos: Failed to build query runner.")
+	}
+	return queryRunner.getDatabaseInfos()
 }

--- a/internal/bundle_files.go
+++ b/internal/bundle_files.go
@@ -55,6 +55,14 @@ type StatBundleFiles struct {
 	fileStats RelFileStatistics
 }
 
+func (files *StatBundleFiles) AddFileWithCorruptBlocks(tarHeader *tar.Header, fileInfo os.FileInfo, isIncremented bool, corruptedBlocks []uint32, storeAllBlocks bool) {
+	updatesCount := files.fileStats.getFileUpdateCount(tarHeader.Name)
+	fileDescription := BackupFileDescription{IsSkipped: false, IsIncremented: isIncremented, MTime: fileInfo.ModTime(),
+		UpdatesCount: updatesCount}
+	fileDescription.SetCorruptBlocks(corruptedBlocks, storeAllBlocks)
+	files.Store(tarHeader.Name, fileDescription)
+}
+
 func (files *StatBundleFiles) AddSkippedFile(tarHeader *tar.Header, fileInfo os.FileInfo) {
 	updatesCount := files.fileStats.getFileUpdateCount(tarHeader.Name)
 	files.Store(tarHeader.Name,

--- a/internal/catchup_push_handler.go
+++ b/internal/catchup_push_handler.go
@@ -26,6 +26,5 @@ func HandleCatchupPush(uploader *WalUploader, archiveDirectory string, fromLSN u
 		archiveDirectory, utility.CatchupPath,
 		"", fakePreviousBackupSentinelDto,
 		false, true, 0,
-		false, false,
-	)
+		false, false, false)
 }

--- a/internal/catchup_push_handler.go
+++ b/internal/catchup_push_handler.go
@@ -26,5 +26,5 @@ func HandleCatchupPush(uploader *WalUploader, archiveDirectory string, fromLSN u
 		archiveDirectory, utility.CatchupPath,
 		"", fakePreviousBackupSentinelDto,
 		false, true, 0,
-		false, false, false)
+		false, false, RegularComposer)
 }

--- a/internal/compose_rating_evaluator.go
+++ b/internal/compose_rating_evaluator.go
@@ -1,0 +1,24 @@
+package internal
+
+type ComposeRatingEvaluator interface {
+	Evaluate(path string, updatesCount uint64, wasInBase bool) uint64
+}
+
+type DefaultComposeRatingEvaluator struct {
+	incrementFromFiles BackupFileList
+}
+
+func NewDefaultComposeRatingEvaluator(incrementFromFiles BackupFileList) *DefaultComposeRatingEvaluator {
+	return &DefaultComposeRatingEvaluator{incrementFromFiles: incrementFromFiles}
+}
+
+func (evaluator *DefaultComposeRatingEvaluator) Evaluate(path string, updatesCount uint64, wasInBase bool) uint64 {
+	if !wasInBase {
+		return updatesCount
+	}
+	prevUpdateCount := evaluator.incrementFromFiles[path].UpdatesCount
+	if prevUpdateCount == 0 {
+		return updatesCount
+	}
+	return (updatesCount * 100) / prevUpdateCount
+}

--- a/internal/config.go
+++ b/internal/config.go
@@ -33,6 +33,7 @@ const (
 	SkipRedundantTarsSetting     = "WALG_SKIP_REDUNDANT_TARS"
 	VerifyPageChecksumsSetting   = "WALG_VERIFY_PAGE_CHECKSUMS"
 	StoreAllCorruptBlocksSetting = "WALG_STORE_ALL_CORRUPT_BLOCKS"
+	UseRatingComposerSetting     = "WALG_USE_RATING_COMPOSER"
 	LogLevelSetting              = "WALG_LOG_LEVEL"
 	TarSizeThresholdSetting      = "WALG_TAR_SIZE_THRESHOLD"
 	CseKmsIDSetting              = "WALG_CSE_KMS_ID"
@@ -103,6 +104,7 @@ var (
 		SkipRedundantTarsSetting:     "false",
 		VerifyPageChecksumsSetting:   "false",
 		StoreAllCorruptBlocksSetting: "false",
+		UseRatingComposerSetting:     "false",
 
 		OplogArchiveTimeoutInterval:    "60s",
 		OplogArchiveAfterSize:          "16777216", // 32 << (10 * 2)
@@ -141,6 +143,7 @@ var (
 		SkipRedundantTarsSetting:     true,
 		VerifyPageChecksumsSetting:   true,
 		StoreAllCorruptBlocksSetting: true,
+		UseRatingComposerSetting:     true,
 
 		// Postgres
 		PgPortSetting:     true,

--- a/internal/connect.go
+++ b/internal/connect.go
@@ -12,12 +12,18 @@ import (
 // and the connection is `<nil>`.
 //
 // Example: PGHOST=/var/run/postgresql or PGHOST=10.0.0.1
-func Connect() (*pgx.Conn, error) {
+func Connect(configOptions ...func(config *pgx.ConnConfig) error) (*pgx.Conn, error) {
 	config, err := pgx.ParseEnvLibpq()
 	if err != nil {
 		return nil, errors.Wrap(err, "Connect: unable to read environment variables")
 	}
-
+	// apply passed custom config options, if any
+	for _, option := range configOptions {
+		err := option(&config)
+		if err != nil {
+			return nil, err
+		}
+	}
 	conn, err := pgx.Connect(config)
 	if err != nil {
 		if config.Host != "localhost" {

--- a/internal/paged_file_delta_map.go
+++ b/internal/paged_file_delta_map.go
@@ -111,6 +111,9 @@ func GetRelFileNodeFrom(filePath string) (*walparser.RelFileNode, error) {
 	folderPath, name := path.Split(filePath)
 	folderPathParts := strings.Split(strings.TrimSuffix(folderPath, "/"), string(os.PathSeparator))
 	match := pagedFilenameRegexp.FindStringSubmatch(name)
+	if match == nil {
+		return nil, errors.New("GetRelFileNodeFrom: can't parse path: " + filePath)
+	}
 	relNode, err := strconv.Atoi(match[1])
 	if err != nil {
 		return nil, errors.Wrapf(err, "GetRelFileNodeFrom: can't get relNode from: '%s'", filePath)

--- a/internal/pagefile.go
+++ b/internal/pagefile.go
@@ -136,6 +136,37 @@ func ReadIncrementalFile(filePath string, fileSize int64, lsn uint64, deltaBitma
 	return pageReader, incrementSize, nil
 }
 
+func ReadIncrementLocations(filePath string, fileSize int64, lsn uint64) ([]walparser.BlockLocation, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	fileReadSeekCloser := &ioextensions.ReadSeekCloserImpl{
+		Reader: NewDiskLimitReader(file),
+		Seeker: file,
+		Closer: file,
+	}
+	pageReader := &IncrementalPageReader{fileReadSeekCloser, fileSize, lsn, nil, nil}
+	err = pageReader.FullScanInitialize()
+	if err != nil {
+		return nil, err
+	}
+	return convertBlocksToLocations(filePath, pageReader.Blocks)
+}
+
+func convertBlocksToLocations(filePath string, blocks []uint32) ([]walparser.BlockLocation, error) {
+	relFileNode, err := GetRelFileNodeFrom(filePath)
+	if err != nil {
+		return nil, err
+	}
+	locations := make([]walparser.BlockLocation, 0, len(blocks))
+	for _, blockNo := range blocks {
+		locations = append(locations, *walparser.NewBlockLocation(relFileNode.SpcNode, relFileNode.DBNode, relFileNode.RelNode, blockNo))
+	}
+	return locations, nil
+}
+
 // ApplyFileIncrement changes pages according to supplied change map file
 func ApplyFileIncrement(fileName string, increment io.Reader, createNewIncrementalFiles bool) error {
 	tracelog.DebugLogger.Printf("Incrementing %s\n", fileName)

--- a/internal/queryRunner.go
+++ b/internal/queryRunner.go
@@ -2,10 +2,10 @@ package internal
 
 import (
 	"fmt"
-
 	"github.com/jackc/pgx"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/walparser"
 )
 
 type NoPostgresVersionError struct {
@@ -39,6 +39,18 @@ type QueryRunner interface {
 	StartBackup(backup string) (string, string, bool, error)
 	// Inform database that contents are copied, get information on backup
 	StopBackup() (string, string, string, error)
+}
+
+type PgDatabaseInfo struct {
+	name      string
+	oid       walparser.Oid
+	tblSpcOid walparser.Oid
+}
+
+type PgRelationStat struct {
+	insertedTuplesCount uint64
+	updatedTuplesCount  uint64
+	deletedTuplesCount  uint64
 }
 
 // PgQueryRunner is implementation for controlling PostgreSQL 9.0+
@@ -169,4 +181,108 @@ func (queryRunner *PgQueryRunner) stopBackup() (label string, offsetMap string, 
 	}
 
 	return label, offsetMap, lsnStr, nil
+}
+
+// BuildStatisticsQuery formats a query that fetch relations statistics from database
+func (queryRunner *PgQueryRunner) BuildStatisticsQuery() (string, error) {
+	switch {
+	case queryRunner.Version >= 90000:
+		return "SELECT c.relfilenode, c.reltablespace, s.n_tup_ins, s.n_tup_upd, s.n_tup_del " +
+			"FROM pg_class c " +
+			"LEFT OUTER JOIN pg_stat_all_tables s " +
+			"ON c.oid = s.relid " +
+			"WHERE relfilenode != 0 " +
+			"AND n_tup_ins IS NOT NULL", nil
+	case queryRunner.Version == 0:
+		return "", newNoPostgresVersionError()
+	default:
+		return "", newUnsupportedPostgresVersionError(queryRunner.Version)
+	}
+}
+
+// getStatistics queries the relations statistics from database
+func (queryRunner *PgQueryRunner) getStatistics(dbInfo *PgDatabaseInfo) (map[walparser.RelFileNode]PgRelationStat, error) {
+	tracelog.InfoLogger.Println("Querying pg_stat_all_tables")
+	getStatQuery, err := queryRunner.BuildStatisticsQuery()
+	conn := queryRunner.connection
+	if err != nil {
+		return nil, errors.Wrap(err, "QueryRunner GetStatistics: Building get statistics query failed")
+	}
+
+	rows, err := conn.Query(getStatQuery)
+	if err != nil {
+		return nil, errors.Wrap(err, "QueryRunner GetStatistics: pg_stat_all_tables query failed")
+	}
+
+	defer rows.Close()
+	relationsStats := make(map[walparser.RelFileNode]PgRelationStat)
+	for rows.Next() {
+		var relationStat PgRelationStat
+		var relFileNodeId uint32
+		var spcNode uint32
+		if err := rows.Scan(&relFileNodeId, &spcNode, &relationStat.insertedTuplesCount, &relationStat.updatedTuplesCount,
+			&relationStat.deletedTuplesCount); err != nil {
+			tracelog.WarningLogger.Printf("GetStatistics:  %v\n", err.Error())
+		}
+		relFileNode := walparser.RelFileNode{DBNode: dbInfo.oid,
+			RelNode: walparser.Oid(relFileNodeId), SpcNode: walparser.Oid(spcNode)}
+		// if tablespace id is zero, use the default database tablespace id
+		if relFileNode.SpcNode == walparser.Oid(0) {
+			relFileNode.SpcNode = dbInfo.tblSpcOid
+		}
+		relationsStats[relFileNode] = relationStat
+	}
+
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	return relationsStats, nil
+}
+
+// BuildGetDatabasesQuery formats a query to get all databases in cluster which are allowed to connect
+func (queryRunner *PgQueryRunner) BuildGetDatabasesQuery() (string, error) {
+	switch {
+	case queryRunner.Version >= 90000:
+		return "SELECT oid, datname, dattablespace FROM pg_database WHERE datallowconn", nil
+	case queryRunner.Version == 0:
+		return "", newNoPostgresVersionError()
+	default:
+		return "", newUnsupportedPostgresVersionError(queryRunner.Version)
+	}
+}
+
+// getDatabaseInfos fetches a list of all databases in cluster which are allowed to connect
+func (queryRunner *PgQueryRunner) getDatabaseInfos() ([]PgDatabaseInfo, error) {
+	tracelog.InfoLogger.Println("Querying pg_database")
+	getDbInfoQuery, err := queryRunner.BuildGetDatabasesQuery()
+	conn := queryRunner.connection
+	if err != nil {
+		return nil, errors.Wrap(err, "QueryRunner GetDatabases: Building db names query failed")
+	}
+
+	rows, err := conn.Query(getDbInfoQuery)
+	if err != nil {
+		return nil, errors.Wrap(err, "QueryRunner GetDatabases: pg_database query failed")
+	}
+
+	defer rows.Close()
+	databases := make([]PgDatabaseInfo, 0)
+	for rows.Next() {
+		dbInfo := PgDatabaseInfo{}
+		var dbOid uint32
+		var dbTblSpcOid uint32
+		if err := rows.Scan(&dbOid, &dbInfo.name, &dbTblSpcOid); err != nil {
+			tracelog.WarningLogger.Printf("GetStatistics:  %v\n", err.Error())
+		}
+		dbInfo.oid = walparser.Oid(dbOid)
+		dbInfo.tblSpcOid = walparser.Oid(dbTblSpcOid)
+		databases = append(databases, dbInfo)
+	}
+
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	return databases, nil
 }

--- a/internal/rating_tar_ball_composer.go
+++ b/internal/rating_tar_ball_composer.go
@@ -50,10 +50,6 @@ type RatedComposeFileInfo struct {
 	expectedSize uint64
 }
 
-//
-// UNCHANGED FRAGMENT START
-//
-
 // TarFilesCollection stores the files which are going to be written
 // to the same tarball
 type TarFilesCollection struct {
@@ -69,10 +65,6 @@ func (collection *TarFilesCollection) AddFile(file *RatedComposeFileInfo) {
 	collection.files = append(collection.files, file)
 	collection.expectedSize += file.expectedSize
 }
-
-//
-// UNCHANGED FRAGMENT END
-//
 
 // RatingTarBallComposer receives all files and tar headers
 // that are going to be written to the backup,
@@ -238,10 +230,6 @@ func (c *RatingTarBallComposer) sortFiles() {
 	})
 }
 
-//
-// UNCHANGED FRAGMENT START
-//
-
 func (c *RatingTarBallComposer) composeFiles() ([]*tar.Header, []*TarFilesCollection) {
 	c.sortFiles()
 	tarFilesCollections := make([]*TarFilesCollection, 0)
@@ -264,10 +252,6 @@ func (c *RatingTarBallComposer) composeFiles() ([]*tar.Header, []*TarFilesCollec
 	tarFilesCollections = append(tarFilesCollections, currentFilesCollection)
 	return c.headersToCompose, tarFilesCollections
 }
-
-//
-// UNCHANGED FRAGMENT END
-//
 
 func (c *RatingTarBallComposer) getExpectedFileSize(cfi *ComposeFileInfo) (uint64, error) {
 	if !cfi.isIncremented {

--- a/internal/rating_tar_ball_composer.go
+++ b/internal/rating_tar_ball_composer.go
@@ -1,0 +1,297 @@
+package internal
+
+import (
+	"archive/tar"
+	"context"
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal/crypto"
+	"golang.org/x/sync/errgroup"
+	"os"
+	"sort"
+	"sync"
+)
+
+type RatedComposeFileInfo struct {
+	ComposeFileInfo
+	updateRating uint64
+	updatesCount uint64
+	// for regular files this value should match their size on the disk
+	// for increments this value is the estimated size of the increment that is going to be created
+	expectedSize uint64
+}
+
+//
+// UNCHANGED FRAGMENT START
+//
+
+// TarFilesCollection stores the files which are going to be written
+// to the same tarball
+type TarFilesCollection struct {
+	files        []*RatedComposeFileInfo
+	expectedSize uint64
+}
+
+func newTarFilesCollection() *TarFilesCollection {
+	return &TarFilesCollection{files: make([]*RatedComposeFileInfo, 0), expectedSize: 0}
+}
+
+func (collection *TarFilesCollection) AddFile(file *RatedComposeFileInfo) {
+	collection.files = append(collection.files, file)
+	collection.expectedSize += file.expectedSize
+}
+
+//
+// UNCHANGED FRAGMENT END
+//
+
+// RatingTarBallComposer receives all files and tar headers
+// that are going to be written to the backup,
+// and composes the tarballs by placing the files
+// with similar update rating in the same tarballs
+type RatingTarBallComposer struct {
+	filesToCompose         []*RatedComposeFileInfo
+	filesToComposeMutex    sync.Mutex
+	headersToCompose       []*tar.Header
+	composeRatingEvaluator ComposeRatingEvaluator
+
+	tarBallQueue  *TarBallQueue
+	tarFilePacker *TarBallFilePacker
+	crypter       crypto.Crypter
+
+	addFileQueue     chan *ComposeFileInfo
+	addFileWaitGroup sync.WaitGroup
+
+	fileStats   RelFileStatistics
+	bundleFiles BundleFiles
+
+	incrementBaseLsn *uint64
+	tarSizeThreshold uint64
+
+	deltaMap         PagedFileDeltaMap
+	deltaMapMutex    sync.Mutex
+	deltaMapComplete bool
+
+	errorGroup *errgroup.Group
+}
+
+func NewRatingTarBallComposer(
+	tarSizeThreshold uint64, updateRatingEvaluator ComposeRatingEvaluator,
+	incrementBaseLsn *uint64, deltaMap PagedFileDeltaMap, tarBallQueue *TarBallQueue,
+	crypter crypto.Crypter, fileStats RelFileStatistics, bundleFiles BundleFiles) (*RatingTarBallComposer, error) {
+
+	errorGroup, _ := errgroup.WithContext(context.Background())
+	deltaMapComplete := true
+	if deltaMap == nil {
+		deltaMapComplete = false
+		deltaMap = NewPagedFileDeltaMap()
+	}
+
+	composer := &RatingTarBallComposer{
+		headersToCompose:       make([]*tar.Header, 0),
+		filesToCompose:         make([]*RatedComposeFileInfo, 0),
+		tarSizeThreshold:       tarSizeThreshold,
+		incrementBaseLsn:       incrementBaseLsn,
+		composeRatingEvaluator: updateRatingEvaluator,
+		deltaMapComplete:       deltaMapComplete,
+		deltaMap:               deltaMap,
+		tarBallQueue:           tarBallQueue,
+		crypter:                crypter,
+		fileStats:              fileStats,
+		bundleFiles:            bundleFiles,
+		tarFilePacker:          newTarBallFilePacker(deltaMap, incrementBaseLsn, bundleFiles),
+		errorGroup:             errorGroup,
+	}
+
+	maxUploadDiskConcurrency, err := getMaxUploadDiskConcurrency()
+	if err != nil {
+		return nil, err
+	}
+	composer.addFileQueue = make(chan *ComposeFileInfo, maxUploadDiskConcurrency)
+	for i := 0; i < maxUploadDiskConcurrency; i++ {
+		composer.addFileWaitGroup.Add(1)
+		composer.errorGroup.Go(func() error {
+			return composer.addFileWorker(composer.addFileQueue)
+		})
+	}
+	return composer, nil
+}
+
+func (c *RatingTarBallComposer) AddFile(info *ComposeFileInfo) {
+	c.addFileQueue <- info
+}
+
+func (c *RatingTarBallComposer) AddHeader(fileInfoHeader *tar.Header, info os.FileInfo) error {
+	c.headersToCompose = append(c.headersToCompose, fileInfoHeader)
+	c.bundleFiles.AddFile(fileInfoHeader, info, false)
+	return nil
+}
+
+func (c *RatingTarBallComposer) SkipFile(tarHeader *tar.Header, fileInfo os.FileInfo) {
+	c.bundleFiles.AddSkippedFile(tarHeader, fileInfo)
+}
+
+func (c *RatingTarBallComposer) PackTarballs() (TarFileSets, error) {
+	close(c.addFileQueue)
+	err := c.errorGroup.Wait()
+	if err != nil {
+		return nil, err
+	}
+	c.addFileWaitGroup.Wait()
+
+	c.tarFilePacker.UpdateDeltaMap(c.deltaMap)
+	headers, tarFilesCollections := c.composeFiles()
+	headersTarName, headersNames, err := c.writeHeaders(headers)
+	if err != nil {
+		return nil, err
+	}
+
+	tarFileSets := make(map[string][]string, 0)
+	tarFileSets[headersTarName] = headersNames
+
+	for _, tarFilesCollection := range tarFilesCollections {
+		tarBall := c.tarBallQueue.Deque()
+		tarBall.SetUp(c.crypter)
+		for _, composeFileInfo := range tarFilesCollection.files {
+			tarFileSets[tarBall.Name()] = append(tarFileSets[tarBall.Name()], composeFileInfo.header.Name)
+		}
+		// tarFilesCollection closure
+		tarFilesCollectionLocal := tarFilesCollection
+		go func() {
+			for _, fileInfo := range tarFilesCollectionLocal.files {
+				err := c.tarFilePacker.PackFileIntoTar(&fileInfo.ComposeFileInfo, tarBall)
+				if err != nil {
+					panic(err)
+				}
+			}
+			err := c.tarBallQueue.FinishTarBall(tarBall)
+			if err != nil {
+				panic(err)
+			}
+		}()
+	}
+
+	return tarFileSets, nil
+}
+
+func (c *RatingTarBallComposer) GetFiles() BundleFiles {
+	return c.bundleFiles
+}
+
+func (c *RatingTarBallComposer) addFileWorker(tasks <-chan *ComposeFileInfo) error {
+	for task := range tasks {
+		err := c.addFile(task)
+		if err != nil {
+			return err
+		}
+	}
+	c.addFileWaitGroup.Done()
+	return nil
+}
+
+func (c *RatingTarBallComposer) addFile(cfi *ComposeFileInfo) error {
+	expectedFileSize, err := c.getExpectedFileSize(cfi)
+	if err != nil {
+		return err
+	}
+	updatesCount := c.fileStats.getFileUpdateCount(cfi.path)
+	updateRating := c.composeRatingEvaluator.Evaluate(cfi.path, updatesCount, cfi.wasInBase)
+	ratedComposeFileInfo := &RatedComposeFileInfo{*cfi, updateRating, updatesCount, expectedFileSize}
+	c.filesToComposeMutex.Lock()
+	defer c.filesToComposeMutex.Unlock()
+	c.filesToCompose = append(c.filesToCompose, ratedComposeFileInfo)
+	return nil
+}
+
+func (c *RatingTarBallComposer) sortFiles() {
+	sort.Slice(c.filesToCompose, func(i, j int) bool {
+		return c.filesToCompose[i].updateRating < c.filesToCompose[j].updateRating
+	})
+}
+
+//
+// UNCHANGED FRAGMENT START
+//
+
+func (c *RatingTarBallComposer) composeFiles() ([]*tar.Header, []*TarFilesCollection) {
+	c.sortFiles()
+	tarFilesCollections := make([]*TarFilesCollection, 0)
+	currentFilesCollection := newTarFilesCollection()
+	prevUpdateRating := uint64(0)
+
+	for _, file := range c.filesToCompose {
+		// if the estimated size of the current collection exceeds the threshold,
+		// or if the updateRating just went to non-zero from zero,
+		// start packing to the new tar files collection
+		if currentFilesCollection.expectedSize > c.tarSizeThreshold ||
+			prevUpdateRating == 0 && file.updateRating > 0 {
+			tarFilesCollections = append(tarFilesCollections, currentFilesCollection)
+			currentFilesCollection = newTarFilesCollection()
+		}
+		currentFilesCollection.AddFile(file)
+		prevUpdateRating = file.updateRating
+	}
+
+	tarFilesCollections = append(tarFilesCollections, currentFilesCollection)
+	return c.headersToCompose, tarFilesCollections
+}
+
+//
+// UNCHANGED FRAGMENT END
+//
+
+func (c *RatingTarBallComposer) getExpectedFileSize(cfi *ComposeFileInfo) (uint64, error) {
+	if !cfi.isIncremented {
+		return uint64(cfi.fileInfo.Size()), nil
+	}
+
+	if !c.deltaMapComplete {
+		err := c.scanDeltaMapFor(cfi.path, cfi.fileInfo.Size())
+		if err != nil {
+			return 0, err
+		}
+	}
+	bitmap, err := c.deltaMap.GetDeltaBitmapFor(cfi.path)
+	if _, ok := err.(NoBitmapFoundError); ok {
+		// this file has changed after the start of backup and will be skipped
+		// so the expected size in tar is zero
+		return 0, nil
+	}
+	if err != nil {
+		return 0, errors.Wrapf(err, "getExpectedFileSize: failed to find corresponding bitmap '%s'\n", cfi.path)
+	}
+	incrementBlocksCount := bitmap.GetCardinality()
+	// expected header size =
+	// length(IncrementFileHeader) + sizeOf(fileSize) + sizeOf(diffBlockCount) + sizeOf(blockNo)*incrementBlocksCount
+	incrementHeaderSize := uint64(len(IncrementFileHeader)) + sizeofInt64 + sizeofInt32 + (incrementBlocksCount * sizeofInt32)
+	incrementPageDataSize := incrementBlocksCount * uint64(DatabasePageSize)
+	return incrementHeaderSize + incrementPageDataSize, nil
+}
+
+func (c *RatingTarBallComposer) scanDeltaMapFor(filePath string, fileSize int64) error {
+	locations, err := ReadIncrementLocations(filePath, fileSize, *c.incrementBaseLsn)
+	if err != nil {
+		return err
+	}
+	c.deltaMapMutex.Lock()
+	defer c.deltaMapMutex.Unlock()
+	if len(locations) == 0 {
+		return nil
+	}
+	c.deltaMap.AddLocationsToDelta(locations)
+	return nil
+}
+
+func (c *RatingTarBallComposer) writeHeaders(headers []*tar.Header) (string, []string, error) {
+	headersTarBall := c.tarBallQueue.Deque()
+	headersTarBall.SetUp(c.crypter)
+	headersNames := make([]string, 0, len(headers))
+	for _, header := range headers {
+		err := headersTarBall.TarWriter().WriteHeader(header)
+		headersNames = append(headersNames, header.Name)
+		if err != nil {
+			return "", nil, errors.Wrap(err, "addToBundle: failed to write header")
+		}
+	}
+	c.tarBallQueue.EnqueueBack(headersTarBall)
+	return headersTarBall.Name(), headersNames, nil
+}

--- a/internal/regular_tar_ball_composer.go
+++ b/internal/regular_tar_ball_composer.go
@@ -34,6 +34,20 @@ func NewRegularTarBallComposer(
 	}
 }
 
+type RegularTarBallComposerMaker struct {
+	filePackerOptions TarBallFilePackerOptions
+}
+
+func NewRegularTarBallComposerMaker(filePackerOptions TarBallFilePackerOptions) *RegularTarBallComposerMaker {
+	return &RegularTarBallComposerMaker{filePackerOptions: filePackerOptions}
+}
+
+func (maker *RegularTarBallComposerMaker) Make(bundle *Bundle) (TarBallComposer, error) {
+	bundleFiles := &RegularBundleFiles{}
+	tarBallFilePacker := newTarBallFilePacker(bundle.DeltaMap, bundle.IncrementFromLsn, bundleFiles, maker.filePackerOptions)
+	return NewRegularTarBallComposer(bundle.TarBallQueue, tarBallFilePacker, bundleFiles, bundle.Crypter), nil
+}
+
 func (c *RegularTarBallComposer) AddFile(info *ComposeFileInfo) {
 	tarBall := c.tarBallQueue.Deque()
 	tarBall.SetUp(c.crypter)

--- a/internal/walk_test.go
+++ b/internal/walk_test.go
@@ -327,7 +327,15 @@ func isEmpty(t *testing.T, path string) bool {
 	return false
 }
 
-func TestWalk(t *testing.T) {
+func TestWalk_RegularComposer(t *testing.T) {
+	testWalk(t, false)
+}
+
+func TestWalk_RatingComposer(t *testing.T) {
+	testWalk(t, true)
+}
+
+func testWalk(t *testing.T, useRatingComposer bool) {
 	// Generate random data and write to tmp dir `data...`.
 	data := generateData(t)
 	tarSizeThreshold := int64(10)
@@ -348,8 +356,8 @@ func TestWalk(t *testing.T) {
 	if err != nil {
 		t.Log(err)
 	}
-	
-	err = bundle.SetupComposer(internal.TarBallFilePackerOptions{}, nil)
+
+	err = bundle.SetupComposer(setupTestTarBallComposerMaker(useRatingComposer))
 	if err != nil {
 		t.Log(err)
 	}
@@ -403,4 +411,14 @@ func TestWalk(t *testing.T) {
 		// t.Errorf("upload: expected no error to occur but got %+v", err)
 		t.Logf("%+v\n", err)
 	}
+}
+
+func setupTestTarBallComposerMaker(useRatingComposer bool) internal.TarBallComposerMaker {
+	filePackOptions := internal.NewTarBallFilePackerOptions(false, false)
+	if !useRatingComposer {
+		return internal.NewRegularTarBallComposerMaker(filePackOptions)
+	}
+	relFileStats := make(internal.RelFileStatistics, 0)
+	composerMaker, _ := internal.NewRatingTarBallComposerMaker(relFileStats, filePackOptions)
+	return composerMaker
 }

--- a/internal/walk_test.go
+++ b/internal/walk_test.go
@@ -348,8 +348,8 @@ func TestWalk(t *testing.T) {
 	if err != nil {
 		t.Log(err)
 	}
-
-	err = bundle.SetupComposer(internal.TarBallFilePackerOptions{})
+	
+	err = bundle.SetupComposer(internal.TarBallFilePackerOptions{}, nil)
 	if err != nil {
 		t.Log(err)
 	}


### PR DESCRIPTION
RatingTarBallComposer receives all files and tar headers which are going to be written to the backup and composes the tarballs by placing the files with similar update rating in the same tarballs.

Also, there is a new StatBundleFiles implementation of BundleFiles which uses the statistics about page files updates count from pg_stat_all_tables and records this statistics into backup sentinel json. This information is used in future backups by ComposeRatingEvaluator to calculate the update rating for file.