### PR TITLE
Fix GetBackupTimeSlices: now it doesn't return empty structs for files that hasn't suffix

### DIFF
--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -77,7 +77,6 @@ func GetBackupsAndGarbage(folder storage.Folder) (backups []BackupTime, garbage 
 	return sortTimes, garbage, nil
 }
 
-// TODO : unit tests
 func GetBackupTimeSlices(backups []storage.Object) []BackupTime {
 	sortTimes := make([]BackupTime, 0)
 	for _, object := range backups {

--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -79,15 +79,16 @@ func GetBackupsAndGarbage(folder storage.Folder) (backups []BackupTime, garbage 
 
 // TODO : unit tests
 func GetBackupTimeSlices(backups []storage.Object) []BackupTime {
-	sortTimes := make([]BackupTime, len(backups))
-	for i, object := range backups {
+	sortTimes := make([]BackupTime, 0)
+	for _, object := range backups {
 		key := object.GetName()
 		if !strings.HasSuffix(key, utility.SentinelSuffix) {
 			continue
 		}
 		time := object.GetLastModified()
-		sortTimes[i] = BackupTime{utility.StripRightmostBackupName(key), time,
+		backup := BackupTime{utility.StripRightmostBackupName(key), time,
 			utility.StripWalFileName(key)}
+		sortTimes = append(sortTimes, backup)
 	}
 	sort.Slice(sortTimes, func(i, j int) bool {
 		return sortTimes[i].Time.After(sortTimes[j].Time)

--- a/internal/backup_util_test.go
+++ b/internal/backup_util_test.go
@@ -1,0 +1,55 @@
+package internal_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
+	"github.com/wal-g/wal-g/utility"
+)
+
+var (
+	testStreamBackup = internal.BackupTime{
+		BackupName: "stream_20210329T125616Z",
+		Time:       time.Now(),
+	}
+)
+
+func TestGetBackupTimeSlices_emptyList(t *testing.T) {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	_ = folder.PutObject("base_123312", &bytes.Buffer{})
+	objects, _, _ := folder.ListFolder()
+	result := internal.GetBackupTimeSlices(objects)
+	assert.Equalf(t, []internal.BackupTime{}, result, "GetBackupTimeSlices returned not empty list: something wrong")
+}
+
+func TestGetBackupTimeSlices_List(t *testing.T) {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	_ = folder.PutObject("base_123312", &bytes.Buffer{})
+	_ = folder.PutObject(testStreamBackup.BackupName+utility.SentinelSuffix, &bytes.Buffer{})
+
+	objects, _, _ := folder.ListFolder()
+
+	result := internal.GetBackupTimeSlices(objects)
+
+	assert.Equalf(t, 1, len(result), "GetBackupTimeSlices returned wrong count of backup: something wrong")
+	assert.Equalf(t, testStreamBackup.BackupName, result[0].BackupName, "GetBackupTimeSlices returned strange name")
+	assert.True(t, testStreamBackup.Time.Before(result[0].Time), "GetBackupTimeSlices returned bad time: storage time less then mock time")
+}
+
+func TestGetBackupTimeSlices_OrderCheck(t *testing.T) {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	_ = folder.PutObject(testStreamBackup.BackupName+".1"+utility.SentinelSuffix, &bytes.Buffer{})
+	_ = folder.PutObject(testStreamBackup.BackupName+".2"+utility.SentinelSuffix, &bytes.Buffer{})
+
+	objects, _, _ := folder.ListFolder()
+
+	result := internal.GetBackupTimeSlices(objects)
+
+	assert.Equalf(t, 2, len(result), "GetBackupTimeSlices returned wrong count of backup: something wrong")
+	assert.True(t, result[0].BackupName == testStreamBackup.BackupName+".2", "GetBackupTimeSlices returned bad time ordering: Second file should be first, because second was added last")
+	assert.True(t, result[0].Time.After(result[1].Time), "GetBackupTimeSlices returned bad time ordering: order should be Descending")
+}


### PR DESCRIPTION
Found bug: I've created "test" file, and _GetBackupTimeSlices_ with default (empty) struct _BackupTime_

### Database name
All databases that uses _GetBackupTimeSlices_

# Pull request description

Found bug: I've created "test" file, and _GetBackupTimeSlices_ returned default (empty) struct _BackupTime_
What I've changed: _GetBackupTimeSlices_ preallocates defaults structs, and if !strings.HasSuffix(key, utility.SentinelSuffix)  happens doesn't change result array len. This PR fix this behaviour

### Provide steps to reproduce
Create any file in backupDir and try do delete backups with purge. It will fails,

```ERROR: 2021/05/12 16:55:10.165736 can not fetch stream sentinel: failed to fetch sentinel: object 'tmp/basebackups_005/_backup_stop_sentinel.json' not found in storage```
