### PR TITLE
Fix delete everything FORCE for MySQL

### DIFF
--- a/cmd/mysql/delete.go
+++ b/cmd/mysql/delete.go
@@ -62,20 +62,7 @@ type DeleteHandler struct {
 func runDeleteEverything(cmd *cobra.Command, args []string) {
 	deleteHandler, err := NewMySQLDeleteHandler()
 	tracelog.ErrorLogger.FatalOnError(err)
-
-	if p := deleteHandler.permanentObjects; len(p) > 0 {
-		tracelog.InfoLogger.Fatalf("found permanent objects %s\n", strings.Join(func() []string {
-			ret := make([]string, 0)
-
-			for e := range p {
-				ret = append(ret, e)
-			}
-
-			return ret
-		}(), ","))
-	}
-
-	deleteHandler.DeleteEverything(confirmed)
+	deleteHandler.HandleDeleteEverything(args, deleteHandler.permanentObjects, confirmed)
 }
 
 func runDeleteTarget(cmd *cobra.Command, args []string) {

--- a/cmd/mysql/delete.go
+++ b/cmd/mysql/delete.go
@@ -1,8 +1,6 @@
 package mysql
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/wal-g/storages/storage"
 	"github.com/wal-g/tracelog"

--- a/cmd/pg/delete.go
+++ b/cmd/pg/delete.go
@@ -92,26 +92,12 @@ func runDeleteEverything(cmd *cobra.Command, args []string) {
 	folder, err := internal.ConfigureFolder()
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	forceModifier := false
-	modifier := internal.ExtractDeleteEverythingModifierFromArgs(args)
-	if modifier == internal.ForceDeleteModifier {
-		forceModifier = true
-	}
-
 	permanentBackups, permanentWals := postgres.GetPermanentBackupsAndWals(folder)
-	if len(permanentBackups) > 0 {
-		if !forceModifier {
-			tracelog.ErrorLogger.Fatalf("Found permanent objects: backups=%v, wals=%v\n",
-				permanentBackups, permanentWals)
-		}
-		tracelog.InfoLogger.Printf("Found permanent objects: backups=%v, wals=%v\n",
-			permanentBackups, permanentWals)
-	}
 
 	deleteHandler, err := newPostgresDeleteHandler(folder, permanentBackups, permanentWals)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	deleteHandler.DeleteEverything(confirmed)
+	deleteHandler.HandleDeleteEverything(args, permanentBackups, confirmed)
 }
 
 func runDeleteTarget(cmd *cobra.Command, args []string) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       &&  mkdir -p /export/mysqlfullmysqldumpbucket
       &&  mkdir -p /export/mysqlbinlogpushfetchbucket
       &&  mkdir -p /export/mysqldeleteendtoendbucket
+      &&  mkdir -p /export/mysqldeleteeverythingpermanent
       &&  mkdir -p /export/mysqlmarkbucket
       &&  mkdir -p /export/mysqlbinlogreplaybucket
       &&  mkdir -p /export/mysqlpitrxtrabackupbucket

--- a/docker/mysql_tests/scripts/delete_tests/delete_everything_w_permanent.sh
+++ b/docker/mysql_tests/scripts/delete_tests/delete_everything_w_permanent.sh
@@ -41,4 +41,4 @@ fi
 wal-g delete everything FORCE --confirm
 
 # check that we don't have any backups left after delete
-test "1" -eq "$(wal-g backup-list | wc -l)"
+test "0" -eq "$(wal-g backup-list | wc -l)"

--- a/docker/mysql_tests/scripts/delete_tests/delete_everything_w_permanent.sh
+++ b/docker/mysql_tests/scripts/delete_tests/delete_everything_w_permanent.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mysqldeleteeverythingpermanent
+
+# initialize mysql
+mysqld --initialize --init-file=/etc/mysql/init.sql
+service mysql start
+sysbench --table-size=10 prepare
+mysql -e "FLUSH LOGS"
+
+# permanent backup
+sysbench --time=3 run
+wal-g backup-push --permanent
+sysbench --time=3 run
+mysql -e "FLUSH LOGS"
+wal-g binlog-push
+sleep 1
+
+# non-permanent backup
+sysbench --time=3 run
+wal-g backup-push
+sysbench --time=3 run
+mysql -e "FLUSH LOGS"
+wal-g binlog-push
+sleep 1
+
+test "3" -eq "$(wal-g backup-list | wc -l)"
+
+# assert that WAL-G can't delete permanent backups without the FORCE flag
+if wal-g delete everything --confirm; then
+    echo '
+    wal-g delete everything deleted permanent backup without the FORCE flag
+    '
+    exit 1
+fi
+
+# assert that WAL-G can delete permanent backup with the FORCE flag
+wal-g delete everything FORCE --confirm
+
+# check that we don't have any backups left after delete
+test "1" -eq "$(wal-g backup-list | wc -l)"

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -198,6 +198,22 @@ func (h *DeleteHandler) HandleDeleteTarget(targetSelector BackupSelector, confir
 	tracelog.ErrorLogger.FatalOnError(err)
 }
 
+func (h *DeleteHandler) HandleDeleteEverything(args []string, permanentBackups map[string]bool, confirmed bool) {
+	forceModifier := false
+	modifier := ExtractDeleteEverythingModifierFromArgs(args)
+	if modifier == ForceDeleteModifier {
+		forceModifier = true
+	}
+
+	if len(permanentBackups) > 0 {
+		if !forceModifier {
+			tracelog.ErrorLogger.Fatalf("Found permanent backups=%v\n", permanentBackups)
+		}
+		tracelog.InfoLogger.Printf("Found permanent backups=%v\n", permanentBackups)
+	}
+	h.DeleteEverything(confirmed)
+}
+
 func (h *DeleteHandler) FindTargetBeforeName(name string, modifier int) (BackupObject, error) {
 	choiceFunc := getBeforeChoiceFunc(name, modifier)
 	if choiceFunc == nil {


### PR DESCRIPTION
Currently, when some of the MySQL backups is marked as the permanent, the following command will fail:

```
wal-g delete everything FORCE --config /etc/wal-g/wal-g.yaml 
INFO: 2021/04/27 12:28:48.716712 retrieving permanent objects
INFO: 2021/04/27 12:28:48.749695 found permanent objects stream_20210427T070815Z
```

This PR should fix it:
```
wal-g delete everything FORCE --config /etc/wal-g/wal-g.yaml 
INFO: 2021/04/27 13:09:09.599114 retrieving permanent objects
INFO: 2021/04/27 13:09:09.996867 Found permanent backups=map[stream_20210427T070815Z:true]
INFO: 2021/04/27 13:09:10.038406 Objects in folder:
INFO: 2021/04/27 13:09:10.038424 	will be deleted: basebackups_005/stream_20210426T073434Z_backup_stop_sentinel.json
INFO: 2021/04/27 13:09:10.038430 	will be deleted: basebackups_005/stream_20210426T233331Z_backup_stop_sentinel.json
INFO: 2021/04/27 13:09:10.038435 	will be deleted: basebackups_005/stream_20210427T070815Z_backup_stop_sentinel.json
INFO: 2021/04/27 13:09:10.038440 	will be deleted: binlog_005/mysql-bin-log-xxx.000003.br
INFO: 2021/04/27 13:09:10.038445 	will be deleted: binlog_005/mysql-bin-log-xxx.000004.br
...
INFO: 2021/04/27 13:09:10.038513 	will be deleted: binlog_005/mysql-bin-log-xxx.000018.br
INFO: 2021/04/27 13:09:10.038518 	will be deleted: basebackups_005/stream_20210426T073434Z/stream.br
INFO: 2021/04/27 13:09:10.038523 	will be deleted: basebackups_005/stream_20210426T233331Z/stream.br
INFO: 2021/04/27 13:09:10.038530 	will be deleted: basebackups_005/stream_20210427T070815Z/stream.br
INFO: 2021/04/27 13:09:10.038536 Dry run, nothing were deleted
```
