### PR TITLE
Fix bug in MySQL detailed backup-list

### DIFF
--- a/internal/databases/mysql/backup_list_handler.go
+++ b/internal/databases/mysql/backup_list_handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/wal-g/storages/storage"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
-	"github.com/wal-g/wal-g/utility"
 )
 
 type BackupDetail struct {
@@ -56,7 +55,7 @@ func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 
 	backupDetails := make([]BackupDetail, 0, len(backupTimes))
 	for _, backupTime := range backupTimes {
-		backup := internal.NewBackup(folder.GetSubFolder(utility.BaseBackupPath), backupTime.BackupName)
+		backup := internal.NewBackup(folder, backupTime.BackupName)
 
 		var sentinel StreamSentinelDto
 		err = backup.FetchSentinel(&sentinel)


### PR DESCRIPTION
Fix for failing `--detail` flag of backup-list command in MySQL
```
/home/usernamedt # wal-g-mysql backup-list --detail --config wal-g.yaml 
ERROR: 2021/06/30 14:23:59.015087 Failed to load sentinel for backup failed to fetch sentinel: object 'xxxxxx/basebackups_005/basebackups_005/stream_20210629T220914Z_backup_stop_sentinel.json' not found in storage
```
