### PR TITLE
Add user data to MySQL backup-push and backup-fetch

### DIFF
--- a/cmd/mysql/backup_fetch.go
+++ b/cmd/mysql/backup_fetch.go
@@ -2,35 +2,57 @@ package mysql
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 )
 
-const backupFetchShortDescription = "Fetches desired backup from storage"
+const (
+	backupFetchShortDescription = "Fetches desired backup from storage"
+	targetUserDataDescription   = "Fetch storage backup which has the specified user data"
+)
 
-// backupFetchCmd represents the streamFetch command
-var backupFetchCmd = &cobra.Command{
-	Use:   "backup-fetch backup-name",
-	Short: backupFetchShortDescription,
-	Args:  cobra.ExactArgs(1),
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.NameStreamRestoreCmd] = true
-		err := internal.AssertRequiredSettingsSet()
-		tracelog.ErrorLogger.FatalOnError(err)
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		folder, err := internal.ConfigureFolder()
-		tracelog.ErrorLogger.FatalOnError(err)
-		restoreCmd, err := internal.GetCommandSetting(internal.NameStreamRestoreCmd)
-		tracelog.ErrorLogger.FatalOnError(err)
-		prepareCmd, _ := internal.GetCommandSetting(internal.MysqlBackupPrepareCmd)
-		targetBackupSelector, err := internal.NewBackupNameSelector(args[0])
-		tracelog.ErrorLogger.FatalOnError(err)
-		mysql.HandleBackupFetch(folder, targetBackupSelector, restoreCmd, prepareCmd)
-	},
+var (
+	// backupFetchCmd represents the streamFetch command
+	backupFetchCmd = &cobra.Command{
+		Use:   "backup-fetch backup-name",
+		Short: backupFetchShortDescription,
+		Args:  cobra.RangeArgs(0, 1),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			internal.RequiredSettings[internal.NameStreamRestoreCmd] = true
+			err := internal.AssertRequiredSettingsSet()
+			tracelog.ErrorLogger.FatalOnError(err)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			folder, err := internal.ConfigureFolder()
+			tracelog.ErrorLogger.FatalOnError(err)
+			restoreCmd, err := internal.GetCommandSetting(internal.NameStreamRestoreCmd)
+			tracelog.ErrorLogger.FatalOnError(err)
+			prepareCmd, _ := internal.GetCommandSetting(internal.MysqlBackupPrepareCmd)
+
+			targetBackupSelector, err := createTargetBackupSelector(args, fetchTargetUserData)
+			tracelog.ErrorLogger.FatalOnError(err)
+
+			mysql.HandleBackupFetch(folder, targetBackupSelector, restoreCmd, prepareCmd)
+		},
+	}
+	fetchTargetUserData string
+)
+
+func createTargetBackupSelector(args []string, fetchTargetUserData string) (internal.BackupSelector, error) {
+	if fetchTargetUserData == "" {
+		fetchTargetUserData = viper.GetString(internal.FetchTargetUserDataSetting)
+	}
+	fetchTargetBackupName := ""
+	if len(args) >= 1 {
+		fetchTargetBackupName = args[0]
+	}
+	return internal.NewTargetBackupSelector(fetchTargetUserData, fetchTargetBackupName, mysql.NewGenericMetaFetcher())
 }
 
 func init() {
 	cmd.AddCommand(backupFetchCmd)
+	backupFetchCmd.Flags().StringVar(&fetchTargetUserData, "target-user-data",
+		"", targetUserDataDescription)
 }

--- a/cmd/mysql/backup_push.go
+++ b/cmd/mysql/backup_push.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
@@ -11,6 +12,7 @@ const (
 	backupPushShortDescription = "Creates new backup and pushes it to storage"
 	permanentFlag              = "permanent"
 	permanentShorthand         = "p"
+	addUserDataFlag            = "add-user-data"
 )
 
 var (
@@ -29,10 +31,16 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 			backupCmd, err := internal.GetCommandSetting(internal.NameStreamCreateCmd)
 			tracelog.ErrorLogger.FatalOnError(err)
-			mysql.HandleBackupPush(uploader, backupCmd, permanent)
+
+			if userData == "" {
+				userData = viper.GetString(internal.SentinelUserDataSetting)
+			}
+
+			mysql.HandleBackupPush(uploader, backupCmd, permanent, userData)
 		},
 	}
 	permanent = false
+	userData  = ""
 )
 
 func init() {
@@ -42,4 +50,6 @@ func init() {
 	// to avoid code duplication in command handlers
 	backupPushCmd.Flags().BoolVarP(&permanent, permanentFlag, permanentShorthand,
 		false, "Pushes permanent backup")
+	backupPushCmd.Flags().StringVar(&userData, addUserDataFlag,
+		"", "Write the provided user data to the backup sentinel and metadata files.")
 }

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-func HandleBackupPush(uploader *internal.Uploader, backupCmd *exec.Cmd, isPermanent bool) {
+func HandleBackupPush(uploader *internal.Uploader, backupCmd *exec.Cmd, isPermanent bool, userData string) {
 	uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.BaseBackupPath)
 
 	db, err := getMySQLConnection()
@@ -56,6 +56,7 @@ func HandleBackupPush(uploader *internal.Uploader, backupCmd *exec.Cmd, isPerman
 		CompressedSize:   uploadedSize,
 		UncompressedSize: rawSize,
 		IsPermanent:      isPermanent,
+		UserData:         userData,
 	}
 	tracelog.InfoLogger.Printf("Backup sentinel: %s", sentinel.String())
 


### PR DESCRIPTION
Add user data functionality to MySQL similar to existing in Postgres.

```
# to create backup with specified user data
wal-g backup-push --add-user-data "xyz" --config /etc/wal-g/wal-g.yaml

# to fetch backup with specified user data
wal-g backup-fetch  --target-user-data "test" --config /etc/wal-g/wal-g.yaml
```
