### PR TITLE
[Feature Request 857] Add Catchup-List command proposal draft

### DIFF
--- a/cmd/pg/catchup_list.go
+++ b/cmd/pg/catchup_list.go
@@ -1,0 +1,38 @@
+package pg
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/utility"
+)
+
+const (
+	catchupListShortDescription = "Prints available incremental backups"
+)
+
+var (
+	// catchupListCmd represents the catchupList command
+	catchupListCmd = &cobra.Command{
+		Use:   "catchup-list",
+		Short: catchupListShortDescription, // TODO : improve description
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			folder, err := internal.ConfigureFolder()
+			tracelog.ErrorLogger.FatalOnError(err)
+			if pretty || json || detail {
+				internal.HandleBackupListWithFlagsAndTarget(folder, pretty, json, detail, utility.CatchupPath)
+			} else {
+				internal.DefaultHandleBackupListWithTarget(folder, utility.CatchupPath)
+			}
+		},
+	}
+)
+
+func init() {
+	cmd.AddCommand(catchupListCmd)
+
+	catchupListCmd.Flags().BoolVar(&pretty, PrettyFlag, false, "Prints more readable output")
+	catchupListCmd.Flags().BoolVar(&json, JsonFlag, false, "Prints output in json format")
+	catchupListCmd.Flags().BoolVar(&detail, DetailFlag, false, "Prints extra backup details")
+}

--- a/internal/backup.go
+++ b/internal/backup.go
@@ -373,7 +373,11 @@ func GetBackupSentinelObjects(folder storage.Folder) ([]storage.Object, error) {
 // TODO : unit tests
 // GetBackups receives backup descriptions and sorts them by time
 func GetBackups(folder storage.Folder) (backups []BackupTime, err error) {
-	backups, _, err = GetBackupsAndGarbage(folder)
+	return GetBackupsWithTarget(folder, utility.BaseBackupPath)
+}
+
+func GetBackupsWithTarget(folder storage.Folder, targetPath string) (backups []BackupTime, err error) {
+	backups, _, err = GetBackupsAndGarbageWithTarget(folder, targetPath)
 	if err != nil {
 		return nil, err
 	}
@@ -385,9 +389,13 @@ func GetBackups(folder storage.Folder) (backups []BackupTime, err error) {
 	return
 }
 
-// TODO : unit tests
 func GetBackupsAndGarbage(folder storage.Folder) (backups []BackupTime, garbage []string, err error) {
-	backupObjects, subFolders, err := folder.GetSubFolder(utility.BaseBackupPath).ListFolder()
+	return GetBackupsAndGarbageWithTarget(folder, utility.BaseBackupPath)
+}
+
+// TODO : unit tests
+func GetBackupsAndGarbageWithTarget(folder storage.Folder, targetPath string) (backups []BackupTime, garbage []string, err error) {
+	backupObjects, subFolders, err := folder.GetSubFolder(targetPath).ListFolder()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/backup_list_handler.go
+++ b/internal/backup_list_handler.go
@@ -28,8 +28,12 @@ type Logging struct {
 }
 
 func DefaultHandleBackupList(folder storage.Folder) {
+	DefaultHandleBackupListWithTarget(folder, utility.BaseBackupPath)
+}
+
+func DefaultHandleBackupListWithTarget(folder storage.Folder, targetPath string) {
 	getBackupsFunc := func() ([]BackupTime, error) {
-		return GetBackups(folder)
+		return GetBackupsWithTarget(folder, targetPath)
 	}
 	writeBackupListFunc := func(backups []BackupTime) {
 		WriteBackupList(backups, os.Stdout)
@@ -57,9 +61,13 @@ func HandleBackupList(
 	writeBackupListFunc(backups)
 }
 
-// TODO : unit tests
 func HandleBackupListWithFlags(folder storage.Folder, pretty bool, json bool, detail bool) {
-	backups, err := GetBackups(folder)
+	HandleBackupListWithFlagsAndTarget(folder, pretty, json, detail, utility.BaseBackupPath)
+}
+
+// TODO : unit tests
+func HandleBackupListWithFlagsAndTarget(folder storage.Folder, pretty bool, json bool, detail bool, targetPath string) {
+	backups, err := GetBackupsWithTarget(folder, targetPath)
 	if len(backups) == 0 {
 		tracelog.InfoLogger.Println("No backups found")
 		return
@@ -90,9 +98,13 @@ func HandleBackupListWithFlags(folder storage.Folder, pretty bool, json bool, de
 }
 
 func GetBackupsDetails(folder storage.Folder, backups []BackupTime) ([]BackupDetail, error) {
+	return GetBackupsDetailsWithTarget(folder, backups, utility.BaseBackupPath)
+}
+
+func GetBackupsDetailsWithTarget(folder storage.Folder, backups []BackupTime, targetPath string) ([]BackupDetail, error) {
 	backupsDetails := make([]BackupDetail, 0, len(backups))
 	for i := len(backups) - 1; i >= 0; i-- {
-		details, err := GetBackupDetails(folder, backups[i])
+		details, err := GetBackupDetailsWithTarget(folder, backups[i], targetPath)
 		if err != nil {
 			return nil, err
 		}
@@ -102,7 +114,11 @@ func GetBackupsDetails(folder storage.Folder, backups []BackupTime) ([]BackupDet
 }
 
 func GetBackupDetails(folder storage.Folder, backupTime BackupTime) (BackupDetail, error) {
-	backup, err := GetBackupByName(backupTime.BackupName, utility.BaseBackupPath, folder)
+	return GetBackupDetailsWithTarget(folder, backupTime, utility.BaseBackupPath)
+}
+
+func GetBackupDetailsWithTarget(folder storage.Folder, backupTime BackupTime, targetPath string) (BackupDetail, error) {
+	backup, err := GetBackupByName(backupTime.BackupName, targetPath, folder)
 	if err != nil {
 		return BackupDetail{}, err
 	}


### PR DESCRIPTION
Adds the `catchup-list` CLI command from #857

- Refactors existing `backup.go` internal code to allow path specification
- Backward compatible to allow the `pg` code to mature while leaving other shared paths in tact

Happy to help make updates  and  add tests as requested.