### PR TITLE
Alter file sync/close order in tar_interpreter_new

### DIFF
--- a/internal/tar_interpreter_new.go
+++ b/internal/tar_interpreter_new.go
@@ -24,8 +24,8 @@ func (tarInterpreter *FileTarInterpreter) unwrapRegularFileNew(fileReader io.Rea
 	if err != nil {
 		return err
 	}
-	defer utility.LoggedSync(localFile, "")
 	defer utility.LoggedClose(localFile, "")
+	defer utility.LoggedSync(localFile, "")
 	var unwrapResult *FileUnwrapResult
 	var unwrapError error
 	if isNewFile {


### PR DESCRIPTION
This should mitigate sync issues because of the already closed file in the reverse unpack tar interpreter