### PR TITLE
fix mssql driver import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cyberdelia/lzo v0.0.0-20171006181345-d85071271a6f
-	github.com/denisenkom/go-mssqldb v0.9.0 // indirect
+	github.com/denisenkom/go-mssqldb v0.9.0
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/wal-g/storages/storage"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/wal-g/storages/storage"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"

--- a/main/sqlserver/main.go
+++ b/main/sqlserver/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/wal-g/wal-g/cmd/sqlserver"
 )
 


### PR DESCRIPTION
### Database name
SQL Server

# Pull request description

### Describe what this PR fix
mssqldb driver has been removed during some refactoring

### Please provide steps to reproduce (if it's a bug)
wal-g-sqlserver is unable to connect to sql server for any operation. For example to backup-push

### Please add config and wal-g stdout/stderr logs for debug purpose
.\wal-g-sqlserver.exe --config C:\\ProgramData\\wal-g\\wal-g.yaml backup-push --databases db1
ERROR: 2021/07/14 12:43:14.421058 failed to connect to SQLServer: sql: unknown driver "sqlserver" (forgotten import?)
