### PR TITLE
MySQL: Fetch binlog-replay startTS from the base backup

### DIFF
--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -168,7 +168,7 @@ Here's typical wal-g configuration for that case:
  WALG_STREAM_CREATE_COMMAND="xtrabackup --backup --stream=xbstream --datadir=/var/lib/mysql"                                                                                                                               
  WALG_STREAM_RESTORE_COMMAND="xbstream -x -C /var/lib/mysql"                                                                                                                       
  WALG_MYSQL_BACKUP_PREPARE_COMMAND="xtrabackup --prepare --target-dir=/var/lib/mysql"                                                                                              
- WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
+ WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --start-datetime="$WALG_MYSQL_BINLOG_START_TS" --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
 ```
 
 Restore procedure is a bit tricky:
@@ -197,7 +197,7 @@ Here's typical wal-g configuration for that case:
  WALG_MYSQL_DATASOURCE_NAME=user:pass@localhost/mysql                                                                                                               
  WALG_STREAM_CREATE_COMMAND="mysqldump --all-databases --single-transaction --set-gtid-purged=ON"                                                                                                                               
  WALG_STREAM_RESTORE_COMMAND="mysql"
- WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
+ WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --start-datetime="$WALG_MYSQL_BINLOG_START_TS" --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
 ```
 
 Restore procedure is straightforward:

--- a/internal/databases/mysql/binlog_fetch_handler.go
+++ b/internal/databases/mysql/binlog_fetch_handler.go
@@ -45,7 +45,7 @@ func HandleBinlogFetch(folder storage.Folder, backupName string, untilTS string)
 	dstDir, err := internal.GetLogsDstSettings(internal.MysqlBinlogDstSetting)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	startTS, endTS, err := getTimestamps(folder, backupName, untilTS)
+	startTS, _, endTS, err := getTimestamps(folder, backupName, untilTS)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	handler := newIndexHandler(dstDir)


### PR DESCRIPTION
### Database name
MySQL

# Pull request description
Since backups are normally taken when some binlog is already being processed, it looks reasonable to avoid replaying the whole first binlog, but to start replaying it from the Backup's start time timestamp. Otherwise binlog replaying can fail.
This PR:
1. Extracts `StartLocalTime` from backup info and uses it as `WALG_MYSQL_BINLOG_START_TS` environment variable during binlog replaying.
2. Updates MySQL proposed `WALG_MYSQL_BINLOG_REPLAY_COMMAND` command to use this environment variable.

### Describe what this PR fix
After this PR binlogs are replayed from the moment of backup creation and not from the very beginning of a first binlog.
So if, for example, a database was created right before the backup was taken, it won't lead to `binlog-replay` failure anymore.

### Please provide steps to reproduce (if it's a bug)
1. Create a new database `test`.
2. Take a backup by `wal-g backup-push`.
3. Generate enough data to archive the binlog that was used during steps 1 and 2.
4. Archive this binlog by `wal-g binlog-push`.
5. Cleanup data / switch to another testing server.
6. Restore backup by `wal-g backup-fetch LATEST`.
7. Try to replay binlogs by `wal-g binlog-replay`.

### Please add config and wal-g stdout/stderr logs for debug purpose
Behaviour before the fix:
```
wal-g binlog-replay
INFO: 2021/06/23 13:22:37.647564 LATEST backup is: 'stream_20210622T103510Z'
INFO: 2021/06/23 13:22:37.685656 Backup sentinel: {"BinLogStart":"walg-test-m-0-bin.000002","BinLogEnd":"walg-test-m-0-bin.000002","StartLocalTime":"2021-06-22T10:35:10.80798Z","StopLocalTime":"2021-06-22T10:35:13.183299Z","UncompressedSize":26027904,"CompressedSize":1345714,"Hostname":"walg-test-m-0","UserData":""}
INFO: 2021/06/23 13:22:37.817300 Backup sentinel file: stream_20210622T103510Z_backup_stop_sentinel.json (2021-06-22 10:35:13.317 +0000 UTC)
INFO: 2021/06/23 13:22:37.930095 Backup start binlog: walg-test-m-0-bin.000002.lz4 (2021-06-22 10:38:16.218 +0000 UTC)
INFO: 2021/06/23 13:22:37.930165 Fetching binlogs since 2021-06-22 10:35:13.317 +0000 UTC until 2021-06-23 13:22:37 +0000 UTC
INFO: 2021/06/23 13:22:37.982688 downloading walg-test-m-0-bin.000002 into /data/mysql/temp/walg-test-m-0-bin.000002
INFO: 2021/06/23 13:22:38.072176 downloading walg-test-m-0-bin.000003 into /data/mysql/temp/walg-test-m-0-bin.000003
INFO: 2021/06/23 13:22:38.072442 replaying walg-test-m-0-bin.000002 ...
ERROR 1007 (HY000) at line 31: Can't create database ‘test’; database exists
```
Behaviour after fix:
```
/tmp/wal-g binlog-replay
INFO: 2021/06/23 13:25:45.976964 LATEST backup is: 'stream_20210622T103510Z'
INFO: 2021/06/23 13:25:46.045925 Backup sentinel: {"BinLogStart":"walg-test-m-0-bin.000002","BinLogEnd":"walg-test-m-0-bin.000002","StartLocalTime":"2021-06-22T10:35:10.80798Z","StopLocalTime":"2021-06-22T10:35:13.183299Z","UncompressedSize":26027904,"CompressedSize":1345714,"Hostname":"walg-test-m-0","UserData":""}
INFO: 2021/06/23 13:25:46.158706 Backup sentinel file: stream_20210622T103510Z_backup_stop_sentinel.json (2021-06-22 10:35:13.317 +0000 UTC)
INFO: 2021/06/23 13:25:46.282031 Backup start binlog: walg-test-m-0-bin.000002.lz4 (2021-06-22 10:38:16.218 +0000 UTC)
INFO: 2021/06/23 13:25:46.282115 Fetching binlogs since 2021-06-22 10:35:13.317 +0000 UTC until 2021-06-23 13:25:45 +0000 UTC
INFO: 2021/06/23 13:25:46.428604 downloading walg-test-m-0-bin.000002 into /data/mysql/temp/walg-test-m-0-bin.000002
INFO: 2021/06/23 13:25:46.551494 downloading walg-test-m-0-bin.000003 into /data/mysql/temp/walg-test-m-0-bin.000003
INFO: 2021/06/23 13:25:46.551673 replaying walg-test-m-0-bin.000002 ...
INFO: 2021/06/23 13:26:01.652730 replaying walg-test-m-0-bin.000003 ...
```