### PR TITLE
Greenplum backup-push improvements

### DIFF
--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -35,6 +35,10 @@ func NewSegmentUserData() SegmentUserData {
 	return SegmentUserData{ID: uuid.New().String()}
 }
 
+func NewSegmentUserDataFromID(backupID string) SegmentUserData {
+	return SegmentUserData{ID: backupID}
+}
+
 // QuotedString will do json.Marshal-ing followed by quoting in order to escape special control characters
 // in the resulting JSON so it can be transferred as the cmdline argument to a segment
 func (d SegmentUserData) QuotedString() string {
@@ -60,8 +64,8 @@ type BackupWorkers struct {
 
 // CurBackupInfo holds all information that is harvest during the backup process
 type CurBackupInfo struct {
-	backupName          string
-	backupIDByContentID map[int]string
+	backupName     string
+	segmentBackups map[string]*cluster.SegConfig
 }
 
 // BackupHandler is the main struct which is handling the backup process
@@ -75,7 +79,7 @@ type BackupHandler struct {
 func (bh *BackupHandler) buildCommand(contentID int) string {
 	segment := bh.globalCluster.ByContent[contentID][0]
 	segUserData := NewSegmentUserData()
-	bh.curBackupInfo.backupIDByContentID[contentID] = segUserData.ID
+	bh.curBackupInfo.segmentBackups[segUserData.ID] = segment
 	cmd := []string{
 		"WALG_LOG_LEVEL=DEVEL",
 		fmt.Sprintf("PGPORT=%d", segment.Port),
@@ -116,10 +120,10 @@ func (bh *BackupHandler) HandleBackupPush() {
 
 	err := bh.connect()
 	tracelog.ErrorLogger.FatalOnError(err)
-	err = bh.createRestorePoint(bh.curBackupInfo.backupName)
+	restoreLSNs, err := bh.createRestorePoint(bh.curBackupInfo.backupName)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	sentinelDto := NewBackupSentinelDto(bh.curBackupInfo)
+	sentinelDto := NewBackupSentinelDto(bh.curBackupInfo, restoreLSNs)
 	tracelog.InfoLogger.Println("Uploading sentinel file")
 	tracelog.DebugLogger.Println(sentinelDto.String())
 	err = internal.UploadSentinel(bh.workers.Uploader, sentinelDto, bh.curBackupInfo.backupName)
@@ -139,14 +143,17 @@ func (bh *BackupHandler) connect() (err error) {
 	return
 }
 
-func (bh *BackupHandler) createRestorePoint(restorePointName string) (err error) {
+func (bh *BackupHandler) createRestorePoint(restorePointName string) (restoreLSNs map[int]string, err error) {
 	tracelog.InfoLogger.Printf("Creating restore point with name %s", restorePointName)
 	queryRunner, err := NewGpQueryRunner(bh.workers.Conn)
 	if err != nil {
 		return
 	}
-	_, err = queryRunner.CreateGreenplumRestorePoint(restorePointName)
-	return
+	restoreLSNs, err = queryRunner.CreateGreenplumRestorePoint(restorePointName)
+	if err != nil {
+		return nil, err
+	}
+	return restoreLSNs, nil
 }
 
 func getGpCluster() (globalCluster *cluster.Cluster, err error) {
@@ -191,6 +198,8 @@ func NewBackupHandler(arguments BackupArguments) (bh *BackupHandler, err error) 
 	if err != nil {
 		return bh, err
 	}
+	uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.BaseBackupPath)
+
 	globalCluster, err := getGpCluster()
 	if err != nil {
 		return bh, err
@@ -203,7 +212,7 @@ func NewBackupHandler(arguments BackupArguments) (bh *BackupHandler, err error) 
 		},
 		globalCluster: globalCluster,
 		curBackupInfo: CurBackupInfo{
-			backupIDByContentID: make(map[int]string),
+			segmentBackups: make(map[string]*cluster.SegConfig),
 		},
 	}
 	return bh, err

--- a/internal/databases/greenplum/backup_sentinel_dto.go
+++ b/internal/databases/greenplum/backup_sentinel_dto.go
@@ -1,11 +1,58 @@
 package greenplum
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+)
+
+type SegmentRole string
+
+const (
+	Primary SegmentRole = "p"
+	Mirror  SegmentRole = "m"
+)
+
+type SegmentMetadata struct {
+	DatabaseID int         `json:"db_id"`
+	ContentID  int         `json:"content_id"`
+	Role       SegmentRole `json:"role"`
+	Port       int         `json:"port"`
+	Hostname   string      `json:"hostname"`
+	DataDir    string      `json:"data_dir"`
+
+	BackupID        string `json:"backup_id"`
+	RestorePointLSN string `json:"restore_point_lsn"`
+}
+
+func (c SegmentMetadata) ToSegConfig() cluster.SegConfig {
+	return cluster.SegConfig{
+		DbID:      c.DatabaseID,
+		ContentID: c.ContentID,
+		Role:      string(c.Role),
+		Port:      c.Port,
+		Hostname:  c.Hostname,
+		DataDir:   c.DataDir,
+	}
+}
+
+func NewSegmentMetadata(backupID string, segCfg cluster.SegConfig, restoreLSN string) SegmentMetadata {
+	return SegmentMetadata{
+		DatabaseID:      segCfg.DbID,
+		ContentID:       segCfg.ContentID,
+		Role:            SegmentRole(segCfg.Role),
+		Port:            segCfg.Port,
+		Hostname:        segCfg.Hostname,
+		DataDir:         segCfg.DataDir,
+		BackupID:        backupID,
+		RestorePointLSN: restoreLSN,
+	}
+}
 
 // BackupSentinelDto describes file structure of json sentinel
 type BackupSentinelDto struct {
-	RestorePoint      *string        `json:"RestorePoint,omitempty"`
-	BackupIdentifiers map[int]string `json:"BackupIDs,omitempty"`
+	RestorePoint *string           `json:"restore_point,omitempty"`
+	Segments     []SegmentMetadata `json:"segments,omitempty"`
 }
 
 func (s *BackupSentinelDto) String() string {
@@ -17,10 +64,15 @@ func (s *BackupSentinelDto) String() string {
 }
 
 // NewBackupSentinelDto returns new BackupSentinelDto instance
-func NewBackupSentinelDto(curBackupInfo CurBackupInfo) BackupSentinelDto {
+func NewBackupSentinelDto(curBackupInfo CurBackupInfo, restoreLSNs map[int]string) BackupSentinelDto {
 	sentinel := BackupSentinelDto{
-		RestorePoint:      &curBackupInfo.backupName,
-		BackupIdentifiers: curBackupInfo.backupIDByContentID,
+		RestorePoint: &curBackupInfo.backupName,
+		Segments:     make([]SegmentMetadata, 0, len(curBackupInfo.segmentBackups)),
+	}
+
+	for backupID, cfg := range curBackupInfo.segmentBackups {
+		restoreLSN := restoreLSNs[cfg.ContentID]
+		sentinel.Segments = append(sentinel.Segments, NewSegmentMetadata(backupID, *cfg, restoreLSN))
 	}
 	return sentinel
 }


### PR DESCRIPTION
Populate the backup sentinel with some meaningful info about the created backup.

Example of the new sentinel:
```
{
  "restore_point": "backup_20210804T130701Z",
  "segments": [
    {
      "db_id": 1,
      "content_id": -1,
      "role": "p",
      "port": 5432,
      "hostname": "gp6master",
      "data_dir": "/gpdata/master/gpseg-1",
      "backup_id": "4cc7e8c8-7506-4310-ac0f-d5fd40878645",
      "restore_point_lsn": "0/5C0000C8"
    },
    {
      "db_id": 2,
      "content_id": 0,
      "role": "p",
      "port": 6000,
      "hostname": "gp6segment1",
      "data_dir": "/gpdata/primary/gpseg0",
      "backup_id": "d6d4c084-b3b9-4cbe-bd0a-074517677c2e",
      "restore_point_lsn": "0/58000090"
    },
    {
      "db_id": 3,
      "content_id": 1,
      "role": "p",
      "port": 6001,
      "hostname": "gp6segment1",
      "data_dir": "/gpdata/primary/gpseg1",
      "backup_id": "0b14c687-709f-4d41-a9bc-0a7557c6ff4a",
      "restore_point_lsn": "0/580000C8"
    },
    {
      "db_id": 4,
      "content_id": 2,
      "role": "p",
      "port": 6002,
      "hostname": "gp6segment1",
      "data_dir": "/gpdata/primary/gpseg2",
      "backup_id": "e8279219-69f8-4f72-b652-0fcdefb07cbd",
      "restore_point_lsn": "0/580000C8"
    },
    {
      "db_id": 5,
      "content_id": 3,
      "role": "p",
      "port": 6003,
      "hostname": "gp6segment1",
      "data_dir": "/gpdata/primary/gpseg3",
      "backup_id": "bcce04bd-fd33-4c7e-9cd7-2c9822350194",
      "restore_point_lsn": "0/58000090"
    }
  ]
}
```