### PR TITLE
Change badges from Travis to Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # WAL-G
-[![Build Status](https://travis-ci.org/wal-g/wal-g.svg?branch=master)](https://travis-ci.org/wal-g/wal-g)
+![Docker-tests-status](https://github.com/wal-g/wal-g/workflows/Docker%20tests/badge.svg)
+![Unit-tests-status](https://github.com/wal-g/wal-g/workflows/Unit%20tests/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/wal-g/wal-g)](https://goreportcard.com/report/github.com/wal-g/wal-g)
 
 WAL-G is an archival restoration tool for Postgres(beta for MySQL, MariaDB, and MongoDB)


### PR DESCRIPTION
Replace the badges, since we [switched to Github Actions](https://github.com/wal-g/wal-g/pull/819) and [eliminated Travis](https://github.com/wal-g/wal-g/pull/826)