### PR TITLE
wal-verify: ignore permanent backups

### DIFF
--- a/internal/backup_list_handler_test.go
+++ b/internal/backup_list_handler_test.go
@@ -140,11 +140,11 @@ func TestHandleBackupListLogNoBackups(t *testing.T) {
 
 func TestWritePrettyBackupList_LongColumnsValues(t *testing.T) {
 	expectedRes := "+---+-----------+----------+-----------------------------------+\n" +
-				   "| # | NAME      | MODIFIED | WAL SEGMENT BACKUP START          |\n" +
-				   "+---+-----------+----------+-----------------------------------+\n" +
-				   "| 0 | backup000 | -        | veryVeryVeryVeryVeryLongWallName0 |\n" +
-				   "| 1 | backup001 | -        | veryVeryVeryVeryVeryLongWallName1 |\n" +
-				   "+---+-----------+----------+-----------------------------------+\n"
+		"| # | NAME      | MODIFIED | WAL SEGMENT BACKUP START          |\n" +
+		"+---+-----------+----------+-----------------------------------+\n" +
+		"| 0 | backup000 | -        | veryVeryVeryVeryVeryLongWallName0 |\n" +
+		"| 1 | backup001 | -        | veryVeryVeryVeryVeryLongWallName1 |\n" +
+		"+---+-----------+----------+-----------------------------------+\n"
 
 	b := bytes.Buffer{}
 	internal.WritePrettyBackupList(longBackups, &b)
@@ -154,11 +154,11 @@ func TestWritePrettyBackupList_LongColumnsValues(t *testing.T) {
 
 func TestWritePrettyBackupList_ShortColumnsValues(t *testing.T) {
 	expectedRes := "+---+------+----------+--------------------------+\n" +
-				   "| # | NAME | MODIFIED | WAL SEGMENT BACKUP START |\n" +
-				   "+---+------+----------+--------------------------+\n" +
-				   "| 0 | b0   | -        | shortWallName0           |\n" +
-				   "| 1 | b1   | -        | shortWallName1           |\n" +
-				   "+---+------+----------+--------------------------+\n"
+		"| # | NAME | MODIFIED | WAL SEGMENT BACKUP START |\n" +
+		"+---+------+----------+--------------------------+\n" +
+		"| 0 | b0   | -        | shortWallName0           |\n" +
+		"| 1 | b1   | -        | shortWallName1           |\n" +
+		"+---+------+----------+--------------------------+\n"
 
 	b := bytes.Buffer{}
 	internal.WritePrettyBackupList(shortBackups, &b)
@@ -168,9 +168,9 @@ func TestWritePrettyBackupList_ShortColumnsValues(t *testing.T) {
 
 func TestWritePrettyBackupList_WriteNoBackupList(t *testing.T) {
 	expectedRes := "+---+------+----------+--------------------------+\n" +
-				   "| # | NAME | MODIFIED | WAL SEGMENT BACKUP START |\n" +
-				   "+---+------+----------+--------------------------+\n" +
-				   "+---+------+----------+--------------------------+\n"
+		"| # | NAME | MODIFIED | WAL SEGMENT BACKUP START |\n" +
+		"+---+------+----------+--------------------------+\n" +
+		"+---+------+----------+--------------------------+\n"
 
 	backups := make([]internal.BackupTime, 0)
 
@@ -182,12 +182,12 @@ func TestWritePrettyBackupList_WriteNoBackupList(t *testing.T) {
 
 func TestWritePrettyBackupList_EmptyColumnsValues(t *testing.T) {
 	expectedRes := "+---+------+----------+--------------------------+\n" +
-				   "| # | NAME | MODIFIED | WAL SEGMENT BACKUP START |\n" +
-				   "+---+------+----------+--------------------------+\n" +
-				   "| 0 |      | -        | shortWallName0           |\n" +
-				   "| 1 | b1   | -        |                          |\n" +
-				   "| 2 |      | -        |                          |\n" +
-				   "+---+------+----------+--------------------------+\n"
+		"| # | NAME | MODIFIED | WAL SEGMENT BACKUP START |\n" +
+		"+---+------+----------+--------------------------+\n" +
+		"| 0 |      | -        | shortWallName0           |\n" +
+		"| 1 | b1   | -        |                          |\n" +
+		"| 2 |      | -        |                          |\n" +
+		"+---+------+----------+--------------------------+\n"
 
 	b := bytes.Buffer{}
 	internal.WritePrettyBackupList(emptyColonsBackups, &b)
@@ -207,9 +207,9 @@ func TestWriteBackupList_NoBackups(t *testing.T) {
 
 func TestWriteBackupList_EmptyColumnsValues(t *testing.T) {
 	expectedRes := "name modified wal_segment_backup_start\n" +
-				   "     -        shortWallName0\n" +
-				   "b1   -        \n" +
-				   "     -        \n"
+		"     -        shortWallName0\n" +
+		"b1   -        \n" +
+		"     -        \n"
 
 	b := bytes.Buffer{}
 	internal.WriteBackupList(emptyColonsBackups, &b)
@@ -219,8 +219,8 @@ func TestWriteBackupList_EmptyColumnsValues(t *testing.T) {
 
 func TestWriteBackupList_ShortColumnsValues(t *testing.T) {
 	expectedRes := "name modified wal_segment_backup_start\n" +
-				   "b0   -        shortWallName0\n" +
-				   "b1   -        shortWallName1\n"
+		"b0   -        shortWallName0\n" +
+		"b1   -        shortWallName1\n"
 	b := bytes.Buffer{}
 	internal.WriteBackupList(shortBackups, &b)
 
@@ -229,8 +229,8 @@ func TestWriteBackupList_ShortColumnsValues(t *testing.T) {
 
 func TestWriteBackupList_LongColumnsValues(t *testing.T) {
 	expectedRes := "name      modified wal_segment_backup_start\n" +
-                   "backup000 -        veryVeryVeryVeryVeryLongWallName0\n" +
-                   "backup001 -        veryVeryVeryVeryVeryLongWallName1\n"
+		"backup000 -        veryVeryVeryVeryVeryLongWallName0\n" +
+		"backup001 -        veryVeryVeryVeryVeryLongWallName1\n"
 	b := bytes.Buffer{}
 	internal.WriteBackupList(longBackups, &b)
 

--- a/internal/backup_util_test.go
+++ b/internal/backup_util_test.go
@@ -52,7 +52,7 @@ func TestGetBackupTimeSlices_OrderCheck(t *testing.T) {
 
 	result := internal.GetBackupTimeSlices(objects)
 	internal.SortBackupTimeSlices(result)
-	
+
 	assert.Equalf(t, 2, len(result), "GetBackupTimeSlices returned wrong count of backup: something wrong")
 	assert.True(t, result[0].BackupName == testStreamBackup.BackupName+".1", "GetBackupTimeSlices returned bad time ordering: "+testStreamBackup.BackupName+".1 should be first, because second was added earlier")
 	assert.True(t, result[0].Time.Before(result[1].Time), "GetBackupTimeSlices returned bad time ordering: order should be Ascending")

--- a/internal/databases/postgres/backup_list_handler_test.go
+++ b/internal/databases/postgres/backup_list_handler_test.go
@@ -1,13 +1,13 @@
 package postgres_test
 
 import (
-	"testing"
 	"bytes"
+	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
-	"github.com/stretchr/testify/assert"
 )
 
 var shortBackups = []postgres.BackupDetail{
@@ -73,11 +73,11 @@ var emptyColonsBackups = []postgres.BackupDetail{
 
 func TestWritePrettyBackupList_LongColumnsValues(t *testing.T) {
 	expectedRes := "+---+-----------+----------+-----------------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-				   "| # | NAME      | MODIFIED | WAL SEGMENT BACKUP START          | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
-				   "+---+-----------+----------+-----------------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-				   "| 0 | backup000 | -        | veryVeryVeryVeryVeryLongWallName0 | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-				   "| 1 | backup001 | -        | veryVeryVeryVeryVeryLongWallName1 | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-				   "+---+-----------+----------+-----------------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
+		"| # | NAME      | MODIFIED | WAL SEGMENT BACKUP START          | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
+		"+---+-----------+----------+-----------------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
+		"| 0 | backup000 | -        | veryVeryVeryVeryVeryLongWallName0 | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"| 1 | backup001 | -        | veryVeryVeryVeryVeryLongWallName1 | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"+---+-----------+----------+-----------------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
 	b := bytes.Buffer{}
 	postgres.WritePrettyBackupListDetails(longBackups, &b)
 
@@ -86,11 +86,11 @@ func TestWritePrettyBackupList_LongColumnsValues(t *testing.T) {
 
 func TestWritePrettyBackupList_ShortColumnsValues(t *testing.T) {
 	expectedRes := "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-				   "| # | NAME | MODIFIED | WAL SEGMENT BACKUP START | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
-				   "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-				   "| 0 | b0   | -        | shortWallName0           | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-				   "| 1 | b1   | -        | shortWallName1           | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-				   "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
+		"| # | NAME | MODIFIED | WAL SEGMENT BACKUP START | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
+		"+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
+		"| 0 | b0   | -        | shortWallName0           | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"| 1 | b1   | -        | shortWallName1           | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
 	b := bytes.Buffer{}
 	postgres.WritePrettyBackupListDetails(shortBackups, &b)
 
@@ -99,9 +99,9 @@ func TestWritePrettyBackupList_ShortColumnsValues(t *testing.T) {
 
 func TestWritePrettyBackupList_WriteNoBackupList(t *testing.T) {
 	expectedRes := "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-				   "| # | NAME | MODIFIED | WAL SEGMENT BACKUP START | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
-				   "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-				   "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
+		"| # | NAME | MODIFIED | WAL SEGMENT BACKUP START | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
+		"+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
+		"+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
 	backups := make([]postgres.BackupDetail, 0)
 
 	b := bytes.Buffer{}
@@ -112,12 +112,12 @@ func TestWritePrettyBackupList_WriteNoBackupList(t *testing.T) {
 
 func TestWritePrettyBackupList_EmptyColumnsValues(t *testing.T) {
 	expectedRes := "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-				   "| # | NAME | MODIFIED | WAL SEGMENT BACKUP START | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
-				   "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-				   "| 0 |      | -        | shortWallName0           | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-				   "| 1 | b1   | -        |                          | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-				   "| 2 |      | -        |                          | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-				   "+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
+		"| # | NAME | MODIFIED | WAL SEGMENT BACKUP START | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
+		"+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
+		"| 0 |      | -        | shortWallName0           | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"| 1 | b1   | -        |                          | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"| 2 |      | -        |                          | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"+---+------+----------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
 	b := bytes.Buffer{}
 	postgres.WritePrettyBackupListDetails(emptyColonsBackups, &b)
 
@@ -136,9 +136,9 @@ func TestWriteBackupList_NoBackups(t *testing.T) {
 
 func TestWriteBackupList_EmptyColumnsValues(t *testing.T) {
 	expectedRes := "name modified wal_segment_backup_start start_time finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
-				   "     -        shortWallName0           -          -                             0          0         0          false\n" +
-				   "b1   -                                 -          -                             0          0         0          false\n" +
-				   "     -                                 -          -                             0          0         0          false\n"
+		"     -        shortWallName0           -          -                             0          0         0          false\n" +
+		"b1   -                                 -          -                             0          0         0          false\n" +
+		"     -                                 -          -                             0          0         0          false\n"
 	b := bytes.Buffer{}
 	postgres.WriteBackupListDetails(emptyColonsBackups, &b)
 
@@ -147,8 +147,8 @@ func TestWriteBackupList_EmptyColumnsValues(t *testing.T) {
 
 func TestWriteBackupList_ShortColumnsValues(t *testing.T) {
 	expectedRes := "name modified wal_segment_backup_start start_time finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
-				   "b0   -        shortWallName0           -          -                             0          0         0          false\n" +
-				   "b1   -        shortWallName1           -          -                             0          0         0          false\n"
+		"b0   -        shortWallName0           -          -                             0          0         0          false\n" +
+		"b1   -        shortWallName1           -          -                             0          0         0          false\n"
 
 	b := bytes.Buffer{}
 	postgres.WriteBackupListDetails(shortBackups, &b)
@@ -158,8 +158,8 @@ func TestWriteBackupList_ShortColumnsValues(t *testing.T) {
 
 func TestWriteBackupList_LongColumnsValues(t *testing.T) {
 	expectedRes := "name      modified wal_segment_backup_start          start_time finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
-				   "backup000 -        veryVeryVeryVeryVeryLongWallName0 -          -                             0          0         0          false\n" +
-				   "backup001 -        veryVeryVeryVeryVeryLongWallName1 -          -                             0          0         0          false\n"
+		"backup000 -        veryVeryVeryVeryVeryLongWallName0 -          -                             0          0         0          false\n" +
+		"backup001 -        veryVeryVeryVeryVeryLongWallName1 -          -                             0          0         0          false\n"
 
 	b := bytes.Buffer{}
 	postgres.WriteBackupListDetails(longBackups, &b)

--- a/internal/databases/postgres/backup_list_test.go
+++ b/internal/databases/postgres/backup_list_test.go
@@ -19,10 +19,10 @@ func TestBackupListFlagsFindsBackups(t *testing.T) {
 
 func TestBackupListCorrectOutput(t *testing.T) {
 	const expected = "" +
-	"name   modified             wal_segment_backup_start\n" +
-	"base_1 2017-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n" +
-	"base_0 2018-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n" +
-	"base_2 2020-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n"
+		"name   modified             wal_segment_backup_start\n" +
+		"base_1 2017-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n" +
+		"base_0 2018-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n" +
+		"base_2 2020-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n"
 
 	folder := testtools.CreatePostgresMockStorageFolderWithTimeMetadata(t, testtools.NoCreationTime)
 	backups, err := internal.GetBackups(folder)
@@ -34,14 +34,13 @@ func TestBackupListCorrectOutput(t *testing.T) {
 }
 
 func TestBackupListCorrectPrettyOutput(t *testing.T) {
-	const expected =
-	"+---+--------+-----------------------------------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-	"| # | NAME   | MODIFIED                          | WAL SEGMENT BACKUP START | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
-	"+---+--------+-----------------------------------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
-	"| 0 | base_1 | Sunday, 01-Jan-17 01:01:01 UTC    | ZZZZZZZZZZZZZZZZZZZZZZZZ | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-	"| 1 | base_0 | Monday, 01-Jan-18 01:01:01 UTC    | ZZZZZZZZZZZZZZZZZZZZZZZZ | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-	"| 2 | base_2 | Wednesday, 01-Jan-20 01:01:01 UTC | ZZZZZZZZZZZZZZZZZZZZZZZZ | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
-	"+---+--------+-----------------------------------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
+	const expected = "+---+--------+-----------------------------------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
+		"| # | NAME   | MODIFIED                          | WAL SEGMENT BACKUP START | START TIME | FINISH TIME | HOSTNAME | DATADIR | PG VERSION | START LSN | FINISH LSN | PERMANENT |\n" +
+		"+---+--------+-----------------------------------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n" +
+		"| 0 | base_1 | Sunday, 01-Jan-17 01:01:01 UTC    | ZZZZZZZZZZZZZZZZZZZZZZZZ | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"| 1 | base_0 | Monday, 01-Jan-18 01:01:01 UTC    | ZZZZZZZZZZZZZZZZZZZZZZZZ | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"| 2 | base_2 | Wednesday, 01-Jan-20 01:01:01 UTC | ZZZZZZZZZZZZZZZZZZZZZZZZ | -          | -           |          |         |          0 |         0 |          0 | false     |\n" +
+		"+---+--------+-----------------------------------+--------------------------+------------+-------------+----------+---------+------------+-----------+------------+-----------+\n"
 
 	folder := testtools.CreatePostgresMockStorageFolderWithTimeMetadata(t, testtools.NoCreationTime)
 	backups, err := internal.GetBackups(folder)
@@ -55,11 +54,10 @@ func TestBackupListCorrectPrettyOutput(t *testing.T) {
 }
 
 func TestBackupListCorrectOrderingCreationTimeGaps(t *testing.T) {
-	const expected =
-	"name   modified             wal_segment_backup_start start_time           finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
-	"base_1 2017-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ -                    -                             0          0         0          false\n" +
-	"base_0 2018-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ -                    -                             0          0         0          false\n" +
-	"base_2 2020-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1998-01-01T01:01:01Z -                             0          0         0          false\n"
+	const expected = "name   modified             wal_segment_backup_start start_time           finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
+		"base_1 2017-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ -                    -                             0          0         0          false\n" +
+		"base_0 2018-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ -                    -                             0          0         0          false\n" +
+		"base_2 2020-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1998-01-01T01:01:01Z -                             0          0         0          false\n"
 
 	folder := testtools.CreatePostgresMockStorageFolderWithTimeMetadata(t, testtools.CreationTimeGaps)
 	backups, err := internal.GetBackups(folder)
@@ -74,11 +72,10 @@ func TestBackupListCorrectOrderingCreationTimeGaps(t *testing.T) {
 }
 
 func TestBackupListCorrectOrderingModificationTimeGaps(t *testing.T) {
-	const expected =
-	"name   modified             wal_segment_backup_start start_time           finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
-	"base_0 -                    ZZZZZZZZZZZZZZZZZZZZZZZZ 1997-01-01T01:01:01Z -                             0          0         0          false\n" +
-	"base_2 2020-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1998-01-01T01:01:01Z -                             0          0         0          false\n" +
-	"base_1 -                    ZZZZZZZZZZZZZZZZZZZZZZZZ 1999-01-01T01:01:01Z -                             0          0         0          false\n"
+	const expected = "name   modified             wal_segment_backup_start start_time           finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
+		"base_0 -                    ZZZZZZZZZZZZZZZZZZZZZZZZ 1997-01-01T01:01:01Z -                             0          0         0          false\n" +
+		"base_2 2020-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1998-01-01T01:01:01Z -                             0          0         0          false\n" +
+		"base_1 -                    ZZZZZZZZZZZZZZZZZZZZZZZZ 1999-01-01T01:01:01Z -                             0          0         0          false\n"
 
 	folder := testtools.CreatePostgresMockStorageFolderWithTimeMetadata(t, testtools.ModificationTimeGaps)
 	backups, err := internal.GetBackups(folder)
@@ -93,11 +90,10 @@ func TestBackupListCorrectOrderingModificationTimeGaps(t *testing.T) {
 }
 
 func TestBackupListCorrectOrderingNoTimeGaps(t *testing.T) {
-	const expected =
-	"name   modified             wal_segment_backup_start start_time           finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
-	"base_0 2018-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1997-01-01T01:01:01Z -                             0          0         0          false\n" +
-	"base_2 2020-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1998-01-01T01:01:01Z -                             0          0         0          false\n" +
-	"base_1 2017-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1999-01-01T01:01:01Z -                             0          0         0          false\n" 
+	const expected = "name   modified             wal_segment_backup_start start_time           finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
+		"base_0 2018-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1997-01-01T01:01:01Z -                             0          0         0          false\n" +
+		"base_2 2020-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1998-01-01T01:01:01Z -                             0          0         0          false\n" +
+		"base_1 2017-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1999-01-01T01:01:01Z -                             0          0         0          false\n"
 
 	folder := testtools.CreatePostgresMockStorageFolderWithTimeMetadata(t, testtools.NoTimeGaps)
 	backups, err := internal.GetBackups(folder)
@@ -112,12 +108,11 @@ func TestBackupListCorrectOrderingNoTimeGaps(t *testing.T) {
 }
 
 func TestBackupListCorrectOrderingTimeGaps(t *testing.T) {
-	const expected =
-	"name   modified             wal_segment_backup_start start_time           finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
-    "base_2 -                    ZZZZZZZZZZZZZZZZZZZZZZZZ 1998-01-01T01:01:01Z -                             0          0         0          false\n" +
-	"base_1 2017-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ -                    -                             0          0         0          false\n" +
-	"base_0 2018-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1997-01-01T01:01:01Z -                             0          0         0          false\n"
-	
+	const expected = "name   modified             wal_segment_backup_start start_time           finish_time hostname data_dir pg_version start_lsn finish_lsn is_permanent\n" +
+		"base_2 -                    ZZZZZZZZZZZZZZZZZZZZZZZZ 1998-01-01T01:01:01Z -                             0          0         0          false\n" +
+		"base_1 2017-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ -                    -                             0          0         0          false\n" +
+		"base_0 2018-01-01T01:01:01Z ZZZZZZZZZZZZZZZZZZZZZZZZ 1997-01-01T01:01:01Z -                             0          0         0          false\n"
+
 	folder := testtools.CreatePostgresMockStorageFolderWithTimeMetadata(t, testtools.CreationAndModificationTimeGaps)
 	backups, err := internal.GetBackups(folder)
 	assert.NoError(t, err)
@@ -202,7 +197,7 @@ func TestBackupListCorrectPrettyJsonOutput(t *testing.T) {
 		"        \"system_identifier\": null,\n" +
 		"        \"uncompressed_size\": 0,\n" +
 		"        \"compressed_size\": 0\n" +
-		"    }\n" +		
+		"    }\n" +
 		"]"
 
 	folder := testtools.CreatePostgresMockStorageFolderWithTimeMetadata(t, testtools.NoCreationTime)

--- a/internal/databases/postgres/backup_sentinel_dto.go
+++ b/internal/databases/postgres/backup_sentinel_dto.go
@@ -11,6 +11,8 @@ import (
 	"github.com/wal-g/wal-g/internal"
 )
 
+const MetadataDatetimeFormat = "%Y-%m-%dT%H:%M:%S.%fZ"
+
 // BackupSentinelDto describes file structure of json sentinel
 type BackupSentinelDto struct {
 	BackupStartLSN    *uint64 `json:"LSN"`
@@ -84,7 +86,7 @@ func NewExtendedMetadataDto(isPermanent bool, dataDir string, startTime time.Tim
 	if err != nil {
 		tracelog.WarningLogger.Printf("Failed to fetch the hostname for metadata, leaving empty: %v", err)
 	}
-	meta.DatetimeFormat = "%Y-%m-%dT%H:%M:%S.%fZ"
+	meta.DatetimeFormat = MetadataDatetimeFormat
 	meta.StartTime = startTime
 	meta.FinishTime = utility.TimeNowCrossPlatformUTC()
 	meta.Hostname = hostname

--- a/internal/databases/postgres/backup_test.go
+++ b/internal/databases/postgres/backup_test.go
@@ -161,7 +161,7 @@ func TestGetLatestBackupNameNoBackupsInFolder(t *testing.T) {
 	assert.Equal(t, backupName, "")
 }
 
-func TestGetLastBackupNameWithGarbage(t *testing.T)  {
+func TestGetLastBackupNameWithGarbage(t *testing.T) {
 	folder := testtools.CreateMockStorageFolder()
 	subFolder := folder.GetSubFolder(utility.BaseBackupPath)
 	latestBackup, err := internal.GetLatestBackupName(subFolder)

--- a/internal/databases/postgres/wal_metadata_uploader.go
+++ b/internal/databases/postgres/wal_metadata_uploader.go
@@ -54,7 +54,7 @@ func (u *WalMetadataUploader) UploadWalMetadata(walFileName string, createdTime 
 	var walMetadata WalMetadataDescription
 	walMetadataMap := make(map[string]WalMetadataDescription)
 	walMetadataName := walFileName + ".json"
-	walMetadata.DatetimeFormat = "%Y-%m-%dT%H:%M:%S.%fZ"
+	walMetadata.DatetimeFormat = MetadataDatetimeFormat
 	walMetadata.CreatedTime = createdTime
 	walMetadataMap[walFileName] = walMetadata
 

--- a/internal/databases/postgres/wal_verify_handler_test.go
+++ b/internal/databases/postgres/wal_verify_handler_test.go
@@ -2,9 +2,11 @@ package postgres_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 
@@ -545,21 +547,25 @@ func TestWalVerify_WalkUntilFirstBackup(t *testing.T) {
 
 	storageFiles := make(map[string]*bytes.Buffer, 4)
 
-	backupSentinelNames := []string{
-		// this backup should not be selected as the earliest,
+	// there are a couple of mock backups in storage, but only one
+	// should be selected as the first one
+	backupsWalNames := map[string]postgres.ExtendedMetadataDto {
+		// INCORRECT: this backup should not be selected as the earliest,
 		// because it does not belong to the current timeline history
 		// since the timeline switch occurred
 		// at the 000000060000000000000005 WAL segment
-		utility.BackupNamePrefix + "000000050000000000000005" + utility.SentinelSuffix,
-		// this backup should not be selected as the earliest,
-		// because it is not
-		utility.BackupNamePrefix + "000000060000000000000007" + utility.SentinelSuffix,
-		// this backup should be selected as the earliest
-		utility.BackupNamePrefix + "000000060000000000000006" + utility.SentinelSuffix,
+		"000000050000000000000005": newMockExtendedMetadataDto(false),
+		// INCORRECT: this backup should not be selected as the earliest, because it is not the earliest one
+		"000000060000000000000007": newMockExtendedMetadataDto(false),
+		// OK: this backup should be selected as the earliest
+		"000000060000000000000006": newMockExtendedMetadataDto(false),
+		// INCORRECT: backup has been created before the timeline switch LSN
+		"000000060000000000000002": newMockExtendedMetadataDto(false),
+		// INCORRECT: backup is marked permanent
+		"000000050000000000000003": newMockExtendedMetadataDto(true),
 	}
-	for _, name := range backupSentinelNames {
-		storageFiles[utility.BaseBackupPath+name] = new(bytes.Buffer)
-	}
+
+	addMockBackupsStorageFiles(backupsWalNames, storageFiles)
 
 	// set switch point to somewhere in the 5th segment
 	switchPointLsn := 5*postgres.WalSegmentSize + 100
@@ -602,6 +608,16 @@ func TestWalVerify_WalkUntilFirstBackup(t *testing.T) {
 		storageSegments:        storageSegments,
 		storageFiles:           storageFiles,
 	})
+}
+
+func addMockBackupsStorageFiles(backups map[string]postgres.ExtendedMetadataDto, storageFiles map[string]*bytes.Buffer) {
+	for name, meta := range backups {
+		// sentinel
+		storageFiles[utility.BaseBackupPath+utility.BackupNamePrefix+name+utility.SentinelSuffix] = new(bytes.Buffer)
+		// metadata
+		metaBytes, _ := json.Marshal(meta)
+		storageFiles[utility.BaseBackupPath+utility.BackupNamePrefix+name+"/"+utility.MetadataFileName] = bytes.NewBuffer(metaBytes)
+	}
 }
 
 func testWalVerify(t *testing.T, setup WalVerifyTestSetup) {
@@ -656,5 +672,24 @@ func compareResults(
 
 		assert.True(t, reflect.DeepEqual(expected[checkType].Details, checkResult.Details),
 			"Result details don't match the expected values")
+	}
+}
+
+func newMockExtendedMetadataDto(isPermanent bool) postgres.ExtendedMetadataDto {
+	// currently we do not need any fields except the isPermanent
+	return postgres.ExtendedMetadataDto{
+		StartTime:        time.Now(),
+		FinishTime:       time.Now().Add(time.Second),
+		DatetimeFormat:   postgres.MetadataDatetimeFormat,
+		Hostname:         "test_host",
+		DataDir:          "",
+		PgVersion:        10000,
+		StartLsn:         0,
+		FinishLsn:        0,
+		IsPermanent:      isPermanent,
+		SystemIdentifier: nil,
+		UncompressedSize: 0,
+		CompressedSize:   0,
+		UserData:         nil,
 	}
 }

--- a/internal/databases/postgres/wal_verify_handler_test.go
+++ b/internal/databases/postgres/wal_verify_handler_test.go
@@ -549,7 +549,7 @@ func TestWalVerify_WalkUntilFirstBackup(t *testing.T) {
 
 	// there are a couple of mock backups in storage, but only one
 	// should be selected as the first one
-	backupsWalNames := map[string]postgres.ExtendedMetadataDto {
+	backupsWalNames := map[string]postgres.ExtendedMetadataDto{
 		// INCORRECT: this backup should not be selected as the earliest,
 		// because it does not belong to the current timeline history
 		// since the timeline switch occurred

--- a/testtools/util.go
+++ b/testtools/util.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"strconv"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -180,7 +180,7 @@ func CreatePostgresMockStorageFolderWithTimeMetadata(t *testing.T, dataFilling D
 		AnyTimes()
 
 	for i := 0; i < backupsCount; i++ {
-		currentSentinelPath := backupsName[i]+utility.SentinelSuffix
+		currentSentinelPath := backupsName[i] + utility.SentinelSuffix
 		mockBaseBackupFolder.EXPECT().Exists(currentSentinelPath).Return(true, nil).AnyTimes()
 		currentMetadataPath := backupsName[i] + "/" + utility.MetadataFileName
 		mockBaseBackupFolder.EXPECT().ReadObject(currentMetadataPath).Return(folder.ReadObject(currentMetadataPath)).AnyTimes()


### PR DESCRIPTION
Currently, `wal-verify` picks the oldest backup in storage to determine the scan range. However, if oldest backup is marked permanent, it should be ignored because WAL-G does not provide PITR for old permanent backups.