### PR TITLE
Update python in docker image to 3.7

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -5,7 +5,7 @@ ENV TERM xterm-256color
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends --no-install-suggests \
-    python3.6 \
+    python3.7 \
     python3-setuptools \
     python3-pip \
     git \
@@ -16,7 +16,6 @@ RUN apt-get update && \
     lzop \
     libbrotli1 && \
     rm -rf /var/lib/apt/lists/* && \
-    pip3 install --upgrade pip && \
-    pip3 install git+https://github.com/wal-e/wal-e.git && \
-    pip3 install boto
-
+    python3.7 -m pip install --upgrade pip && \
+    python3.7 -m pip install git+https://github.com/wal-e/wal-e.git && \
+    python3.7 -m pip install boto


### PR DESCRIPTION
Looks like [there is no gevent wheel for python3.6 on linux](https://www.wheelodex.org/projects/gevent/), which is required to install wal-e. Upgrading to python3.7 should fix the failing CI.