### PR TITLE
mysql: until option for binlog push

### DIFF
--- a/cmd/mysql/binlog_push.go
+++ b/cmd/mysql/binlog_push.go
@@ -9,6 +9,8 @@ import (
 
 const binlogPushShortDescription = ""
 
+var untilBinlog string
+
 // binlogPushCmd represents the cron command
 var binlogPushCmd = &cobra.Command{
 	Use:   "binlog-push",
@@ -17,7 +19,7 @@ var binlogPushCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		uploader, err := internal.ConfigureUploader()
 		tracelog.ErrorLogger.FatalOnError(err)
-		mysql.HandleBinlogPush(uploader)
+		mysql.HandleBinlogPush(uploader, untilBinlog)
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
@@ -28,4 +30,5 @@ var binlogPushCmd = &cobra.Command{
 
 func init() {
 	cmd.AddCommand(binlogPushCmd)
+	binlogPushCmd.Flags().StringVar(&untilBinlog, "until", "", "binlog file name to stop at. Current active by default")
 }


### PR DESCRIPTION
### Database name
mysql

# Pull request description

### Describe what this PR fix
After primary node crash and recovery one or two last binary logs file may contain invalid data break PITR.
We need option to specify which binary logs are ok to upload.

