### PR TITLE
setting db to single_user mode to avoid blocking

### DIFF
--- a/internal/databases/sqlserver/backup_restore_handler.go
+++ b/internal/databases/sqlserver/backup_restore_handler.go
@@ -78,7 +78,10 @@ func restoreSingleDatabase(ctx context.Context,
 		return err
 	}
 	urls := buildRestoreUrls(baseURL, blobs)
-	sql := fmt.Sprintf("RESTORE DATABASE %s FROM %s WITH REPLACE, NORECOVERY", quoteName(dbname), urls)
+	sql := fmt.Sprintf(`IF EXISTS (SELECT 1 FROM sys.databases WHERE name = '%s')
+	ALTER DATABASE %s SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+	RESTORE DATABASE %s FROM %s WITH REPLACE, NORECOVERY;`,
+		dbname, quoteName(dbname), quoteName(dbname), urls)
 	if dbname != fromName {
 		files, err := listDatabaseFiles(db, urls)
 		if err != nil {


### PR DESCRIPTION
### Database name
SQLSERVER

# Pull request description
Kill database connections during database restore in case of replace.
### Describe what this PR fix
If we restore a database replacing the existing one, then, if there are open connections to it, then restore operation will be blocked.

### Please provide steps to reproduce (if it's a bug)
open a connection to a database and try to restore it from backup. Operation will timeout.
