### PR TITLE
Greenplum backup-fetch

### DIFF
--- a/cmd/gp/backup_fetch.go
+++ b/cmd/gp/backup_fetch.go
@@ -1,0 +1,76 @@
+package gp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+
+	"github.com/wal-g/wal-g/internal/databases/postgres"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+)
+
+const (
+	backupFetchShortDescription  = "Fetches a backup from storage"
+	targetUserDataDescription    = "Fetch storage backup which has the specified user data"
+	restoreConfigPathDescription = "Path to the cluster restore configuration"
+)
+
+var fetchTargetUserData string
+var restoreConfigPath string
+
+var backupFetchCmd = &cobra.Command{
+	Use:   "backup-fetch [backup_name | --target-user-data <data>]",
+	Short: backupFetchShortDescription, // TODO : improve description
+	Args:  cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if fetchTargetUserData == "" {
+			fetchTargetUserData = viper.GetString(internal.FetchTargetUserDataSetting)
+		}
+		targetBackupSelector, err := createTargetFetchBackupSelector(cmd, args, fetchTargetUserData)
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		folder, err := internal.ConfigureFolder()
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		file, err := ioutil.ReadFile(restoreConfigPath)
+		tracelog.ErrorLogger.FatalfOnError("Failed to open the provided restore config file: %v", err)
+
+		var restoreCfg greenplum.ClusterRestoreConfig
+		err = json.Unmarshal(file, &restoreCfg)
+		tracelog.ErrorLogger.FatalfOnError("Failed to unmarshal the provided restore config file: %v", err)
+
+		internal.HandleBackupFetch(folder, targetBackupSelector, greenplum.NewGreenplumBackupFetcher(restoreCfg))
+	},
+}
+
+// create the BackupSelector to select the backup to fetch
+func createTargetFetchBackupSelector(cmd *cobra.Command,
+	args []string, targetUserData string) (internal.BackupSelector, error) {
+	targetName := ""
+	if len(args) >= 1 {
+		targetName = args[0]
+	}
+
+	backupSelector, err := internal.NewTargetBackupSelector(targetUserData, targetName, postgres.NewGenericMetaFetcher())
+	if err != nil {
+		fmt.Println(cmd.UsageString())
+		return nil, err
+	}
+	return backupSelector, nil
+}
+
+func init() {
+	backupFetchCmd.Flags().StringVar(&fetchTargetUserData, "target-user-data",
+		"", targetUserDataDescription)
+	backupFetchCmd.Flags().StringVar(&restoreConfigPath, "restore-config",
+		"", restoreConfigPathDescription)
+	_ = backupFetchCmd.MarkFlagRequired("restore-config")
+
+	cmd.AddCommand(backupFetchCmd)
+}

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -1,0 +1,114 @@
+package greenplum
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type SegmentRestoreConfig struct {
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port"`
+	DataDir  string `json:"data_dir"`
+}
+
+// ClusterRestoreConfig is used to describe the restored cluster
+type ClusterRestoreConfig struct {
+	Segments map[int]SegmentRestoreConfig `json:"segments"`
+}
+
+type FetchHandler struct {
+	cluster             *cluster.Cluster
+	backupIDByContentID map[int]string
+}
+
+func NewFetchHandler(sentinel BackupSentinelDto, restoreCfg ClusterRestoreConfig) *FetchHandler {
+	backupIDByContentID := make(map[int]string)
+	segmentConfigs := make([]cluster.SegConfig, 0)
+
+	for _, segMeta := range sentinel.Segments {
+		if segMeta.Role == Primary {
+			backupIDByContentID[segMeta.ContentID] = segMeta.BackupID
+			segmentCfg := segMeta.ToSegConfig()
+			segRestoreCfg, ok := restoreCfg.Segments[segMeta.ContentID]
+			if !ok {
+				tracelog.ErrorLogger.Fatalf(
+					"Could not find content ID %d in the provided restore configuration", segMeta.ContentID)
+			}
+			segmentCfg.Hostname = segRestoreCfg.Hostname
+			segmentCfg.Port = segRestoreCfg.Port
+			segmentCfg.DataDir = segRestoreCfg.DataDir
+			segmentConfigs = append(segmentConfigs, segmentCfg)
+		} else {
+			// currently, WAL-G does not restore the mirrors
+			tracelog.WarningLogger.Printf(
+				"Skipping non-primary segment: DatabaseID %d, Hostname %s, DataDir: %s\n", segMeta.DatabaseID, segMeta.Hostname, segMeta.DataDir)
+		}
+	}
+	gplog.InitializeLogging("wal-g", "")
+
+	globalCluster := cluster.NewCluster(segmentConfigs)
+	tracelog.DebugLogger.Printf("cluster %v\n", globalCluster)
+
+	return &FetchHandler{
+		cluster:             globalCluster,
+		backupIDByContentID: backupIDByContentID,
+	}
+}
+
+func (fh *FetchHandler) Fetch() error {
+	remoteOutput := fh.cluster.GenerateAndExecuteCommand("Running wal-g",
+		cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER,
+		func(contentID int) string {
+			return fh.buildCommand(contentID)
+		})
+
+	fh.cluster.CheckClusterError(remoteOutput, "Unable to run wal-g", func(contentID int) string {
+		return "Unable to run wal-g"
+	})
+
+	for _, command := range remoteOutput.Commands {
+		tracelog.DebugLogger.Printf("WAL-G output (segment %d):\n%s\n", command.Content, command.Stderr)
+	}
+	return nil
+}
+
+func (fh *FetchHandler) buildCommand(contentID int) string {
+	segment := fh.cluster.ByContent[contentID][0]
+	backupID, ok := fh.backupIDByContentID[contentID]
+	if !ok {
+		// this should never happen
+		tracelog.ErrorLogger.Fatalf("Failed to load backup id by content id")
+	}
+
+	segUserData := NewSegmentUserDataFromID(backupID)
+	cmd := []string{
+		"WALG_LOG_LEVEL=DEVEL",
+		fmt.Sprintf("PGPORT=%d", segment.Port),
+		"wal-g pg",
+		fmt.Sprintf("backup-fetch %s", segment.DataDir),
+		fmt.Sprintf("--walg-storage-prefix=%d", segment.ContentID),
+		fmt.Sprintf("--target-user-data=%s", segUserData.QuotedString()),
+		fmt.Sprintf("--config=%s", internal.CfgFile),
+	}
+
+	cmdLine := strings.Join(cmd, " ")
+	tracelog.DebugLogger.Printf("Command to run on segment %d: %s", contentID, cmdLine)
+	return cmdLine
+}
+
+func NewGreenplumBackupFetcher(restoreCfg ClusterRestoreConfig) func(folder storage.Folder, backup internal.Backup) {
+	return func(folder storage.Folder, backup internal.Backup) {
+		var sentinel BackupSentinelDto
+		err := backup.FetchSentinel(&sentinel)
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		err = NewFetchHandler(sentinel, restoreCfg).Fetch()
+		tracelog.ErrorLogger.FatalOnError(err)
+	}
+}

--- a/internal/databases/greenplum/pg_hba_cfg_maker.go
+++ b/internal/databases/greenplum/pg_hba_cfg_maker.go
@@ -1,0 +1,89 @@
+package greenplum
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+)
+
+const pgHbaTemplate = `
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/24            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+#local   replication     gpadmin                                trust
+#host    replication     gpadmin        127.0.0.1/32            trust
+#host    replication     gpadmin        ::1/128                 trust
+host    all             all             localhost               trust
+`
+
+func NewPgHbaMaker(segments map[int][]*cluster.SegConfig) PgHbaMaker {
+	return PgHbaMaker{segments: segments}
+}
+
+type PgHbaMaker struct {
+	segments map[int][]*cluster.SegConfig
+}
+
+func (m PgHbaMaker) Make() (string, error) {
+	pgHbaRows := []string{pgHbaTemplate}
+
+	masters, ok := m.segments[-1]
+	if !ok {
+		return "", errors.New("failed to make pg_hba: no master segment exists")
+	}
+
+	// add entries for both master primary and standby hosts
+	for _, cfg := range masters {
+		row := fmt.Sprintf("host    all             all             %s              trust", cfg.Hostname)
+		pgHbaRows = append(pgHbaRows, row)
+	}
+
+	primarySegments := make([]*cluster.SegConfig, 0)
+	for _, configs := range m.segments {
+		for _, config := range configs {
+			if config.ContentID == -1 {
+				break // we are not interested in mdw segments
+			}
+
+			if SegmentRole(config.Role) == Primary {
+				primarySegments = append(primarySegments, config)
+			}
+		}
+	}
+
+	writtenHosts := make(map[string]bool)
+	// add entries for sdwN primary segments (w/o master hosts)
+	for _, primary := range primarySegments {
+		if writtenHosts[primary.Hostname] {
+			continue // do not write duplicate entries
+		}
+		row := fmt.Sprintf("host    all             gpadmin         %s              trust", primary.Hostname)
+		writtenHosts[primary.Hostname] = true
+		pgHbaRows = append(pgHbaRows, row)
+	}
+
+	// add entries for replication
+	pgHbaRows = append(pgHbaRows, "host    replication     gpadmin         samehost                trust")
+
+	writtenHosts = make(map[string]bool)
+	// add entries for sdwN primary segments (w/o master hosts)
+	for _, primary := range primarySegments {
+		if writtenHosts[primary.Hostname] {
+			continue // do not write duplicate entries
+		}
+		row := fmt.Sprintf("host    replication     gpadmin         %s              trust", primary.Hostname)
+		writtenHosts[primary.Hostname] = true
+		pgHbaRows = append(pgHbaRows, row)
+	}
+
+	return strings.Join(pgHbaRows, "\n"), nil
+}

--- a/internal/databases/greenplum/pg_hba_cfg_maker_test.go
+++ b/internal/databases/greenplum/pg_hba_cfg_maker_test.go
@@ -1,3 +1,51 @@
-package greenplum
+package greenplum_test
 
-//todo
+import (
+	"testing"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+)
+
+func TestGeneratePgHbaConf(t *testing.T) {
+	segments := map[int][]*cluster.SegConfig{
+		-1: {{
+			DbID:      1,
+			ContentID: -1,
+			Role:      "p",
+			Port:      5432,
+			Hostname:  "mdw",
+			DataDir:   "/path/to/gpseg-1",
+		}},
+		0: {{
+			DbID:      2,
+			ContentID: 0,
+			Role:      "p",
+			Port:      6000,
+			Hostname:  "sdw1",
+			DataDir:   "/path/to/gpseg0",
+		}},
+		1: {{
+			DbID:      3,
+			ContentID: 1,
+			Role:      "p",
+			Port:      6001,
+			Hostname:  "sdw2",
+			DataDir:   "/path/to/gpseg1",
+		}},
+	}
+	expectedOutput := greenplum.PgHbaTemplate + `
+host    all             all             mdw              trust
+host    all             gpadmin         sdw1              trust
+host    all             gpadmin         sdw2              trust
+host    replication     gpadmin         samehost                trust
+host    replication     gpadmin         sdw1              trust
+host    replication     gpadmin         sdw2              trust`
+
+	pgHbaMaker := greenplum.NewPgHbaMaker(segments)
+	output, err := pgHbaMaker.Make()
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedOutput, output, "generated pg_hba.conf does not match the expected one")
+}

--- a/internal/databases/greenplum/pg_hba_cfg_maker_test.go
+++ b/internal/databases/greenplum/pg_hba_cfg_maker_test.go
@@ -1,0 +1,3 @@
+package greenplum
+
+//todo

--- a/internal/databases/greenplum/recovery_cfg_maker.go
+++ b/internal/databases/greenplum/recovery_cfg_maker.go
@@ -1,0 +1,29 @@
+package greenplum
+
+import (
+	"fmt"
+	"strings"
+)
+
+func NewRecoveryConfigMaker(walgBinaryPath, cfgPath, recoveryTargetName string) RecoveryConfigMaker {
+	return RecoveryConfigMaker{
+		walgBinaryPath:     walgBinaryPath,
+		cfgPath:            cfgPath,
+		recoveryTargetName: recoveryTargetName,
+	}
+}
+
+type RecoveryConfigMaker struct {
+	walgBinaryPath     string
+	cfgPath            string
+	recoveryTargetName string
+}
+
+func (m RecoveryConfigMaker) Make(contentID int) string {
+	restoreCmd := fmt.Sprintf(
+		"restore_command = '%s pg wal-fetch \"%%f\" \"%%p\" --walg-storage-prefix=%d --config %s'",
+		m.walgBinaryPath, contentID, m.cfgPath)
+	recoveryTarget := fmt.Sprintf("recovery_target_name = '%s'", m.recoveryTargetName)
+
+	return strings.Join([]string{restoreCmd, recoveryTarget}, "\n")
+}

--- a/internal/databases/greenplum/recovery_cfg_maker_test.go
+++ b/internal/databases/greenplum/recovery_cfg_maker_test.go
@@ -1,3 +1,21 @@
-package greenplum
+package greenplum_test
 
-//todo
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+)
+
+func TestGenerateRecoveryConf(t *testing.T) {
+	walgPath := "/usr/bin/wal-g"
+	cfgPath := "/etc/wal-g/wal-g.yaml"
+	recoveryTargetName := "some_backup"
+	recCfgMaker := greenplum.NewRecoveryConfigMaker(walgPath, cfgPath, recoveryTargetName)
+	contentId := -1
+
+	expectedCfg := `restore_command = '/usr/bin/wal-g pg wal-fetch "%f" "%p" --walg-storage-prefix=-1 --config /etc/wal-g/wal-g.yaml'
+recovery_target_name = 'some_backup'`
+	actualCfg := recCfgMaker.Make(contentId)
+	assert.Equal(t, expectedCfg, actualCfg, "Actual recovery.conf does not match the expected one")
+}

--- a/internal/databases/greenplum/recovery_cfg_maker_test.go
+++ b/internal/databases/greenplum/recovery_cfg_maker_test.go
@@ -1,0 +1,3 @@
+package greenplum
+
+//todo

--- a/internal/databases/postgres/bundle_test.go
+++ b/internal/databases/postgres/bundle_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/compression"
 	"github.com/wal-g/wal-g/internal/compression/lz4"
+	"github.com/wal-g/wal-g/internal/walparser"
 	"github.com/wal-g/wal-g/pkg/storages/memory"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
-	"github.com/wal-g/wal-g/internal/walparser"
 	"github.com/wal-g/wal-g/testtools"
 	"github.com/wal-g/wal-g/utility"
 )

--- a/internal/databases/postgres/delta_file_manager_test.go
+++ b/internal/databases/postgres/delta_file_manager_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wal-g/wal-g/pkg/storages/memory"
 	"github.com/wal-g/wal-g/internal/walparser"
+	"github.com/wal-g/wal-g/pkg/storages/memory"
 	"github.com/wal-g/wal-g/testtools"
 )
 

--- a/testtools/util.go
+++ b/testtools/util.go
@@ -19,10 +19,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/fsutil"
+	"github.com/wal-g/wal-g/internal/walparser"
 	"github.com/wal-g/wal-g/pkg/storages/memory"
 	"github.com/wal-g/wal-g/pkg/storages/s3"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
-	"github.com/wal-g/wal-g/internal/walparser"
 	"github.com/wal-g/wal-g/test/mocks"
 	"github.com/wal-g/wal-g/utility"
 )


### PR DESCRIPTION
Add MVP implementation of Greenplum backup-fetch.

Usage:
```
wal-g backup-fetch LATEST --restore-config /path/to/restore.json --config /path/to/wal-g.yaml
```

`backup-fetch` requires a backup config which declares where (host, folder) each segment should be restored. It is required that the config with path /path/to/wal-g.yaml should be available on the each host.

Sample restore config:
```
{
        "segments": {
                "-1": {
                        "hostname": "gp6master",
                        "port": 5432,
                        "data_dir": "/gpdata/master/gpseg-1"
                },
                "0": {
                        "hostname": "gp6segment1",
                        "port": 6000,
                        "data_dir": "/gpdata/primary/gpseg0"
                },
                "1": {
                        "hostname": "gp6segment1",
                        "port": 6001,
                        "data_dir": "/gpdata/primary/gpseg1"
                },
                "2": {
                        "hostname": "gp6segment1",
                        "port": 6002,
                        "data_dir": "/gpdata/primary/gpseg2"
                },
                "3": {
                        "hostname": "gp6segment1",
                        "port": 6003,
                        "data_dir": "/gpdata/primary/gpseg3"
                }
        }
}
```