### PR TITLE
Add `--live-replay` option to mysql `wal-g binlog-replay`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ load_docker_common:
 mysql_integration_test: deps mysql_build unlink_brotli load_docker_common
 	./link_brotli.sh
 	docker-compose build mysql $(MYSQL_TEST)
-	docker-compose up --exit-code-from $(MYSQL_TEST) $(MYSQL_TEST)
+	docker-compose up --force-recreate --exit-code-from $(MYSQL_TEST) $(MYSQL_TEST)
 
 mysql_clean:
 	(cd $(MAIN_MYSQL_PATH) && go clean)
@@ -106,7 +106,7 @@ mariadb_test: deps mysql_build unlink_brotli mariadb_integration_test
 
 mariadb_integration_test: load_docker_common
 	docker-compose build mariadb mariadb_tests
-	docker-compose up --exit-code-from mariadb_tests mariadb_tests
+	docker-compose up --force-recreate --exit-code-from mariadb_tests mariadb_tests
 
 mongo_test: deps mongo_build unlink_brotli
 

--- a/MySQL.md
+++ b/MySQL.md
@@ -141,6 +141,10 @@ User may also specify time in  RFC3339 format until which should be fetched (use
 Binlogs are temporarily save in `WALG_MYSQL_BINLOG_DST` folder.
 Replay command gets name of binlog to replay via environment variable `WALG_MYSQL_CURRENT_BINLOG` and stop-date via `WALG_MYSQL_BINLOG_END_TS`, which are set for each invocation.
 
+When `--live-replay` specified WAL-G will be checking for newly uploaded binlogs after each iteration of binlog replay.
+This flag may be useful for huge databases - it prevents users from getting replica that cannot replicate master due too binlog rotation.
+WAL-G won't block in waiting for new binlogs, it will exit as soon as one of the following events happen: no new binlog uploaded during previous iteration or requested PITR reached.
+
 ```
 wal-g binlog-replay --since "backupname"
 ```
@@ -151,6 +155,10 @@ wal-g binlog-replay --since "backupname" --until "2006-01-02T15:04:05Z07:00"
 or
 ```
 wal-g binlog-replay --since LATEST --until "2006-01-02T15:04:05Z07:00"
+```
+
+```
+wal-g binlog-replay --since LATEST --until "2006-01-02T15:04:05Z07:00" --live-replay
 ```
 
 Typical configurations

--- a/cmd/mysql/binlog_replay.go
+++ b/cmd/mysql/binlog_replay.go
@@ -12,9 +12,11 @@ import (
 
 const replaySinceFlagShortDescr = "backup name starting from which you want to fetch binlogs"
 const replayUntilFlagShortDescr = "time in RFC3339 for PITR"
+const liveReplayFlagShortDescr = "check for newly uploaded files"
 
 var replayBackupName string
 var replayUntilTS string
+var liveReplay bool
 
 var binlogReplayCmd = &cobra.Command{
 	Use:   "binlog-replay",
@@ -23,7 +25,7 @@ var binlogReplayCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
-		mysql.HandleBinlogReplay(folder, replayBackupName, replayUntilTS)
+		mysql.HandleBinlogReplay(folder, replayBackupName, replayUntilTS, liveReplay)
 	},
 }
 
@@ -31,5 +33,6 @@ func init() {
 	binlogReplayCmd.PersistentFlags().StringVar(&replayBackupName, "since", "LATEST", replaySinceFlagShortDescr)
 	binlogReplayCmd.PersistentFlags().StringVar(&replayUntilTS, "until",
 		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339), replayUntilFlagShortDescr)
+	binlogReplayCmd.PersistentFlags().BoolVar(&liveReplay, "live-replay", false, liveReplayFlagShortDescr)
 	cmd.AddCommand(binlogReplayCmd)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       &&  mkdir -p /export/mysqlbinlogreplaybucket
       &&  mkdir -p /export/mysqlpitrxtrabackupbucket
       &&  mkdir -p /export/mysqlpitrmysqldumpbucket
+      &&  mkdir -p /export/mysqllivereplay
       &&  mkdir -p /export/mysqlpermanentbackupbucket
       &&  mkdir -p /export/mariadbfullmysqldumpbucket
       &&  mkdir -p /export/mariadbfullmariabackupbucket

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -5,7 +5,7 @@ ENV MYSQLDATA /var/lib/mysql
 
 # fixme: the package of MariaDB 10.4 doesn't work in this environement because it's not being added to the services.
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests software-properties-common dirmngr gnupg2 curl && \
+    apt-get install --yes --no-install-recommends --no-install-suggests software-properties-common dirmngr gnupg2 curl apt-transport-https && \
     curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | /bin/bash -s -- --mariadb-server-version="mariadb-10.3" && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes \

--- a/docker/mariadb/export_common.sh
+++ b/docker/mariadb/export_common.sh
@@ -9,6 +9,7 @@ export WALG_MYSQL_BACKUP_PREPARE_COMMAND="mariabackup --prepare --target-dir=${M
 
 # test tools
 mariadb_kill_and_clean_data() {
+    service mysql stop || true
     kill -9 `pidof mysqld` || true
     rm -rf "${MYSQLDATA}"/*
     rm -rf /root/.walg_mysql_binlogs_cache

--- a/docker/mysql/export_test_funcs.sh
+++ b/docker/mysql/export_test_funcs.sh
@@ -2,6 +2,7 @@
 
 # test tools
 mysql_kill_and_clean_data() {
+    service mysql stop || true
     kill -9 "$(pidof mysqld)" || true
     rm -rf "${MYSQLDATA}"/*
     rm -rf "${MYSQLDATA}"/.tmp

--- a/docker/mysql_tests/scripts/base_tests/live_replay.sh
+++ b/docker/mysql_tests/scripts/base_tests/live_replay.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mysqllivereplay
+export WALG_MYSQL_BINLOG_REPLAY_COMMAND='echo "Ok" >> "$WALG_MYSQL_CURRENT_BINLOG.ok" ; while [ ! -f "$WALG_MYSQL_CURRENT_BINLOG.in" ]; do sleep 1; done'
+export WALG_MYSQL_BINLOG_DST="/tmp"
+
+mysqld --initialize --init-file=/etc/mysql/init.sql
+service mysql start
+wal-g backup-push
+sleep 1
+
+mysql -e "CREATE TABLE sbtest.pitr(id VARCHAR(32), ts DATETIME)"
+#  REPLAY_COMMAND may lag behind DOWNLOAD for 'binlogFetchAhead' (internal/databases/mysql/binlog_replay_handler.go)
+#  so, we are making a lot of binlog files:
+for idx in 1 2 3 4 5 6 7
+do
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr$idx', NOW())"
+mysql -e "FLUSH LOGS"
+wal-g binlog-push
+done
+sleep 1
+
+wal-g binlog-replay --until "2030-01-01T00:00:00.000000000+00:00" --live-replay &
+
+while [ ! -f "/tmp/mysql-bin.000001.ok" ]; do sleep 1; done
+
+# wal-g should be blocked in REPLAY_COMMAND waiting for /tmp/mysql-bin.000002.in
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr_last', NOW())"
+mysql -e "FLUSH LOGS"
+wal-g binlog-push
+sleep 1
+
+echo "proceed" > /tmp/mysql-bin.000001.in
+
+for idx in 2 3 4 5 6 7 8 9
+do
+while [ ! -f "/tmp/mysql-bin.00000$idx.ok" ]; do sleep 1; done
+echo "proceed" > "/tmp/mysql-bin.00000$idx.in"
+done

--- a/docker/mysql_tests/scripts/run_integration_tests.sh
+++ b/docker/mysql_tests/scripts/run_integration_tests.sh
@@ -24,7 +24,7 @@ for i in "$prefix"/*; do
   echo "===== RUNNING $i ====="
   set -x
   chmod a+x "$i"
-  "$i"
+  timeout 3m "$i"
   set +x
   echo "===== SUCCESS $i ====="
   echo

--- a/internal/backup_fetch_handler.go
+++ b/internal/backup_fetch_handler.go
@@ -34,8 +34,10 @@ func GetCommandStreamFetcher(cmd *exec.Cmd) func(folder storage.Folder, backup B
 		tracelog.ErrorLogger.FatalfOnError("Failed to start restore command: %v\n", err)
 		err = downloadAndDecompressStream(backup, stdin)
 		cmdErr := cmd.Wait()
-		if cmdErr != nil {
+		if err != nil || cmdErr != nil {
 			tracelog.ErrorLogger.Printf("Restore command output:\n%s", stderr.String())
+		}
+		if cmdErr != nil {
 			err = cmdErr
 		}
 		tracelog.ErrorLogger.FatalfOnError("Failed to fetch backup: %v\n", err)

--- a/internal/databases/mysql/binlog_fetch_handler.go
+++ b/internal/databases/mysql/binlog_fetch_handler.go
@@ -51,7 +51,7 @@ func HandleBinlogFetch(folder storage.Folder, backupName string, untilTS string)
 	handler := newIndexHandler(dstDir)
 
 	tracelog.InfoLogger.Printf("Fetching binlogs since %s until %s", startTS, endTS)
-	err = fetchLogs(folder, dstDir, startTS, endTS, handler)
+	err = fetchLogs(folder, dstDir, startTS, endTS, false, handler)
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch binlogs: %v", err)
 
 	err = handler.createIndexFile()

--- a/internal/databases/mysql/binlog_replay_handler.go
+++ b/internal/databases/mysql/binlog_replay_handler.go
@@ -72,7 +72,7 @@ func (rh *replayHandler) handleBinlog(binlogPath string) error {
 	}
 }
 
-func HandleBinlogReplay(folder storage.Folder, backupName string, untilTS string) {
+func HandleBinlogReplay(folder storage.Folder, backupName string, untilTS string, liveReplay bool) {
 	dstDir, err := internal.GetLogsDstSettings(internal.MysqlBinlogDstSetting)
 	tracelog.ErrorLogger.FatalOnError(err)
 
@@ -82,7 +82,7 @@ func HandleBinlogReplay(folder storage.Folder, backupName string, untilTS string
 	handler := newReplayHandler(endTS)
 
 	tracelog.InfoLogger.Printf("Fetching binlogs since %s until %s", startTS, endTS)
-	err = fetchLogs(folder, dstDir, startTS, endTS, handler)
+	err = fetchLogs(folder, dstDir, startTS, endTS, liveReplay, handler)
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch binlogs: %v", err)
 
 	err = handler.wait()

--- a/internal/databases/mysql/mysql.go
+++ b/internal/databases/mysql/mysql.go
@@ -162,29 +162,38 @@ type binlogHandler interface {
 	handleBinlog(binlogPath string) error
 }
 
-func fetchLogs(folder storage.Folder, dstDir string, startTS time.Time, endTS time.Time, handler binlogHandler) error {
+func fetchLogs(folder storage.Folder, dstDir string, startTS time.Time, endTS time.Time, liveReplay bool, handler binlogHandler) error {
 	logFolder := folder.GetSubFolder(BinlogPath)
-	logsToFetch, err := getLogsCoveringInterval(logFolder, startTS)
-	if err != nil {
-		return err
-	}
-	for _, logFile := range logsToFetch {
-		binlogName := utility.TrimFileExtension(logFile.GetName())
-		binlogPath := path.Join(dstDir, binlogName)
-		tracelog.InfoLogger.Printf("downloading %s into %s", binlogName, binlogPath)
-		if err = internal.DownloadFileTo(logFolder, binlogName, binlogPath); err != nil {
-			tracelog.ErrorLogger.Printf("failed to download %s: %v", binlogName, err)
-			return err
-		}
-		timestamp, err := GetBinlogStartTimestamp(binlogPath)
+	includeStart := true
+outer:
+	for {
+		logsToFetch, err := getLogsCoveringInterval(logFolder, startTS, includeStart)
+		includeStart = false
 		if err != nil {
 			return err
 		}
-		err = handler.handleBinlog(binlogPath)
-		if err != nil {
-			return err
+		for _, logFile := range logsToFetch {
+			startTS = logFile.GetLastModified()
+			binlogName := utility.TrimFileExtension(logFile.GetName())
+			binlogPath := path.Join(dstDir, binlogName)
+			tracelog.InfoLogger.Printf("downloading %s into %s", binlogName, binlogPath)
+			if err = internal.DownloadFileTo(logFolder, binlogName, binlogPath); err != nil {
+				tracelog.ErrorLogger.Printf("failed to download %s: %v", binlogName, err)
+				return err
+			}
+			timestamp, err := GetBinlogStartTimestamp(binlogPath)
+			if err != nil {
+				return err
+			}
+			err = handler.handleBinlog(binlogPath)
+			if err != nil {
+				return err
+			}
+			if timestamp.After(endTS) {
+				break outer
+			}
 		}
-		if timestamp.After(endTS) {
+		if len(logsToFetch) == 0 || !liveReplay {
 			break
 		}
 	}
@@ -230,7 +239,7 @@ func getBinlogSinceTS(folder storage.Folder, backup internal.Backup) (time.Time,
 }
 
 // getLogsCoveringInterval lists the operation logs that cover the interval
-func getLogsCoveringInterval(folder storage.Folder, start time.Time) ([]storage.Object, error) {
+func getLogsCoveringInterval(folder storage.Folder, start time.Time, includeStart bool) ([]storage.Object, error) {
 	logFiles, _, err := folder.ListFolder()
 	if err != nil {
 		return nil, err
@@ -240,7 +249,7 @@ func getLogsCoveringInterval(folder storage.Folder, start time.Time) ([]storage.
 	})
 	var logsToFetch []storage.Object
 	for _, logFile := range logFiles {
-		if start.Before(logFile.GetLastModified()) || start.Equal(logFile.GetLastModified()) {
+		if start.Before(logFile.GetLastModified()) || includeStart && start.Equal(logFile.GetLastModified()) {
 			logsToFetch = append(logsToFetch, logFile)
 		}
 	}


### PR DESCRIPTION
Add `--live-replay` option to mysql `wal-g binlog-replay` to prevent users from getting replica that cannot replicate master due too binlog rotation.

 * fix flaky mysql/mariadb tests
 * improve logging when restore command fails