### PR TITLE
Update PostgreSQL.md

### DIFF
--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -11,6 +11,17 @@ Prepare on Ubuntu:
 sudo apt-get install liblzo2-dev
 ```
 
+Prepare on Mac OS:
+```
+# brew command is Homebrew for Mac OS
+brew install cmake
+export USE_LIBSODIUM="true" # since we're linking libsodium later
+./link_brotli.sh
+./link_libsodium.sh
+make install_and_build_pg
+```
+> The compiled binary to run is in `main/pg/wal-g`
+
 To compile and build the binary for Postgres:
 
 Optional:


### PR DESCRIPTION
Adds in instructions for MacOS (or unix in general as well) to mention the need to link the dependencies so that we can `go build` the wal-g binary