### PR TITLE
Do not fail wal-show if no backups found in storage

### DIFF
--- a/internal/databases/postgres/wal_show_handler.go
+++ b/internal/databases/postgres/wal_show_handler.go
@@ -169,6 +169,10 @@ func groupSegmentsByTimelines(segments map[WalSegmentDescription]bool) map[uint3
 func addBackupsInfo(timelineInfos []*TimelineInfo, rootFolder storage.Folder) ([]*TimelineInfo, error) {
 	backups, err := internal.GetBackups(rootFolder)
 	if err != nil {
+		if _, ok := err.(internal.NoBackupsFoundError); ok {
+			tracelog.InfoLogger.Println("No backups found in storage.")
+			return timelineInfos, nil
+		}
 		return nil, err
 	}
 	backupDetails, err := GetBackupsDetails(rootFolder, backups)


### PR DESCRIPTION
Currently, wal-show will fail if no backups found in storage:
```
wal-g wal-show --config wal-g.yaml 

ERROR: 2021/04/20 09:59:39.514139 Failed to add backups info: No backups found
```
In this case, to be able to get any information about the WALs in storage, user need to explicitly set `--without-backups` flag:
```
wal-g wal-show --without-backups --config wal-g.yaml 
+-----+------------+-----------------+--------------------------+--------------------------+---------------+----------------+--------+
| TLI | PARENT TLI | SWITCHPOINT LSN | START SEGMENT            | END SEGMENT              | SEGMENT RANGE | SEGMENTS COUNT | STATUS |
+-----+------------+-----------------+--------------------------+--------------------------+---------------+----------------+--------+
|  11 |          0 |               0 | 0000000B000002810000005C | 0000000B0000028C00000011 |          2742 |           2742 | OK     |
|  12 |         11 |   2800620667032 | 0000000C0000028C00000012 | 0000000C000002DA0000007A |         20073 |          20073 | OK     |
|  13 |         12 |   3137389723800 | 0000000D000002DA0000007B | 0000000D0000038F000000D4 |         46426 |          46426 | OK     |
+-----+------------+-----------------+--------------------------+--------------------------+---------------+----------------+--------+
```

This PR contains a fix so user should be able to get the wal-show output with no backups in storage even when `--without-backups` is not set:
```
wal-g wal-show --config wal-g.yaml 
INFO: 2021/04/20 11:01:18.245926 No backups found in storage.
+-----+------------+-----------------+--------------------------+--------------------------+---------------+----------------+--------+---------------+
| TLI | PARENT TLI | SWITCHPOINT LSN | START SEGMENT            | END SEGMENT              | SEGMENT RANGE | SEGMENTS COUNT | STATUS | BACKUPS COUNT |
+-----+------------+-----------------+--------------------------+--------------------------+---------------+----------------+--------+---------------+
|  11 |          0 |               0 | 0000000B000002810000005C | 0000000B0000028C00000011 |          2742 |           2742 | OK     |             0 |
|  12 |         11 |   2800620667032 | 0000000C0000028C00000012 | 0000000C000002DA0000007A |         20073 |          20073 | OK     |             0 |
|  13 |         12 |   3137389723800 | 0000000D000002DA0000007B | 0000000D0000038F000000DB |         46433 |          46433 | OK     |             0 |
+-----+------------+-----------------+--------------------------+--------------------------+---------------+----------------+--------+---------------+
```