### PR TITLE
Old postgres version system identifier workaround

### DIFF
--- a/internal/databases/postgres/queryRunner.go
+++ b/internal/databases/postgres/queryRunner.go
@@ -174,6 +174,10 @@ func (queryRunner *PgQueryRunner) getCurrentLsn() (lsn string, err error) {
 }
 
 func (queryRunner *PgQueryRunner) getSystemIdentifier() (err error) {
+	if queryRunner.Version < 90600 {
+		tracelog.WarningLogger.Println("GetSystemIdentifier: Unable to get system identifier")
+		return nil
+	}
 	conn := queryRunner.connection
 	err = conn.QueryRow(queryRunner.buildGetSystemIdentifier()).Scan(&queryRunner.SystemIdentifier)
 	return errors.Wrap(err, "System Identifier: getting identifier of DB failed")


### PR DESCRIPTION
Fix for https://github.com/wal-g/wal-g/issues/1018

The getSystemIdentifier function will fail on older versions of postgres
(9.5 and earlier.) This commit adds a workaround to allow WAL-G to work
on older versions of postgres.

### Database name
postgres

# Pull request description

### Describe what this PR fix
Fix for postgres 9.5 breakage

### Please provide steps to reproduce (if it's a bug)
Run on postgres 9.5 or earlier.

### Please add config and wal-g stdout/stderr logs for debug purpose

Refer to linked issue for most details.