### PR TITLE
Lock go version to 1.15 in CI

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -15,6 +15,7 @@ env:
   IMAGE_UBUNTU: wal-g/ubuntu
   IMAGE_GOLANG: wal-g/golang
   IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
+  GO_VERSION: 1.15
 
 jobs:
   buildimages:
@@ -40,7 +41,7 @@ jobs:
         if: steps.cache-images.outputs.cache-hit != 'true'
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code into the Go module directory
@@ -116,7 +117,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,11 +4,21 @@ on:
     branches:
       - master
   pull_request:
+
+env:
+  GO_VERSION: 1.15
+
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+        id: go
+
       - name: Install deps
         run: sudo apt-get install liblzo2-dev brotli libsodium-dev
 
@@ -17,4 +27,5 @@ jobs:
         uses: golangci/golangci-lint-action@v2.4.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.37
+          skip-go-installation: true

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  GO_VERSION: 1.15
+
 jobs:
   unittest:
     name: all_unittests
@@ -17,7 +20,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ${{ env.GO_VERSION }}
         id: go
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
I propose to lock the Go version in Github Actions CI until all issues related to Go 1.16 will be resolved