### PR TITLE
wal-verify: warning instead of failure in case when no backups

### DIFF
--- a/internal/databases/postgres/integrity_check_runner.go
+++ b/internal/databases/postgres/integrity_check_runner.go
@@ -43,6 +43,7 @@ type IntegrityCheckRunner struct {
 	delayedSegmentRangeSize   int
 	walFolderFilenames        []string
 	timelineSwitchMap         map[WalSegmentNo]*TimelineHistoryRecord
+	noBackupsFound            bool
 }
 
 func NewIntegrityCheckRunner(
@@ -57,11 +58,13 @@ func NewIntegrityCheckRunner(
 		return IntegrityCheckRunner{}, errors.Wrap(err, "Failed to initialize timeline history map")
 	}
 
+	noBackupsFound := false
 	stopWalSegmentNo, err := getEarliestBackupStartSegmentNo(timelineSwitchMap, currentWalSegment.Timeline, rootFolder)
 	if err != nil {
 		tracelog.WarningLogger.Printf("Failed to detect earliest backup WAL segment no: '%v',"+
 			"will scan until the 0000000X0000000000000001 segment.\n", err)
 		stopWalSegmentNo = 1
+		noBackupsFound = true
 	}
 
 	// uploadingSegmentRangeSize is needed to determine max amount of missing WAL segments
@@ -78,6 +81,7 @@ func NewIntegrityCheckRunner(
 		delayedSegmentRangeSize:   viper.GetInt(internal.MaxDelayedSegmentsCount),
 		walFolderFilenames:        walFolderFilenames,
 		timelineSwitchMap:         timelineSwitchMap,
+		noBackupsFound:            noBackupsFound,
 	}, nil
 }
 
@@ -96,7 +100,7 @@ func (check IntegrityCheckRunner) Run() (WalVerifyCheckResult, error) {
 
 	integrityScanSegmentSequences := collapseSegmentsByStatusAndTimeline(segmentScanner.ScannedSegments)
 
-	return newWalIntegrityCheckResult(integrityScanSegmentSequences), nil
+	return check.newWalIntegrityCheckResult(integrityScanSegmentSequences), nil
 }
 
 func (check IntegrityCheckRunner) Type() WalVerifyCheckType {
@@ -107,16 +111,26 @@ func (check IntegrityCheckRunner) Type() WalVerifyCheckType {
 // StatusOk if there are no missing segments in storage
 // StatusWarning if storage contains some ProbablyUploading or ProbablyDelayed segments
 // StatusFailure if storage contains Lost segments
-func newWalIntegrityCheckResult(segmentSequences []*IntegrityScanSegmentSequence) WalVerifyCheckResult {
+func (check IntegrityCheckRunner) newWalIntegrityCheckResult(segmentSequences []*IntegrityScanSegmentSequence) WalVerifyCheckResult {
 	result := WalVerifyCheckResult{
 		Status:  StatusOk,
 		Details: IntegrityCheckDetails(segmentSequences),
 	}
+
+	prevFound := false
 	for _, row := range segmentSequences {
 		switch row.Status {
+		case Found:
+			prevFound = true
 		case Lost:
-			result.Status = StatusFailure
-			return result
+			if check.noBackupsFound && !prevFound {
+				// If there are no backups in storage, WAL-G can't determine the first segment to start the scan from.
+				// So, skip the first not found segment sequences instead of failing.
+				result.Status = StatusWarning
+			} else {
+				result.Status = StatusFailure
+				return result
+			}
 		case ProbablyDelayed, ProbablyUploading:
 			result.Status = StatusWarning
 		}

--- a/internal/databases/postgres/wal_verify_handler_test.go
+++ b/internal/databases/postgres/wal_verify_handler_test.go
@@ -59,7 +59,7 @@ func TestWalVerify_EmptyStorage(t *testing.T) {
 	storageSegments := make([]string, 0)
 
 	expectedIntegrityCheck := postgres.WalVerifyCheckResult{
-		Status: postgres.StatusFailure,
+		Status: postgres.StatusWarning,
 		Details: postgres.IntegrityCheckDetails{
 			{
 				TimelineID:    3,
@@ -118,7 +118,7 @@ func TestWalVerify_OnlyGarbageInStorage(t *testing.T) {
 	currentSegment, _ := postgres.NewWalSegmentDescription(currentSegmentName)
 
 	expectedIntegrityCheck := postgres.WalVerifyCheckResult{
-		Status: postgres.StatusFailure,
+		Status: postgres.StatusWarning,
 		Details: postgres.IntegrityCheckDetails{
 			{
 				TimelineID:    3,


### PR DESCRIPTION
If there are no backups in storage, WAL-G can't determine the first segment to start the scan from.
 So, skip the first not found segment sequences instead of failing:
 
```
~ # ./wal-g-test wal-verify timeline integrity --config /etc/wal-g/wal-g.yaml
INFO: 2021/08/24 15:06:12.259733 Current WAL segment: 0000002B000055D1000000E6
INFO: 2021/08/24 15:06:12.279406 Building check runner: timeline
INFO: 2021/08/24 15:06:12.279414 Running the check: timeline
INFO: 2021/08/24 15:06:12.279427 Building check runner: integrity
WARNING: 2021/08/24 15:06:12.304202 Failed to detect earliest backup WAL segment no: 'No backups found',will scan until the 0000000X0000000000000001 segment.
INFO: 2021/08/24 15:06:12.304216 Running the check: integrity
[wal-verify] integrity check status: WARNING
[wal-verify] integrity check details:
+-----+--------------------------+--------------------------+----------------+--------------+
| TLI | START                    | END                      | SEGMENTS COUNT |       STATUS |
+-----+--------------------------+--------------------------+----------------+--------------+
|  43 | 0000002B0000000000000001 | 0000002B000055D10000009B |        5624219 | MISSING_LOST |
|  43 | 0000002B000055D10000009C | 0000002B000055D1000000E5 |             74 |        FOUND |
+-----+--------------------------+--------------------------+----------------+--------------+
[wal-verify] timeline check status: OK
[wal-verify] timeline check details:
Highest timeline found in storage: 43
Current cluster timeline: 43
```