### PR TITLE
Fix the incorrect behavior on backup mark

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -96,6 +96,7 @@ jobs:
                    'make TEST="pg_delete_target_test" pg_integration_test',
                    'make TEST="pg_delete_target_delta_test" pg_integration_test',
                    'make TEST="pg_delete_target_delta_find_full_test" pg_integration_test',
+                   'make TEST="pg_backup_mark_permanent_no_error_test" pg_integration_test',
                    'make mongo_test',
                    'make MONGO_VERSION="4.4.3" MONGO_MAJOR="4.4" mongo_features',
                    'make MONGO_VERSION="4.2.12" MONGO_MAJOR="4.2" mongo_features',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,17 @@ services:
     links:
       - s3
 
+  pg_backup_mark_permanent_no_error_test:
+    build:
+      dockerfile: docker/pg_tests/Dockerfile_backup_mark_permanent_no_error_test
+      context: .
+    image: wal-g/backup_mark_permanent_no_error_test
+    container_name: wal-g_pg_backup_mark_permanent_no_error_test
+    depends_on:
+      - s3
+    links:
+      - s3
+
   pg_backup_mark_impermanent_test:
     build:
       dockerfile: docker/pg_tests/Dockerfile_backup_mark_impermanent_test

--- a/docker/pg_tests/Dockerfile_backup_mark_permanent_no_error_test
+++ b/docker/pg_tests/Dockerfile_backup_mark_permanent_no_error_test
@@ -1,0 +1,3 @@
+FROM wal-g/docker_prefix:latest
+
+CMD su postgres -c "/tmp/tests/backup_mark_permanent_no_error_test.sh"

--- a/docker/pg_tests/scripts/configs/backup_mark_permanent_no_error_test_config.json
+++ b/docker/pg_tests/scripts/configs/backup_mark_permanent_no_error_test_config.json
@@ -1,0 +1,3 @@
+"WALG_DELTA_MAX_STEPS": "1000",
+"WALE_S3_PREFIX": "s3://deletebeforepermanentfullbucket",
+"WALG_USE_WAL_DELTA": "true"

--- a/docker/pg_tests/scripts/tests/backup_mark_permanent_no_error_test.sh
+++ b/docker/pg_tests/scripts/tests/backup_mark_permanent_no_error_test.sh
@@ -41,8 +41,8 @@ last_backup_name=`wal-g --config=${TMP_CONFIG} backup-list | tail -n 1 | cut -f 
 wal-g --config=${TMP_CONFIG} backup-mark "$last_backup_name"
 
 # both should be true (is_permanent: true)
-first_backup_status=$(wal-g --config=${TMP_CONFIG} backup-list --detail | awk 'NR==2 {print $1}' | egrep -o -e "true" -e "false")
-last_backup_status=$(wal-g --config=${TMP_CONFIG} backup-list --detail | awk 'END {print $1}' | egrep -o -e "true" -e "false")
+first_backup_status=$(wal-g --config=${TMP_CONFIG} backup-list --detail | awk 'NR==2 {print $0}' | egrep -o -e "true" -e "false")
+last_backup_status=$(wal-g --config=${TMP_CONFIG} backup-list --detail | awk 'END {print $0}' | egrep -o -e "true" -e "false")
 
 if [ $first_backup_status != $last_backup_status ];
 then

--- a/docker/pg_tests/scripts/tests/backup_mark_permanent_no_error_test.sh
+++ b/docker/pg_tests/scripts/tests/backup_mark_permanent_no_error_test.sh
@@ -58,24 +58,4 @@ pgbench -i -s 1 postgres &
 sleep 1
 wal-g --config=${TMP_CONFIG} backup-push "${PGDATA}" --permanent
 
-# save backup-list output before delete
-lines_before_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
-wal-g --config=${TMP_CONFIG} backup-list > /tmp/list_before_delete
-
-# try to delete all backups
-last_backup_name=$(wal-g --config=${TMP_CONFIG} backup-list | tail -n 1 | cut -f 1 -d " ")
-wal-g --config=${TMP_CONFIG} delete before "$last_backup_name" --confirm
-wal-g --config=${TMP_CONFIG} backup-list
-
-lines_after_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
-wal-g --config=${TMP_CONFIG} backup-list > /tmp/list_after_delete
-
-if [ $(($lines_before_delete)) -ne $lines_after_delete ];
-then
-    echo $(($lines_before_delete)) > /tmp/before_delete
-    echo $lines_after_delete > /tmp/after_delete
-    echo "Wrong number of deleted lines"
-    diff /tmp/before_delete /tmp/after_delete
-fi
-
 /tmp/scripts/drop_pg.sh

--- a/docker/pg_tests/scripts/tests/backup_mark_permanent_no_error_test.sh
+++ b/docker/pg_tests/scripts/tests/backup_mark_permanent_no_error_test.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -e -x
+
+CONFIG_FILE="/tmp/configs/backup_mark_permanent_no_error_test_config.json"
+
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/scripts/wrap_config_file.sh ${TMP_CONFIG}
+
+/usr/lib/postgresql/10/bin/initdb ${PGDATA}
+
+echo "archive_mode = on" >> /var/lib/postgresql/10/main/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 /usr/bin/wal-g --config=${TMP_CONFIG} wal-push %p'" >> /var/lib/postgresql/10/main/postgresql.conf
+echo "archive_timeout = 600" >> /var/lib/postgresql/10/main/postgresql.conf
+
+/usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+# this test checks that wal-g correctly behaves when we are trying to mark existing permanent backup
+# as permanent (should not produce any error and exit normally)
+
+# push some impermanent backups (base + 2 deltas)
+for i in 1 2 3
+do
+    pgbench -i -s 1 postgres &
+    sleep 1
+    wal-g --config=${TMP_CONFIG} backup-push "${PGDATA}"
+done
+
+wal-g --config=${TMP_CONFIG} backup-list
+# shellcheck disable=SC2006
+last_backup_name=`wal-g --config=${TMP_CONFIG} backup-list | tail -n 1 | cut -f 1 -d " "`
+
+# should mark all backups as permanent
+wal-g --config=${TMP_CONFIG} backup-mark "$last_backup_name"
+
+# both should be true (is_permanent: true)
+first_backup_status=$(wal-g --config=${TMP_CONFIG} backup-list --detail | awk 'NR==2 {print $1}' | egrep -o -e "true" -e "false")
+last_backup_status=$(wal-g --config=${TMP_CONFIG} backup-list --detail | awk 'END {print $1}' | egrep -o -e "true" -e "false")
+
+if [ $first_backup_status != $last_backup_status ];
+then
+    echo "Wrong backup status"
+    exit 2
+fi
+
+# mark the backup as permanent again, should not cause any error
+wal-g --config=${TMP_CONFIG} backup-mark "$last_backup_name"
+
+# push a new permanent delta backup, should not produce any error
+pgbench -i -s 1 postgres &
+sleep 1
+wal-g --config=${TMP_CONFIG} backup-push "${PGDATA}" --permanent
+
+# save backup-list output before delete
+lines_before_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
+wal-g --config=${TMP_CONFIG} backup-list > /tmp/list_before_delete
+
+# try to delete all backups
+last_backup_name=$(wal-g --config=${TMP_CONFIG} backup-list | tail -n 1 | cut -f 1 -d " ")
+wal-g --config=${TMP_CONFIG} delete before "$last_backup_name" --confirm
+wal-g --config=${TMP_CONFIG} backup-list
+
+lines_after_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
+wal-g --config=${TMP_CONFIG} backup-list > /tmp/list_after_delete
+
+if [ $(($lines_before_delete)) -ne $lines_after_delete ];
+then
+    echo $(($lines_before_delete)) > /tmp/before_delete
+    echo $lines_after_delete > /tmp/after_delete
+    echo "Wrong number of deleted lines"
+    diff /tmp/before_delete /tmp/after_delete
+fi
+
+/tmp/scripts/drop_pg.sh

--- a/internal/backup_mark.go
+++ b/internal/backup_mark.go
@@ -124,14 +124,17 @@ func getMarkedImpermanentBackupMetadata(folder storage.Folder, backupName string
 		return nil, newBackupHasPermanentBackupInFutureError(backupName)
 	}
 
-	meta.IsPermanent = false
-	metadataUploadObject, err := GetMetadataUploadObject(backup.Name, &meta)
-	if err != nil {
-		return nil, err
+	metadataToUpload := make([]UploadObject,0)
+	if meta.IsPermanent {
+		meta.IsPermanent = false
+		metadataUploadObject, err := GetMetadataUploadObject(backup.Name, &meta)
+		if err != nil {
+			return nil, err
+		}
+		metadataToUpload = append(metadataToUpload, metadataUploadObject)
 	}
-	backupMetadata := []UploadObject{metadataUploadObject}
 
-	return backupMetadata, nil
+	return metadataToUpload, nil
 }
 
 func getBackupNumber(backupName string) string {

--- a/internal/backup_mark.go
+++ b/internal/backup_mark.go
@@ -48,7 +48,7 @@ func GetMarkedBackupMetadataToUpload(
 		if !meta.IsPermanent {
 			permanentType = "impermanent"
 		}
-		return nil, newBackupAlreadyThisTypePermanentError(backupName, permanentType)
+		tracelog.WarningLogger.Printf("Backup %s is already marked as %s, ignoring...", backupName, permanentType)
 	}
 
 	if toPermanent {
@@ -198,15 +198,6 @@ func GetMetadataUploadObject(backupName string, meta *ExtendedMetadataDto) (Uplo
 		return UploadObject{}, err
 	}
 	return UploadObject{metaFilePath, bytes.NewReader(dtoBody)}, nil
-}
-
-type BackupAlreadyThisTypePermanentError struct {
-	error
-}
-
-//raise when user try make permanent/impermanent already permanent/impermanent backup,
-func newBackupAlreadyThisTypePermanentError(backupName string, permanentType string) BackupAlreadyThisTypePermanentError {
-	return BackupAlreadyThisTypePermanentError{errors.Errorf("Backup '%s' is already %s.", backupName, permanentType)}
 }
 
 type BackupHasPermanentBackupInFutureError struct {

--- a/internal/backup_mark.go
+++ b/internal/backup_mark.go
@@ -124,7 +124,7 @@ func getMarkedImpermanentBackupMetadata(folder storage.Folder, backupName string
 		return nil, newBackupHasPermanentBackupInFutureError(backupName)
 	}
 
-	metadataToUpload := make([]UploadObject,0)
+	metadataToUpload := make([]UploadObject, 0)
 	if meta.IsPermanent {
 		meta.IsPermanent = false
 		metadataUploadObject, err := GetMetadataUploadObject(backup.Name, &meta)

--- a/internal/backup_mark_test.go
+++ b/internal/backup_mark_test.go
@@ -189,7 +189,7 @@ func TestGetBackupMetadataToUpload_tryToMarkAlreadyMarkedBackup(t *testing.T) {
 	expectUploadObjectLen := 0
 	expectUploadObjectPaths := map[int]string{}
 
-	testGetBackupMetadataToUpload(backups, true, true, toMark, expectUploadObjectLen, expectUploadObjectPaths, t)
+	testGetBackupMetadataToUpload(backups, true, false, toMark, expectUploadObjectLen, expectUploadObjectPaths, t)
 }
 
 func TestGetBackupMetadataToUpload_tryToUnmarkAlreadyUnmarkedBackup(t *testing.T) {
@@ -207,7 +207,7 @@ func TestGetBackupMetadataToUpload_tryToUnmarkAlreadyUnmarkedBackup(t *testing.T
 	expectUploadObjectLen := 0
 	expectUploadObjectPaths := map[int]string{}
 
-	testGetBackupMetadataToUpload(backups, false, true, toMark, expectUploadObjectLen, expectUploadObjectPaths, t)
+	testGetBackupMetadataToUpload(backups, false, false, toMark, expectUploadObjectLen, expectUploadObjectPaths, t)
 }
 
 func TestGetBackupMetadataToUpload_tryToUnmarkBackupWithMarkedIncrementBackups(t *testing.T) {
@@ -261,7 +261,7 @@ func testGetBackupMetadataToUpload(
 	uploadObjects, err := internal.GetMarkedBackupMetadataToUpload(folder, toMark, toPermanent)
 	if !isErrorExpect {
 		assert.NoError(t, err)
-		assert.Equal(t, len(uploadObjects), expectUploadObjectLen)
+		assert.Equal(t, expectUploadObjectLen, len(uploadObjects))
 		for idx, path := range expectUploadObjectPaths {
 			assert.Equal(t, uploadObjects[idx].Path, path)
 		}


### PR DESCRIPTION
Current behaviour:
```
usernamedt-osx:wal-g usernamedt$ wal-g backup-mark base_0000000100000001000000B2 --config /Users/usernamedt/wal-g.yaml 
INFO: 2021/04/07 20:22:38.649549 Retrieving previous related backups to be marked: toPermanent=true
INFO: 2021/04/07 20:22:39.424125 Retrieved backups to be marked, marking: [{base_0000000100000001000000B2/metadata.json 0xc0004c2000}]
usernamedt-osx:wal-g usernamedt$ wal-g backup-mark base_0000000100000001000000B2 --config /Users/usernamedt/wal-g.yaml 
INFO: 2021/04/07 20:22:41.328992 Retrieving previous related backups to be marked: toPermanent=true
ERROR: 2021/04/07 20:22:41.681544 Failed to get previous backups: Backup 'base_0000000100000001000000B2' is already permanent.
```
The problem: wal-g should not produce any error when trying to mark the existing permanent backup as permanent. This PR should fix the incorrect behavior.

New behavior:
```
usernamedt-osx:wal-g usernamedt$ wal-g backup-mark base_0000000100000001000000B2 --config /Users/usernamedt/wal-g.yaml 
INFO: 2021/04/07 20:22:38.649549 Retrieving previous related backups to be marked: toPermanent=true
INFO: 2021/04/07 20:22:39.424125 Retrieved backups to be marked, marking: [{base_0000000100000001000000B2/metadata.json 0xc0004c2000}]
usernamedt-osx:pg usernamedt$ ./wal-g backup-mark base_0000000100000001000000B2 --config /Users/usernamedt/wal-g.yaml 
INFO: 2021/04/07 20:54:43.506994 Retrieving previous related backups to be marked: toPermanent=true
WARNING: 2021/04/07 20:54:43.872087 Backup base_0000000100000001000000B2 is already marked as permanent, ignoring...
INFO: 2021/04/07 20:54:44.193498 Retrieved backups to be marked, marking: []
```