### PR TITLE
Fix SIGSEGV errors of wal-g delete

### DIFF
--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -138,6 +138,10 @@ func FindTargetBeforeTime(folder storage.Folder,
 	if err != nil {
 		return nil, err
 	}
+	if potentialTarget == nil {
+		return nil, nil
+	}
+
 	greater := func(object1, object2 storage.Object) bool {
 		return less(object2, object1)
 	}
@@ -227,11 +231,19 @@ func FindTargetRetainAfterTime(folder storage.Folder,
 		return nil, err
 	}
 
-	if greater(target2, target1) {
-		return target1, nil
-	} else {
+	if target1 == nil {
 		return target2, nil
 	}
+	
+	if target2 == nil {
+		return target1, nil
+	}
+
+	if greater(target2, target1) {
+		return target1, nil
+	}
+
+	return target2, nil
 }
 
 func findTarget(folder storage.Folder,


### PR DESCRIPTION
This fix addresses the following WAL-G command:
wal-g delete before DATE

Currently, If there are no backups with a date greater than DATE, WAL-G will get a runtime error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x17763f1]

goroutine 1 [running]:
github.com/wal-g/wal-g/internal.FindTargetBeforeTime(0x1de8660, 0xc000520c40, 0x0, 0xed7597b9c, 0x0, 0x0, 0xc0004e2fe0, 0x1c040e0, 0x0, 0x0, ...)
	/xxx/src/github.com/wal-g/wal-g/internal/delete_handler.go:144 +0x111
github.com/wal-g/wal-g/internal.HandleDeleteBefore(0x1de8660, 0xc000520c40, 0xc000407680, 0x1, 0x3, 0x0, 0xc0004e2fe0, 0x1c040e0)
	/xxx/src/github.com/wal-g/wal-g/internal/delete_handler.go:406 +0x44b
github.com/wal-g/wal-g/cmd/pg.runDeleteBefore(0x27f0020, 0xc000407680, 0x1, 0x3)
	/xxx/src/github.com/wal-g/wal-g/cmd/pg/delete.go:55 +0xea
github.com/spf13/cobra.(*Command).execute(0x27f0020, 0xc000407590, 0x3, 0x3, 0x27f0020, 0xc000407590)
	/xxx/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:830 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x27edd20, 0xa4248a, 0x2803880, 0xc000000180)
	/xxx/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:914 +0x30b
github.com/spf13/cobra.(*Command).Execute(...)
	/xxx/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:864
github.com/wal-g/wal-g/cmd/pg.Execute()
	/xxx/src/github.com/wal-g/wal-g/cmd/pg/pg.go:36 +0x31
main.main()
	/xxx/src/github.com/wal-g/wal-g/main/pg/main.go:8 +0x25

```

This fix adds the necessary checks for nulls