### PR TITLE
Always prevent overwrite of .history files

### DIFF
--- a/docker/pg_tests/scripts/tests/test_functions/test_full_backup.sh
+++ b/docker/pg_tests/scripts/tests/test_functions/test_full_backup.sh
@@ -36,6 +36,21 @@ test_full_backup()
   echo "Full backup success!!!!!!"
 
   # Also we test here WAL overwrite prevention as a part of regular backup functionality
+  # First test that .history files prevent overwrite even if WALG_PREVENT_WAL_OVERWRITE is false
+
+  export WALG_PREVENT_WAL_OVERWRITE=false
+
+  echo test > ${PGDATA}/pg_wal/test_file.history
+  wal-g --config=${TMP_CONFIG} wal-push ${PGDATA}/pg_wal/test_file.history
+  wal-g --config=${TMP_CONFIG} wal-push ${PGDATA}/pg_wal/test_file.history
+
+  echo test1 > ${PGDATA}/pg_wal/test_file.history
+  wal-g --config=${TMP_CONFIG} wal-push ${PGDATA}/pg_wal/test_file && EXIT_STATUS=$? || EXIT_STATUS=$?
+
+  if [ "$EXIT_STATUS" -eq 0 ] ; then
+      echo "Error: Duplicate .history with different content was pushed"
+      exit 1
+  fi
 
   export WALG_PREVENT_WAL_OVERWRITE=true
 

--- a/internal/databases/postgres/wal_push_handler.go
+++ b/internal/databases/postgres/wal_push_handler.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/wal-g/wal-g/internal"
 
@@ -48,7 +49,8 @@ func HandleWALPush(uploader *WalUploader, walFilePath string) {
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	totalBgUploadedLimit := viper.GetInt32(internal.TotalBgUploadedLimit)
-	preventWalOverwrite := viper.GetBool(internal.PreventWalOverwriteSetting)
+	// .history files must not be overwritten, see https://github.com/wal-g/wal-g/issues/420
+	preventWalOverwrite := viper.GetBool(internal.PreventWalOverwriteSetting) || strings.HasSuffix(walFilePath, ".history")
 	readyRename := viper.GetBool(internal.PgReadyRename)
 
 	bgUploader := NewBgUploader(walFilePath, int32(concurrency-1), totalBgUploadedLimit-1, uploader, preventWalOverwrite, readyRename)


### PR DESCRIPTION
### Database name
Postgres

### Describe what this PR fix
Fixes #420 (wal-g should never overwrite .history files as postgres relies on overwrite detection in this case)

### Please provide steps to reproduce (if it's a bug)
With WALG_PREVENT_WAL_OVERWRITE=false, create a .history file, push it, change it, push it again. The second push should fail