### PR TITLE
Pages checksum verification

### DIFF
--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -1,6 +1,7 @@
 package pg
 
 import (
+	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 
@@ -11,8 +12,10 @@ const (
 	BackupPushShortDescription = "Makes backup and uploads it to storage"
 	PermanentFlag              = "permanent"
 	FullBackupFlag             = "full"
+	VerifyPagesFlag            = "verify"
 	PermanentShorthand         = "p"
 	FullBackupShorthand        = "f"
+	VerifyPagesShorthand       = "v"
 )
 
 var (
@@ -24,11 +27,13 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			uploader, err := internal.ConfigureWalUploader()
 			tracelog.ErrorLogger.FatalOnError(err)
-			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup)
+			verifyPageChecksums = verifyPageChecksums || viper.GetBool(internal.VerifyPageChecksumsSetting)
+			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums)
 		},
 	}
 	permanent  = false
 	fullBackup = false
+	verifyPageChecksums = false
 )
 
 func init() {
@@ -36,4 +41,5 @@ func init() {
 
 	backupPushCmd.Flags().BoolVarP(&permanent, PermanentFlag, PermanentShorthand, false, "Pushes permanent backup")
 	backupPushCmd.Flags().BoolVarP(&fullBackup, FullBackupFlag, FullBackupShorthand, false, "Make full backup-push")
+	backupPushCmd.Flags().BoolVarP(&verifyPageChecksums, VerifyPagesFlag, VerifyPagesShorthand, false, "Verify page checksums")
 }

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -9,13 +9,15 @@ import (
 )
 
 const (
-	BackupPushShortDescription = "Makes backup and uploads it to storage"
-	PermanentFlag              = "permanent"
-	FullBackupFlag             = "full"
-	VerifyPagesFlag            = "verify"
-	PermanentShorthand         = "p"
-	FullBackupShorthand        = "f"
-	VerifyPagesShorthand       = "v"
+	BackupPushShortDescription     = "Makes backup and uploads it to storage"
+	PermanentFlag                  = "permanent"
+	FullBackupFlag                 = "full"
+	VerifyPagesFlag                = "verify"
+	StoreAllCorruptBlocksFlag      = "store-all-corrupt"
+	PermanentShorthand             = "p"
+	FullBackupShorthand            = "f"
+	VerifyPagesShorthand           = "v"
+	StoreAllCorruptBlocksShorthand = "s"
 )
 
 var (
@@ -28,12 +30,14 @@ var (
 			uploader, err := internal.ConfigureWalUploader()
 			tracelog.ErrorLogger.FatalOnError(err)
 			verifyPageChecksums = verifyPageChecksums || viper.GetBool(internal.VerifyPageChecksumsSetting)
-			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums)
+			storeAllCorruptBlocks = storeAllCorruptBlocks || viper.GetBool(internal.StoreAllCorruptBlocksSetting)
+			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums, storeAllCorruptBlocks)
 		},
 	}
-	permanent  = false
-	fullBackup = false
-	verifyPageChecksums = false
+	permanent             = false
+	fullBackup            = false
+	verifyPageChecksums   = false
+	storeAllCorruptBlocks = false
 )
 
 func init() {
@@ -42,4 +46,6 @@ func init() {
 	backupPushCmd.Flags().BoolVarP(&permanent, PermanentFlag, PermanentShorthand, false, "Pushes permanent backup")
 	backupPushCmd.Flags().BoolVarP(&fullBackup, FullBackupFlag, FullBackupShorthand, false, "Make full backup-push")
 	backupPushCmd.Flags().BoolVarP(&verifyPageChecksums, VerifyPagesFlag, VerifyPagesShorthand, false, "Verify page checksums")
+	backupPushCmd.Flags().BoolVarP(&storeAllCorruptBlocks, StoreAllCorruptBlocksFlag, StoreAllCorruptBlocksShorthand,
+		false, "Store all corrupt blocks found during page checksum verification")
 }

--- a/internal/backup_file_description.go
+++ b/internal/backup_file_description.go
@@ -1,15 +1,36 @@
 package internal
 
-import "time"
+import (
+	"sort"
+	"time"
+)
+
+const MaxCorruptBlocksInFileDesc int = 10
 
 type BackupFileDescription struct {
 	IsIncremented bool // should never be both incremented and Skipped
 	IsSkipped     bool
 	MTime         time.Time
+	CorruptBlocks []uint32 `json:",omitempty"`
 }
 
 func NewBackupFileDescription(isIncremented, isSkipped bool, modTime time.Time) *BackupFileDescription {
-	return &BackupFileDescription{isIncremented, isSkipped, modTime}
+	return &BackupFileDescription{isIncremented, isSkipped, modTime, nil}
+}
+
+func (desc *BackupFileDescription) SetCorruptBlocks(corruptBlockNumbers []uint32) {
+	sort.Slice(corruptBlockNumbers, func(i, j int) bool {
+		return corruptBlockNumbers[i] < corruptBlockNumbers[j]
+	})
+
+	// write no more than MaxCorruptBlocksInFileDesc
+	desc.CorruptBlocks = make([]uint32, 0)
+	for idx, blockNo := range corruptBlockNumbers {
+		if idx >= MaxCorruptBlocksInFileDesc {
+			break
+		}
+		desc.CorruptBlocks = append(desc.CorruptBlocks, blockNo)
+	}
 }
 
 type BackupFileList map[string]BackupFileDescription

--- a/internal/backup_file_description.go
+++ b/internal/backup_file_description.go
@@ -11,25 +11,38 @@ type BackupFileDescription struct {
 	IsIncremented bool // should never be both incremented and Skipped
 	IsSkipped     bool
 	MTime         time.Time
-	CorruptBlocks []uint32 `json:",omitempty"`
+	CorruptBlocks *CorruptBlocksInfo `json:",omitempty"`
 }
 
 func NewBackupFileDescription(isIncremented, isSkipped bool, modTime time.Time) *BackupFileDescription {
 	return &BackupFileDescription{isIncremented, isSkipped, modTime, nil}
 }
 
-func (desc *BackupFileDescription) SetCorruptBlocks(corruptBlockNumbers []uint32) {
+type CorruptBlocksInfo struct {
+	CorruptBlocksCount int
+	SomeCorruptBlocks  []uint32
+}
+
+func (desc *BackupFileDescription) SetCorruptBlocks(corruptBlockNumbers []uint32, storeAllBlocks bool) {
+	if len(corruptBlockNumbers) == 0 {
+		return
+	}
 	sort.Slice(corruptBlockNumbers, func(i, j int) bool {
 		return corruptBlockNumbers[i] < corruptBlockNumbers[j]
 	})
 
+	corruptBlocksCount := len(corruptBlockNumbers)
 	// write no more than MaxCorruptBlocksInFileDesc
-	desc.CorruptBlocks = make([]uint32, 0)
+	someCorruptBlocks := make([]uint32, 0)
 	for idx, blockNo := range corruptBlockNumbers {
-		if idx >= MaxCorruptBlocksInFileDesc {
+		if !storeAllBlocks && idx >= MaxCorruptBlocksInFileDesc {
 			break
 		}
-		desc.CorruptBlocks = append(desc.CorruptBlocks, blockNo)
+		someCorruptBlocks = append(someCorruptBlocks, blockNo)
+	}
+	desc.CorruptBlocks = &CorruptBlocksInfo{
+		CorruptBlocksCount: corruptBlocksCount,
+		SomeCorruptBlocks:  someCorruptBlocks,
 	}
 }
 

--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -75,6 +75,7 @@ func createAndPushBackup(
 	previousBackupSentinelDto BackupSentinelDto,
 	isPermanent, forceIncremental bool,
 	incrementCount int,
+	verifyPageChecksums bool,
 ) {
 	folder := uploader.UploadingFolder
 	uploader.UploadingFolder = folder.GetSubFolder(backupsFolder) // TODO: AB: this subfolder switch look ugly. I think typed storage folders could be better (i.e. interface BasebackupStorageFolder, WalStorageFolder etc)
@@ -121,7 +122,7 @@ func createAndPushBackup(
 	// Start a new tar bundle, walk the archiveDirectory and upload everything there.
 	err = bundle.StartQueue(NewStorageTarBallMaker(backupName, uploader.Uploader))
 	tracelog.ErrorLogger.FatalOnError(err)
-	err = bundle.SetupComposer()
+	err = bundle.SetupComposer(verifyPageChecksums)
 	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.InfoLogger.Println("Walking ...")
 	err = filepath.Walk(archiveDirectory, bundle.HandleWalkedFSObject)
@@ -199,7 +200,7 @@ func createAndPushBackup(
 
 // TODO : unit tests
 // HandleBackupPush is invoked to perform a wal-g backup-push
-func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanent bool, isFullBackup bool) {
+func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanent, isFullBackup, verifyPageChecksums bool) {
 	archiveDirectory = utility.ResolveSymlink(archiveDirectory)
 	maxDeltas, fromFull := getDeltaConfig()
 	checkPgVersionAndPgControl(archiveDirectory)
@@ -250,7 +251,8 @@ func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanen
 		tracelog.InfoLogger.Println("Doing full backup.")
 	}
 
-	createAndPushBackup(uploader, archiveDirectory, utility.BaseBackupPath, previousBackupName, previousBackupSentinelDto, isPermanent, false, incrementCount)
+	createAndPushBackup(uploader, archiveDirectory, utility.BaseBackupPath, previousBackupName,
+		previousBackupSentinelDto, isPermanent, false, incrementCount, verifyPageChecksums)
 }
 
 // TODO : unit tests

--- a/internal/bundle.go
+++ b/internal/bundle.go
@@ -103,8 +103,8 @@ func (bundle *Bundle) StartQueue(tarBallMaker TarBallMaker) error {
 	return bundle.TarBallQueue.StartQueue()
 }
 
-func (bundle *Bundle) SetupComposer(verifyPageChecksums bool) (err error) {
-	bundle.TarBallComposer, err = NewTarBallComposer(RegularComposer, bundle, verifyPageChecksums)
+func (bundle *Bundle) SetupComposer(filePackOptions TarBallFilePackerOptions) (err error) {
+	bundle.TarBallComposer, err = NewTarBallComposer(RegularComposer, bundle, filePackOptions)
 	return err
 }
 

--- a/internal/bundle.go
+++ b/internal/bundle.go
@@ -103,8 +103,8 @@ func (bundle *Bundle) StartQueue(tarBallMaker TarBallMaker) error {
 	return bundle.TarBallQueue.StartQueue()
 }
 
-func (bundle *Bundle) SetupComposer() (err error) {
-	bundle.TarBallComposer, err = NewTarBallComposer(RegularComposer, bundle)
+func (bundle *Bundle) SetupComposer(verifyPageChecksums bool) (err error) {
+	bundle.TarBallComposer, err = NewTarBallComposer(RegularComposer, bundle, verifyPageChecksums)
 	return err
 }
 

--- a/internal/bundle_files.go
+++ b/internal/bundle_files.go
@@ -10,6 +10,7 @@ import (
 type BundleFiles interface {
 	AddSkippedFile(tarHeader *tar.Header, fileInfo os.FileInfo)
 	AddFile(tarHeader *tar.Header, fileInfo os.FileInfo, isIncremented bool)
+	AddFileWithCorruptBlocks(tarHeader *tar.Header, fileInfo os.FileInfo, isIncremented bool, corruptedBlocks []uint32)
 	GetUnderlyingMap() *sync.Map
 }
 
@@ -25,6 +26,13 @@ func (files *RegularBundleFiles) AddSkippedFile(tarHeader *tar.Header, fileInfo 
 func (files *RegularBundleFiles) AddFile(tarHeader *tar.Header, fileInfo os.FileInfo, isIncremented bool) {
 	files.Store(tarHeader.Name,
 		BackupFileDescription{IsSkipped: false, IsIncremented: isIncremented, MTime: fileInfo.ModTime()})
+}
+
+func (files *RegularBundleFiles) AddFileWithCorruptBlocks(tarHeader *tar.Header, fileInfo os.FileInfo,
+	isIncremented bool, corruptedBlocks []uint32) {
+	fileDescription := BackupFileDescription{IsSkipped: false, IsIncremented: isIncremented, MTime: fileInfo.ModTime()}
+	fileDescription.SetCorruptBlocks(corruptedBlocks)
+	files.Store(tarHeader.Name, fileDescription)
 }
 
 func (files *RegularBundleFiles) GetUnderlyingMap() *sync.Map {

--- a/internal/bundle_files.go
+++ b/internal/bundle_files.go
@@ -10,7 +10,8 @@ import (
 type BundleFiles interface {
 	AddSkippedFile(tarHeader *tar.Header, fileInfo os.FileInfo)
 	AddFile(tarHeader *tar.Header, fileInfo os.FileInfo, isIncremented bool)
-	AddFileWithCorruptBlocks(tarHeader *tar.Header, fileInfo os.FileInfo, isIncremented bool, corruptedBlocks []uint32)
+	AddFileWithCorruptBlocks(tarHeader *tar.Header, fileInfo os.FileInfo, isIncremented bool,
+		corruptedBlocks []uint32, storeAllBlocks bool)
 	GetUnderlyingMap() *sync.Map
 }
 
@@ -29,9 +30,9 @@ func (files *RegularBundleFiles) AddFile(tarHeader *tar.Header, fileInfo os.File
 }
 
 func (files *RegularBundleFiles) AddFileWithCorruptBlocks(tarHeader *tar.Header, fileInfo os.FileInfo,
-	isIncremented bool, corruptedBlocks []uint32) {
+	isIncremented bool, corruptedBlocks []uint32, storeAllBlocks bool) {
 	fileDescription := BackupFileDescription{IsSkipped: false, IsIncremented: isIncremented, MTime: fileInfo.ModTime()}
-	fileDescription.SetCorruptBlocks(corruptedBlocks)
+	fileDescription.SetCorruptBlocks(corruptedBlocks, storeAllBlocks)
 	files.Store(tarHeader.Name, fileDescription)
 }
 

--- a/internal/catchup_push_handler.go
+++ b/internal/catchup_push_handler.go
@@ -26,6 +26,6 @@ func HandleCatchupPush(uploader *WalUploader, archiveDirectory string, fromLSN u
 		archiveDirectory, utility.CatchupPath,
 		"", fakePreviousBackupSentinelDto,
 		false, true, 0,
-		false,
+		false, false,
 	)
 }

--- a/internal/catchup_push_handler.go
+++ b/internal/catchup_push_handler.go
@@ -26,5 +26,6 @@ func HandleCatchupPush(uploader *WalUploader, archiveDirectory string, fromLSN u
 		archiveDirectory, utility.CatchupPath,
 		"", fakePreviousBackupSentinelDto,
 		false, true, 0,
+		false,
 	)
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -32,6 +32,7 @@ const (
 	UseReverseUnpackSetting      = "WALG_USE_REVERSE_UNPACK"
 	SkipRedundantTarsSetting     = "WALG_SKIP_REDUNDANT_TARS"
 	VerifyPageChecksumsSetting   = "WALG_VERIFY_PAGE_CHECKSUMS"
+	StoreAllCorruptBlocksSetting = "WALG_STORE_ALL_CORRUPT_BLOCKS"
 	LogLevelSetting              = "WALG_LOG_LEVEL"
 	TarSizeThresholdSetting      = "WALG_TAR_SIZE_THRESHOLD"
 	CseKmsIDSetting              = "WALG_CSE_KMS_ID"
@@ -101,6 +102,7 @@ var (
 		UseReverseUnpackSetting:      "false",
 		SkipRedundantTarsSetting:     "false",
 		VerifyPageChecksumsSetting:   "false",
+		StoreAllCorruptBlocksSetting: "false",
 
 		OplogArchiveTimeoutInterval:    "60s",
 		OplogArchiveAfterSize:          "16777216", // 32 << (10 * 2)
@@ -138,6 +140,7 @@ var (
 		UseReverseUnpackSetting:      true,
 		SkipRedundantTarsSetting:     true,
 		VerifyPageChecksumsSetting:   true,
+		StoreAllCorruptBlocksSetting: true,
 
 		// Postgres
 		PgPortSetting:     true,

--- a/internal/config.go
+++ b/internal/config.go
@@ -31,6 +31,7 @@ const (
 	UseWalDeltaSetting           = "WALG_USE_WAL_DELTA"
 	UseReverseUnpackSetting      = "WALG_USE_REVERSE_UNPACK"
 	SkipRedundantTarsSetting     = "WALG_SKIP_REDUNDANT_TARS"
+	VerifyPageChecksumsSetting   = "WALG_VERIFY_PAGE_CHECKSUMS"
 	LogLevelSetting              = "WALG_LOG_LEVEL"
 	TarSizeThresholdSetting      = "WALG_TAR_SIZE_THRESHOLD"
 	CseKmsIDSetting              = "WALG_CSE_KMS_ID"
@@ -99,6 +100,7 @@ var (
 		TotalBgUploadedLimit:         "32",
 		UseReverseUnpackSetting:      "false",
 		SkipRedundantTarsSetting:     "false",
+		VerifyPageChecksumsSetting:   "false",
 
 		OplogArchiveTimeoutInterval:    "60s",
 		OplogArchiveAfterSize:          "16777216", // 32 << (10 * 2)
@@ -135,6 +137,7 @@ var (
 		NameStreamRestoreCmd:         true,
 		UseReverseUnpackSetting:      true,
 		SkipRedundantTarsSetting:     true,
+		VerifyPageChecksumsSetting:   true,
 
 		// Postgres
 		PgPortSetting:     true,

--- a/internal/ioextensions/io.go
+++ b/internal/ioextensions/io.go
@@ -64,3 +64,24 @@ func CreateFileWith(filePath string, content io.Reader) error {
 	_, err = utility.FastCopy(file, content)
 	return err
 }
+
+type MultiCloser struct {
+	closers []io.Closer
+}
+
+func NewMultiCloser(closers []io.Closer) *MultiCloser {
+	return &MultiCloser{
+		closers: closers,
+	}
+}
+func (m *MultiCloser) Close() error {
+	var err error
+	for _, c := range m.closers {
+		// still call Close on each, even if one returns an error
+		if e := c.Close(); e != nil {
+			err = e
+		}
+	}
+	return err
+}
+

--- a/internal/ioextensions/io.go
+++ b/internal/ioextensions/io.go
@@ -1,6 +1,7 @@
 package ioextensions
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -79,9 +80,12 @@ func (m *MultiCloser) Close() error {
 	for _, c := range m.closers {
 		// still call Close on each, even if one returns an error
 		if e := c.Close(); e != nil {
-			err = e
+			if err != nil {
+				err = fmt.Errorf("%w; %v", err, e)
+			} else {
+				err = e
+			}
 		}
 	}
 	return err
 }
-

--- a/internal/paged_file_verifier.go
+++ b/internal/paged_file_verifier.go
@@ -1,0 +1,240 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"github.com/wal-g/tracelog"
+	"io"
+	"io/ioutil"
+	"os"
+	"unsafe"
+)
+
+// This code is an adaptation of Postgres data page checksum calculation code written in Go.
+// It uses a modified version of FNV-1a hash algorithm.
+// Full description of the hashing algorithm and original code can be found in origin.
+// Origin: https://github.com/postgres/postgres/blob/REL_12_STABLE/src/include/storage/checksum_impl.h
+
+const (
+	// number of checksums to calculate in parallel
+	NSums int = 32
+	// prime multiplier of FNV-1a hash
+	FnvPrime uint32 = 16777619
+	// page header checksum offset
+	PdChecksumOffset = 8
+	// page header checksum length (in bytes)
+	PdChecksumLen = 2
+)
+
+// There is an unsafe pointer logic with PgDatabasePage and PgChecksummablePage.
+// Be careful if modifying these data types.
+
+// PgDatabasePage represents single database page
+type PgDatabasePage [DatabasePageSize]byte
+
+// PgChecksummablePage represents single database page divided by NSums blocks
+// for checksum calculation
+type PgChecksummablePage [DatabasePageSize / int64(NSums*sizeofInt32)][NSums]uint32
+
+// Base offsets to initialize each of the parallel FNV hashes into a different initial state
+var checksumBaseOffsets [NSums]uint32
+
+// ignoredFileNames contains filenames of files that can not be verified
+var ignoredFileNames map[string]bool
+
+func init() {
+	checksumBaseOffsets = [NSums]uint32{
+		0x5B1F36E9, 0xB8525960, 0x02AB50AA, 0x1DE66D2A,
+		0x79FF467A, 0x9BB9F8A3, 0x217E7CD2, 0x83E13D2C,
+		0xF8D4474F, 0xE39EB970, 0x42C6AE16, 0x993216FA,
+		0x7B093B5D, 0x98DAFF3C, 0xF718902A, 0x0B1C9CDB,
+		0xE58F764B, 0x187636BC, 0x5D7B3BB1, 0xE73DE7DE,
+		0x92BEC979, 0xCCA6C0B2, 0x304A0979, 0x85AA43D4,
+		0x783125BB, 0x6CA8EAA2, 0xE407EAC6, 0x4B5CFC3E,
+		0x9FBF8C76, 0x15CA20BE, 0xF2CA9FD3, 0x959BD756,
+	}
+	ignoredFileNames = map[string]bool{
+		"pg_internal.init": true,
+	}
+}
+
+// Calculate one round of the checksum.
+func calculateSum(checksum, value uint32) uint32 {
+	tmp := checksum ^ value
+	return (tmp * FnvPrime) ^ (tmp >> 17)
+}
+
+// Compute the checksum for a Postgres page.
+//
+// The page must be adequately aligned (at least on a 4-byte boundary).
+//
+// The checksum includes the block number (to detect the case where a page is
+// somehow moved to a different location), the page header (excluding the
+// checksum itself), and the page data.
+func pgChecksumPage(blockNo uint32, pageBytes [DatabasePageSize]byte) (uint16, error) {
+	// Set pd_checksum to zero, so that the checksum calculation
+	// isn't affected by the checksum stored on the page.
+	for i := PdChecksumOffset; i < PdChecksumOffset+PdChecksumLen; i++ {
+		pageBytes[i] = 0
+	}
+	checksum := pgChecksumBlock(pageBytes)
+
+	// Mix in the block number to detect transposed pages
+	checksum ^= blockNo
+
+	// Reduce to a uint16 (to fit in the pd_checksum field) with an offset of
+	// one. That avoids checksums of zero, which seems like a good idea.
+	return uint16((checksum % 65535) + 1), nil
+}
+
+// Block checksum algorithm. The page must be adequately aligned (at least on 4-byte boundary).
+func pgChecksumBlock(page [DatabasePageSize]byte) uint32 {
+	// Initialize partial checksums to their corresponding offsets
+	sums := checksumBaseOffsets
+	var pageForChecksum = *(*PgChecksummablePage)(unsafe.Pointer(&page))
+	hashIterationsCount := DatabasePageSize / int64(NSums*sizeofInt32)
+
+	// main checksum calculation
+	for i := int64(0); i < hashIterationsCount; i++ {
+		for j := 0; j < NSums; j++ {
+			sums[j] = calculateSum(sums[j], pageForChecksum[i][j])
+		}
+	}
+
+	// finally add in two rounds of zeroes for additional mixing
+	for i := 0; i < 2; i++ {
+		for j := 0; j < NSums; j++ {
+			sums[j] = calculateSum(sums[j], 0)
+		}
+	}
+
+	result := uint32(0)
+	// xor fold partial checksums together
+	for i := 0; i < NSums; i++ {
+		result ^= sums[i]
+	}
+
+	return result
+}
+
+// This function is an adaptation of is_page_corrupted() from
+// https://github.com/google/pg_page_verification/blob/master/pg_page_verification.c
+
+// Function checks a page header checksum value against the current
+// checksum value of a page.  NewPage checksums will be zero until they
+// are set.  There is a similar function PageIsVerified responsible for
+// checking pages before they are loaded into buffer pool.
+//
+// see:  src/backend/storage/page/bufpage.c
+func isPageCorrupted(path string, blockNo uint32, page PgDatabasePage) (bool, error) {
+	pageHeader, err := parsePostgresPageHeader(bytes.NewReader(page[:]))
+	if err != nil {
+		return false, err
+	}
+	valid := pageHeader.isValid()
+	if !valid {
+		tracelog.WarningLogger.Printf("Invalid page header encountered: blockNo %d, path %s", blockNo, path)
+	}
+
+	// We only calculate the checksum for properly-initialized pages
+	isNew := pageHeader.isNew()
+	if isNew {
+		return false, nil
+	}
+
+	if pageHeader.pdChecksum == 0 {
+		// Zero value means that there is no checksum calculated for this page.
+		// Probably checksums are disabled in the cluster
+		return false, nil
+	}
+
+	// calculating blkno needs to be aboslute so that subsequent segment files
+	// have the blkno calculated based on all segment files and not relative to
+	// the current segment file. see: https://goo.gl/qRTn46
+
+	// Number of current segment
+	relFileId, err := GetRelFileIdFrom(path)
+	if err != nil {
+		return false, err
+	}
+
+	// segmentBlockOffset is the absolute blockNumber of the block when taking
+	// into account any previous segment files.
+	segmentBlockOffset := uint32(relFileId * BlocksInRelFile)
+
+	checksum, err := pgChecksumPage(segmentBlockOffset+blockNo, page)
+	if err != nil {
+		return false, err
+	}
+
+	corrupted := checksum != pageHeader.pdChecksum
+	if corrupted {
+		tracelog.WarningLogger.Printf("Corruption found in %s/[%d], expected %x, found %x\n",
+			path, blockNo, pageHeader.pdChecksum, checksum)
+	}
+
+	return corrupted, nil
+}
+
+// VerifyPagedFileIncrement verifies pages of an increment
+func VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Reader) ([]uint32, error) {
+	_, diffBlockCount, diffMap, err := GetIncrementHeaderFields(increment)
+	if err != nil {
+		return nil, err
+	}
+	blockNumbers := make([]uint32, 0, diffBlockCount)
+	for i := uint32(0); i < diffBlockCount; i++ {
+		blockNo := binary.LittleEndian.Uint32(diffMap[i*sizeofInt32 : (i+1)*sizeofInt32])
+		blockNumbers = append(blockNumbers, blockNo)
+	}
+	return verifyPageBlocks(path, fileInfo, increment, blockNumbers)
+}
+
+// VerifyPagedFileBase verifies pages of a standard paged file
+func VerifyPagedFileBase(path string, fileInfo os.FileInfo, pagedFile io.Reader) ([]uint32, error) {
+	size := fileInfo.Size()
+	filePageCount := uint32(size / DatabasePageSize)
+	blockNumbers := make([]uint32, 0, filePageCount)
+	for i := uint32(0); i < filePageCount; i++ {
+		blockNumbers = append(blockNumbers, i)
+	}
+	return verifyPageBlocks(path, fileInfo, pagedFile, blockNumbers)
+}
+
+// verifyPageBlocks verifies provided page blocks from the pagedBlocks reader
+func verifyPageBlocks(path string, fileInfo os.FileInfo, pageBlocks io.Reader,
+	blockNumbers []uint32) (corruptBlockNumbers []uint32, err error) {
+	if _, ignored := ignoredFileNames[fileInfo.Name()]; ignored || !isPagedFile(fileInfo, path) {
+		_, err = io.Copy(ioutil.Discard, pageBlocks)
+		return nil, err
+	}
+	for _, blockNo := range blockNumbers {
+		corrupted, err := verifySinglePage(path, blockNo, pageBlocks)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if corrupted {
+			corruptBlockNumbers = append(corruptBlockNumbers, blockNo)
+		}
+	}
+	// check if some extra delta blocks left in increment
+	if isEmpty := isTarReaderEmpty(pageBlocks); !isEmpty {
+		tracelog.WarningLogger.Printf("verifyPageBlocks: Unexpected extra bytes: %s\n", path)
+	}
+	tracelog.DebugLogger.Printf("verifyPageBlocks: %s, checked %d blocks, found %d corrupt\n",
+		path, len(blockNumbers), len(corruptBlockNumbers))
+	return corruptBlockNumbers, nil
+}
+
+// verifySinglePage reads and verifies single paged file block
+func verifySinglePage(path string, blockNo uint32, pageBlocks io.Reader) (bool, error) {
+	page := PgDatabasePage{}
+	_, err := io.ReadFull(pageBlocks, page[:])
+	if err != nil {
+		return false, err
+	}
+	return isPageCorrupted(path, blockNo, page)
+}

--- a/internal/tar_ball_composer.go
+++ b/internal/tar_ball_composer.go
@@ -38,11 +38,11 @@ const (
 	RegularComposer TarBallComposerType = iota + 1
 )
 
-func NewTarBallComposer(composerType TarBallComposerType, bundle *Bundle) (TarBallComposer, error) {
+func NewTarBallComposer(composerType TarBallComposerType, bundle *Bundle, verifyPageChecksums bool) (TarBallComposer, error) {
 	switch composerType {
 	case RegularComposer:
 		bundleFiles := &RegularBundleFiles{}
-		tarBallFilePacker := newTarBallFilePacker(bundle.DeltaMap, bundle.IncrementFromLsn, bundleFiles)
+		tarBallFilePacker := newTarBallFilePacker(bundle.DeltaMap, bundle.IncrementFromLsn, bundleFiles, verifyPageChecksums)
 		return NewRegularTarBallComposer(bundle.TarBallQueue, tarBallFilePacker, bundleFiles, bundle.Crypter), nil
 	default:
 		return nil, errors.New("NewTarBallComposer: Unknown TarBallComposerType")

--- a/internal/tar_ball_composer.go
+++ b/internal/tar_ball_composer.go
@@ -38,11 +38,12 @@ const (
 	RegularComposer TarBallComposerType = iota + 1
 )
 
-func NewTarBallComposer(composerType TarBallComposerType, bundle *Bundle, verifyPageChecksums bool) (TarBallComposer, error) {
+func NewTarBallComposer(composerType TarBallComposerType, bundle *Bundle,
+	filePackOptions TarBallFilePackerOptions) (TarBallComposer, error) {
 	switch composerType {
 	case RegularComposer:
 		bundleFiles := &RegularBundleFiles{}
-		tarBallFilePacker := newTarBallFilePacker(bundle.DeltaMap, bundle.IncrementFromLsn, bundleFiles, verifyPageChecksums)
+		tarBallFilePacker := newTarBallFilePacker(bundle.DeltaMap, bundle.IncrementFromLsn, bundleFiles, filePackOptions)
 		return NewRegularTarBallComposer(bundle.TarBallQueue, tarBallFilePacker, bundleFiles, bundle.Crypter), nil
 	default:
 		return nil, errors.New("NewTarBallComposer: Unknown TarBallComposerType")

--- a/internal/tar_ball_file_packer.go
+++ b/internal/tar_ball_file_packer.go
@@ -47,12 +47,13 @@ type TarBallFilePacker struct {
 	verifyPageChecksums bool
 }
 
-func newTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *uint64, files BundleFiles) *TarBallFilePacker {
+func newTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *uint64, files BundleFiles,
+	verifyPageChecksums bool) *TarBallFilePacker {
 	return &TarBallFilePacker{
 		deltaMap:            deltaMap,
 		incrementFromLsn:    incrementFromLsn,
 		files:               files,
-		verifyPageChecksums: false,
+		verifyPageChecksums: verifyPageChecksums,
 	}
 }
 

--- a/internal/tar_ball_file_packer.go
+++ b/internal/tar_ball_file_packer.go
@@ -2,27 +2,57 @@ package internal
 
 import (
 	"archive/tar"
+	"context"
+	"fmt"
 	"github.com/RoaringBitmap/roaring"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/ioextensions"
 	"github.com/wal-g/wal-g/utility"
+	"golang.org/x/sync/errgroup"
 	"io"
+	"io/ioutil"
 	"os"
 )
 
+type SkippedFileError struct {
+	error
+}
+
+func newSkippedFileError(path string) SkippedFileError {
+	return SkippedFileError{errors.Errorf("File is skipped from the current backup: %s\n", path)}
+}
+
+func (err SkippedFileError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}
+
+type IgnoredFileError struct {
+	error
+}
+
+func newIgnoredFileError(path string) IgnoredFileError {
+	return IgnoredFileError{errors.Errorf("File is ignored: %s\n", path)}
+}
+
+func (err IgnoredFileError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}
+
 // TarBallFilePacker is used to pack bundle file into tarball.
 type TarBallFilePacker struct {
-	deltaMap         PagedFileDeltaMap
-	incrementFromLsn *uint64
-	files            BundleFiles
+	deltaMap            PagedFileDeltaMap
+	incrementFromLsn    *uint64
+	files               BundleFiles
+	verifyPageChecksums bool
 }
 
 func newTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *uint64, files BundleFiles) *TarBallFilePacker {
 	return &TarBallFilePacker{
-		deltaMap:         deltaMap,
-		incrementFromLsn: incrementFromLsn,
-		files:            files,
+		deltaMap:            deltaMap,
+		incrementFromLsn:    incrementFromLsn,
+		files:               files,
+		verifyPageChecksums: false,
 	}
 }
 
@@ -39,58 +69,93 @@ func (p *TarBallFilePacker) UpdateDeltaMap(deltaMap PagedFileDeltaMap) {
 
 // TODO : unit tests
 func (p *TarBallFilePacker) PackFileIntoTar(cfi *ComposeFileInfo, tarBall TarBall) error {
-	var fileReader io.ReadCloser
+	fileReadCloser, err := p.createFileReadCloser(cfi)
+	if err != nil {
+		switch err.(type) {
+		case SkippedFileError:
+			p.files.AddSkippedFile(cfi.header, cfi.fileInfo)
+			return nil
+		case IgnoredFileError:
+			return nil
+		default:
+			return err
+		}
+	}
+	errorGroup, _ := errgroup.WithContext(context.Background())
+
+	if p.verifyPageChecksums {
+		var secondReadCloser io.ReadCloser
+		// newTeeReadCloser is used to provide the fileReadCloser to two consumers:
+		// fileReadCloser is needed for PackFileTo, secondReadCloser is for the page verification
+		fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
+		errorGroup.Go(func() (err error) {
+			corruptBlocks, err := verifyFile(cfi.path, cfi.fileInfo, secondReadCloser, cfi.isIncremented)
+			if err != nil {
+				return err
+			}
+			p.files.AddFileWithCorruptBlocks(cfi.header, cfi.fileInfo, cfi.isIncremented, corruptBlocks)
+			return nil
+		})
+	} else {
+		p.files.AddFile(cfi.header, cfi.fileInfo, cfi.isIncremented)
+	}
+
+	errorGroup.Go(func() error {
+		defer utility.LoggedClose(fileReadCloser, "")
+		packedFileSize, err := PackFileTo(tarBall, cfi.header, fileReadCloser)
+		if err != nil {
+			return errors.Wrap(err, "PackFileIntoTar: operation failed")
+		}
+		if packedFileSize != cfi.header.Size {
+			return newTarSizeError(packedFileSize, cfi.header.Size)
+		}
+		return nil
+	})
+
+	return errorGroup.Wait()
+}
+
+func (p *TarBallFilePacker) createFileReadCloser(cfi *ComposeFileInfo) (io.ReadCloser, error) {
+	var fileReadCloser io.ReadCloser
 	if cfi.isIncremented {
 		bitmap, err := p.getDeltaBitmapFor(cfi.path)
 		if _, ok := err.(NoBitmapFoundError); ok { // this file has changed after the start of backup, so just skip it
-			p.files.AddSkippedFile(cfi.header, cfi.fileInfo)
-			return nil
+			return nil, newSkippedFileError(cfi.path)
 		} else if err != nil {
-			return errors.Wrapf(err, "PackFileIntoTar: failed to find corresponding bitmap '%s'\n", cfi.path)
+			return nil, errors.Wrapf(err, "PackFileIntoTar: failed to find corresponding bitmap '%s'\n", cfi.path)
 		}
-		fileReader, cfi.header.Size, err = ReadIncrementalFile(cfi.path, cfi.fileInfo.Size(), *p.incrementFromLsn, bitmap)
+		fileReadCloser, cfi.header.Size, err = ReadIncrementalFile(cfi.path, cfi.fileInfo.Size(), *p.incrementFromLsn, bitmap)
 		if os.IsNotExist(err) { // File was deleted before opening
 			// We should ignore file here as if it did not exist.
-			return nil
+			return nil, newIgnoredFileError(cfi.path)
 		}
 		switch err.(type) {
 		case nil:
-			fileReader = &ioextensions.ReadCascadeCloser{
+			fileReadCloser = &ioextensions.ReadCascadeCloser{
 				Reader: &io.LimitedReader{
-					R: io.MultiReader(fileReader, &ioextensions.ZeroReader{}),
+					R: io.MultiReader(fileReadCloser, &ioextensions.ZeroReader{}),
 					N: cfi.header.Size,
 				},
-				Closer: fileReader,
+				Closer: fileReadCloser,
 			}
 		case InvalidBlockError: // fallback to full file backup
 			tracelog.WarningLogger.Printf("failed to read file '%s' as incremented\n", cfi.header.Name)
 			cfi.isIncremented = false
-			fileReader, err = startReadingFile(cfi.header, cfi.fileInfo, cfi.path, fileReader)
+			fileReadCloser, err = startReadingFile(cfi.header, cfi.fileInfo, cfi.path, fileReadCloser)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		default:
-			return errors.Wrapf(err, "PackFileIntoTar: failed reading incremental file '%s'\n", cfi.path)
+			return nil, errors.Wrapf(err, "PackFileIntoTar: failed reading incremental file '%s'\n", cfi.path)
 		}
 	} else {
 		var err error
-		fileReader, err = startReadingFile(cfi.header, cfi.fileInfo, cfi.path, fileReader)
+		fileReadCloser, err = startReadingFile(cfi.header, cfi.fileInfo, cfi.path, fileReadCloser)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	defer utility.LoggedClose(fileReader, "")
-	p.files.AddFile(cfi.header, cfi.fileInfo, cfi.isIncremented)
-	packedFileSize, err := PackFileTo(tarBall, cfi.header, fileReader)
-	if err != nil {
-		return errors.Wrap(err, "PackFileIntoTar: operation failed")
-	}
-
-	if packedFileSize != cfi.header.Size {
-		return newTarSizeError(packedFileSize, cfi.header.Size)
-	}
-
-	return nil
+	return fileReadCloser, nil
 }
 
 // TODO : unit tests
@@ -109,4 +174,27 @@ func startReadingFile(fileInfoHeader *tar.Header, info os.FileInfo, path string,
 		Closer: file,
 	}
 	return fileReader, nil
+}
+
+func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool) ([]uint32, error) {
+	if !isPagedFile(fileInfo, path) {
+		_, err := io.Copy(ioutil.Discard, fileReader)
+		return nil, err
+	}
+
+	if isIncremented {
+		return VerifyPagedFileIncrement(path, fileInfo, fileReader)
+	}
+	return VerifyPagedFileBase(path, fileInfo, fileReader)
+}
+
+// TeeReadCloser creates two io.ReadClosers from one
+func newTeeReadCloser(readCloser io.ReadCloser) (io.ReadCloser, io.ReadCloser) {
+	pipeReader, pipeWriter := io.Pipe()
+
+	// teeReader is used to provide the readCloser to two consumers
+	teeReader := io.TeeReader(readCloser, pipeWriter)
+	// MultiCloser closes both pipeWriter and readCloser on Close() call
+	closer := ioextensions.NewMultiCloser([]io.Closer{readCloser, pipeWriter})
+	return &ioextensions.ReadCascadeCloser{Reader: teeReader, Closer: closer}, pipeReader
 }

--- a/internal/walk_test.go
+++ b/internal/walk_test.go
@@ -349,7 +349,7 @@ func TestWalk(t *testing.T) {
 		t.Log(err)
 	}
 
-	err = bundle.SetupComposer()
+	err = bundle.SetupComposer(false)
 	if err != nil {
 		t.Log(err)
 	}

--- a/internal/walk_test.go
+++ b/internal/walk_test.go
@@ -349,7 +349,7 @@ func TestWalk(t *testing.T) {
 		t.Log(err)
 	}
 
-	err = bundle.SetupComposer(false)
+	err = bundle.SetupComposer(internal.TarBallFilePackerOptions{})
 	if err != nil {
 		t.Log(err)
 	}


### PR DESCRIPTION
In this PR I propose the page checksums verification functionality for `backup-push`

I've adapted the Postgres page hash calculation (modified version of FNV-1a hash algorithm) from C origin:
https://github.com/postgres/postgres/blob/REL_12_STABLE/src/include/storage/checksum_impl.h

Also, I've also partially borrowed the logic of is_page_corrupted() from pg_page_verification tool: https://github.com/google/pg_page_verification/blob/master/pg_page_verification.c

Users can enable the page verification using `--verify` flag or by setting `WALG_VERIFY_PAGE_CHECKSUMS` env variable. If found any, corrupted block numbers (currently no more than 10 of them) will be recorded to the backup sentinel json, for example:
```json
...
 "/base/13690/13535": {
      "IsSkipped": true,
      "MTime": "2020-08-20T21:02:56.690095409+05:00",
      "IsIncremented": false
    },
    "/base/16384/16397": {
      "CorruptBlocks": [
        1
      ],
      "IsIncremented": false,
      "IsSkipped": false,
      "MTime": "2020-08-21T19:09:52.966149937+05:00"
    },
...
```