### PR TITLE
Enqueue the tarball back when PackFileIntoTar errors

### DIFF
--- a/internal/regular_tar_ball_composer.go
+++ b/internal/regular_tar_ball_composer.go
@@ -56,6 +56,9 @@ func (c *RegularTarBallComposer) AddFile(info *ComposeFileInfo) {
 	c.errorGroup.Go(func() error {
 		err := c.tarFilePacker.PackFileIntoTar(info, tarBall)
 		if err != nil {
+			// put it back otherwise another Dequeu will block and the user
+			// might never see the error because of a deadlock there.
+			c.tarBallQueue.EnqueueBack(tarBall)
 			return err
 		}
 		return c.tarBallQueue.CheckSizeAndEnqueueBack(tarBall)


### PR DESCRIPTION
If it's not put back then another AddFile or AddHeader will block
indefinitely on Deque. This can cause the program to deadlock and the
user to never see the error that PackFileIntoTar returned.