### PR TITLE
Add get/put/rm to storage tools

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -120,6 +120,7 @@ jobs:
                    'make MYSQL_TEST=mysql_delete_tests mysql_integration_test',
                    'make MYSQL_TEST=mysql_copy_tests mysql_integration_test',
                    'make gp_test',
+                   'make st_test',
       ]
       # do not cancel all tests if one failed
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,12 @@ gp_integration_test: load_docker_common
 	docker-compose build gp gp_tests
 	docker-compose up --exit-code-from gp_tests gp_tests
 
+st_test: deps pg_build unlink_brotli st_integration_test
+
+st_integration_test: load_docker_common
+	docker-compose build st_tests
+	docker-compose up --exit-code-from st_tests st_tests
+
 unittest:
 	go list ./... | grep -Ev 'vendor|submodules|tmp' | xargs go vet
 	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/

--- a/cmd/st/delete_object.go
+++ b/cmd/st/delete_object.go
@@ -1,0 +1,27 @@
+package st
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/storagetools"
+)
+
+const deleteObjectShortDescription = "Delete the specified storage object"
+
+// deleteObjectCmd represents the deleteObject command
+var deleteObjectCmd = &cobra.Command{
+	Use:   "rm relative_object_path",
+	Short: deleteObjectShortDescription,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		folder, err := internal.ConfigureFolder()
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		storagetools.HandleDeleteObject(args[0], folder)
+	},
+}
+
+func init() {
+	StorageToolsCmd.AddCommand(deleteObjectCmd)
+}

--- a/cmd/st/get_object.go
+++ b/cmd/st/get_object.go
@@ -1,8 +1,6 @@
 package st
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -12,8 +10,8 @@ import (
 const (
 	getObjectShortDescription = "Download the specified storage object"
 
-	downloadModeFlag      = "mode"
-	downloadModeShorthand = "m"
+	noDecryptFlag    = "no-decrypt"
+	noDecompressFlag = "no-decompress"
 )
 
 // getObjectCmd represents the getObject command
@@ -28,30 +26,15 @@ var getObjectCmd = &cobra.Command{
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		mode, err := ParseDownloadMode(downloadModeRaw)
-		tracelog.ErrorLogger.FatalOnError(err)
-
-		storagetools.HandleGetObject(objectPath, dstPath, folder, mode)
+		storagetools.HandleGetObject(objectPath, dstPath, folder, !noDecrypt, !noDecompress)
 	},
 }
 
-var downloadModeRaw string
-
-func ParseDownloadMode(mode string) (storagetools.DownloadMode, error) {
-	switch mode {
-	case "raw":
-		return storagetools.DownloadRaw, nil
-	case "decrypt":
-		return storagetools.DownloadDecrypt, nil
-	case "decompress":
-		return storagetools.DownloadDecompress, nil
-	default:
-		return "", fmt.Errorf("unknown download mode: %s", mode)
-	}
-}
+var noDecrypt bool
+var noDecompress bool
 
 func init() {
 	StorageToolsCmd.AddCommand(getObjectCmd)
-	getObjectCmd.Flags().StringVarP(&downloadModeRaw, downloadModeFlag, downloadModeShorthand,
-		"raw", "Download mode: raw/decrypt/decompress")
+	getObjectCmd.Flags().BoolVar(&noDecrypt, noDecryptFlag, false, "Do not noDecrypt the object")
+	getObjectCmd.Flags().BoolVar(&noDecompress, noDecompressFlag, false, "Do not noDecompress the object")
 }

--- a/cmd/st/get_object.go
+++ b/cmd/st/get_object.go
@@ -1,0 +1,57 @@
+package st
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/storagetools"
+)
+
+const (
+	getObjectShortDescription = "Download the specified storage object"
+
+	downloadModeFlag      = "mode"
+	downloadModeShorthand = "m"
+)
+
+// getObjectCmd represents the getObject command
+var getObjectCmd = &cobra.Command{
+	Use:   "get relative_object_path destination_path",
+	Short: getObjectShortDescription,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		objectPath := args[0]
+		dstPath := args[1]
+
+		folder, err := internal.ConfigureFolder()
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		mode, err := ParseDownloadMode(downloadModeRaw)
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		storagetools.HandleGetObject(objectPath, dstPath, folder, mode)
+	},
+}
+
+var downloadModeRaw string
+
+func ParseDownloadMode(mode string) (storagetools.DownloadMode, error) {
+	switch mode {
+	case "raw":
+		return storagetools.DownloadRaw, nil
+	case "decrypt":
+		return storagetools.DownloadDecrypt, nil
+	case "decompress":
+		return storagetools.DownloadDecompress, nil
+	default:
+		return "", fmt.Errorf("unknown download mode: %s", mode)
+	}
+}
+
+func init() {
+	StorageToolsCmd.AddCommand(getObjectCmd)
+	getObjectCmd.Flags().StringVarP(&downloadModeRaw, downloadModeFlag, downloadModeShorthand,
+		"raw", "Download mode: raw/decrypt/decompress")
+}

--- a/cmd/st/get_object.go
+++ b/cmd/st/get_object.go
@@ -35,6 +35,6 @@ var noDecompress bool
 
 func init() {
 	StorageToolsCmd.AddCommand(getObjectCmd)
-	getObjectCmd.Flags().BoolVar(&noDecrypt, noDecryptFlag, false, "Do not noDecrypt the object")
-	getObjectCmd.Flags().BoolVar(&noDecompress, noDecompressFlag, false, "Do not noDecompress the object")
+	getObjectCmd.Flags().BoolVar(&noDecrypt, noDecryptFlag, false, "Do not decrypt the object")
+	getObjectCmd.Flags().BoolVar(&noDecompress, noDecompressFlag, false, "Do not decompress the object")
 }

--- a/cmd/st/put_object.go
+++ b/cmd/st/put_object.go
@@ -10,6 +10,8 @@ import (
 const (
 	putObjectShortDescription = "Upload the specified file to the storage"
 
+	noEncryptFlag      = "no-encrypt"
+	noCompressFlag     = "no-compress"
 	overwriteFlag      = "force"
 	overwriteShorthand = "f"
 )
@@ -26,14 +28,18 @@ var putObjectCmd = &cobra.Command{
 		localPath := args[0]
 		dstPath := args[1]
 
-		storagetools.HandlePutObject(localPath, dstPath, uploader, overwrite)
+		storagetools.HandlePutObject(localPath, dstPath, uploader, overwrite, !noEncrypt, !noCompress)
 	},
 }
 
+var noEncrypt bool
+var noCompress bool
 var overwrite bool
 
 func init() {
 	StorageToolsCmd.AddCommand(putObjectCmd)
+	putObjectCmd.Flags().BoolVar(&noEncrypt, noEncryptFlag, false, "Do not encrypt the object")
+	putObjectCmd.Flags().BoolVar(&noCompress, noCompressFlag, false, "Do not compress the object")
 	putObjectCmd.Flags().BoolVarP(&overwrite, overwriteFlag, overwriteShorthand,
 		false, "Overwrite the existing object")
 }

--- a/cmd/st/put_object.go
+++ b/cmd/st/put_object.go
@@ -1,0 +1,39 @@
+package st
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/storagetools"
+)
+
+const (
+	putObjectShortDescription = "Upload the specified file to the storage"
+
+	overwriteFlag      = "force"
+	overwriteShorthand = "f"
+)
+
+// putObjectCmd represents the putObject command
+var putObjectCmd = &cobra.Command{
+	Use:   "put local_path destination_path",
+	Short: putObjectShortDescription,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		uploader, err := internal.ConfigureUploader()
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		localPath := args[0]
+		dstPath := args[1]
+
+		storagetools.HandlePutObject(localPath, dstPath, uploader, overwrite)
+	},
+}
+
+var overwrite bool
+
+func init() {
+	StorageToolsCmd.AddCommand(putObjectCmd)
+	putObjectCmd.Flags().BoolVarP(&overwrite, overwriteFlag, overwriteShorthand,
+		false, "Overwrite the existing object")
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       &&  mkdir -p /export/mysqldeletebinlogs
       &&  mkdir -p /export/archivereadyrename
       &&  mkdir -p /export/gpfullbucket
+      &&  mkdir -p /export/storagetoolsbucket
       &&  /usr/bin/minio server /export'
 
   s3-another:
@@ -620,6 +621,19 @@ services:
       - docker/common/common_walg.env
     depends_on:
       - gp
+      - s3
+    links:
+      - s3
+
+  st_tests:
+    build:
+      dockerfile: docker/st_tests/Dockerfile
+      context: .
+    image: wal-g/st_tests
+    container_name: wal-g_st_tests
+    env_file:
+      - docker/common/common_walg.env
+    depends_on:
       - s3
     links:
       - s3

--- a/docker/st_tests/Dockerfile
+++ b/docker/st_tests/Dockerfile
@@ -1,0 +1,33 @@
+FROM wal-g/golang:latest as build
+
+WORKDIR /go/src/github.com/wal-g/wal-g
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends --no-install-suggests \
+    liblzo2-dev \
+    brotli
+
+RUN ls
+
+COPY go.mod go.mod
+COPY vendor/ vendor/
+COPY internal/ internal/
+COPY pkg/ pkg/
+COPY cmd/ cmd/
+COPY main/ main/
+COPY utility/ utility/
+
+RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
+        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
+    sed -i 's|\(#cgo LDFLAGS:\) .*|\1 -Wl,-Bstatic -llzo2 -Wl,-Bdynamic|' \
+        vendor/github.com/cyberdelia/lzo/lzo.go && \
+    cd main/pg && \
+    go build -mod vendor -race -o wal-g -tags "brotli lzo" -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+
+FROM wal-g/ubuntu:latest
+
+COPY --from=build /go/src/github.com/wal-g/wal-g/main/pg/wal-g /usr/bin
+
+COPY docker/st_tests/scripts/ /tmp
+
+CMD /tmp/tests/storage_tool_tests.sh

--- a/docker/st_tests/Dockerfile
+++ b/docker/st_tests/Dockerfile
@@ -4,8 +4,7 @@ WORKDIR /go/src/github.com/wal-g/wal-g
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends --no-install-suggests \
-    liblzo2-dev \
-    brotli
+    liblzo2-dev
 
 RUN ls
 
@@ -25,6 +24,8 @@ RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
     go build -mod vendor -race -o wal-g -tags "brotli lzo" -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
 
 FROM wal-g/ubuntu:latest
+
+RUN apt-get update && apt-get install --yes --no-install-recommends --no-install-suggests brotli
 
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/pg/wal-g /usr/bin
 

--- a/docker/st_tests/scripts/tests/storage_tool_tests.sh
+++ b/docker/st_tests/scripts/tests/storage_tool_tests.sh
@@ -26,7 +26,7 @@ wal-g st ls
 test "2" -eq "$(wal-g st ls | wc -l)"
 
 # WAL-G should be able to download the uploaded file
-wal-g st get -m decompress testfolder/testfile.br fetched_testfile
+wal-g st get testfolder/testfile.br fetched_testfile
 
 # Downloaded file should be identical to the original one
 diff testfile fetched_testfile

--- a/docker/st_tests/scripts/tests/storage_tool_tests.sh
+++ b/docker/st_tests/scripts/tests/storage_tool_tests.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e -x
+
+export WALE_S3_PREFIX=s3://storagetoolsbucket
+
+# Empty list on empty storage
+test "1" -eq "$(wal-g st ls | wc -l)"
+
+# Generate and upload some file to storage
+head -c 100M </dev/urandom >testfile
+wal-g st put testfile testfolder/testfile
+
+# Should not upload the duplicate file by default
+wal-g st put testfile testfolder/testfile && EXIT_STATUS=$? || EXIT_STATUS=$?
+
+if [ "$EXIT_STATUS" -eq 0 ] ; then
+    echo "Error: Duplicate object was uploaded without the -f flag"
+    exit 1
+fi
+
+# Should upload the duplicate file if -f flag is present
+wal-g st put testfile testfolder/testfile -f
+
+wal-g st ls
+# WAL-G should show the uploaded file in the wal-g st ls output
+test "2" -eq "$(wal-g st ls | wc -l)"
+
+# WAL-G should be able to download the uploaded file
+wal-g st get -m decompress testfolder/testfile.br fetched_testfile
+
+# Downloaded file should be identical to the original one
+diff testfile fetched_testfile
+
+# WAL-G should be able to delete the uploaded file
+wal-g st rm testfolder/testfile.br
+
+# Should get empty storage after file removal
+test "1" -eq "$(wal-g st ls | wc -l)"

--- a/docker/st_tests/scripts/tests/storage_tool_tests.sh
+++ b/docker/st_tests/scripts/tests/storage_tool_tests.sh
@@ -31,6 +31,12 @@ wal-g st get testfolder/testfile.br fetched_testfile
 # Downloaded file should be identical to the original one
 diff testfile fetched_testfile
 
+# WAL-G should be able to download the uploaded file without decompression
+wal-g st get testfolder/testfile.br uncompressed_testfile.br --no-decompress
+
+brotli --decompress uncompressed_testfile.br
+diff testfile uncompressed_testfile
+
 # WAL-G should be able to delete the uploaded file
 wal-g st rm testfolder/testfile.br
 

--- a/docker/st_tests/scripts/tests/storage_tool_tests.sh
+++ b/docker/st_tests/scripts/tests/storage_tool_tests.sh
@@ -30,15 +30,25 @@ wal-g st get testfolder/testfile.br fetched_testfile
 
 # Downloaded file should be identical to the original one
 diff testfile fetched_testfile
+rm fetched_testfile
 
 # WAL-G should be able to download the uploaded file without decompression
 wal-g st get testfolder/testfile.br uncompressed_testfile.br --no-decompress
 
 brotli --decompress uncompressed_testfile.br
 diff testfile uncompressed_testfile
+rm uncompressed_testfile
 
 # WAL-G should be able to delete the uploaded file
 wal-g st rm testfolder/testfile.br
 
 # Should get empty storage after file removal
 test "1" -eq "$(wal-g st ls | wc -l)"
+
+# Should upload the file uncompressed without error
+wal-g st put testfile testfolder/testfile --no-compress
+
+# Should download the file uncompressed without error
+wal-g st get testfolder/testfile uncompressed_file --no-decompress
+
+diff testfile uncompressed_file

--- a/docs/README.md
+++ b/docs/README.md
@@ -159,16 +159,37 @@ If `FIND_FULL` is specified, WAL-G will calculate minimum backup needed to keep 
 ``target FIND_FULL base_0000000100000000000000C9_D_0000000100000000000000C4`` delete delta backup and all delta backups with the same base backup
 
 ## Storage tools (danger zone)
-Storage tools allow interacting with the configured storage. Be aware that these commands can do potentially harmful operations and make sure that you know what you're doing.
+`wal-g st` command series allows interacting with the configured storage. Be aware that these commands can do potentially harmful operations and make sure that you know what you're doing.
 
 ### ``ls``
 Prints listing of the objects in the provided storage folder.
 
-Examples:
+``wal-g st ls`` get listing with all objects in the configured storage.
 
-``wal-g dh ls`` get listing with all objects in the configured storage.
+``wal-g st ls some_folder/some_subfolder`` get listing with all objects in the provided storage path.
 
-``wal-g dh ls some_folder/some_subfolder`` get listing with all objects in the provided storage path.
+### ``get``
+Download the specified storage object. It has 3 different download modes:
+
+1. `raw` (default) - download the remote object as it is (no decryption/decompression)
+2. `decrypt` - download and decrypt the remote object
+3. `decompress` - download, decrypt and decompress the remote object
+
+To specify the download mode, add the `-m [mode]` flag.
+
+``wal-g st get path/to/remote_file path/to/local_file`` download the file from storage.
+
+``wal-g st get path/to/remote_file path/to/local_file -m decrypt`` download and decrypt the file from storage.
+
+### ``rm``
+Remove the specified storage object.
+
+``wal-g st rm path/to/remote_file`` remove the file from storage.
+
+### ``put``
+Upload the specified file to the storage. 
+
+``wal-g st put path/to/local_file path/to/remote_file`` upload the local file to storage.
 
 **More commands are available for the chosen database engine. See it in [Databases](#databases)**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,6 +158,8 @@ If `FIND_FULL` is specified, WAL-G will calculate minimum backup needed to keep 
 
 ``target FIND_FULL base_0000000100000000000000C9_D_0000000100000000000000C4`` delete delta backup and all delta backups with the same base backup
 
+**More commands are available for the chosen database engine. See it in [Databases](#databases)**
+
 ## Storage tools (danger zone)
 `wal-g st` command series allows interacting with the configured storage. Be aware that these commands can do potentially harmful operations and make sure that you know what you're doing.
 
@@ -169,29 +171,35 @@ Prints listing of the objects in the provided storage folder.
 ``wal-g st ls some_folder/some_subfolder`` get listing with all objects in the provided storage path.
 
 ### ``get``
-Download the specified storage object. It has 3 different download modes:
+Download the specified storage object. By default, the command will try to apply the decompression and decryption (if configured).
 
-1. `raw` (default) - download the remote object as it is (no decryption/decompression)
-2. `decrypt` - download and decrypt the remote object
-3. `decompress` - download, decrypt and decompress the remote object
+Flags:
+1. Add `--no-decompress` to download the remote object without decompression
+2. Add `--no-decrypt` to download the remote object without decryption
 
-To specify the download mode, add the `-m [mode]` flag.
+Examples:
 
 ``wal-g st get path/to/remote_file path/to/local_file`` download the file from storage.
 
-``wal-g st get path/to/remote_file path/to/local_file -m decrypt`` download and decrypt the file from storage.
+``wal-g st get path/to/remote_file path/to/local_file --no-decrypt`` download the file from storage without decryption.
 
 ### ``rm``
 Remove the specified storage object.
 
+Example:
+
 ``wal-g st rm path/to/remote_file`` remove the file from storage.
 
 ### ``put``
-Upload the specified file to the storage. 
+Upload the specified file to the storage. By default, the command will try to apply the compression and encryption (if configured).
+
+Flags:
+1. Add `--no-compress` to upload the object without compression
+2. Add `--no-encrypt` to upload the object without encryption
+
+Example:
 
 ``wal-g st put path/to/local_file path/to/remote_file`` upload the local file to storage.
-
-**More commands are available for the chosen database engine. See it in [Databases](#databases)**
 
 Databases
 -----------

--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -19,6 +19,11 @@ func GetDecompressorByCompressor(compressor Compressor) Decompressor {
 }
 
 func FindDecompressor(fileExtension string) Decompressor {
+	// cut the leading '.' (e.g. ".lz4" => "lz4")
+	if len(fileExtension) > 0 && fileExtension[0] == '.' {
+		fileExtension = fileExtension[1:]
+	}
+
 	for _, decompressor := range Decompressors {
 		if decompressor.FileExtension() == fileExtension {
 			return decompressor

--- a/internal/storagetools/delete_object_handler.go
+++ b/internal/storagetools/delete_object_handler.go
@@ -1,0 +1,17 @@
+package storagetools
+
+import (
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+func HandleDeleteObject(objectPath string, folder storage.Folder) {
+	// some storages may not produce an error on deleting the non-existing object
+	exists, err := folder.Exists(objectPath)
+	tracelog.ErrorLogger.FatalfOnError("Failed to check object existence: %v", err)
+	if !exists {
+		tracelog.ErrorLogger.Fatalf("Object %s does not exist", objectPath)
+	}
+	err = folder.DeleteObjects([]string{objectPath})
+	tracelog.ErrorLogger.FatalfOnError("Failed to delete the specified object: %v", err)
+}

--- a/internal/storagetools/get_object_handler.go
+++ b/internal/storagetools/get_object_handler.go
@@ -67,7 +67,8 @@ func downloadObject(objectPath string, folder storage.Folder, fileWriter io.Writ
 		}
 
 		tracelog.WarningLogger.Printf(
-			"decompressor for extension '%s' was not found, will download uncompressed", fileExt)
+			"decompressor for extension '%s' was not found (supported methods: %v), will download uncompressed",
+			fileExt, compression.CompressingAlgorithms)
 	}
 
 	_, err = utility.FastCopy(fileWriter, objReadCloser)

--- a/internal/storagetools/get_object_handler.go
+++ b/internal/storagetools/get_object_handler.go
@@ -20,10 +20,13 @@ func HandleGetObject(objectPath, dstPath string, folder storage.Folder, decrypt,
 
 	dstFile, err := os.OpenFile(targetPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0640)
 	tracelog.ErrorLogger.FatalfOnError("Failed to open the destination file: %v", err)
-	defer dstFile.Close()
 
 	err = downloadObject(objectPath, folder, dstFile, decrypt, decompress)
-	tracelog.ErrorLogger.FatalfOnError("Failed to download the file: %v", err)
+	dstFile.Close()
+	if err != nil {
+		os.Remove(targetPath)
+		tracelog.ErrorLogger.Fatalf("Failed to download the file: %v", err)
+	}
 }
 
 func getTargetFilePath(dstPath string, fileName string) (string, error) {

--- a/internal/storagetools/get_object_handler.go
+++ b/internal/storagetools/get_object_handler.go
@@ -1,0 +1,105 @@
+package storagetools
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/compression"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
+)
+
+type DownloadMode string
+
+const (
+	DownloadRaw        DownloadMode = "raw"
+	DownloadDecompress DownloadMode = "decompress"
+	DownloadDecrypt    DownloadMode = "decrypt"
+)
+
+func HandleGetObject(objectPath, dstPath string, folder storage.Folder, mode DownloadMode) {
+	fileName := path.Base(objectPath)
+	targetPath, err := getTargetFilePath(dstPath, fileName)
+	tracelog.ErrorLogger.FatalfOnError("Failed to determine the destination path: %v", err)
+
+	dstFile, err := os.OpenFile(targetPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0666)
+	tracelog.ErrorLogger.FatalfOnError("Failed to open the destination file: %v", err)
+	defer dstFile.Close()
+
+	err = downloadObject(objectPath, folder, mode, dstFile)
+	tracelog.ErrorLogger.FatalfOnError("Failed to download the file: %v", err)
+}
+
+func getTargetFilePath(dstPath string, fileName string) (string, error) {
+	info, err := os.Stat(dstPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return dstPath, nil
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	if info.IsDir() {
+		return path.Join(dstPath, fileName), nil
+	}
+
+	return dstPath, nil
+}
+
+func downloadObject(objectPath string, folder storage.Folder, mode DownloadMode, fileWriter io.WriteCloser) error {
+	switch mode {
+	case DownloadDecrypt:
+		return decryptDownload(objectPath, folder, fileWriter)
+
+	case DownloadDecompress:
+		return decompressDownload(objectPath, folder, fileWriter)
+
+	default:
+		return rawDownload(objectPath, folder, fileWriter)
+	}
+}
+
+func rawDownload(objectPath string, folder storage.Folder, dstWriter io.Writer) error {
+	fileReadCloser, err := folder.ReadObject(objectPath)
+	if err != nil {
+		return err
+	}
+	defer fileReadCloser.Close()
+
+	_, err = utility.FastCopy(dstWriter, fileReadCloser)
+	return err
+}
+
+func decompressDownload(objectPath string, folder storage.Folder, dstWriter io.WriteCloser) error {
+	fileName := path.Base(objectPath)
+	fileExt := path.Ext(fileName)
+
+	decompressor := compression.FindDecompressor(fileExt)
+	if decompressor == nil {
+		tracelog.WarningLogger.Printf(
+			"decompressor for extension '%s' was not found, will download uncompressed", fileExt)
+		return rawDownload(objectPath, folder, dstWriter)
+	}
+
+	return internal.DownloadFile(folder, objectPath, fileExt, dstWriter)
+}
+
+func decryptDownload(objectPath string, folder storage.Folder, dstWriter io.Writer) error {
+	rawFileReadCloser, err := folder.ReadObject(objectPath)
+	if err != nil {
+		return err
+	}
+	defer rawFileReadCloser.Close()
+
+	fileReadCloser, err := internal.DecryptBytes(rawFileReadCloser)
+	if err != nil {
+		return err
+	}
+	_, err = utility.FastCopy(dstWriter, fileReadCloser)
+	return err
+}

--- a/internal/storagetools/put_object_handler.go
+++ b/internal/storagetools/put_object_handler.go
@@ -1,0 +1,51 @@
+package storagetools
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/wal-g/wal-g/utility"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/ioextensions"
+)
+
+func HandlePutObject(localPath, dstPath string, uploader *internal.Uploader, overwrite bool) {
+	checkOverwrite(dstPath, uploader, overwrite)
+
+	fileReadCloser := openLocalFile(localPath)
+	defer fileReadCloser.Close()
+
+	storageFolderPath := utility.SanitizePath(filepath.Dir(dstPath))
+	if storageFolderPath != "" {
+		folder := uploader.UploadingFolder
+		uploader.UploadingFolder = folder.GetSubFolder(storageFolderPath)
+	}
+
+	fileName := utility.SanitizePath(filepath.Base(dstPath))
+	err := uploader.UploadFile(ioextensions.NewNamedReaderImpl(fileReadCloser, fileName))
+	tracelog.ErrorLogger.FatalfOnError("Failed to upload: %v", err)
+}
+
+func checkOverwrite(dstPath string, uploader *internal.Uploader, overwrite bool) {
+	fullPath := dstPath + "." + uploader.Compressor.FileExtension()
+	exists, err := uploader.UploadingFolder.Exists(fullPath)
+	tracelog.ErrorLogger.FatalfOnError("Failed to check object existence: %v", err)
+	if exists && !overwrite {
+		tracelog.ErrorLogger.Fatalf("Object %s already exists. To overwrite it, add the -f flag.", fullPath)
+	}
+}
+
+func openLocalFile(localPath string) io.ReadCloser {
+	localFile, err := os.Open(localPath)
+	tracelog.ErrorLogger.FatalfOnError("Could not open the local file: %v", err)
+	fileInfo, err := localFile.Stat()
+	tracelog.ErrorLogger.FatalfOnError("Could not Stat() the local file: %v", err)
+	if fileInfo.IsDir() {
+		tracelog.ErrorLogger.Fatalf("Provided local path (%s) points to a directory, exiting", localPath)
+	}
+
+	return localFile
+}


### PR DESCRIPTION

### ``get``
Download the specified storage object. It has 3 different download modes:

1. `raw` (default) - download the remote object as it is (no decryption/decompression)
2. `decrypt` - download and decrypt the remote object
3. `decompress` - download, decrypt and decompress the remote object

To specify the download mode, add the `-m [mode]` flag.

``wal-g st get path/to/remote_file path/to/local_file`` download the file from storage.

``wal-g st get path/to/remote_file path/to/local_file -m decrypt`` download and decrypt the file from storage.

### ``rm``
Remove the specified storage object.

``wal-g st rm path/to/remote_file`` remove the file from storage.

### ``put``
Upload the specified file to the storage. 

``wal-g st put path/to/local_file path/to/remote_file`` upload the local file to storage.
