### PR TITLE
Fixed libsodium building on Illumos / Solaris.

### DIFF
--- a/link_libsodium.sh
+++ b/link_libsodium.sh
@@ -3,6 +3,7 @@
 set -e
 
 readonly CWD=$PWD
+readonly OS=$(uname)
 readonly LIBSODIUM_VERSION="1.0.17"
 
 test -d tmp/libsodium || mkdir -p tmp/libsodium
@@ -12,7 +13,13 @@ cd tmp/libsodium
 curl --retry 5 --retry-delay 0 -sL https://github.com/jedisct1/libsodium/releases/download/$LIBSODIUM_VERSION/libsodium-$LIBSODIUM_VERSION.tar.gz -o libsodium-$LIBSODIUM_VERSION.tar.gz
 tar xfz libsodium-$LIBSODIUM_VERSION.tar.gz --strip-components=1
 
-./configure --prefix $PWD
+CONFIGURE_ARGS="--prefix ${PWD}"
+if [[ "${OS}" == "SunOS" ]]; then
+  # On Illumos / Solaris libssp causes linking issues when building wal-g.
+  CONFIGURE_ARGS="${CONFIGURE_ARGS} --disable-ssp"
+fi      
+
+./configure ${CONFIGURE_ARGS}
 make && make check && make install
 
 # Remove shared libraries for using static


### PR DESCRIPTION
### Database name

PostgreSQL

# Pull request description

On Illumos / Solaris enabling libssp causes linking issues when building wal-g.

### Please provide steps to reproduce (if it's a bug)

Build WAL-G on Illumos (or Solaris).

### Please add config and wal-g stdout/stderr logs for debug purpose

Build fails with:

```
$ make pg_build
(cd main/pg && go build -mod vendor -tags "brotli libsodium" -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/pg.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/pg.gitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd/pg.walgVersion=`git tag -l --points-at HEAD`")
# github.com/wal-g/wal-g/internal/crypto/libsodium
Undefined                       first referenced
 symbol                             in file
__stack_chk_fail                    /root/wal-g/tmp/libsodium/lib/libsodium.a(libsodium_la-secretstream_xchacha20poly1305.o)
__stack_chk_guard                   /root/wal-g/tmp/libsodium/lib/libsodium.a(libsodium_la-secretstream_xchacha20poly1305.o)
ld: fatal: symbol referencing errors. No output written to $WORK/b236/_cgo_.o
collect2: error: ld returned 1 exit status
make: *** [Makefile:38: pg_build] Error 2
```
