### PR TITLE
Add permanent backup push for MySQL

### DIFF
--- a/cmd/mysql/backup_push.go
+++ b/cmd/mysql/backup_push.go
@@ -7,27 +7,39 @@ import (
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 )
 
-const backupPushShortDescription = "Creates new backup and pushes it to storage"
+const (
+	backupPushShortDescription = "Creates new backup and pushes it to storage"
+	permanentFlag              = "permanent"
+	permanentShorthand         = "p"
+)
 
-// backupPushCmd represents the streamPush command
-var backupPushCmd = &cobra.Command{
-	Use:   "backup-push",
-	Short: backupPushShortDescription,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.NameStreamCreateCmd] = true
-		internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
-		err := internal.AssertRequiredSettingsSet()
-		tracelog.ErrorLogger.FatalOnError(err)
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		uploader, err := internal.ConfigureUploader()
-		tracelog.ErrorLogger.FatalOnError(err)
-		backupCmd, err := internal.GetCommandSetting(internal.NameStreamCreateCmd)
-		tracelog.ErrorLogger.FatalOnError(err)
-		mysql.HandleBackupPush(uploader, backupCmd)
-	},
-}
+var (
+	// backupPushCmd represents the streamPush command
+	backupPushCmd = &cobra.Command{
+		Use:   "backup-push",
+		Short: backupPushShortDescription,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			internal.RequiredSettings[internal.NameStreamCreateCmd] = true
+			internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
+			err := internal.AssertRequiredSettingsSet()
+			tracelog.ErrorLogger.FatalOnError(err)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			uploader, err := internal.ConfigureUploader()
+			tracelog.ErrorLogger.FatalOnError(err)
+			backupCmd, err := internal.GetCommandSetting(internal.NameStreamCreateCmd)
+			tracelog.ErrorLogger.FatalOnError(err)
+			mysql.HandleBackupPush(uploader, backupCmd, permanent)
+		},
+	}
+	permanent = false
+)
 
 func init() {
 	cmd.AddCommand(backupPushCmd)
+
+	// TODO: Merge similar backup-push functionality
+	// to avoid code duplication in command handlers
+	backupPushCmd.Flags().BoolVarP(&permanent, permanentFlag, permanentShorthand,
+		false, "Pushes permanent backup")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       &&  mkdir -p /export/mysqlbinlogreplaybucket
       &&  mkdir -p /export/mysqlpitrxtrabackupbucket
       &&  mkdir -p /export/mysqlpitrmysqldumpbucket
+      &&  mkdir -p /export/mysqlpermanentbackupbucket
       &&  mkdir -p /export/mariadbfullmysqldumpbucket
       &&  mkdir -p /export/mariadbfullmariabackupbucket
       &&  mkdir -p /export/mongostreampushbucket

--- a/docker/mysql_tests/scripts/base_tests/permanent_backup_test.sh
+++ b/docker/mysql_tests/scripts/base_tests/permanent_backup_test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mysqlpermanentbackupbucket
+
+
+mysqld --initialize --init-file=/etc/mysql/init.sql
+
+service mysql start
+
+sysbench --table-size=10 prepare
+
+sysbench --time=5 run
+
+mysql -e 'FLUSH LOGS'
+
+mysqldump sbtest > /tmp/dump_before_backup
+
+wal-g backup-push --permanent
+
+mysql_kill_and_clean_data
+
+# this should fail because the pushed backup is permanent
+if wal-g delete everything --confirm; then
+  echo '
+  permanent backups deleted!!!
+'
+  exit 1
+fi

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-func HandleBackupPush(uploader *internal.Uploader, backupCmd *exec.Cmd) {
+func HandleBackupPush(uploader *internal.Uploader, backupCmd *exec.Cmd, isPermanent bool) {
 	uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.BaseBackupPath)
 
 	db, err := getMySQLConnection()
@@ -49,6 +49,7 @@ func HandleBackupPush(uploader *internal.Uploader, backupCmd *exec.Cmd) {
 		Hostname:         hostname,
 		CompressedSize:   *uploader.TarSize,
 		UncompressedSize: uncompressedSize,
+		IsPermanent:      isPermanent,
 	}
 	tracelog.InfoLogger.Printf("Backup sentinel: %s", sentinel.String())
 


### PR DESCRIPTION
Add `--permanent` flag similar to Postgres backup-push

```
wal-g backup-push --permanent --config /etc/wal-g/wal-g.yaml

INFO: 2021/04/27 13:30:03.313558 FILE PATH: stream_20210427T102947Z/stream.br
INFO: 2021/04/27 13:30:03.314288 Backup sentinel: {"BinLogStart":"mysql-bin-log-xxx.000019","BinLogEnd":"mysql-bin-log-xxxx.000020","StartLocalTime":"2021-04-27T13:29:47.854247+03:00","StopLocalTime":"2021-04-27T13:30:03.314135+03:00","UncompressedSize":129334017,"CompressedSize":15684657,"Hostname":"xxxx","IsPermanent":true}
```