### PR TITLE
Getting backup finish date from backup file.

### DIFF
--- a/internal/databases/sqlserver/log_restore_handler.go
+++ b/internal/databases/sqlserver/log_restore_handler.go
@@ -63,17 +63,17 @@ func HandleLogRestore(backupName string, untilTS string, dbnames []string, fromn
 			return err
 		}
 		urls := buildRestoreUrls(baseURL, blobs)
-		backup_metadata, err := ListBackupProperties(db, urls, baseURL)
+		backupMetadata, err := ListBackupProperties(db, urls, baseURL)
 		if err != nil {
 			return err
 		}
-		var dbbackup_metadata *BackupProperties
-		for _, dbbackup_metadata = range backup_metadata {
-			if dbbackup_metadata.DatabaseName == fromname {
+		var dbBackupMetadata *BackupProperties
+		for _, dbBackupMetadata = range backupMetadata {
+			if dbBackupMetadata.DatabaseName == fromname {
 				break
 			}
 		}
-		prevBackupFinishdate := dbbackup_metadata.BackupFinishDate
+		prevBackupFinishdate := dbBackupMetadata.BackupFinishDate
 		for _, logBackupName := range logs {
 			ok, err := doesLogBackupContainDB(folder, logBackupName, fromname)
 			if err != nil {
@@ -86,7 +86,14 @@ func HandleLogRestore(backupName string, untilTS string, dbnames []string, fromn
 					logBackupName, fromname)
 				continue
 			}
-			isLastOne, CurrentBackupFinishdate, err := restoreSingleLog(ctx, db, folder, logBackupName, dbname, fromname, stopAt, prevBackupFinishdate)
+			isLastOne, CurrentBackupFinishdate, err := restoreSingleLog(ctx,
+				db,
+				folder,
+				logBackupName,
+				dbname,
+				fromname,
+				stopAt,
+				prevBackupFinishdate)
 			if err != nil {
 				return err
 			}

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -441,7 +441,7 @@ type BackupProperties struct {
 	BackupFile        string
 }
 
-func ListBackupProperties(db *sql.DB, urls string, logBackupName string) ([]*BackupProperties, error) {
+func ListBackupProperties(db *sql.DB, urls string, backupName string) ([]*BackupProperties, error) {
 	var res []*BackupProperties
 	query := fmt.Sprintf("RESTORE HEADERONLY FROM %s", urls)
 	rows, err := db.Query(query)
@@ -472,7 +472,7 @@ func ListBackupProperties(db *sql.DB, urls string, logBackupName string) ([]*Bac
 			return nil, err
 		}
 		dbf.BackupURL = urls
-		dbf.BackupFile = logBackupName
+		dbf.BackupFile = backupName
 		res = append(res, &dbf)
 	}
 	return res, nil

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -441,7 +441,12 @@ type BackupProperties struct {
 	BackupFile        string
 }
 
-func GetBackupProperties(db *sql.DB, folder storage.Folder, logBackup bool, backupName string, databaseName string) ([]*BackupProperties, error) {
+func GetBackupProperties(db *sql.DB,
+	folder storage.Folder,
+	logBackup bool,
+	backupName string,
+	databaseName string,
+) ([]*BackupProperties, error) {
 	var res []*BackupProperties
 	var baseURL string
 	var basePath string

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -441,8 +441,22 @@ type BackupProperties struct {
 	BackupFile        string
 }
 
-func ListBackupProperties(db *sql.DB, urls string, backupName string) ([]*BackupProperties, error) {
+func GetBackupProperties(db *sql.DB, folder storage.Folder, logBackup bool, backupName string, databaseName string) ([]*BackupProperties, error) {
 	var res []*BackupProperties
+	var baseURL string
+	var basePath string
+	if logBackup {
+		baseURL = getLogBackupURL(backupName, databaseName)
+		basePath = getLogBackupPath(backupName, databaseName)
+	} else {
+		baseURL = getDatabaseBackupURL(backupName, databaseName)
+		basePath = getDatabaseBackupPath(backupName, databaseName)
+	}
+	blobs, err := listBackupBlobs(folder.GetSubFolder(basePath))
+	if err != nil {
+		return res, err
+	}
+	urls := buildRestoreUrls(baseURL, blobs)
 	query := fmt.Sprintf("RESTORE HEADERONLY FROM %s", urls)
 	rows, err := db.Query(query)
 	if err != nil {


### PR DESCRIPTION
Validating if stopat position falls into current log restore operation interval

### Database name
SQLSERVER
# Pull request description
Additional check per every log restore operation to make sure that stopat position is not left behind in the previous log or database backup. 
### Describe what this PR fix
This happens if we are trying to restore database to a point right after the full backup. Chances are that stopat position is in the full backup and when we are trying to apply the very first log backup we get and error that database is already rolled forward further that the stopat point.
### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
