### PR TITLE
Allow libsodium key settings

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -142,6 +142,8 @@ var (
 		PgpKeySetting:                true,
 		PgpKeyPathSetting:            true,
 		PgpKeyPassphraseSetting:      true,
+		LibsodiumKeySetting:          true,
+		LibsodiumKeyPathSetting:      true,
 		TotalBgUploadedLimit:         true,
 		NameStreamCreateCmd:          true,
 		NameStreamRestoreCmd:         true,


### PR DESCRIPTION
Fix `WALG_LIBSODIUM_KEY is unknown`

```
WARNING: 2020/10/01 17:34:15.752569 WALG_LIBSODIUM_KEY is unknown
WARNING: 2020/10/01 17:34:15.752737 We found that some variables in your config file detected as 'Unknown'.
  If this is not right, please create issue https://github.com/wal-g/wal-g/issues/new
```