### PR TITLE
Fix wrong logging in mysql/backup_push, when err == nil

### DIFF
--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 
@@ -42,10 +41,14 @@ func HandleBackupPush(uploader *internal.Uploader, backupCmd *exec.Cmd, isPerman
 	}
 
 	uploadedSize, err := uploader.UploadedDataSize()
-	tracelog.ErrorLogger.PrintOnError(fmt.Errorf("failed to calc uploaded data size: %v", err))
+	if err != nil {
+		tracelog.ErrorLogger.Printf("Failed to calc uploaded data size: %v", err)
+	}
 
 	rawSize, err := uploader.RawDataSize()
-	tracelog.ErrorLogger.PrintOnError(fmt.Errorf("failed to calc raw data size: %v", err))
+	if err != nil {
+		tracelog.ErrorLogger.Printf("Failed to calc raw data size: %v", err)
+	}
 
 	sentinel := StreamSentinelDto{
 		BinLogStart:      binlogStart,


### PR DESCRIPTION
Found in logs that we write error even we have 'nil' error, this PR fix this behavior