### PR TITLE
Split settings: binary now ask db specific settings, not all settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ vendor/
 .idea/
 
 # bin
+main/fdb/wal-g
+main/sqlserver/wal-g
 main/pg/wal-g
 main/mysql/wal-g
 main/redis/wal-g

--- a/cmd/fdb/fdb.go
+++ b/cmd/fdb/fdb.go
@@ -37,6 +37,7 @@ func Execute() {
 }
 
 func init() {
+	internal.ConfigureSettings(internal.FDB)
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 
 	cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.wal-g.yaml)")

--- a/cmd/mongo/mongo.go
+++ b/cmd/mongo/mongo.go
@@ -39,6 +39,7 @@ func Execute() {
 }
 
 func init() {
+	internal.ConfigureSettings(internal.MONGO)
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 
 	internal.RequiredSettings[internal.MongoDBUriSetting] = true

--- a/cmd/mysql/mysql.go
+++ b/cmd/mysql/mysql.go
@@ -39,6 +39,7 @@ func Execute() {
 }
 
 func init() {
+	internal.ConfigureSettings(internal.MYSQL)
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 
 	cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")

--- a/cmd/pg/pg.go
+++ b/cmd/pg/pg.go
@@ -45,6 +45,7 @@ func Execute() {
 }
 
 func init() {
+	internal.ConfigureSettings(internal.PG)
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 
 	cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")

--- a/cmd/redis/backup_push.go
+++ b/cmd/redis/backup_push.go
@@ -58,4 +58,3 @@ func init() {
 	backupPushCmd.Flags().BoolVarP(&permanent, PermanentFlag, PermanentShorthand, false, "Pushes backup with 'permanent' flag")
 	cmd.AddCommand(backupPushCmd)
 }
-

--- a/cmd/redis/redis.go
+++ b/cmd/redis/redis.go
@@ -37,6 +37,7 @@ func Execute() {
 }
 
 func init() {
+	internal.ConfigureSettings(internal.REDIS)
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 
 	cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")

--- a/cmd/sqlserver/sqlserver.go
+++ b/cmd/sqlserver/sqlserver.go
@@ -32,6 +32,7 @@ func Execute() {
 }
 
 func init() {
+	internal.ConfigureSettings(internal.SQLSERVER)
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 	cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")
 	cmd.InitDefaultVersionFlag()

--- a/internal/backup_fetch_test.go
+++ b/internal/backup_fetch_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func init() {
+	internal.ConfigureSettings("")
 	internal.InitConfig()
 	internal.Configure()
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -16,6 +16,13 @@ import (
 )
 
 const (
+	PG        = "PG"
+	SQLSERVER = "SQLSERVER"
+	MYSQL     = "MYSQL"
+	REDIS     = "REDIS"
+	FDB       = "FDB"
+	MONGO     = "MONGO"
+
 	DownloadConcurrencySetting   = "WALG_DOWNLOAD_CONCURRENCY"
 	UploadConcurrencySetting     = "WALG_UPLOAD_CONCURRENCY"
 	UploadDiskConcurrencySetting = "WALG_UPLOAD_DISK_CONCURRENCY"
@@ -109,7 +116,9 @@ const (
 
 var (
 	CfgFile             string
-	defaultConfigValues = map[string]string{
+	defaultConfigValues map[string]string
+
+	commonDefaultConfigValues = map[string]string{
 		DownloadConcurrencySetting:   "10",
 		UploadConcurrencySetting:     "16",
 		UploadDiskConcurrencySetting: "1",
@@ -127,18 +136,25 @@ var (
 		StoreAllCorruptBlocksSetting: "false",
 		UseRatingComposerSetting:     "false",
 		MaxDelayedSegmentsCount:      "0",
+	}
 
-		OplogArchiveTimeoutInterval:    "60s",
-		OplogArchiveAfterSize:          "16777216", // 32 << (10 * 2)
-		MongoDBLastWriteUpdateInterval: "3s",
-		PgWalSize:                      "16",
+	MongoDefaultSettings = map[string]string{
 		OplogPushStatsLoggingInterval:  "30s",
 		OplogPushStatsUpdateInterval:   "30s",
 		OplogPushWaitForBecomePrimary:  "false",
 		OplogPushPrimaryCheckInterval:  "30s",
+		OplogArchiveTimeoutInterval:    "60s",
+		OplogArchiveAfterSize:          "16777216", // 32 << (10 * 2)
+		MongoDBLastWriteUpdateInterval: "3s",
 	}
 
-	AllowedSettings = map[string]bool{
+	PGDefaultSettings = map[string]string{
+		PgWalSize: "16",
+	}
+
+	AllowedSettings map[string]bool
+
+	CommonAllowedSettings = map[string]bool{
 		// WAL-G core
 		DownloadConcurrencySetting:   true,
 		UploadConcurrencySetting:     true,
@@ -174,19 +190,6 @@ var (
 		DeltaFromNameSetting:         true,
 		DeltaFromUserDataSetting:     true,
 		FetchTargetUserDataSetting:   true,
-
-		// Postgres
-		PgPortSetting:     true,
-		PgUserSetting:     true,
-		PgHostSetting:     true,
-		PgDataSetting:     true,
-		PgPasswordSetting: true,
-		PgDatabaseSetting: true,
-		PgSslModeSetting:  true,
-		PgSlotName:        true,
-		PgWalSize:         true,
-		"PGPASSFILE":      true,
-		PrefetchDir:       true,
 
 		// Swift
 		"WALG_SWIFT_PREFIX": true,
@@ -250,6 +253,31 @@ var (
 		//File
 		"WALG_FILE_PREFIX": true,
 
+		// GOLANG
+		GoMaxProcs: true,
+
+		// Web server
+		HTTPListen:       true,
+		HTTPExposePprof:  true,
+		HTTPExposeExpVar: true,
+	}
+
+	PGAllowedSettings = map[string]bool{
+		// Postgres
+		PgPortSetting:     true,
+		PgUserSetting:     true,
+		PgHostSetting:     true,
+		PgDataSetting:     true,
+		PgPasswordSetting: true,
+		PgDatabaseSetting: true,
+		PgSslModeSetting:  true,
+		PgSlotName:        true,
+		PgWalSize:         true,
+		"PGPASSFILE":      true,
+		PrefetchDir:       true,
+	}
+
+	MongoAllowedSettings = map[string]bool{
 		// MongoDB
 		MongoDBUriSetting:              true,
 		MongoDBLastWriteUpdateInterval: true,
@@ -262,7 +290,18 @@ var (
 		OplogPushWaitForBecomePrimary:  true,
 		OplogPushPrimaryCheckInterval:  true,
 		OplogPITRDiscoveryInterval:     true,
+	}
 
+	SQLServerAllowedSettings = map[string]bool{
+		// SQLServer
+		SQLServerBlobHostname:     true,
+		SQLServerBlobCertFile:     true,
+		SQLServerBlobKeyFile:      true,
+		SQLServerBlobLockFile:     true,
+		SQLServerConnectionString: true,
+	}
+
+	MysqlAllowedSettings = map[string]bool{
 		// MySQL
 		MysqlDatasourceNameSetting: true,
 		MysqlSslCaSetting:          true,
@@ -270,21 +309,6 @@ var (
 		MysqlBinlogDstSetting:      true,
 		MysqlBackupPrepareCmd:      true,
 		MysqlTakeBinlogsFromMaster: true,
-
-		// GOLANG
-		GoMaxProcs: true,
-
-		// Web server
-		HTTPListen:       true,
-		HTTPExposePprof:  true,
-		HTTPExposeExpVar: true,
-
-		// SQLServer
-		SQLServerBlobHostname:     true,
-		SQLServerBlobCertFile:     true,
-		SQLServerBlobKeyFile:      true,
-		SQLServerBlobLockFile:     true,
-		SQLServerConnectionString: true,
 	}
 
 	RequiredSettings       = make(map[string]bool)
@@ -295,6 +319,49 @@ var (
 	}
 	Turbo bool
 )
+
+func ConfigureSettings(currentType string) {
+	if len(defaultConfigValues) == 0 {
+		defaultConfigValues = commonDefaultConfigValues
+		dbSpecificDefaultSettings := map[string]string{}
+		switch currentType {
+		case PG:
+			dbSpecificDefaultSettings = PGDefaultSettings
+		case MONGO:
+			dbSpecificDefaultSettings = MongoDefaultSettings
+		}
+
+		for k, v := range dbSpecificDefaultSettings {
+			defaultConfigValues[k] = v
+		}
+	}
+
+	if len(AllowedSettings) == 0 {
+		AllowedSettings = CommonAllowedSettings
+		dbSpecificSettings := map[string]bool{}
+		switch currentType {
+		case PG:
+			dbSpecificSettings = PGAllowedSettings
+		case MONGO:
+			dbSpecificSettings = MongoAllowedSettings
+		case MYSQL:
+			dbSpecificSettings = MysqlAllowedSettings
+		case SQLSERVER:
+			dbSpecificSettings = SQLServerAllowedSettings
+		}
+
+		for k, v := range dbSpecificSettings {
+			AllowedSettings[k] = v
+		}
+
+		for _, adapter := range StorageAdapters {
+			for _, setting := range adapter.settingNames {
+				AllowedSettings[setting] = true
+			}
+			AllowedSettings["WALG_"+adapter.prefixName] = true
+		}
+	}
+}
 
 func isAllowedSetting(setting string, AllowedSettings map[string]bool) (exists bool) {
 	_, exists = AllowedSettings[setting]
@@ -347,13 +414,6 @@ func Configure() {
 	}
 
 	configureLimiters()
-
-	for _, adapter := range StorageAdapters {
-		for _, setting := range adapter.settingNames {
-			AllowedSettings[setting] = true
-		}
-		AllowedSettings["WALG_"+adapter.prefixName] = true
-	}
 }
 
 // ConfigureAndRunDefaultWebServer configures and runs web server

--- a/internal/databases/postgres/bundle_test.go
+++ b/internal/databases/postgres/bundle_test.go
@@ -26,6 +26,7 @@ var BundleTestLocations = []walparser.BlockLocation{
 }
 
 func TestEmptyBundleQueue(t *testing.T) {
+	internal.ConfigureSettings(internal.PG)
 	internal.InitConfig()
 	internal.Configure()
 

--- a/internal/databases/postgres/wal_push_handler_test.go
+++ b/internal/databases/postgres/wal_push_handler_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func init() {
+	internal.ConfigureSettings(internal.PG)
 	internal.InitConfig()
 	internal.Configure()
 }

--- a/internal/upload_test.go
+++ b/internal/upload_test.go
@@ -42,6 +42,7 @@ func doConfigureWithBucketPath(t *testing.T, bucketPath string, expectedServer s
 		t.Errorf("upload: Expected error 'UnconfiguredStorageError' but got %s", err)
 	}
 	assert.Nil(t, uploader)
+	internal.ConfigureSettings("")
 	internal.InitConfig()
 	internal.Configure()
 	viper.Set("AWS_ACCESS_KEY_ID", "aws_access_key_id")


### PR DESCRIPTION
Problem:
We have different binaries for every db, but that binary provider config options for all databases. That's not really good.

So I split the config for each binary. Now every certain binary has common options + db specific options.