### PR TITLE
Upgrade runner from 16.04 to 20.04

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   buildimages:
     name: Build images
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       #  use cache to pass docker images to the test jobs
       - name: Docker images caching

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unittest:
     name: all_unittests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install deps
         run: sudo apt-get install liblzo2-dev


### PR DESCRIPTION
Ubuntu 16.04 is losing general support in 2 months. Good time to upgrade the runners, I guess.