### PR TITLE
Use errorGroup ctx in Deque for RegularTarBallComposer

### DIFF
--- a/internal/tar_ball_queue.go
+++ b/internal/tar_ball_queue.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
@@ -57,11 +58,25 @@ func (tarQueue *TarBallQueue) StartQueue() error {
 	return nil
 }
 
-func (tarQueue *TarBallQueue) Deque() TarBall {
+// DequeCtx returns a TarBall from the queue. If the context finishes before it
+// can do so, it returns the result of ctx.Err().
+func (tarQueue *TarBallQueue) DequeCtx(ctx context.Context) (TarBall, error) {
 	if tarQueue.started.IsNotSet() {
 		panic("Trying to deque from not started Queue")
 	}
-	return <-tarQueue.tarsToFillQueue
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case tarball := <-tarQueue.tarsToFillQueue:
+		return tarball, nil
+	}
+}
+
+func (tarQueue *TarBallQueue) Deque() TarBall {
+	// The error can be ignored, since context.Background will never finish, so
+	// DequeCtx will never return an error.
+	tarball, _ := tarQueue.DequeCtx(context.Background())
+	return tarball
 }
 
 func (tarQueue *TarBallQueue) FinishQueue() error {


### PR DESCRIPTION
Otherwise errors inside the errorGroup could cause a deadlock, because
its errorGroup go routines only enqueue the TarBall back in their happy
path.

When making a similar change for RatingTargBallComposer unittests
started failing, so that's left out of this change.

