### PR TITLE
Add docker_lint target and fix exist Makefile lint order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,14 +175,18 @@ fmt: $(CMD_FILES) $(PKG_FILES) $(TEST_FILES)
 	gofmt -s -w $(CMD_FILES) $(PKG_FILES) $(TEST_FILES)
 
 lint:
-	@#Linux (has sudo)
-	@if [ "$(shell command -v golangci-lint)" = "" ]; then curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION) && sudo cp ./bin/golangci-lint $(go env GOPATH)/bin/; fi;
 	@#Github Actions
 	@if [ "$(shell command -v golangci-lint)" = "" ] && [ "$(GITHUB_WORKFLOW)" != "" ]; then curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b $(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); fi;
 	@#MacOS (brew)
 	@if [ "$(shell command -v golangci-lint)" = "" ] && [ "$(shell command -v brew)" != "" ]; then brew install golangci-lint; fi;
+	@#Linux (has sudo)
+	@if [ "$(shell command -v golangci-lint)" = "" ]; then curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION) && sudo cp ./bin/golangci-lint $(go env GOPATH)/bin/; fi;
 	@echo "running golangci-lint..."
 	@golangci-lint run
+
+docker_lint:
+	docker build -t wal-g/lint - < docker/lint/Dockerfile
+	docker run --rm -v `pwd`:/app wal-g/lint golangci-lint run -v
 
 deps: go_deps link_external_deps
 

--- a/docker/lint/Dockerfile
+++ b/docker/lint/Dockerfile
@@ -1,0 +1,10 @@
+FROM golangci/golangci-lint:latest
+WORKDIR /app
+RUN apt-get update && apt-get install -y \
+    liblzo2-dev \
+    libbrotli-dev \
+    libsodium-dev \
+    build-essential \
+    gcc \
+    cmake \
+    libc-dev


### PR DESCRIPTION
In this PR I propose:
- fix for existing lint target order
- add docker_lint target to run linter in docker container without the need to install golangci-lint