### PR TITLE
Run unit tests with build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,19 +165,19 @@ clean_redis_features:
 
 unittest:
 	go list ./... | grep -Ev 'vendor|submodules|tmp' | xargs go vet
-	go test -v $(TEST_MODIFIER) ./internal/
-	go test -v $(TEST_MODIFIER) ./internal/compression/
-	go test -v $(TEST_MODIFIER) ./internal/crypto/openpgp/
-	go test -v $(TEST_MODIFIER) ./internal/crypto/awskms/
-	go test -v $(TEST_MODIFIER) ./internal/abool
+	go test -v $(TEST_MODIFIER) -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/compression/
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/openpgp/
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/awskms/
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/abool
 	@if [ ! -z "${USE_LIBSODIUM}" ]; then\
-		go test -v $(TEST_MODIFIER) -tags libsodium ./internal/crypto/libsodium/;\
+		go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/libsodium/;\
 	fi
-	go test -v $(TEST_MODIFIER) ./internal/databases/mysql
-	go test -v $(TEST_MODIFIER) ./internal/databases/mongo/...
-	go test -v $(TEST_MODIFIER) ./internal/databases/postgres
-	go test -v $(TEST_MODIFIER) ./internal/walparser/
-	go test -v $(TEST_MODIFIER) ./utility
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/mysql
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/mongo/...
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/postgres
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/walparser/
+	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./utility
 
 coverage:
 	go list ./... | grep -Ev 'vendor|submodules|tmp' | xargs go test -v $(TEST_MODIFIER) -coverprofile=$(COVERAGE_FILE) | grep -v 'no test files'

--- a/Makefile
+++ b/Makefile
@@ -165,19 +165,19 @@ clean_redis_features:
 
 unittest:
 	go list ./... | grep -Ev 'vendor|submodules|tmp' | xargs go vet
-	go test -v $(TEST_MODIFIER) -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/compression/
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/openpgp/
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/awskms/
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/abool
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/compression/
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/openpgp/
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/awskms/
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/abool
 	@if [ ! -z "${USE_LIBSODIUM}" ]; then\
-		go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/libsodium/;\
+		go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/libsodium/;\
 	fi
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/mysql
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/mongo/...
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/postgres
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/walparser/
-	go test -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./utility
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/mysql
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/mongo/...
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/postgres
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/walparser/
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./utility
 
 coverage:
 	go list ./... | grep -Ev 'vendor|submodules|tmp' | xargs go test -v $(TEST_MODIFIER) -coverprofile=$(COVERAGE_FILE) | grep -v 'no test files'

--- a/internal/crypto_comp_test.go
+++ b/internal/crypto_comp_test.go
@@ -34,10 +34,6 @@ func init() {
 	waleGpgKey = string(waleGpgKeyBytes)
 }
 
-func noPassphrase() (string, bool) {
-	return "", false
-}
-
 // This test extracts WAL-E-encrypted WAL, decrypts it by external
 // GPG, compares result with OpenGPG decryption and invokes Lzop
 // decompression to check integrity. Test will leave gpg key


### PR DESCRIPTION
Currently, WAL-G ignores build constraints during make all_unittests, because there are no build tags specified in the go test command. Because of that, some of the unit tests are not being executed (`crypto_comp_test.go, lzo_test.go, crypter_test.go`)

This PR should fix this issue.