### PR TITLE
[Greenplum] Add detailed info to the backup sentinel

### DIFF
--- a/docker/gp/Dockerfile
+++ b/docker/gp/Dockerfile
@@ -16,7 +16,7 @@ RUN ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 
 WORKDIR /usr/local/gpdb_src
 RUN locale-gen en_US.utf8
-RUN ./README.Ubuntu.bash
+RUN sed -i 's/apt-get install/DEBIAN_FRONTEND=noninteractive apt-get install/g' README.Ubuntu.bash && ./README.Ubuntu.bash
 
 WORKDIR /usr/local/gpdb_src
 RUN ./configure --with-perl --with-python --with-libxml --with-gssapi --prefix=/usr/local/gpdb_src > /dev/nul && \

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/google/uuid"
 
 	"github.com/blang/semver"
@@ -39,14 +41,18 @@ func NewSegmentUserDataFromID(backupID string) SegmentUserData {
 	return SegmentUserData{ID: backupID}
 }
 
-// QuotedString will do json.Marshal-ing followed by quoting in order to escape special control characters
-// in the resulting JSON so it can be transferred as the cmdline argument to a segment
-func (d SegmentUserData) QuotedString() string {
+func (d SegmentUserData) String() string {
 	b, err := json.Marshal(d)
 	if err != nil {
 		panic(err)
 	}
-	return strconv.Quote(string(b))
+	return string(b)
+}
+
+// QuotedString will do json.Marshal-ing followed by quoting in order to escape special control characters
+// in the resulting JSON so it can be transferred as the cmdline argument to a segment
+func (d SegmentUserData) QuotedString() string {
+	return strconv.Quote(d.String())
 }
 
 // SegmentFwdArg describes the specific WAL-G
@@ -64,8 +70,12 @@ type BackupWorkers struct {
 
 // CurBackupInfo holds all information that is harvest during the backup process
 type CurBackupInfo struct {
-	backupName     string
-	segmentBackups map[string]*cluster.SegConfig
+	backupName       string
+	segmentBackups   map[string]*cluster.SegConfig
+	startTime        time.Time
+	systemIdentifier *uint64
+	gpVersion        semver.Version
+	segmentsMetadata map[string]postgres.ExtendedMetadataDto
 }
 
 // BackupHandler is the main struct which is handling the backup process
@@ -102,6 +112,7 @@ func (bh *BackupHandler) buildCommand(contentID int) string {
 // HandleBackupPush handles the backup being read from filesystem and being pushed to the repository
 func (bh *BackupHandler) HandleBackupPush() {
 	bh.curBackupInfo.backupName = "backup_" + time.Now().Format(utility.BackupTimeFormat)
+	bh.curBackupInfo.startTime = utility.TimeNowCrossPlatformUTC()
 
 	tracelog.InfoLogger.Println("Running wal-g on segments")
 	gplog.InitializeLogging("wal-g", "")
@@ -123,15 +134,25 @@ func (bh *BackupHandler) HandleBackupPush() {
 	restoreLSNs, err := bh.createRestorePoint(bh.curBackupInfo.backupName)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	sentinelDto := NewBackupSentinelDto(bh.curBackupInfo, restoreLSNs, bh.arguments.userData)
-	tracelog.InfoLogger.Println("Uploading sentinel file")
-	tracelog.InfoLogger.Println(sentinelDto.String())
-	err = internal.UploadSentinel(bh.workers.Uploader, sentinelDto, bh.curBackupInfo.backupName)
+	bh.curBackupInfo.segmentsMetadata, err = bh.fetchSegmentBackupsMetadata()
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	sentinelDto := NewBackupSentinelDto(bh.curBackupInfo, restoreLSNs, bh.arguments.userData, bh.arguments.isPermanent)
+	err = bh.uploadSentinel(sentinelDto)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("Failed to upload sentinel file for backup: %s", bh.curBackupInfo.backupName)
 		tracelog.ErrorLogger.FatalError(err)
 	}
 	tracelog.InfoLogger.Printf("Backup %s successfully created", bh.curBackupInfo.backupName)
+}
+
+func (bh *BackupHandler) uploadSentinel(sentinelDto BackupSentinelDto) (err error) {
+	tracelog.InfoLogger.Println("Uploading sentinel file")
+	tracelog.InfoLogger.Println(sentinelDto.String())
+
+	sentinelUploader := bh.workers.Uploader
+	sentinelUploader.UploadingFolder = sentinelUploader.UploadingFolder.GetSubFolder(utility.BaseBackupPath)
+	return internal.UploadSentinel(sentinelUploader, sentinelDto, bh.curBackupInfo.backupName)
 }
 
 func (bh *BackupHandler) connect() (err error) {
@@ -156,21 +177,21 @@ func (bh *BackupHandler) createRestorePoint(restorePointName string) (restoreLSN
 	return restoreLSNs, nil
 }
 
-func getGpCluster() (globalCluster *cluster.Cluster, err error) {
+func getGpClusterInfo() (globalCluster *cluster.Cluster, version semver.Version, systemIdentifier *uint64, err error) {
 	tracelog.DebugLogger.Println("Initializing tmp connection to read Greenplum info")
 	tmpConn, err := postgres.Connect()
 	if err != nil {
-		return globalCluster, err
+		return globalCluster, semver.Version{}, nil, err
 	}
 
 	queryRunner, err := NewGpQueryRunner(tmpConn)
 	if err != nil {
-		return globalCluster, err
+		return globalCluster, semver.Version{}, nil, err
 	}
 
 	versionStr, err := queryRunner.GetGreenplumVersion()
 	if err != nil {
-		return globalCluster, err
+		return globalCluster, semver.Version{}, nil, err
 	}
 	tracelog.DebugLogger.Printf("Greenplum version: %s", versionStr)
 	versionStart := strings.Index(versionStr, "(Greenplum Database ") + len("(Greenplum Database ")
@@ -180,16 +201,16 @@ func getGpCluster() (globalCluster *cluster.Cluster, err error) {
 	threeDigitVersion := pattern.FindStringSubmatch(versionStr)[0]
 	semVer, err := semver.Make(threeDigitVersion)
 	if err != nil {
-		return globalCluster, err
+		return globalCluster, semver.Version{}, nil, err
 	}
 
 	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo(semVer)
 	if err != nil {
-		return globalCluster, err
+		return globalCluster, semver.Version{}, nil, err
 	}
 	globalCluster = cluster.NewCluster(segConfigs)
 
-	return globalCluster, nil
+	return globalCluster, semVer, queryRunner.pgQueryRunner.SystemIdentifier, nil
 }
 
 // NewBackupHandler returns a backup handler object, which can handle the backup
@@ -198,9 +219,8 @@ func NewBackupHandler(arguments BackupArguments) (bh *BackupHandler, err error) 
 	if err != nil {
 		return bh, err
 	}
-	uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.BaseBackupPath)
 
-	globalCluster, err := getGpCluster()
+	globalCluster, version, systemIdentifier, err := getGpClusterInfo()
 	if err != nil {
 		return bh, err
 	}
@@ -212,7 +232,9 @@ func NewBackupHandler(arguments BackupArguments) (bh *BackupHandler, err error) 
 		},
 		globalCluster: globalCluster,
 		curBackupInfo: CurBackupInfo{
-			segmentBackups: make(map[string]*cluster.SegConfig),
+			segmentBackups:   make(map[string]*cluster.SegConfig),
+			gpVersion:        version,
+			systemIdentifier: systemIdentifier,
 		},
 	}
 	return bh, err
@@ -225,4 +247,34 @@ func NewBackupArguments(isPermanent bool, userData interface{}, fwdArgs []Segmen
 		userData:       userData,
 		segmentFwdArgs: fwdArgs,
 	}
+}
+
+func (bh *BackupHandler) fetchSegmentBackupsMetadata() (map[string]postgres.ExtendedMetadataDto, error) {
+	metadata := make(map[string]postgres.ExtendedMetadataDto)
+	for backupID, segCfg := range bh.curBackupInfo.segmentBackups {
+		selector, err := internal.NewUserDataBackupSelector(NewSegmentUserDataFromID(backupID).String(), postgres.NewGenericMetaFetcher())
+		if err != nil {
+			return nil, err
+		}
+		segBackupsFolder := bh.workers.Uploader.UploadingFolder.GetSubFolder(strconv.Itoa(segCfg.ContentID))
+
+		backupName, err := selector.Select(segBackupsFolder)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to select matching backup for id %s from subfolder %s", backupID, segBackupsFolder.GetPath())
+		}
+		backup, err := internal.GetBackupByName(backupName, utility.BaseBackupPath, segBackupsFolder)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to get %s backup from subfolder %s", backupName, segBackupsFolder.GetPath())
+		}
+
+		var meta postgres.ExtendedMetadataDto
+		err = backup.FetchMetadata(&meta)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to get %s backup metadata from subfolder %s", backupName, segBackupsFolder.GetPath())
+		}
+
+		metadata[backupID] = meta
+	}
+
+	return metadata, nil
 }

--- a/internal/databases/greenplum/backup_sentinel_dto.go
+++ b/internal/databases/greenplum/backup_sentinel_dto.go
@@ -80,7 +80,7 @@ func (s *BackupSentinelDto) String() string {
 }
 
 // NewBackupSentinelDto returns new BackupSentinelDto instance
-func NewBackupSentinelDto(curBackupInfo CurBackupInfo, restoreLSNs map[int]string, userData interface{},
+func NewBackupSentinelDto(currBackupInfo CurrBackupInfo, restoreLSNs map[int]string, userData interface{},
 	isPermanent bool) BackupSentinelDto {
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -88,23 +88,23 @@ func NewBackupSentinelDto(curBackupInfo CurBackupInfo, restoreLSNs map[int]strin
 	}
 
 	sentinel := BackupSentinelDto{
-		RestorePoint:     &curBackupInfo.backupName,
-		Segments:         make([]SegmentMetadata, 0, len(curBackupInfo.segmentBackups)),
+		RestorePoint:     &currBackupInfo.backupName,
+		Segments:         make([]SegmentMetadata, 0, len(currBackupInfo.segmentBackups)),
 		UserData:         userData,
-		StartTime:        curBackupInfo.startTime,
+		StartTime:        currBackupInfo.startTime,
 		FinishTime:       utility.TimeNowCrossPlatformUTC(),
 		Hostname:         hostname,
-		GpVersion:        curBackupInfo.gpVersion.String(),
+		GpVersion:        currBackupInfo.gpVersion.String(),
 		IsPermanent:      isPermanent,
-		SystemIdentifier: curBackupInfo.systemIdentifier,
+		SystemIdentifier: currBackupInfo.systemIdentifier,
 	}
 
-	for idx := range curBackupInfo.segmentsMetadata {
-		sentinel.CompressedSize += curBackupInfo.segmentsMetadata[idx].CompressedSize
-		sentinel.UncompressedSize += curBackupInfo.segmentsMetadata[idx].UncompressedSize
+	for idx := range currBackupInfo.segmentsMetadata {
+		sentinel.CompressedSize += currBackupInfo.segmentsMetadata[idx].CompressedSize
+		sentinel.UncompressedSize += currBackupInfo.segmentsMetadata[idx].UncompressedSize
 	}
 
-	for backupID, cfg := range curBackupInfo.segmentBackups {
+	for backupID, cfg := range currBackupInfo.segmentBackups {
 		restoreLSN := restoreLSNs[cfg.ContentID]
 		sentinel.Segments = append(sentinel.Segments, NewSegmentMetadata(backupID, *cfg, restoreLSN))
 	}


### PR DESCRIPTION
Add start/finish time, hostname, greenplum version, is_permanent, system_identifier, compressed/uncompressed size.

Example:
```
{
   "restore_point":"backup_20210915T183249Z",
   "segments":[
      {
         "db_id":4,
         "content_id":2,
         "role":"p",
         "port":6002,
         "hostname":"gp6segment1",
         "data_dir":"/gpdata/primary/gpseg2",
         "backup_id":"fa49dae3-ab43-4bd5-a333-01ae0ccd752d",
         "restore_point_lsn":"55/A80000C8"
      },
      {
         "db_id":5,
         "content_id":3,
         "role":"p",
         "port":6003,
         "hostname":"gp6segment1",
         "data_dir":"/gpdata/primary/gpseg3",
         "backup_id":"2dbecdeb-4742-4cd3-99d0-2b9eb5bf1e45",
         "restore_point_lsn":"55/A80000C8"
      },
      {
         "db_id":1,
         "content_id":-1,
         "role":"p",
         "port":5432,
         "hostname":"gp6master",
         "data_dir":"/gpdata/master/gpseg-1",
         "backup_id":"1602c076-4573-4ede-afa5-e947cd90716c",
         "restore_point_lsn":"55/C4000090"
      },
      {
         "db_id":2,
         "content_id":0,
         "role":"p",
         "port":6000,
         "hostname":"gp6segment1",
         "data_dir":"/gpdata/primary/gpseg0",
         "backup_id":"b4fe1175-0e9a-49b4-a658-ee19cd4dbf8e",
         "restore_point_lsn":"55/A80000C8"
      },
      {
         "db_id":3,
         "content_id":1,
         "role":"p",
         "port":6001,
         "hostname":"gp6segment1",
         "data_dir":"/gpdata/primary/gpseg1",
         "backup_id":"63579237-03e7-4ee1-821b-158edb998791",
         "restore_point_lsn":"55/A80000C8"
      }
   ],
   "start_time":"2021-09-15T18:32:49.628338Z",
   "finish_time":"2021-09-15T18:32:58.349467Z",
   "hostname":"gp6master",
   "gp_version":"6.17.1",
   "is_permanent":false,
   "system_identifier":null,
   "uncompressed_size":173247,
   "compressed_size":29292
}
```