### PR TITLE
Improve MySQL logging in 'backup-fetch'

### DIFF
--- a/internal/backup_fetch_handler.go
+++ b/internal/backup_fetch_handler.go
@@ -38,6 +38,9 @@ func GetCommandStreamFetcher(cmd *exec.Cmd) func(folder storage.Folder, backup B
 			tracelog.ErrorLogger.Printf("Restore command output:\n%s", stderr.String())
 		}
 		if cmdErr != nil {
+			if err != nil {
+				tracelog.ErrorLogger.Printf("Failed to fetch backup: %v\n", err)
+			}
 			err = cmdErr
 		}
 		tracelog.ErrorLogger.FatalfOnError("Failed to fetch backup: %v\n", err)


### PR DESCRIPTION
If some fetch/decrypt/decompress error raised during MySQL 'backup-fetch' procedure, it usually leads to error in a user-specified process[1]. Unfortunately real error is shaded by user-process error.

This patch changes behaviour to print both errors to stderr.

[1] command defined in WALG_STREAM_RESTORE_COMMAND.