### PR TITLE
Delete target backup (improvements)

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -95,6 +95,7 @@ jobs:
                    'make TEST="pg_delete_before_permanent_delta_test" pg_integration_test',
                    'make TEST="pg_delete_target_test" pg_integration_test',
                    'make TEST="pg_delete_target_delta_test" pg_integration_test',
+                   'make TEST="pg_delete_target_delta_find_full_test" pg_integration_test',
                    'make mongo_test',
                    'make MONGO_VERSION="4.4.3" MONGO_MAJOR="4.4" mongo_features',
                    'make MONGO_VERSION="4.2.12" MONGO_MAJOR="4.2" mongo_features',

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -94,6 +94,7 @@ jobs:
                    'make TEST="pg_delete_before_permanent_full_test" pg_integration_test',
                    'make TEST="pg_delete_before_permanent_delta_test" pg_integration_test',
                    'make TEST="pg_delete_target_test" pg_integration_test',
+                   'make TEST="pg_delete_target_delta_test" pg_integration_test',
                    'make mongo_test',
                    'make MONGO_VERSION="4.4.3" MONGO_MAJOR="4.4" mongo_features',
                    'make MONGO_VERSION="4.2.12" MONGO_MAJOR="4.2" mongo_features',

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Lists names and creation time of available backups.
 
 Is used to delete backups and WALs before them. By default ``delete`` will perform a dry run. If you want to execute deletion, you have to add ``--confirm`` flag at the end of the command. Backups marked as permanent will not be deleted.
 
-``delete`` can operate in three modes: ``retain``, ``before`` and ``everything``.
+``delete`` can operate in four modes: ``retain``, ``before``, ``everything`` and ``target``.
 
 ``retain`` [FULL|FIND_FULL] %number% [--after %name|time%]
 
@@ -210,6 +210,10 @@ $number$ the most recent backups and backups made after %name|time% (including).
 If `FIND_FULL` is specified, WAL-G will calculate minimum backup needed to keep all deltas alive. If FIND_FULL is not specified and call can produce orphaned deltas - the call will fail with the list.
 
 ``everything`` [FORCE]
+
+``target`` [FIND_FULL] %name% | --target-user-data %data% will delete the backup specified by name or user data.
+
+(Only in Postgres) By default, if delta backup is provided as the target, WAL-G will also delete all the dependant delta backups. If `FIND_FULL` is specified, WAL-G will delete all backups with the same base backup as the target.
 
 Examples:
 
@@ -228,6 +232,14 @@ Examples:
 ``before base_000010000123123123`` will fail if `base_000010000123123123` is delta
 
 ``before FIND_FULL base_000010000123123123`` will keep everything after base of base_000010000123123123
+
+``target base_0000000100000000000000C9`` delete the base backup and all dependant delta backups
+
+``  target --target-user-data "{ \"x\": [3], \"y\": 4 }"`` 	delete backup specified by user data
+
+``target base_0000000100000000000000C9_D_0000000100000000000000C4``	delete delta backup and all dependant delta backups
+
+``target FIND_FULL base_0000000100000000000000C9_D_0000000100000000000000C4`` delete delta backup and all delta backups with the same base backup
 
 **More commands are available for the chosen database engine. See it in [Databases](#databases)**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,6 +291,17 @@ services:
     links:
       - s3
 
+  pg_delete_target_delta_find_full_test:
+    build:
+      dockerfile: docker/pg_tests/Dockerfile_delete_target_delta_find_full_test
+      context: .
+    image: wal-g/delete_target_delta_find_full_test
+    container_name: wal-g_pg_delete_target_delta_find_full_test
+    depends_on:
+      - s3
+    links:
+      - s3
+
   pg_ghost_table_test:
     build:
       dockerfile: docker/pg_tests/Dockerfile_ghost_table_test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -280,6 +280,17 @@ services:
     links:
       - s3
 
+  pg_delete_target_delta_test:
+    build:
+      dockerfile: docker/pg_tests/Dockerfile_delete_target_delta_test
+      context: .
+    image: wal-g/delete_target_delta_test
+    container_name: wal-g_pg_delete_target_delta_test
+    depends_on:
+      - s3
+    links:
+      - s3
+
   pg_ghost_table_test:
     build:
       dockerfile: docker/pg_tests/Dockerfile_ghost_table_test

--- a/docker/pg_tests/Dockerfile_delete_target_delta_find_full_test
+++ b/docker/pg_tests/Dockerfile_delete_target_delta_find_full_test
@@ -1,0 +1,3 @@
+FROM wal-g/docker_prefix:latest
+
+CMD su postgres -c "/tmp/tests/delete_target_delta_find_full_test.sh"

--- a/docker/pg_tests/Dockerfile_delete_target_delta_test
+++ b/docker/pg_tests/Dockerfile_delete_target_delta_test
@@ -1,0 +1,3 @@
+FROM wal-g/docker_prefix:latest
+
+CMD su postgres -c "/tmp/tests/delete_target_delta_test.sh"

--- a/docker/pg_tests/scripts/configs/delete_target_delta_find_full_test_config.json
+++ b/docker/pg_tests/scripts/configs/delete_target_delta_find_full_test_config.json
@@ -1,0 +1,3 @@
+"WALG_DELTA_MAX_STEPS": "100",
+"WALE_S3_PREFIX": "s3://deletetargetbucket",
+"WALG_USE_WAL_DELTA": "true"

--- a/docker/pg_tests/scripts/configs/delete_target_delta_test_config.json
+++ b/docker/pg_tests/scripts/configs/delete_target_delta_test_config.json
@@ -1,0 +1,3 @@
+"WALG_DELTA_MAX_STEPS": "100",
+"WALE_S3_PREFIX": "s3://deletetargetbucket",
+"WALG_USE_WAL_DELTA": "true"

--- a/docker/pg_tests/scripts/tests/delete_target_delta_find_full_test.sh
+++ b/docker/pg_tests/scripts/tests/delete_target_delta_find_full_test.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+set -e -x
+  CONFIG_FILE="/tmp/configs/delete_target_delta_find_full_test_config.json"
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/scripts/wrap_config_file.sh ${TMP_CONFIG}
+
+/usr/lib/postgresql/10/bin/initdb ${PGDATA}
+
+echo "archive_mode = on" >> /var/lib/postgresql/10/main/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 /usr/bin/wal-g --config=${TMP_CONFIG} wal-push %p'" >> /var/lib/postgresql/10/main/postgresql.conf
+echo "archive_timeout = 600" >> /var/lib/postgresql/10/main/postgresql.conf
+
+/usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+# create full backup and incremental
+for i in 1 2
+do
+    pgbench -i -s 1 postgres &
+    sleep 1
+    wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+done
+
+# remember the backup-list output
+# later in the test we create new backups which should be deleted so lists should be identical
+lines_before_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
+wal-g --config=${TMP_CONFIG} backup-list | tail -n 2 > /tmp/list_before_delete
+
+# create one full and two increments
+for i in 1 2 3
+do
+    if [ $i -eq 1 ]; then
+       modifier='--full'
+    else
+       modifier=''
+    fi
+    pgbench -i -s 1 postgres &
+    sleep 1
+    wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} ${modifier}
+done
+
+# get the name of the second incremental backup
+SECOND_INCREMENT=$(wal-g --config=${TMP_CONFIG} backup-list | awk 'NR==5 {print $1}')
+
+# make two increments from the SECOND_INCREMENT
+pgbench -i -s 1 postgres & sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --delta-from-name ${SECOND_INCREMENT}
+
+pgbench -i -s 1 postgres & sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --delta-from-name ${SECOND_INCREMENT}
+
+# delete the SECOND_INCREMENT with FIND_FULL, should leave only the first full backup w/ first increment
+wal-g --config=${TMP_CONFIG} delete target FIND_FULL ${SECOND_INCREMENT} --confirm
+
+lines_after_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
+wal-g --config=${TMP_CONFIG} backup-list | tail -n 2 > /tmp/list_after_delete
+
+if [ $(($lines_before_delete)) -ne $lines_after_delete ];
+then
+    echo $(($lines_before_delete)) > /tmp/before_delete
+    echo $lines_after_delete > /tmp/after_delete
+    echo "Wrong number of deleted lines"
+    diff /tmp/before_delete /tmp/after_delete
+fi
+
+
+diff /tmp/list_before_delete /tmp/list_after_delete
+/tmp/scripts/drop_pg.sh
+rm ${TMP_CONFIG}

--- a/docker/pg_tests/scripts/tests/delete_target_delta_test.sh
+++ b/docker/pg_tests/scripts/tests/delete_target_delta_test.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -e -x
+  CONFIG_FILE="/tmp/configs/delete_target_delta_test_config.json"
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/scripts/wrap_config_file.sh ${TMP_CONFIG}
+
+/usr/lib/postgresql/10/bin/initdb ${PGDATA}
+
+echo "archive_mode = on" >> /var/lib/postgresql/10/main/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 /usr/bin/wal-g --config=${TMP_CONFIG} wal-push %p'" >> /var/lib/postgresql/10/main/postgresql.conf
+echo "archive_timeout = 600" >> /var/lib/postgresql/10/main/postgresql.conf
+
+/usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+# create one base backup and one increment
+for i in 1 2
+do
+    pgbench -i -s 1 postgres &
+    sleep 1
+    wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+done
+
+# remember the name of the first increment
+FIRST_INCREMENT=$(wal-g --config=${TMP_CONFIG} backup-list | awk 'END {print $1}')
+
+# make the second full backup
+pgbench -i -s 1 postgres & sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --full
+
+# make the increment from the second full backup
+pgbench -i -s 1 postgres & sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+
+# remember the backup-list output with two full backups and two increments.
+# later in the test we create new backups which should be deleted so lists should be identical
+lines_before_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
+wal-g --config=${TMP_CONFIG} backup-list | tail -n 4 > /tmp/list_before_delete
+
+# now make increment from the FIRST_INCREMENT, which will be deleted later
+pgbench -i -s 1 postgres & sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --delta-from-name ${FIRST_INCREMENT}
+INCREMENT_TO_DELETE=$(wal-g --config=${TMP_CONFIG} backup-list | awk 'END {print $1}')
+
+# make the increment from the INCREMENT_TO_DELETE
+pgbench -i -s 1 postgres & sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --delta-from-name ${INCREMENT_TO_DELETE}
+
+# make one more increment from the INCREMENT_TO_DELETE
+pgbench -i -s 1 postgres & sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --delta-from-name ${INCREMENT_TO_DELETE}
+
+# delete the INCREMENT_TO_DELETE, should leave only the first full backup w/ first increment and the second full backup w/ first increment
+wal-g --config=${TMP_CONFIG} delete target ${INCREMENT_TO_DELETE} --confirm
+
+lines_after_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
+wal-g --config=${TMP_CONFIG} backup-list | tail -n 4 > /tmp/list_after_delete
+
+if [ $(($lines_before_delete)) -ne $lines_after_delete ];
+then
+    echo $(($lines_before_delete)) > /tmp/before_delete
+    echo $lines_after_delete > /tmp/after_delete
+    echo "Wrong number of deleted lines"
+    diff /tmp/before_delete /tmp/after_delete
+fi
+
+
+diff /tmp/list_before_delete /tmp/list_after_delete
+/tmp/scripts/drop_pg.sh
+rm ${TMP_CONFIG}

--- a/internal/backup_object.go
+++ b/internal/backup_object.go
@@ -23,6 +23,10 @@ func (o DefaultBackupObject) GetBaseBackupName() string {
 	return o.GetBackupName()
 }
 
+func (o DefaultBackupObject) GetIncrementFromName() string {
+	return o.GetBackupName()
+}
+
 func (o DefaultBackupObject) IsFullBackup() bool {
 	return true
 }

--- a/internal/delete_test.go
+++ b/internal/delete_test.go
@@ -27,6 +27,10 @@ func (o TestPostgresBackupObject) GetBaseBackupName() string {
 	return o.GetBackupName()
 }
 
+func (o TestPostgresBackupObject) GetIncrementFromName() string {
+	return o.GetBackupName()
+}
+
 func (o TestPostgresBackupObject) IsFullBackup() bool {
 	// this function is only valid for test cases,
 	// since arbitrary WAL file name may contain the "D" symbol


### PR DESCRIPTION
In this PR I propose several improvements to the previously introduced (#913) delete target backup command.

1. Rename the `--find-full` flag to `FIND_FULL` to match the other delete commands.

2. Implement delta backups deletion. If delta backup is provided as the target, WAL-G will also delete all the dependant delta backups. Behaviour of the previously introduced `FIND_FULL` is preserved. If `FIND_FULL` is specified, WAL-G will delete all backups with the same base backup as the target.

Examples:
``target base_0000000100000000000000C9`` delete the base backup and all dependant delta backups

``target base_0000000100000000000000C9_D_0000000100000000000000C4``	delete delta backup and all dependant delta backups

``target FIND_FULL base_0000000100000000000000C9_D_0000000100000000000000C4`` delete delta backup and all delta backups with the same base backup


3. Add docs and tests
