### PR TITLE
Fix release tarball creation to use zero uid and gid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         run: mv main/${{ matrix.db }}/wal-g wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64
 
       - name: Compress WAL-G binary
-        run: tar -zcvf wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.tar.gz wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64
+        run: tar --owner=0 --group=0 -zcvf wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.tar.gz wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64
 
       - name: Upload WAL-G binary
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This PR fixes the release action so that the tarball creation uses a zero uid and gid value for files inside the release archive. Otherwise the archive will inherit the uid/gid of the GitHub Action runner and those values will show up on end user systems if the archive is extracted as root.

Right now there's no explicit uid / gid so it's inheriting the value from the GitHub Action runner:

```
# Named
$ tar -ztvf wal-g-pg-ubuntu-20.04-amd64.tar.gz 
-rwxr-xr-x runner/docker 44110248 2021-05-31 12:38 wal-g-pg-ubuntu-20.04-amd64

# Numerical
$ tar --numeric-owner -ztvf wal-g-pg-ubuntu-20.04-amd64.tar.gz 
-rwxr-xr-x 1001/121   44110248 2021-05-31 12:38 wal-g-pg-ubuntu-20.04-amd64
```

Extracting the release tarball as a non-root user wouldn't notice this as all the files would be written as your current non-root user. But if you extract the tarball as root, then it will assign the ownership to those numerical uid / gid values.