### PR TITLE
postgres/backup_push_handler: handle database's data directory being a symlink when comparing to supplied data directory

### DIFF
--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -311,9 +311,10 @@ func (bh *BackupHandler) HandleBackupPush() {
 		return
 	}
 
-	if utility.ResolveSymlink(bh.arguments.pgDataDirectory) != bh.pgInfo.pgDataDirectory {
-		tracelog.ErrorLogger.Panicf("Data directory read from Postgres (%s) is different then as parsed (%s).",
-			bh.arguments.pgDataDirectory, bh.pgInfo.pgDataDirectory)
+	resolvedDataDirectory := utility.ResolveSymlink(bh.pgInfo.pgDataDirectory)
+	if utility.ResolveSymlink(bh.arguments.pgDataDirectory) != resolvedDataDirectory {
+		tracelog.ErrorLogger.Panicf("Data directory read from Postgres (%s) is different than as parsed (%s).",
+			bh.arguments.pgDataDirectory, resolvedDataDirectory)
 	}
 	bh.checkPgVersionAndPgControl()
 

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -128,7 +128,7 @@ func ResolveSymlink(path string) string {
 	resolve, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		// TODO: Consider descriptive panic here and other checks
-		// Directory may be absent et c.
+		// Directory may be absent etc.
 		return path
 	}
 	return resolve


### PR DESCRIPTION
### Database name
postgres

# Pull request description
#780 introduced a check that the supplied directory to `wal-g backup-push` matched `show data_directory` in postgres, resolving symlinks passed as a parameter. However, it failed to consider the case when `show data_directory` itself is a symlink

### Please provide steps to reproduce (if it's a bug)
Create a pg database with its data directory in a symlink. Pushing a backup will fail, for example

```
> sudo -u postgres -- /usr/local/pgsql-13/bin/wal-g-push backup-push /var/lib/pgsql/13/data
INFO: 2021/08/09 22:05:05.622486 Selecting the latest backup as the base for the current delta backup...
ERROR: 2021/08/09 22:05:05.638626 Data directory read from Postgres (/var/lib/pgsql/13/data) is different then as parsed (/var/lib/pgsql/13/data).
panic: Data directory read from Postgres (/var/lib/pgsql/13/data) is different then as parsed (/var/lib/pgsql/13/data).
```