### PR TITLE
Made ENV print sorted in logs: easier to read

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -420,7 +421,9 @@ func Configure() {
 
 	// Show all ENV vars in DEVEL Logging Mode
 	tracelog.DebugLogger.Println("--- COMPILED ENVIRONMENT VARS ---")
-	for _, pair := range os.Environ() {
+	env := os.Environ()
+	sort.Strings(env)
+	for _, pair := range env {
 		tracelog.DebugLogger.Println(pair)
 	}
 


### PR DESCRIPTION
Env logs in debug mode always in random order - it's hard to diff two logs, hard to search in them.
I've made a sort for it