### PR TITLE
Add docs for new WAL-G commands

### DIFF
--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -148,7 +148,7 @@ wal-g backup-fetch /path LATEST --reverse-unpack
 With [reverse delta unpack](#reverse-delta-unpack) turned on, you also can turn on redundant archives skipping.
 Since this feature involves both backup creation and restore process, in order to fully enable it you need to do two things:
 
-1. Optional, but recommended. [Enable rating tar ball composer](#rating-composer-mode) for `backup-push`.
+1. Optional. Increases the chance of archive skipping, but may result in slower backup creation. [Enable rating tar ball composer](#rating-composer-mode) for `backup-push`.
 
 2. Enable redundant backup archives skipping during backup-fetch. Do one of the following:
   
@@ -172,7 +172,7 @@ If backup is pushed from replication slave, WAL-G will control timeline of the s
 
 #### Rating composer mode
 
-In the rating composer mode, WAL-G places files with similar updates frequencies in the same tarballs during backup creation. This is the recommended option to use in pair with `backup-fetch` [redundant archives skipping](#redundant-archives-skipping). Be aware that although rating composer allows saving more data, it may result in slower backup creation compared to the default tarball composer.
+In the rating composer mode, WAL-G places files with similar updates frequencies in the same tarballs during backup creation. This should increase the effectiveness of `backup-fetch` [redundant archives skipping](#redundant-archives-skipping). Be aware that although rating composer allows saving more data, it may result in slower backup creation compared to the default tarball composer.
 
 To activate this feature, do one of the following:
 

--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -201,6 +201,20 @@ When uploading WAL archives to S3, the user should pass in the absolute path to 
 wal-g wal-push /path/to/archive
 ```
 
+* ``wal-show``
+
+Show information about the WAL storage folder. `wal-show` shows all WAL segment timelines available in storage, displays the available backups for them, and checks them for missing segments.
+
+* if there are no gaps (missing segments) in the range, final status is `OK`
+* if there are some missing segments found, final status is `LOST_SEGMENTS`
+
+```
+wal-g wal-show
+```
+
+By default, `wal-show` shows available backups for each timeline. To turn it off, add the `--without-backups` flag.
+
+By default, `wal-show` output is plaintext table. For detailed JSON output, add the `--detailed-json` flag.
 
 * ``backup-mark``
 

--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -129,6 +129,8 @@ WAL-G can also fetch the latest backup using:
 wal-g backup-fetch ~/extract/to/here LATEST
 ```
 
+#### Reverse delta unpack
+
 Beta feature: WAL-G can unpack delta backups in reverse order to improve fetch efficiency.
 
 [Reverse delta unpack benchmark results](benchmarks/reverse-delta-unpack-26-03-2020.md)
@@ -138,7 +140,23 @@ To activate this feature, do one of the following:
 * set the `WALG_USE_REVERSE_UNPACK`environment variable
 * add the --reverse-unpack flag
 ```
-wal-g backup-fetch ~/extract/to/here LATEST --reverse-unpack
+wal-g backup-fetch /path LATEST --reverse-unpack
+```
+
+#### Redundant archives skipping
+
+With [reverse delta unpack](#reverse-delta-unpack) turned on, you also can turn on redundant archives skipping.
+Since this feature involves both backup creation and restore process, in order to fully enable it you need to do two things:
+
+1. Optional, but recommended. [Enable rating tar ball composer](#rating-composer-mode) for `backup-push`.
+
+2. Enable redundant backup archives skipping during backup-fetch. Do one of the following:
+  
+* set the `WALG_USE_REVERSE_UNPACK` and `WALG_SKIP_REDUNDANT_TARS` environment variables
+* add the `--reverse-unpack` and `--skip-redundant-tars` flags
+
+```  
+wal-g backup-fetch /path LATEST --reverse-unpack --skip-redundant-tars
 ```
 
 * ``backup-push``
@@ -151,6 +169,19 @@ wal-g backup-push /backup/directory/path
 If backup is pushed from replication slave, WAL-G will control timeline of the server. In case of promotion to master or timeline switch, backup will be uploaded but not finalized, WAL-G will exit with an error. In this case logs will contain information necessary to finalize the backup. You can use backuped data if you clearly understand entangled risks.
 
 ``backup-push`` can also be run with the ``--permanent`` flag, which will mark the backup as permanent and prevent it from being removed when running ``delete``.
+
+#### Rating composer mode
+
+In the rating composer mode, WAL-G places files with similar updates frequencies in the same tarballs during backup creation. This is the recommended option to use in pair with `backup-fetch` [redundant archives skipping](#redundant-archives-skipping). Be aware that although rating composer allows saving more data, it may result in slower backup creation compared to the default tarball composer.
+
+To activate this feature, do one of the following:
+
+* set the `WALG_USE_RATING_COMPOSER`environment variable
+* add the --rating-composer flag
+
+```
+wal-g backup-push /path --rating-composer
+```
 
 * ``wal-fetch``
 

--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -216,6 +216,31 @@ By default, `wal-show` shows available backups for each timeline. To turn it off
 
 By default, `wal-show` output is plaintext table. For detailed JSON output, add the `--detailed-json` flag.
 
+* ``wal-verify``
+
+Ensure that there is a consistent WAL segment history for the cluster so WAL-G can perform a PITR for the backup. `wal-verify` verifies that WAL-G has all the necessary WAL segments in storage up to the current cluster LSN.
+
+```
+wal-g wal-verify
+```
+
+In `wal-verify` output, there are four statuses of WAL segments:
+
+* `FOUND` segments are present in WAL storage
+* `MISSING_DELAYED` segments are not present in WAL storage, but probably Postgres did not try to archive them via `archive_command` yet
+* `MISSING_UPLOADING` segments are the segments which are not present in WAL storage, but looks like that they are in the process of uploading to storage
+* `MISSING_LOST` segments are not present in WAL storage and not `MISSING_UPLOADING` nor `MISSING_DELAYED`
+
+Output of wal-verify is the report which consists of two parts:
+
+1. WAL storage status:
+    * `OK` if there are no missing segments 
+    * `WARNING` if there are some missing segments, but they are not `MISSING_LOST` 
+    * `FAILURE` if there are some `MISSING_LOST` segments
+2. A list that shows WAL segments in chronological order grouped by timeline and status.
+
+By default, `wal-verify` output is plaintext. To enable JSON output, add the `--json` flag.
+
 * ``backup-mark``
 
 Backups can be marked as permanent to prevent them from being removed when running ``delete``. Backup permanence can be altered via this command by passing in the name of the backup (retrievable via `wal-g backup-list --pretty --detail --json`), which will mark the named backup and all previous related backups as permanent. The reverse is also possible by providing the `-i` flag.


### PR DESCRIPTION
Add docs for [redundant archives skipping](https://github.com/wal-g/wal-g/pull/687), [rating composer](https://github.com/wal-g/wal-g/pull/734), [wal-verify](https://github.com/wal-g/wal-g/pull/746) and [wal-show](https://github.com/wal-g/wal-g/pull/722)