### PR TITLE
Add user data flag && allow non-JSON user data

### DIFF
--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -72,7 +72,7 @@ func createTargetBackupSelector(cmd *cobra.Command, args []string) (internal.Bac
 
 	case len(args) == 1 && targetUserData != "":
 		tracelog.InfoLogger.Println("Fetching the backup with the specified user data...")
-		return internal.NewUserDataBackupSelector(targetUserData)
+		return internal.NewUserDataBackupSelector(targetUserData), nil
 
 	default:
 		err = errors.New("Insufficient arguments.")

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -20,6 +20,7 @@ const (
 	useRatingComposerFlag     = "rating-composer"
 	deltaFromUserDataFlag     = "delta-from-user-data"
 	deltaFromNameFlag         = "delta-from-name"
+	addUserDataFlag           = "add-user-data"
 
 	permanentShorthand             = "p"
 	fullBackupShorthand            = "f"
@@ -53,8 +54,12 @@ var (
 			deltaBaseSelector, err := createDeltaBaseSelector(cmd, deltaFromName, deltaFromUserData)
 			tracelog.ErrorLogger.FatalOnError(err)
 
+			if userData == "" {
+				userData = viper.GetString(internal.SentinelUserDataSetting)
+			}
+
 			internal.HandleBackupPush(uploader, args[0], permanent, fullBackup, verifyPageChecksums,
-				storeAllCorruptBlocks, tarBallComposerType, deltaBaseSelector)
+				storeAllCorruptBlocks, tarBallComposerType, deltaBaseSelector, userData)
 		},
 	}
 	permanent             = false
@@ -64,6 +69,7 @@ var (
 	useRatingComposer     = false
 	deltaFromName         = ""
 	deltaFromUserData     = ""
+	userData              = ""
 )
 
 // create the BackupSelector for delta backup base according to the provided flags
@@ -100,4 +106,5 @@ func init() {
 	backupPushCmd.Flags().BoolVarP(&useRatingComposer, useRatingComposerFlag, useRatingComposerShorthand, false, "Use rating tar composer (beta)")
 	backupPushCmd.Flags().StringVar(&deltaFromName, deltaFromNameFlag, "", "Select the backup specified by name as the target for the delta backup")
 	backupPushCmd.Flags().StringVar(&deltaFromUserData, deltaFromUserDataFlag, "", "Select the backup specified by UserData as the target for the delta backup")
+	backupPushCmd.Flags().StringVar(&userData, addUserDataFlag, "", "Write the provided user data to the backup sentinel and metadata files.")
 }

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -87,7 +87,7 @@ func createDeltaBaseSelector(cmd *cobra.Command, targetBackupName, targetUserDat
 	case targetUserData != "":
 		tracelog.InfoLogger.Println(
 			"Selecting the backup with specified user data as the base for the current delta backup...")
-		return internal.NewUserDataBackupSelector(targetUserData)
+		return internal.NewUserDataBackupSelector(targetUserData), nil
 
 	default:
 		tracelog.InfoLogger.Println("Selecting the latest backup as the base for the current delta backup...")

--- a/internal/backup_push_handler.go
+++ b/internal/backup_push_handler.go
@@ -67,6 +67,7 @@ type BackupConfig struct {
 	verifyPageChecksums       bool
 	storeAllCorruptBlocks     bool
 	tarBallComposerType       TarBallComposerType
+	userData                  string
 }
 
 // TODO : unit tests
@@ -199,7 +200,7 @@ func uploadBackup(
 // HandleBackupPush is invoked to perform a wal-g backup-push
 func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanent, isFullBackup,
 	verifyPageChecksums, storeAllCorruptBlocks bool, tarBallComposerType TarBallComposerType,
-	deltaBaseSelector BackupSelector) {
+	deltaBaseSelector BackupSelector, userData string) {
 	archiveDirectory = utility.ResolveSymlink(archiveDirectory)
 	maxDeltas, fromFull := getDeltaConfig()
 	checkPgVersionAndPgControl(archiveDirectory)
@@ -262,6 +263,7 @@ func HandleBackupPush(uploader *WalUploader, archiveDirectory string, isPermanen
 		verifyPageChecksums:       verifyPageChecksums,
 		storeAllCorruptBlocks:     storeAllCorruptBlocks,
 		tarBallComposerType:       tarBallComposerType,
+		userData:                  userData,
 	}
 	createAndPushBackup(&backupConfig)
 }

--- a/internal/backup_selector.go
+++ b/internal/backup_selector.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -34,13 +33,8 @@ type UserDataBackupSelector struct {
 	userData interface{}
 }
 
-func NewUserDataBackupSelector(userDataRaw string) (UserDataBackupSelector, error) {
-	var userData interface{}
-	err := json.Unmarshal([]byte(userDataRaw), &userData)
-	if err != nil {
-		return UserDataBackupSelector{}, errors.Wrapf(err, "failed to unmarshal the target UserData")
-	}
-	return UserDataBackupSelector{userData: userData}, nil
+func NewUserDataBackupSelector(userDataRaw string) UserDataBackupSelector {
+	return UserDataBackupSelector{userData: UnmarshalSentinelUserData(userDataRaw)}
 }
 
 func (s UserDataBackupSelector) Select(folder storage.Folder) (string, error) {

--- a/internal/backup_sentinel_dto.go
+++ b/internal/backup_sentinel_dto.go
@@ -55,7 +55,7 @@ func NewBackupSentinelDto(
 
 	sentinel.setFiles(files)
 	sentinel.BackupFinishLSN = &backupFinishLSN
-	sentinel.UserData = GetSentinelUserData()
+	sentinel.UserData = UnmarshalSentinelUserData(bc.userData)
 	sentinel.SystemIdentifier = systemIdentifier
 	sentinel.UncompressedSize = uncompressedSize
 	sentinel.CompressedSize = compressedSize

--- a/internal/catchup_push_handler.go
+++ b/internal/catchup_push_handler.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"github.com/spf13/viper"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -33,6 +34,7 @@ func HandleCatchupPush(uploader *WalUploader, archiveDirectory string, fromLSN u
 		verifyPageChecksums:       false,
 		storeAllCorruptBlocks:     false,
 		tarBallComposerType:       RegularComposer,
+		userData:                  viper.GetString(SentinelUserDataSetting),
 	}
 
 	createAndPushBackup(&backupConfig)

--- a/internal/configure.go
+++ b/internal/configure.go
@@ -365,7 +365,9 @@ func UnmarshalSentinelUserData(userDataStr string) interface{} {
 	var out interface{}
 	err := json.Unmarshal([]byte(userDataStr), &out)
 	if err != nil {
-		tracelog.WarningLogger.PrintError(newUnmarshallingError(SentinelUserDataSetting, err))
+		tracelog.WarningLogger.Printf(
+			"Failed to read the user data as a JSON object, will read as a raw string instead: %s",
+			newUnmarshallingError(userDataStr, err))
 		return userDataStr
 	}
 	return out

--- a/internal/configure.go
+++ b/internal/configure.go
@@ -351,14 +351,22 @@ func GetMaxConcurrency(concurrencyType string) (int, error) {
 
 func GetSentinelUserData() interface{} {
 	dataStr, ok := GetSetting(SentinelUserDataSetting)
-	if !ok || len(dataStr) == 0 {
+	if !ok {
 		return nil
 	}
+	return UnmarshalSentinelUserData(dataStr)
+}
+
+func UnmarshalSentinelUserData(userDataStr string) interface{} {
+	if len(userDataStr) == 0 {
+		return nil
+	}
+
 	var out interface{}
-	err := json.Unmarshal([]byte(dataStr), &out)
+	err := json.Unmarshal([]byte(userDataStr), &out)
 	if err != nil {
 		tracelog.WarningLogger.PrintError(newUnmarshallingError(SentinelUserDataSetting, err))
-		return dataStr
+		return userDataStr
 	}
 	return out
 }


### PR DESCRIPTION
In this PR I propose a couple of improvements for WAL-G user data feature.
1. Add the `--add-user-data` flag for `backup-push` which can be used instead of `WALG_SENTINEL_USER_DATA` variable
2. If failed to unmarshal the user data as JSON object, store it as JSON string instead of failure