### PR TITLE
mysql: add turbo flag to disable limiters

### DIFF
--- a/cmd/mysql/mysql.go
+++ b/cmd/mysql/mysql.go
@@ -43,6 +43,7 @@ func init() {
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 
 	cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")
+	cmd.PersistentFlags().BoolVarP(&internal.Turbo, "turbo", "", false, "Ignore all kinds of throttling defined in config")
 	cmd.InitDefaultVersionFlag()
 	internal.AddConfigFlags(cmd)
 }


### PR DESCRIPTION
### Database name
MySQL

# Pull request description

### Describe what this PR fix
PG has turbo flag that temporary disables all limiters.
Let's add such one for mysql.
