### PR TITLE
Fix libsodium missing from GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   GO_VERSION: 1.15
+  USE_LIBSODIUM: 1
 
 jobs:
   release-ubuntu:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,7 @@
 name: Unit tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/internal/configure_crypter.go
+++ b/internal/configure_crypter.go
@@ -14,9 +14,19 @@ package internal
 // If there is a tag, we can configure the correct implementation of crypter.
 
 import (
+	"github.com/spf13/viper"
+	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/crypto"
 )
 
 func configureLibsodiumCrypter() crypto.Crypter {
+	if viper.IsSet(LibsodiumKeySetting) {
+		tracelog.ErrorLogger.Fatalf("non-empty WALG_LIBSODIUM_KEY but wal-g was not compiled with libsodium")
+	}
+
+	if viper.IsSet(LibsodiumKeyPathSetting) {
+		tracelog.ErrorLogger.Fatalf("non-empty WALG_LIBSODIUM_KEY_PATH but wal-g was not compiled with libsodium")
+	}
+
 	return nil
 }


### PR DESCRIPTION
This PR fixes a security issue with wal-g that the binary releases published as GitHub Releases are built without libsodium support and silently ignore user requests to use libsodium encryption. The three commits in this PR:

* Enable libsodium in the GitHub release builds.
* Exit with failure if the user requests to use libsodium encryption but the application was not compiled with libsodium support.
* Enables manual triggering of unit tests GitHub Action (not really related but was helpful for testing)

The security issue is that a user would expect that their backup files are encrypted but they're silently processed and uploaded as plaintext. The exit-with-failure piece checks if either WALG_LIBSODIUM_KEY or WALG_LIBSODIUM_KEY_PATH are specified and if the binary was not compiled with libsodium support, then it prints an error and immediately exits.

This will be a breaking change for anybody using the GitHub Release binaries who specify libsodium keys on their primary (performing the uploads) but do not include them in their replicas. Previously everything was handled as plaintext so the replicas would have been able to read the primary's plaintext backups. After including this fix, the primary will be uploading encrypted files but any replicas that are missing the libsodium keys will no longer be able to read them unless they also have the same environment variables specified for the libsodium keys (so users need to make sure all their servers are in sync for libsodium usage).

Longer term I think it'd be simpler if there was a single way to specify how to handle encryption. Right now it's a series of if-then-else logic that checks against a bunch of different environment variables, e.g. there's WALG_GPG_KEY_ID, WALG_PGP_KEY, WALG_LIBSODIUM_KEY... If more than one is defined than the one that is picked is based upon the if-then-else order.

A single environment variable, e.g. WALG_ENCRYPTION, could instead be used for both the encryption mechanism and where to look for key material. That way it's explicit and a user indicating a given mechanism knows for sure that's what shall be used, or the app could fail if it's not possible (e.g. no compiled support for the requested mechanism).

That'd be a separate, possibly breaking change, so just leaving it here for future discussion.