### PR TITLE
AZURE_STORAGE_SAS_TOKEN: prepend a ? when not included in token

### DIFF
--- a/pkg/storages/azure/folder.go
+++ b/pkg/storages/azure/folder.go
@@ -68,6 +68,11 @@ func ConfigureFolder(prefix string, settings map[string]string) (storage.Folder,
 		if accountToken, usingToken = settings[SasTokenSetting]; !usingToken {
 			return nil, NewCredentialError(AccessKeySetting)
 		}
+
+		// Tokens may or may not begin with ?, normalize these cases
+		if !strings.HasPrefix(accountToken, "?") {
+			accountToken = "?" + accountToken
+		}
 	}
 	if environmentName, ok = settings[EnvironmentName]; !ok {
 		environmentName = defaultEnvName


### PR DESCRIPTION
I originally understood the ? to be part of the token,
but it turns out most SAS token libraries don't include it

Fixes #1034