### PR TITLE
Greenplum improvements

### DIFF
--- a/cmd/gp/gp.go
+++ b/cmd/gp/gp.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/wal-g/wal-g/cmd/pg"
+
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -44,4 +46,9 @@ func init() {
 	_ = cmd.MarkFlagRequired("config") // config is required for Greenplum WAL-G
 	cmd.InitDefaultVersionFlag()
 	internal.AddConfigFlags(cmd)
+
+	// wrap the Postgres command so it can be used in the same binary
+	wrappedPgCmd := pg.Cmd
+	wrappedPgCmd.Use = "pg"
+	cmd.AddCommand(wrappedPgCmd)
 }

--- a/cmd/gp/gp.go
+++ b/cmd/gp/gp.go
@@ -50,5 +50,11 @@ func init() {
 	// wrap the Postgres command so it can be used in the same binary
 	wrappedPgCmd := pg.Cmd
 	wrappedPgCmd.Use = "pg"
+	wrappedPreRun := wrappedPgCmd.PersistentPreRun
+	wrappedPgCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		// storage prefix setting is required in order to get the corresponding segment subfolder
+		internal.RequiredSettings[internal.StoragePrefixSetting] = true
+		wrappedPreRun(cmd, args)
+	}
 	cmd.AddCommand(wrappedPgCmd)
 }

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -81,5 +81,5 @@ func init() {
 		false, skipRedundantTarsDescription)
 	backupFetchCmd.Flags().StringVar(&fetchTargetUserData, "target-user-data",
 		"", targetUserDataDescription)
-	cmd.AddCommand(backupFetchCmd)
+	Cmd.AddCommand(backupFetchCmd)
 }

--- a/cmd/pg/backup_list.go
+++ b/cmd/pg/backup_list.go
@@ -37,7 +37,7 @@ var (
 )
 
 func init() {
-	cmd.AddCommand(backupListCmd)
+	Cmd.AddCommand(backupListCmd)
 
 	// TODO: Merge similar backup-list functionality
 	// to avoid code duplication in command handlers

--- a/cmd/pg/backup_mark.go
+++ b/cmd/pg/backup_mark.go
@@ -33,5 +33,5 @@ var (
 
 func init() {
 	backupMarkCmd.Flags().BoolVarP(&toImpermanent, ImpermanentFlag, "i", false, ImpermanentDescription)
-	cmd.AddCommand(backupMarkCmd)
+	Cmd.AddCommand(backupMarkCmd)
 }

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -111,7 +111,7 @@ func createDeltaBaseSelector(cmd *cobra.Command,
 }
 
 func init() {
-	cmd.AddCommand(backupPushCmd)
+	Cmd.AddCommand(backupPushCmd)
 
 	backupPushCmd.Flags().BoolVarP(&permanent, permanentFlag, permanentShorthand,
 		false, "Pushes permanent backup")

--- a/cmd/pg/catchup_fetch.go
+++ b/cmd/pg/catchup_fetch.go
@@ -29,5 +29,5 @@ var catchupFetchCmd = &cobra.Command{
 func init() {
 	catchupFetchCmd.Flags().BoolVar(&useNewUnwrap, "use-new-unwrap",
 		false, UseNewUnwrapDescription)
-	cmd.AddCommand(catchupFetchCmd)
+	Cmd.AddCommand(catchupFetchCmd)
 }

--- a/cmd/pg/catchup_list.go
+++ b/cmd/pg/catchup_list.go
@@ -31,7 +31,7 @@ var (
 )
 
 func init() {
-	cmd.AddCommand(catchupListCmd)
+	Cmd.AddCommand(catchupListCmd)
 
 	catchupListCmd.Flags().BoolVar(&pretty, PrettyFlag, false, "Prints more readable output")
 	catchupListCmd.Flags().BoolVar(&json, JSONFlag, false, "Prints output in json format")

--- a/cmd/pg/catchup_push.go
+++ b/cmd/pg/catchup_push.go
@@ -23,7 +23,7 @@ var (
 )
 
 func init() {
-	cmd.AddCommand(catchupPushCmd)
+	Cmd.AddCommand(catchupPushCmd)
 
 	catchupPushCmd.Flags().Uint64Var(&fromLSN, "from-lsn", 0, "LSN to start incremental backup")
 }

--- a/cmd/pg/copy.go
+++ b/cmd/pg/copy.go
@@ -48,7 +48,7 @@ func runBackupCopy(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	cmd.AddCommand(backupCopyCmd)
+	Cmd.AddCommand(backupCopyCmd)
 
 	backupCopyCmd.Flags().StringVarP(&backupName, backupNameFlag, backupNameShorthand, "", backupNameDescription)
 	backupCopyCmd.Flags().StringVarP(&toConfigFile, toFlag, toShorthand, "", toDescription)

--- a/cmd/pg/delete.go
+++ b/cmd/pg/delete.go
@@ -126,7 +126,7 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	cmd.AddCommand(deleteCmd)
+	Cmd.AddCommand(deleteCmd)
 
 	deleteTargetCmd.Flags().StringVar(
 		&deleteTargetUserData, internal.DeleteTargetUserDataFlag, "", internal.DeleteTargetUserDataDescription)

--- a/cmd/pg/pg.go
+++ b/cmd/pg/pg.go
@@ -21,7 +21,7 @@ var (
 	gitRevision = "devel"
 	buildDate   = "devel"
 
-	cmd = &cobra.Command{
+	Cmd = &cobra.Command{
 		Use:     "wal-g",
 		Short:   WalgShortDescription, // TODO : improve short and long descriptions
 		Version: strings.Join([]string{walgVersion, gitRevision, buildDate, "PostgreSQL"}, "\t"),
@@ -38,7 +38,7 @@ var (
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the PgCmd.
 func Execute() {
-	if err := cmd.Execute(); err != nil {
+	if err := Cmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -48,8 +48,8 @@ func init() {
 	internal.ConfigureSettings(internal.PG)
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 
-	cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")
-	cmd.PersistentFlags().BoolVarP(&internal.Turbo, "turbo", "", false, "Ignore all kinds of throttling defined in config")
-	cmd.InitDefaultVersionFlag()
-	internal.AddConfigFlags(cmd)
+	Cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")
+	Cmd.PersistentFlags().BoolVarP(&internal.Turbo, "turbo", "", false, "Ignore all kinds of throttling defined in config")
+	Cmd.InitDefaultVersionFlag()
+	internal.AddConfigFlags(Cmd)
 }

--- a/cmd/pg/pg.go
+++ b/cmd/pg/pg.go
@@ -38,13 +38,14 @@ var (
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the PgCmd.
 func Execute() {
+	configureCommand()
 	if err := Cmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 }
 
-func init() {
+func configureCommand() {
 	internal.ConfigureSettings(internal.PG)
 	cobra.OnInitialize(internal.InitConfig, internal.Configure)
 

--- a/cmd/pg/wal_fetch.go
+++ b/cmd/pg/wal_fetch.go
@@ -22,5 +22,5 @@ var walFetchCmd = &cobra.Command{
 }
 
 func init() {
-	cmd.AddCommand(walFetchCmd)
+	Cmd.AddCommand(walFetchCmd)
 }

--- a/cmd/pg/wal_prefetch.go
+++ b/cmd/pg/wal_prefetch.go
@@ -23,5 +23,5 @@ var walPrefetchCmd = &cobra.Command{
 }
 
 func init() {
-	cmd.AddCommand(walPrefetchCmd)
+	Cmd.AddCommand(walPrefetchCmd)
 }

--- a/cmd/pg/wal_push.go
+++ b/cmd/pg/wal_push.go
@@ -40,5 +40,5 @@ var walPushCmd = &cobra.Command{
 }
 
 func init() {
-	cmd.AddCommand(walPushCmd)
+	Cmd.AddCommand(walPushCmd)
 }

--- a/cmd/pg/wal_receive.go
+++ b/cmd/pg/wal_receive.go
@@ -31,5 +31,5 @@ var walReceiveCmd = &cobra.Command{
 }
 
 func init() {
-	cmd.AddCommand(walReceiveCmd)
+	Cmd.AddCommand(walReceiveCmd)
 }

--- a/cmd/pg/wal_show.go
+++ b/cmd/pg/wal_show.go
@@ -46,7 +46,7 @@ var (
 )
 
 func init() {
-	cmd.AddCommand(walShowCmd)
+	Cmd.AddCommand(walShowCmd)
 	walShowCmd.Flags().BoolVar(&detailedJSONOutput, detailedOutputFlag, false, detailedOutputDescription)
 	walShowCmd.Flags().BoolVar(&disableBackupsLookup, disableBackupsLookupFlag, false, disableBackupsLookupDescription)
 }

--- a/cmd/pg/wal_verify.go
+++ b/cmd/pg/wal_verify.go
@@ -88,6 +88,6 @@ func checkArgs(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
-	cmd.AddCommand(walVerifyCmd)
+	Cmd.AddCommand(walVerifyCmd)
 	walVerifyCmd.Flags().BoolVar(&useJSONOutput, useJSONOutputFlag, false, useJSONOutputDescription)
 }

--- a/docker/gp_tests/Dockerfile
+++ b/docker/gp_tests/Dockerfile
@@ -21,11 +21,6 @@ RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
 
 RUN make gp_build
 
-RUN cd main/pg && \
-    go build -mod vendor -tags brotli -race -o wal-g -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
-
-RUN make pg_build
-
 FROM wal-g/gp:latest
 
 USER root
@@ -34,8 +29,7 @@ COPY docker/pg/PGP_KEY /tmp/PGP_KEY
 COPY docker/pg/gpg.conf /home/gpadmin/.gnupg/gpg.conf
 COPY docker/pg/gpg-agent.conf /home/gpadmin/.gnupg/gpg-agent.conf
 
-COPY --from=build /go/src/github.com/wal-g/wal-g/main/gp/wal-g /usr/bin/wal-g-gp
-COPY --from=build /go/src/github.com/wal-g/wal-g/main/pg/wal-g /usr/bin
+COPY --from=build /go/src/github.com/wal-g/wal-g/main/gp/wal-g /usr/bin/
 
 COPY docker/gp_tests/scripts/ /tmp
 COPY docker/pg_tests/scripts/scripts/ /tmp/pg_scripts

--- a/docker/gp_tests/scripts/tests/gp_full_backup_test.sh
+++ b/docker/gp_tests/scripts/tests/gp_full_backup_test.sh
@@ -14,6 +14,6 @@ cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
 source /usr/local/gpdb_src/gpAux/gpdemo/gpdemo-env.sh && /usr/local/gpdb_src/bin/createdb
 sleep 10
 
-wal-g-gp backup-push --config=${TMP_CONFIG}
+wal-g backup-push --config=${TMP_CONFIG}
 
 echo "Greenplum backup-push test was successful"

--- a/internal/config.go
+++ b/internal/config.go
@@ -133,7 +133,6 @@ var (
 		UploadWalMetadata:            "NOMETADATA",
 		DeltaMaxStepsSetting:         "0",
 		CompressionMethodSetting:     "lz4",
-		StoragePrefixSetting:         "",
 		UseWalDeltaSetting:           "false",
 		TarSizeThresholdSetting:      "1073741823", // (1 << 30) - 1
 		TotalBgUploadedLimit:         "32",

--- a/internal/config.go
+++ b/internal/config.go
@@ -356,6 +356,9 @@ func ConfigureSettings(currentType string) {
 		switch currentType {
 		case PG:
 			dbSpecificSettings = PGAllowedSettings
+		case GP:
+			// as of now, GP specific settings are identical to PG
+			dbSpecificSettings = PGAllowedSettings
 		case MONGO:
 			dbSpecificSettings = MongoAllowedSettings
 		case MYSQL:

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -79,7 +79,7 @@ func (bh *BackupHandler) buildCommand(contentID int) string {
 	cmd := []string{
 		"WALG_LOG_LEVEL=DEVEL",
 		fmt.Sprintf("PGPORT=%d", segment.Port),
-		"wal-g",
+		"wal-g pg",
 		fmt.Sprintf("backup-push %s", segment.DataDir),
 		fmt.Sprintf("--walg-storage-prefix=%d", segment.ContentID),
 		fmt.Sprintf("--add-user-data=%s", segUserData.QuotedString()),


### PR DESCRIPTION
Fixes and improvements for `gp backup-push`.

Greenplum wal-g build now has the `pg` subcommand so it can be run from the segment. Also, this subcommand requires the `StoragePrefixSetting` to be set (basically, it is the folder containing the segment backups).