### PR TITLE
Allow the wal segment size to be set as a variable 

### DIFF
--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -123,6 +123,10 @@ To configure base for next delta backup (only if `WALG_DELTA_MAX_STEPS` is not e
 
 To configure the size of one backup bundle (in bytes). Smaller size causes granularity and more optimal, faster recovering. It also increases the number of storage requests, so it can costs you much money. Default size is 1 GB (`1 << 30 - 1` bytes).
 
+* `WALG_PG_WAL_SIZE`
+
+To configure the wal segment size if different from the postgres default of 16 MB
+
 Usage
 -----
 

--- a/cmd/pg/pg.go
+++ b/cmd/pg/pg.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"fmt"
+	"github.com/spf13/viper"
 	"os"
 	"strings"
 
@@ -25,6 +26,9 @@ var (
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
+			if viper.IsSet(internal.PgWalSize) {
+				internal.SetWalSize(viper.GetUint64(internal.PgWalSize))
+			}
 		},
 	}
 )

--- a/internal/config.go
+++ b/internal/config.go
@@ -52,6 +52,7 @@ const (
 	PgDatabaseSetting            = "PGDATABASE"
 	PgSslModeSetting             = "PGSSLMODE"
 	PgSlotName                   = "WALG_SLOTNAME"
+	PgWalSize                    = "WALG_PG_WAL_SIZE"
 	TotalBgUploadedLimit         = "TOTAL_BG_UPLOADED_LIMIT"
 	NameStreamCreateCmd          = "WALG_STREAM_CREATE_COMMAND"
 	NameStreamRestoreCmd         = "WALG_STREAM_RESTORE_COMMAND"
@@ -118,6 +119,7 @@ var (
 		OplogArchiveTimeoutInterval:    "60s",
 		OplogArchiveAfterSize:          "16777216", // 32 << (10 * 2)
 		MongoDBLastWriteUpdateInterval: "3s",
+		PgWalSize:                      "16",
 		OplogPushStatsLoggingInterval:  "30s",
 		OplogPushStatsUpdateInterval:   "30s",
 		OplogPushWaitForBecomePrimary:  "false",
@@ -163,6 +165,7 @@ var (
 		PgDatabaseSetting: true,
 		PgSslModeSetting:  true,
 		PgSlotName:        true,
+		PgWalSize:         true,
 		"PGPASSFILE":      true,
 
 		// Swift

--- a/internal/timeline.go
+++ b/internal/timeline.go
@@ -14,7 +14,7 @@ type BytesPerWalSegmentError struct {
 }
 
 func newBytesPerWalSegmentError() BytesPerWalSegmentError {
-	return BytesPerWalSegmentError{errors.New("bytes_per_wal_segment of the server does not match expected value")}
+	return BytesPerWalSegmentError{errors.New("bytes_per_wal_segment of the server does not match expected value, you may need to set WALG_PG_WAL_SIZE")}
 }
 
 func (err BytesPerWalSegmentError) Error() string {

--- a/internal/timeline.go
+++ b/internal/timeline.go
@@ -49,14 +49,21 @@ const (
 	hexadecimal     = 16
 )
 
-const (
+var (
 	// WalSegmentSize is the size of one WAL file
-	WalSegmentSize = uint64(16 * 1024 * 1024) // xlog.info line 113ß
-
-	walFileFormat         = "%08X%08X%08X" // xlog_internal.h line 155
-	walHistoryFileFormat  = "%08X.history"
+	WalSegmentSize        = uint64(16 * 1024 * 1024)
 	xLogSegmentsPerXLogId = 0x100000000 / WalSegmentSize // xlog_internal.h line 101
 )
+
+const (
+	walFileFormat        = "%08X%08X%08X" // xlog_internal.h line 155
+	walHistoryFileFormat = "%08X.history"
+)
+
+func SetWalSize(sizeMb uint64) {
+	WalSegmentSize = sizeMb * 1024 * 1024
+	xLogSegmentsPerXLogId = 0x100000000 / WalSegmentSize
+}
 
 // getWalFilename formats WAL file name using PostgreSQL connection. Essentially reads timeline of the server.
 func getWalFilename(lsn uint64, conn *pgx.Conn) (walFilename string, timeline uint32, err error) {

--- a/internal/timeline_test.go
+++ b/internal/timeline_test.go
@@ -65,3 +65,13 @@ func TestParseWALFilename(t *testing.T) {
 	testParseWALFilenameCorrect(t, "10000000f0000000000000a0", 1<<28, 15<<36+10<<4)
 	testParseWALFilenameCorrect(t, "ffffffffffffffff000000ff", 1<<32-1, 1<<40-1)
 }
+
+func TestParseWALFilenameDifferentSize(t *testing.T) {
+	SetWalSize(64)
+	testParseWALFilenameError(t, "10000000f0000000000000a0")
+
+	testParseWALFilenameCorrect(t, "000000010000000000000001", 1, 1)
+	testParseWALFilenameCorrect(t, "000000100000000100000001", 1<<4, 4<<4+1)
+	testParseWALFilenameCorrect(t, "000000100000020000000030", 1<<4, 2<<14+3<<4)
+	testParseWALFilenameCorrect(t, "10000000f000000000000030", 1<<28, 15<<34+3<<4)
+}

--- a/internal/timeline_test.go
+++ b/internal/timeline_test.go
@@ -67,11 +67,15 @@ func TestParseWALFilename(t *testing.T) {
 }
 
 func TestParseWALFilenameDifferentSize(t *testing.T) {
+	assert.Equal(t, WalSegmentSize, uint64(16*1024*1024))
 	SetWalSize(64)
+	assert.Equal(t, WalSegmentSize, uint64(64*1024*1024))
 	testParseWALFilenameError(t, "10000000f0000000000000a0")
 
 	testParseWALFilenameCorrect(t, "000000010000000000000001", 1, 1)
 	testParseWALFilenameCorrect(t, "000000100000000100000001", 1<<4, 4<<4+1)
 	testParseWALFilenameCorrect(t, "000000100000020000000030", 1<<4, 2<<14+3<<4)
 	testParseWALFilenameCorrect(t, "10000000f000000000000030", 1<<28, 15<<34+3<<4)
+	SetWalSize(16)
+	assert.Equal(t, WalSegmentSize, uint64(16*1024*1024))
 }


### PR DESCRIPTION
Postgres 11+ allows the wal segment size to be adjusted in initdb, `wal-segsize`. This PR allows you to set the value that Wal-g uses.

Also reported in #765 and #779

I'm not sure `SetWalSize` should be in `pg.go`, let me know if it should be moved.
