### PR TITLE
changed registry of system catalog view to lowercase

### DIFF
--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -127,7 +127,7 @@ func getDatabasesToRestore(sentinel *SentinelDto, dbnames []string, fromnames []
 }
 
 func listDatabases(db *sql.DB) ([]string, error) {
-	rows, err := db.Query("SELECT name FROM SYS.DATABASES WHERE name != 'tempdb'")
+	rows, err := db.Query("SELECT name FROM sys.databases WHERE name != 'tempdb'")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Database name
SQL Server

# Pull request description
change system catalog view name to lowercase

### Describe what this PR fix

If we use case sensitive collation on our sql server instance, then queries to system catalog views (like sys.databases) should be lowercase or we get an error like "ERROR: 2021/06/16 15:53:49.580074 mssql: Invalid object name 'SYS.DATABASES'."

### Please provide steps to reproduce (if it's a bug)

use it against case sensitive instance of SQL Server and try to take a backup
### Please add config and wal-g stdout/stderr logs for debug purpose
config does not matter
"ERROR: 2021/06/16 15:53:49.580074 mssql: Invalid object name 'SYS.DATABASES'."

