### PR TITLE
Add backup selectors for backup-fetch and backup-push

### DIFF
--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -144,6 +144,11 @@ WAL-G can also fetch the latest backup using:
 wal-g backup-fetch ~/extract/to/here LATEST
 ```
 
+WAL-G can fetch the backup with specific UserData (stored in backup metadata) using the `--target-user-data` flag or `WALG_FETCH_TARGET_USER_DATA` variable:
+```
+wal-g backup-fetch /path --target-user-data "{ \"x\": [3], \"y\": 4 }"
+```
+
 #### Reverse delta unpack
 
 Beta feature: WAL-G can unpack delta backups in reverse order to improve fetch efficiency.
@@ -196,6 +201,19 @@ To activate this feature, do one of the following:
 
 ```
 wal-g backup-push /path --rating-composer
+```
+
+#### Create delta from specific backup
+When creating delta backup, WAL-G uses the latest backup as the base by default. This behaviour can be changed via following flags:
+
+* `--delta-from-name` flag or `WALG_DELTA_FROM_NAME` environment variable to choose the backup with specified name as the base for the delta backup
+
+* `--delta-from-user-data` flag or `WALG_DELTA_FROM_USER_DATA` environment variable to choose the backup with specified UserData as the base for the delta backup
+
+Examples:
+```
+wal-g backup-push /path --delta-from-name base_000000010000000100000072_D_000000010000000100000063
+wal-g backup-push /path --delta-from-user-data "{ \"x\": [3], \"y\": 4 }"
 ```
 
 * ``wal-fetch``

--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -208,7 +208,7 @@ When creating delta backup (`WALG_DELTA_MAX_STEPS` > 0), WAL-G uses the latest b
 
 * `--delta-from-name` flag or `WALG_DELTA_FROM_NAME` environment variable to choose the backup with specified name as the base for the delta backup
 
-* `--delta-from-user-data` flag or `WALG_DELTA_FROM_USER_DATA` environment variable to choose the backup with specified UserData as the base for the delta backup
+* `--delta-from-user-data` flag or `WALG_DELTA_FROM_USER_DATA` environment variable to choose the backup with specified user data as the base for the delta backup
 
 Examples:
 ```

--- a/PostgreSQL.md
+++ b/PostgreSQL.md
@@ -204,7 +204,7 @@ wal-g backup-push /path --rating-composer
 ```
 
 #### Create delta from specific backup
-When creating delta backup, WAL-G uses the latest backup as the base by default. This behaviour can be changed via following flags:
+When creating delta backup (`WALG_DELTA_MAX_STEPS` > 0), WAL-G uses the latest backup as the base by default. This behaviour can be changed via following flags:
 
 * `--delta-from-name` flag or `WALG_DELTA_FROM_NAME` environment variable to choose the backup with specified name as the base for the delta backup
 
@@ -214,6 +214,23 @@ Examples:
 ```
 wal-g backup-push /path --delta-from-name base_000000010000000100000072_D_000000010000000100000063
 wal-g backup-push /path --delta-from-user-data "{ \"x\": [3], \"y\": 4 }"
+```
+
+When using the above flags in combination with `WALG_DELTA_ORIGIN` setting, `WALG_DELTA_ORIGIN` logic applies to the specified backup. For example:
+```
+list of backups in storage:
+base_000000010000000100000040  # full backup
+base_000000010000000100000046_D_000000010000000100000040  # 1st delta
+base_000000010000000100000061_D_000000010000000100000046  # 2nd delta
+base_000000010000000100000070  # full backup
+
+export WALG_DELTA_ORIGIN=LATEST_FULL
+wal-g backup-push /path --delta-from-name base_000000010000000100000046_D_000000010000000100000040
+
+wal-g logs:
+INFO: Selecting the backup with name base_000000010000000100000046_D_000000010000000100000040 as the base for the current delta backup...
+INFO: Delta will be made from full backup.
+INFO: Delta backup from base_000000010000000100000040 with LSN 140000060.
 ```
 
 * ``wal-fetch``

--- a/cmd/fdb/backup_fetch.go
+++ b/cmd/fdb/backup_fetch.go
@@ -29,8 +29,9 @@ var backupFetchCmd = &cobra.Command{
 
 		restoreCmd, err := internal.GetCommandSettingContext(ctx, internal.NameStreamRestoreCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
-
-		fdb.HandleBackupFetch(ctx, folder, args[0], restoreCmd)
+		targetBackupSelector, err := internal.NewBackupNameSelector(args[0])
+		tracelog.ErrorLogger.FatalOnError(err)
+		fdb.HandleBackupFetch(ctx, folder, targetBackupSelector, restoreCmd)
 	},
 }
 

--- a/cmd/mysql/backup_fetch.go
+++ b/cmd/mysql/backup_fetch.go
@@ -25,7 +25,9 @@ var backupFetchCmd = &cobra.Command{
 		restoreCmd, err := internal.GetCommandSetting(internal.NameStreamRestoreCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 		prepareCmd, _ := internal.GetCommandSetting(internal.MysqlBackupPrepareCmd)
-		mysql.HandleBackupFetch(folder, args[0], restoreCmd, prepareCmd)
+		targetBackupSelector, err := internal.NewBackupNameSelector(args[0])
+		tracelog.ErrorLogger.FatalOnError(err)
+		mysql.HandleBackupFetch(folder, targetBackupSelector, restoreCmd, prepareCmd)
 	},
 }
 

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -57,10 +57,10 @@ var backupFetchCmd = &cobra.Command{
 
 // create the BackupSelector to select the backup to fetch
 func createTargetBackupSelector(cmd *cobra.Command, args []string) (internal.BackupSelector, error) {
+	var err error
 	switch {
 	case len(args) == 2 && targetUserData != "":
-		fmt.Println(cmd.UsageString())
-		return nil, errors.New("Incorrect arguments. Specify backup_name OR target flag, not both.")
+		err = errors.New("Incorrect arguments. Specify backup_name OR target flag, not both.")
 
 	case len(args) == 2 && args[1] == internal.LatestString:
 		tracelog.InfoLogger.Printf("Fetching the latest backup...\n")
@@ -75,9 +75,10 @@ func createTargetBackupSelector(cmd *cobra.Command, args []string) (internal.Bac
 		return internal.NewUserDataBackupSelector(targetUserData)
 
 	default:
-		fmt.Println(cmd.UsageString())
-		return nil, errors.New("Insufficient arguments.")
+		err = errors.New("Insufficient arguments.")
 	}
+	fmt.Println(cmd.UsageString())
+	return nil, err
 }
 
 func init() {

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -19,7 +19,7 @@ For information about pattern syntax view: https://golang.org/pkg/path/filepath/
 	restoreSpecDescription        = "Path to file containing tablespace restore specification"
 	reverseDeltaUnpackDescription = "Unpack delta backups in reverse order (beta feature)"
 	skipRedundantTarsDescription  = "Skip tars with no useful data (requires reverse delta unpack)"
-	targetUserDataDescription     = "Fetch storage backup which has the specified UserData"
+	targetUserDataDescription     = "Fetch storage backup which has the specified user data"
 )
 
 var fileMask string
@@ -71,7 +71,7 @@ func createTargetBackupSelector(cmd *cobra.Command, args []string) (internal.Bac
 		return internal.NewBackupNameSelector(args[1])
 
 	case len(args) == 1 && targetUserData != "":
-		tracelog.InfoLogger.Println("Fetching the backup with the specified UserData...")
+		tracelog.InfoLogger.Println("Fetching the backup with the specified user data...")
 		return internal.NewUserDataBackupSelector(targetUserData)
 
 	default:

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -30,7 +31,7 @@ var targetUserData string
 var backupFetchCmd = &cobra.Command{
 	Use:   "backup-fetch destination_directory [backup_name OR target-* flag]",
 	Short: backupFetchShortDescription, // TODO : improve description
-	Args:  cobra.RangeArgs(1,2),
+	Args:  cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		if targetUserData == "" {
 			targetUserData = viper.GetString(internal.TargetUserDataSetting)

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -29,7 +29,7 @@ var skipRedundantTars bool
 var targetUserData string
 
 var backupFetchCmd = &cobra.Command{
-	Use:   "backup-fetch destination_directory [backup_name OR target-* flag]",
+	Use:   "backup-fetch destination_directory [backup_name | --target-user-data <data>]",
 	Short: backupFetchShortDescription, // TODO : improve description
 	Args:  cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -1,6 +1,8 @@
 package pg
 
 import (
+	"fmt"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/wal-g/storages/storage"
@@ -16,18 +18,26 @@ For information about pattern syntax view: https://golang.org/pkg/path/filepath/
 	restoreSpecDescription        = "Path to file containing tablespace restore specification"
 	reverseDeltaUnpackDescription = "Unpack delta backups in reverse order (beta feature)"
 	skipRedundantTarsDescription  = "Skip tars with no useful data (requires reverse delta unpack)"
+	targetUserDataDescription     = "Fetch storage backup which has the specified UserData"
 )
 
 var fileMask string
 var restoreSpec string
 var reverseDeltaUnpack bool
 var skipRedundantTars bool
+var targetUserData string
 
 var backupFetchCmd = &cobra.Command{
-	Use:   "backup-fetch destination_directory backup_name",
+	Use:   "backup-fetch destination_directory [backup_name OR target-* flag]",
 	Short: backupFetchShortDescription, // TODO : improve description
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.RangeArgs(1,2),
 	Run: func(cmd *cobra.Command, args []string) {
+		if targetUserData == "" {
+			targetUserData = viper.GetString(internal.TargetUserDataSetting)
+		}
+		targetBackupSelector, err := createTargetBackupSelector(cmd, args)
+		tracelog.ErrorLogger.FatalOnError(err)
+
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
 
@@ -40,8 +50,33 @@ var backupFetchCmd = &cobra.Command{
 			pgFetcher = internal.GetPgFetcherOld(args[0], fileMask, restoreSpec)
 		}
 
-		internal.HandleBackupFetch(folder, args[1], pgFetcher)
+		internal.HandleBackupFetch(folder, targetBackupSelector, pgFetcher)
 	},
+}
+
+// create the BackupSelector to select the backup to fetch
+func createTargetBackupSelector(cmd *cobra.Command, args []string) (internal.BackupSelector, error) {
+	switch {
+	case len(args) == 2 && targetUserData != "":
+		fmt.Println(cmd.UsageString())
+		return nil, errors.New("Incorrect arguments. Specify backup_name OR target flag, not both.")
+
+	case len(args) == 2 && args[1] == internal.LatestString:
+		tracelog.InfoLogger.Printf("Fetching the latest backup...\n")
+		return internal.NewLatestBackupSelector(), nil
+
+	case len(args) == 2:
+		tracelog.InfoLogger.Printf("Fetching the backup with name %s...\n", args[1])
+		return internal.NewBackupNameSelector(args[1])
+
+	case len(args) == 1 && targetUserData != "":
+		tracelog.InfoLogger.Println("Fetching the backup with the specified UserData...")
+		return internal.NewUserDataBackupSelector(targetUserData)
+
+	default:
+		fmt.Println(cmd.UsageString())
+		return nil, errors.New("Insufficient arguments.")
+	}
 }
 
 func init() {
@@ -51,5 +86,7 @@ func init() {
 		false, reverseDeltaUnpackDescription)
 	backupFetchCmd.Flags().BoolVar(&skipRedundantTars, "skip-redundant-tars",
 		false, skipRedundantTarsDescription)
+	backupFetchCmd.Flags().StringVar(&targetUserData, "target-user-data",
+		"", targetUserDataDescription)
 	cmd.AddCommand(backupFetchCmd)
 }

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -10,15 +11,15 @@ import (
 )
 
 const (
-	backupPushShortDescription     = "Makes backup and uploads it to storage"
+	backupPushShortDescription = "Makes backup and uploads it to storage"
 
-	permanentFlag                  = "permanent"
-	fullBackupFlag                 = "full"
-	verifyPagesFlag                = "verify"
-	storeAllCorruptBlocksFlag      = "store-all-corrupt"
-	useRatingComposerFlag          = "rating-composer"
-	deltaFromUserDataFlag          = "delta-from-user-data"
-	deltaFromNameFlag              = "delta-from-name"
+	permanentFlag             = "permanent"
+	fullBackupFlag            = "full"
+	verifyPagesFlag           = "verify"
+	storeAllCorruptBlocksFlag = "store-all-corrupt"
+	useRatingComposerFlag     = "rating-composer"
+	deltaFromUserDataFlag     = "delta-from-user-data"
+	deltaFromNameFlag         = "delta-from-name"
 
 	permanentShorthand             = "p"
 	fullBackupShorthand            = "f"

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -1,6 +1,8 @@
 package pg
 
 import (
+	"fmt"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
@@ -8,24 +10,28 @@ import (
 )
 
 const (
-	ackupPushShortDescription      = "Makes backup and uploads it to storage"
+	backupPushShortDescription     = "Makes backup and uploads it to storage"
+
 	permanentFlag                  = "permanent"
 	fullBackupFlag                 = "full"
 	verifyPagesFlag                = "verify"
 	storeAllCorruptBlocksFlag      = "store-all-corrupt"
-	UseRatingComposer              = "rating-composer"
+	useRatingComposerFlag          = "rating-composer"
+	deltaFromUserDataFlag          = "delta-from-user-data"
+	deltaFromNameFlag              = "delta-from-name"
+
 	permanentShorthand             = "p"
 	fullBackupShorthand            = "f"
 	verifyPagesShorthand           = "v"
 	storeAllCorruptBlocksShorthand = "s"
-	UseRatingComposerShortHand     = "r"
+	useRatingComposerShorthand     = "r"
 )
 
 var (
 	// backupPushCmd represents the backupPush command
 	backupPushCmd = &cobra.Command{
 		Use:   "backup-push db_directory",
-		Short: ackupPushShortDescription, // TODO : improve description
+		Short: backupPushShortDescription, // TODO : improve description
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			uploader, err := internal.ConfigureWalUploader()
@@ -37,7 +43,17 @@ var (
 			if useRatingComposer {
 				tarBallComposerType = internal.RatingComposer
 			}
-			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums, storeAllCorruptBlocks, tarBallComposerType)
+			if deltaFromName == "" {
+				deltaFromName = viper.GetString(internal.DeltaFromNameSetting)
+			}
+			if deltaFromUserData == "" {
+				deltaFromUserData = viper.GetString(internal.DeltaFromUserDataSetting)
+			}
+			deltaBaseSelector, err := createDeltaBaseSelector(cmd, deltaFromName, deltaFromUserData)
+			tracelog.ErrorLogger.FatalOnError(err)
+
+			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums,
+				storeAllCorruptBlocks, tarBallComposerType, deltaBaseSelector)
 		},
 	}
 	permanent             = false
@@ -45,7 +61,32 @@ var (
 	verifyPageChecksums   = false
 	storeAllCorruptBlocks = false
 	useRatingComposer     = false
+	deltaFromName         = ""
+	deltaFromUserData     = ""
 )
+
+// create the BackupSelector for delta backup base according to the provided flags
+func createDeltaBaseSelector(cmd *cobra.Command, targetBackupName, targetUserData string) (internal.BackupSelector, error) {
+	switch {
+	case targetUserData != "" && targetBackupName != "":
+		fmt.Println(cmd.UsageString())
+		return nil, errors.New("Only one delta target should be specified.")
+
+	case targetBackupName != "":
+		tracelog.InfoLogger.Printf("Selecting the backup with name %s as the base for the current delta backup...\n",
+			targetBackupName)
+		return internal.NewBackupNameSelector(targetBackupName)
+
+	case targetUserData != "":
+		tracelog.InfoLogger.Println(
+			"Selecting the backup with specified UserData as the base for the current delta backup...")
+		return internal.NewUserDataBackupSelector(targetUserData)
+
+	default:
+		tracelog.InfoLogger.Println("Selecting the latest backup as the base for the current delta backup...")
+		return internal.NewLatestBackupSelector(), nil
+	}
+}
 
 func init() {
 	cmd.AddCommand(backupPushCmd)
@@ -55,5 +96,7 @@ func init() {
 	backupPushCmd.Flags().BoolVarP(&verifyPageChecksums, verifyPagesFlag, verifyPagesShorthand, false, "Verify page checksums")
 	backupPushCmd.Flags().BoolVarP(&storeAllCorruptBlocks, storeAllCorruptBlocksFlag, storeAllCorruptBlocksShorthand,
 		false, "Store all corrupt blocks found during page checksum verification")
-	backupPushCmd.Flags().BoolVarP(&useRatingComposer, UseRatingComposer, UseRatingComposerShortHand, false, "Use rating tar composer (beta)")
+	backupPushCmd.Flags().BoolVarP(&useRatingComposer, useRatingComposerFlag, useRatingComposerShorthand, false, "Use rating tar composer (beta)")
+	backupPushCmd.Flags().StringVar(&deltaFromName, deltaFromNameFlag, "", "Select the backup specified by name as the target for the delta backup")
+	backupPushCmd.Flags().StringVar(&deltaFromUserData, deltaFromUserDataFlag, "", "Select the backup specified by UserData as the target for the delta backup")
 }

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -80,7 +80,7 @@ func createDeltaBaseSelector(cmd *cobra.Command, targetBackupName, targetUserDat
 
 	case targetUserData != "":
 		tracelog.InfoLogger.Println(
-			"Selecting the backup with specified UserData as the base for the current delta backup...")
+			"Selecting the backup with specified user data as the base for the current delta backup...")
 		return internal.NewUserDataBackupSelector(targetUserData)
 
 	default:

--- a/internal/backup_fetch_handler.go
+++ b/internal/backup_fetch_handler.go
@@ -118,7 +118,9 @@ func StreamBackupToCommandStdin(cmd *exec.Cmd, backup *Backup) error {
 
 // TODO : unit tests
 // HandleBackupFetch is invoked to perform wal-g backup-fetch
-func HandleBackupFetch(folder storage.Folder, backupName string, fetcher func(folder storage.Folder, backup Backup)) {
+func HandleBackupFetch(folder storage.Folder, targetBackupSelector BackupSelector, fetcher func(folder storage.Folder, backup Backup)) {
+	backupName, err := targetBackupSelector.Select(folder)
+	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.DebugLogger.Printf("HandleBackupFetch(%s, folder,)\n", backupName)
 	backup, err := GetBackupByName(backupName, utility.BaseBackupPath, folder)
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch backup: %v\n", err)

--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -210,7 +210,7 @@ func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanen
 
 	folder := uploader.UploadingFolder
 	basebackupFolder := folder.GetSubFolder(utility.BaseBackupPath)
-	if maxDeltas > 0 && !isFullBackup  {
+	if maxDeltas > 0 && !isFullBackup {
 		previousBackupName, err = deltaBaseSelector.Select(folder)
 		if err != nil {
 			if _, ok := err.(NoBackupsFoundError); ok {

--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -198,7 +198,8 @@ func uploadBackup(
 // TODO : unit tests
 // HandleBackupPush is invoked to perform a wal-g backup-push
 func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanent, isFullBackup,
-	verifyPageChecksums, storeAllCorruptBlocks bool, tarBallComposerType TarBallComposerType) {
+	verifyPageChecksums, storeAllCorruptBlocks bool, tarBallComposerType TarBallComposerType,
+	deltaBaseSelector BackupSelector) {
 	archiveDirectory = utility.ResolveSymlink(archiveDirectory)
 	maxDeltas, fromFull := getDeltaConfig()
 	checkPgVersionAndPgControl(archiveDirectory)
@@ -209,8 +210,8 @@ func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanen
 
 	folder := uploader.UploadingFolder
 	basebackupFolder := folder.GetSubFolder(utility.BaseBackupPath)
-	if maxDeltas > 0 && !isFullBackup {
-		previousBackupName, err = getLatestBackupName(folder)
+	if maxDeltas > 0 && !isFullBackup  {
+		previousBackupName, err = deltaBaseSelector.Select(folder)
 		if err != nil {
 			if _, ok := err.(NoBackupsFoundError); ok {
 				tracelog.InfoLogger.Println("Couldn't find previous backup. Doing full backup.")

--- a/internal/backup_selector.go
+++ b/internal/backup_selector.go
@@ -1,0 +1,116 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/wal-g/storages/storage"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/utility"
+	"reflect"
+	"strings"
+)
+
+// Select the name of storage backup chosen according to the internal rules
+type BackupSelector interface {
+	Select(folder storage.Folder) (string, error)
+}
+
+// Select the latest backup from storage
+type LatestBackupSelector struct {
+}
+
+func NewLatestBackupSelector() LatestBackupSelector {
+	return LatestBackupSelector{}
+}
+
+func (s LatestBackupSelector) Select(folder storage.Folder) (string, error) {
+	return getLatestBackupName(folder)
+}
+
+// Select backup which has the provided user data
+type UserDataBackupSelector struct {
+	userData interface{}
+}
+
+func NewUserDataBackupSelector(userDataRaw string) (UserDataBackupSelector, error) {
+	var userData interface{}
+	err := json.Unmarshal([]byte(userDataRaw), &userData)
+	if err != nil {
+		return UserDataBackupSelector{}, errors.Wrapf(err, "failed to unmarshal the target UserData")
+	}
+	return UserDataBackupSelector{userData: userData}, nil
+}
+
+func (s UserDataBackupSelector) Select(folder storage.Folder) (string, error) {
+	backupDetails, err := findBackupByUserData(s.userData, folder)
+	if err != nil {
+		return "", err
+	}
+	return backupDetails.BackupName, nil
+}
+
+// Find backup with UserData exactly matching the provided one
+func findBackupByUserData(userData interface{}, folder storage.Folder) (BackupDetail, error) {
+	foundBackups, err := searchBackupDetails(
+		func (d BackupDetail) bool {
+			return reflect.DeepEqual(userData, d.UserData)
+		}, folder)
+	if err != nil {
+		return BackupDetail{}, errors.Wrapf(err, "UserData search failed")
+	}
+
+	if len(foundBackups) == 0 {
+		return BackupDetail{}, errors.New("no backups found with specified UserData")
+	}
+
+	if len(foundBackups) > 1 {
+		var backupNames []string
+		for _, b := range foundBackups {
+			backupNames = append(backupNames, b.BackupName)
+		}
+		return BackupDetail{}, fmt.Errorf("too many backups (%d) found with specified UserData: %s\n",
+			len(backupNames), strings.Join(backupNames, " "))
+	}
+
+	return foundBackups[0], nil
+}
+
+// Search backups in storage using specified criteria
+func searchBackupDetails(criteria func (BackupDetail) bool, folder storage.Folder) ([]BackupDetail, error) {
+	backups, err := GetBackupSentinelObjects(folder)
+	if err != nil {
+		return nil, err
+	}
+
+	backupTimes := GetBackupTimeSlices(backups)
+	foundBackups := make([]BackupDetail, 0)
+
+	for _, backupTime := range backupTimes {
+		backupDetails, err := GetBackupDetails(folder, backupTime)
+		if err != nil {
+			tracelog.WarningLogger.Printf("Failed to get metadata of backup %s, error: %s\n",
+				backupTime.BackupName, err.Error())
+		} else if criteria(backupDetails) {
+			foundBackups = append(foundBackups, backupDetails)
+		}
+	}
+	return foundBackups, nil
+}
+
+// Select backup by provided backup name
+type BackupNameSelector struct {
+	backupName string
+}
+
+func NewBackupNameSelector(backupName string) (BackupNameSelector, error) {
+	return BackupNameSelector{backupName: backupName}, nil
+}
+
+func (s BackupNameSelector) Select(folder storage.Folder) (string, error) {
+	_, err := GetBackupByName(s.backupName, utility.BaseBackupPath, folder)
+	if err != nil {
+		return "", err
+	}
+	return s.backupName, nil
+}

--- a/internal/backup_selector.go
+++ b/internal/backup_selector.go
@@ -62,7 +62,7 @@ func findBackupByUserData(userData interface{}, folder storage.Folder) (BackupDe
 	}
 
 	if len(foundBackups) == 0 {
-		return BackupDetail{}, errors.New("no backups found with specified UserData")
+		return BackupDetail{}, errors.New("no backups found with specified user data")
 	}
 
 	if len(foundBackups) > 1 {
@@ -70,7 +70,7 @@ func findBackupByUserData(userData interface{}, folder storage.Folder) (BackupDe
 		for idx := range foundBackups {
 			backupNames = append(backupNames, foundBackups[idx].BackupName)
 		}
-		return BackupDetail{}, fmt.Errorf("too many backups (%d) found with specified UserData: %s\n",
+		return BackupDetail{}, fmt.Errorf("too many backups (%d) found with specified user data: %s\n",
 			len(backupNames), strings.Join(backupNames, " "))
 	}
 

--- a/internal/backup_selector.go
+++ b/internal/backup_selector.go
@@ -3,12 +3,13 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/wal-g/storages/storage"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/utility"
-	"reflect"
-	"strings"
 )
 
 // Select the name of storage backup chosen according to the internal rules
@@ -53,7 +54,7 @@ func (s UserDataBackupSelector) Select(folder storage.Folder) (string, error) {
 // Find backup with UserData exactly matching the provided one
 func findBackupByUserData(userData interface{}, folder storage.Folder) (BackupDetail, error) {
 	foundBackups, err := searchBackupDetails(
-		func (d BackupDetail) bool {
+		func(d BackupDetail) bool {
 			return reflect.DeepEqual(userData, d.UserData)
 		}, folder)
 	if err != nil {
@@ -66,8 +67,8 @@ func findBackupByUserData(userData interface{}, folder storage.Folder) (BackupDe
 
 	if len(foundBackups) > 1 {
 		var backupNames []string
-		for _, b := range foundBackups {
-			backupNames = append(backupNames, b.BackupName)
+		for idx := range foundBackups {
+			backupNames = append(backupNames, foundBackups[idx].BackupName)
 		}
 		return BackupDetail{}, fmt.Errorf("too many backups (%d) found with specified UserData: %s\n",
 			len(backupNames), strings.Join(backupNames, " "))
@@ -77,7 +78,7 @@ func findBackupByUserData(userData interface{}, folder storage.Folder) (BackupDe
 }
 
 // Search backups in storage using specified criteria
-func searchBackupDetails(criteria func (BackupDetail) bool, folder storage.Folder) ([]BackupDetail, error) {
+func searchBackupDetails(criteria func(BackupDetail) bool, folder storage.Folder) ([]BackupDetail, error) {
 	backups, err := GetBackupSentinelObjects(folder)
 	if err != nil {
 		return nil, err

--- a/internal/config.go
+++ b/internal/config.go
@@ -35,6 +35,7 @@ const (
 	UseRatingComposerSetting     = "WALG_USE_RATING_COMPOSER"
 	DeltaFromNameSetting         = "WALG_DELTA_FROM_NAME"
 	DeltaFromUserDataSetting     = "WALG_DELTA_FROM_USER_DATA"
+	TargetUserDataSetting        = "WALG_FETCH_TARGET_USER_DATA"
 	LogLevelSetting              = "WALG_LOG_LEVEL"
 	TarSizeThresholdSetting      = "WALG_TAR_SIZE_THRESHOLD"
 	CseKmsIDSetting              = "WALG_CSE_KMS_ID"
@@ -168,6 +169,7 @@ var (
 		MaxDelayedSegmentsCount:      true,
 		DeltaFromNameSetting:         true,
 		DeltaFromUserDataSetting:     true,
+		TargetUserDataSetting:		  true,
 
 		// Postgres
 		PgPortSetting:     true,

--- a/internal/config.go
+++ b/internal/config.go
@@ -33,6 +33,8 @@ const (
 	VerifyPageChecksumsSetting   = "WALG_VERIFY_PAGE_CHECKSUMS"
 	StoreAllCorruptBlocksSetting = "WALG_STORE_ALL_CORRUPT_BLOCKS"
 	UseRatingComposerSetting     = "WALG_USE_RATING_COMPOSER"
+	DeltaFromNameSetting         = "WALG_DELTA_FROM_NAME"
+	DeltaFromUserDataSetting     = "WALG_DELTA_FROM_USER_DATA"
 	LogLevelSetting              = "WALG_LOG_LEVEL"
 	TarSizeThresholdSetting      = "WALG_TAR_SIZE_THRESHOLD"
 	CseKmsIDSetting              = "WALG_CSE_KMS_ID"
@@ -164,6 +166,8 @@ var (
 		StoreAllCorruptBlocksSetting: true,
 		UseRatingComposerSetting:     true,
 		MaxDelayedSegmentsCount:      true,
+		DeltaFromNameSetting:         true,
+		DeltaFromUserDataSetting:     true,
 
 		// Postgres
 		PgPortSetting:     true,

--- a/internal/config.go
+++ b/internal/config.go
@@ -169,7 +169,7 @@ var (
 		MaxDelayedSegmentsCount:      true,
 		DeltaFromNameSetting:         true,
 		DeltaFromUserDataSetting:     true,
-		TargetUserDataSetting:		  true,
+		TargetUserDataSetting:        true,
 
 		// Postgres
 		PgPortSetting:     true,

--- a/internal/databases/fdb/backup_fetch_handler.go
+++ b/internal/databases/fdb/backup_fetch_handler.go
@@ -8,6 +8,6 @@ import (
 	"github.com/wal-g/wal-g/internal"
 )
 
-func HandleBackupFetch(ctx context.Context, folder storage.Folder, backupName string, restoreCmd *exec.Cmd) {
-	internal.HandleBackupFetch(folder, backupName, internal.GetCommandStreamFetcher(restoreCmd))
+func HandleBackupFetch(ctx context.Context, folder storage.Folder, targetBackupSelector internal.BackupSelector, restoreCmd *exec.Cmd) {
+	internal.HandleBackupFetch(folder, targetBackupSelector, internal.GetCommandStreamFetcher(restoreCmd))
 }

--- a/internal/databases/mysql/backup_fetch_handler.go
+++ b/internal/databases/mysql/backup_fetch_handler.go
@@ -8,8 +8,8 @@ import (
 	"github.com/wal-g/wal-g/internal"
 )
 
-func HandleBackupFetch(folder storage.Folder, backupName string, restoreCmd *exec.Cmd, prepareCmd *exec.Cmd) {
-	internal.HandleBackupFetch(folder, backupName, internal.GetCommandStreamFetcher(restoreCmd))
+func HandleBackupFetch(folder storage.Folder, targetBackupSelector internal.BackupSelector, restoreCmd *exec.Cmd, prepareCmd *exec.Cmd) {
+	internal.HandleBackupFetch(folder, targetBackupSelector, internal.GetCommandStreamFetcher(restoreCmd))
 	if prepareCmd != nil {
 		err := prepareCmd.Run()
 		tracelog.ErrorLogger.FatalfOnError("failed to prepare fetched backup: %v", err)


### PR DESCRIPTION
In this PR I propose to add backup selectors for the additional flexibility of `backup-push` and `backup-fetch` commands.

New functionality for `backup-push` (postgres):
1. Create delta from backup specified by backup name via `--delta-from-name` flag or `WALG_DELTA_FROM_NAME` variable. Sample usage:
```wal-g backup-push /path --delta-from-name base_000000010000000100000072_D_000000010000000100000063```
2. Create delta from backup specified by UserData via `--delta-from-user-data` flag or `WALG_DELTA_FROM_USER_DATA` variable. Sample usage:
```wal-g backup-push /path --delta-from-user-data "{ \"x\": [3], \"y\": 4 }" ```

New functionality for `backup-fetch`:
1. Find the storage backup with the specific UserData via `--target-user-data` flag or `WALG_FETCH_TARGET_USER_DATA` variable and fetch it. Sample usage:
```wal-g backup-fetch /path --target-user-data "{ \"x\": [3], \"y\": 4 }"```


When using the above flags in combination with `WALG_DELTA_ORIGIN` setting, `WALG_DELTA_ORIGIN` logic applies to the specified backup. For example:
```
list of backups in storage:
base_000000010000000100000040  # full backup
base_000000010000000100000046_D_000000010000000100000040  # 1st delta
base_000000010000000100000061_D_000000010000000100000046  # 2nd delta
base_000000010000000100000070  # full backup

export WALG_DELTA_ORIGIN=LATEST_FULL
wal-g backup-push /path --delta-from-name base_000000010000000100000046_D_000000010000000100000040

wal-g logs:
INFO: Selecting the backup with name base_000000010000000100000046_D_000000010000000100000040 as the base for the current delta backup...
INFO: Delta will be made from full backup.
INFO: Delta backup from base_000000010000000100000040 with LSN 140000060.
```
