### PR TITLE
Fix backup list order in delete command

### DIFF
--- a/cmd/pg/delete.go
+++ b/cmd/pg/delete.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"regexp"
 	"time"
 
@@ -12,7 +13,11 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
+const UseSentinelTimeFlag = "use-sentinel-time"
+const UseSentinelTimeDescription = "Use backup creation time from sentinel for backups ordering."
+
 var confirmed = false
+var useSentinelTime = false
 var patternBackupName = fmt.Sprintf("base_%[1]s(_D_%[1]s)?", internal.PatternTimelineAndLogSegNo)
 var regexpBackupName = regexp.MustCompile(patternBackupName)
 
@@ -56,6 +61,10 @@ func runDeleteBefore(cmd *cobra.Command, args []string) {
 
 	lessFunc := postgresTimelineAndSegmentNoLess
 	backupTimeFunc := getBackupTime
+	if newLessFunc, newTimeFunc, ok := tryMakeSentinelTimeFuncs(folder, backups); ok {
+		lessFunc, backupTimeFunc = newLessFunc, newTimeFunc
+	}
+
 	internal.HandleDeleteBefore(folder, backups, args, confirmed, isFullBackup, lessFunc, backupTimeFunc)
 }
 
@@ -65,12 +74,37 @@ func runDeleteRetain(cmd *cobra.Command, args []string) {
 	isFullBackup := func(object storage.Object) bool {
 		return postgresIsFullBackup(folder, object)
 	}
-
 	backups, err := internal.GetBackupSentinelObjects(folder)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	lessFunc := postgresTimelineAndSegmentNoLess
+	if newLessFunc, _, ok := tryMakeSentinelTimeFuncs(folder, backups); ok {
+		lessFunc = newLessFunc
+	}
+
 	internal.HandleDeleteRetain(folder, backups, args, confirmed, isFullBackup, lessFunc)
+}
+
+// tryMakeSentinelTimeFuncs tries to create sentinel time based functions for delete handler
+func tryMakeSentinelTimeFuncs(
+	folder storage.Folder,
+	backups []storage.Object,
+) (func(obj1, obj2 storage.Object) bool, func(obj storage.Object) time.Time, bool) {
+	if !useSentinelTime {
+		return nil, nil, false
+	}
+
+	// If all backups in storage have metadata, we will use backup start time from sentinel.
+	// Otherwise, for example in case when we are dealing with some ancient backup without
+	// metadata included, fall back to the default timeline and segment number comparator.
+	startTimeByBackupName, err := getBackupStartTimeMap(folder, backups)
+	if err != nil {
+		tracelog.WarningLogger.Printf("Failed to get sentinel backup start times: %v,"+
+			" will fall back to timeline and segment number for ordering...\n", err)
+		return nil, nil, false
+	}
+
+	return GetLessFunc(startTimeByBackupName), GetBackupTimeFunc(startTimeByBackupName), true
 }
 
 func runDeleteEverything(cmd *cobra.Command, args []string) {
@@ -84,6 +118,67 @@ func init() {
 
 	deleteCmd.AddCommand(deleteRetainCmd, deleteBeforeCmd, deleteEverythingCmd)
 	deleteCmd.PersistentFlags().BoolVar(&confirmed, internal.ConfirmFlag, false, "Confirms backup deletion")
+	deleteCmd.PersistentFlags().BoolVar(&useSentinelTime, UseSentinelTimeFlag, false, UseSentinelTimeDescription)
+}
+
+func GetLessFunc(startTimeByBackupName map[string]time.Time) func(storage.Object, storage.Object) bool {
+	return func(object1 storage.Object, object2 storage.Object) bool {
+		backupName1 := fetchBackupName(object1)
+		if backupName1 == "" {
+			// we can't compare non-backup storage objects (probably WAL segments) by start time,
+			// so use the segment number comparator instead
+			return postgresSegmentNoLess(object1, object2)
+		}
+		backupName2 := fetchBackupName(object2)
+		if backupName2 == "" {
+			return postgresSegmentNoLess(object1, object2)
+		}
+		startTime1, ok := startTimeByBackupName[backupName1]
+		if !ok {
+			return false
+		}
+		startTime2, ok := startTimeByBackupName[backupName2]
+		if !ok {
+			return false
+		}
+		return startTime1.Before(startTime2)
+	}
+}
+
+func GetBackupTimeFunc(startTimeByBackupName map[string]time.Time) func(storage.Object) time.Time {
+	return func(backupObject storage.Object) time.Time {
+		backupName := fetchBackupName(backupObject)
+		return startTimeByBackupName[backupName]
+	}
+}
+
+// getBackupStartTimeMap returns a map for a fast lookup of the backup start time by the backup name
+func getBackupStartTimeMap(folder storage.Folder, backups []storage.Object) (map[string]time.Time, error) {
+	backupTimes := internal.GetBackupTimeSlices(backups)
+	startTimeByBackupName := make(map[string]time.Time, len(backups))
+
+	for _, backupTime := range backupTimes {
+		backupDetails, err := internal.GetBackupDetails(folder, backupTime)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to get metadata of backup %s: %w",
+				backupTime.BackupName, err)
+		}
+		startTimeByBackupName[backupDetails.BackupName] = backupDetails.StartTime
+	}
+	return startTimeByBackupName, nil
+}
+
+// TODO: create postgres part and move it there, if it will be needed
+func postgresSegmentNoLess(object1 storage.Object, object2 storage.Object) bool {
+	_, segmentNumber1, ok := internal.TryFetchTimelineAndLogSegNo(object1.GetName())
+	if !ok {
+		return false
+	}
+	_, segmentNumber2, ok := internal.TryFetchTimelineAndLogSegNo(object2.GetName())
+	if !ok {
+		return false
+	}
+	return segmentNumber1 < segmentNumber2
 }
 
 // TODO: create postgres part and move it there, if it will be needed

--- a/internal/backup_mark.go
+++ b/internal/backup_mark.go
@@ -158,7 +158,7 @@ func backupHasPermanentInFuture(reverseLinks *map[string][]string, backupName st
 func getGraphFromBaseToIncrement(folder storage.Folder) (map[string][]string, error) {
 	baseBackupFolder := folder.GetSubFolder(utility.BaseBackupPath)
 
-	backups, err := getBackups(folder)
+	backups, err := GetBackups(folder)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -58,7 +58,6 @@ func GetBackupSentinelObjects(folder storage.Folder) ([]storage.Object, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	sentinelObjects := make([]storage.Object, 0, len(objects))
 	for _, object := range objects {
 		if !strings.HasSuffix(object.GetName(), utility.SentinelSuffix) {

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -45,7 +45,7 @@ var MaxTime = time.Unix(1<<63-62135596801, 999999999)
 
 // TODO : unit tests
 func getLatestBackupName(folder storage.Folder) (string, error) {
-	sortTimes, err := getBackups(folder)
+	sortTimes, err := GetBackups(folder)
 	if err != nil {
 		return "", err
 	}
@@ -54,8 +54,8 @@ func getLatestBackupName(folder storage.Folder) (string, error) {
 }
 
 // TODO : unit tests
-// getBackups receives backup descriptions and sorts them by time
-func getBackups(folder storage.Folder) (backups []BackupTime, err error) {
+// GetBackups receives backup descriptions and sorts them by time
+func GetBackups(folder storage.Folder) (backups []BackupTime, err error) {
 	backups, _, err = GetBackupsAndGarbage(folder)
 	if err != nil {
 		return nil, err
@@ -357,7 +357,7 @@ func DeleteBeforeTarget(folder storage.Folder, target storage.Object,
 
 func getPermanentObjects(folder storage.Folder) (map[string]bool, map[string]bool) {
 	tracelog.InfoLogger.Println("retrieving permanent objects")
-	backupTimes, err := getBackups(folder)
+	backupTimes, err := GetBackups(folder)
 	if err != nil {
 		return map[string]bool{}, map[string]bool{}
 	}

--- a/internal/wal_show_handler.go
+++ b/internal/wal_show_handler.go
@@ -166,11 +166,11 @@ func groupSegmentsByTimelines(segments map[WalSegmentDescription]bool) (map[uint
 
 // addBackupsInfo adds info about available backups for each timeline
 func addBackupsInfo(timelineInfos []*TimelineInfo, rootFolder storage.Folder) ([]*TimelineInfo, error) {
-	backups, err := getBackups(rootFolder)
+	backups, err := GetBackups(rootFolder)
 	if err != nil {
 		return nil, err
 	}
-	backupDetails, err := getBackupDetails(rootFolder, backups)
+	backupDetails, err := GetBackupsDetails(rootFolder, backups)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/wal_verify_handler.go
+++ b/internal/wal_verify_handler.go
@@ -236,12 +236,12 @@ func getCurrentTimeline(conn *pgx.Conn) (uint32, error) {
 func getEarliestBackupStartSegmentNo(timelineSwitchMap map[WalSegmentNo]*TimelineHistoryRecord,
 	currentTimeline uint32,
 	rootFolder storage.Folder) (WalSegmentNo, error) {
-	backups, err := getBackups(rootFolder)
+	backups, err := GetBackups(rootFolder)
 	if err != nil {
 		return 0, err
 	}
 
-	backupDetails, err := getBackupDetails(rootFolder, backups)
+	backupDetails, err := GetBackupsDetails(rootFolder, backups)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
In this PR I propose ordering the backups by creation time in the delete command handler.

Backup creation time is taken from backup metadata. If there is no metadata (for example, if we are dealing with an old backup without metadata), the comparator will use the old behavior (timeline and LSN combination) to compare this backup with others.