### PR TITLE
Add recursive flag to the storage tools

### DIFF
--- a/cmd/st/folder_list.go
+++ b/cmd/st/folder_list.go
@@ -8,6 +8,8 @@ import (
 )
 
 const folderListShortDescription = "Prints objects in the provided storage folder"
+const recursiveFlag = "recursive"
+const recursiveShortHand = "r"
 
 // folderListCmd represents the folderList command
 var folderListCmd = &cobra.Command{
@@ -22,10 +24,13 @@ var folderListCmd = &cobra.Command{
 			folder = folder.GetSubFolder(args[0])
 		}
 
-		storagetools.HandleFolderList(folder)
+		storagetools.HandleFolderList(folder, recursive)
 	},
 }
 
+var recursive bool
+
 func init() {
+	folderListCmd.Flags().BoolVarP(&recursive, recursiveFlag, recursiveShortHand, false, "List folder recursively")
 	StorageToolsCmd.AddCommand(folderListCmd)
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -166,7 +166,9 @@ If `FIND_FULL` is specified, WAL-G will calculate minimum backup needed to keep 
 ### ``ls``
 Prints listing of the objects in the provided storage folder.
 
-``wal-g st ls`` get listing with all objects in the configured storage.
+``wal-g st ls`` get listing with all objects and folders in the configured storage.
+
+``wal-g st ls -r`` get recursive listing with all objects in the configured storage.
 
 ``wal-g st ls some_folder/some_subfolder`` get listing with all objects in the provided storage path.
 

--- a/internal/storagetools/folder_list_handler.go
+++ b/internal/storagetools/folder_list_handler.go
@@ -4,29 +4,95 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
-func HandleFolderList(folder storage.Folder) {
-	folderObjects, err := storage.ListFolderRecursively(folder)
+type ListElementType string
+
+const (
+	Object    ListElementType = "obj"
+	Directory ListElementType = "dir"
+)
+
+type ListElement interface {
+	storage.Object
+	Type() ListElementType
+}
+
+type ListObject struct {
+	storage.Object
+}
+
+func NewListObject(object storage.Object) *ListObject {
+	return &ListObject{object}
+}
+
+func (lo *ListObject) Type() ListElementType {
+	return Object
+}
+
+type ListDirectory struct {
+	name string
+}
+
+func NewListDirectory(folder storage.Folder, rootFolder storage.Folder) *ListDirectory {
+	return &ListDirectory{name: strings.TrimPrefix(folder.GetPath(), rootFolder.GetPath())}
+}
+
+func (ld *ListDirectory) GetName() string {
+	return ld.name
+}
+
+func (ld *ListDirectory) GetLastModified() time.Time {
+	return time.Time{}
+}
+
+func (ld *ListDirectory) GetSize() int64 {
+	return 0
+}
+
+func (ld *ListDirectory) Type() ListElementType {
+	return Directory
+}
+
+func HandleFolderList(folder storage.Folder, recursive bool) {
+	var list []ListElement
+	var folderObjects []storage.Object
+	var err error
+
+	if recursive {
+		folderObjects, err = storage.ListFolderRecursively(folder)
+	} else {
+		var subFolders []storage.Folder
+		folderObjects, subFolders, err = folder.ListFolder()
+		for i := range subFolders {
+			list = append(list, NewListDirectory(subFolders[i], folder))
+		}
+	}
+
+	for i := range folderObjects {
+		list = append(list, NewListObject(folderObjects[i]))
+	}
 	tracelog.ErrorLogger.FatalfOnError("Failed to list the folder: %v", err)
 
-	err = WriteObjectsList(folderObjects, os.Stdout)
+	err = WriteObjectsList(list, os.Stdout)
 	tracelog.ErrorLogger.FatalfOnError("Failed to write the folder listing: %v", err)
 }
 
-func WriteObjectsList(objects []storage.Object, output io.Writer) error {
+func WriteObjectsList(objects []ListElement, output io.Writer) error {
 	writer := tabwriter.NewWriter(output, 0, 0, 1, ' ', 0)
 	defer writer.Flush()
-	_, err := fmt.Fprintln(writer, "size\tlast modified\tname")
+	_, err := fmt.Fprintln(writer, "type\tsize\tlast modified\tname")
 	if err != nil {
 		return err
 	}
 	for _, o := range objects {
-		_, err = fmt.Fprintf(writer, "%d\t%s\t%s\n", o.GetSize(), o.GetLastModified(), o.GetName())
+		_, err = fmt.Fprintf(writer, "%s\t%d\t%s\t%s\n", o.Type(), o.GetSize(), o.GetLastModified(), o.GetName())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, storage tools folder listing is always recursive. This might be slow and laggy on some large listings. I propose to add the `-r` flag to the `wal-g st ls` command and make the default behaviour non-recursive.

Example:
```
wal-g st ls --config config.yaml

type size     last modified                     name
dir  0        0001-01-01 00:00:00 +0000 UTC     basebackups_005/
obj  50395968 2021-08-19 07:04:14.283 +0000 UTC obj1
obj  26402287 2021-08-19 09:02:38.22 +0000 UTC  obj2.lz4

wal-g st ls -r --config config.yaml
type size      last modified                     name
obj  50395968  2021-08-19 07:04:14.283 +0000 UTC obj1
obj  26402287  2021-08-19 09:02:38.22 +0000 UTC  obj2.lz4
obj  196       2021-07-19 06:34:53.405 +0000 UTC basebackups_005/base_000000010000000000000062_backup_stop_sentinel.json
obj  329       2021-07-19 06:55:58.913 +0000 UTC basebackups_005/base_000000010000000000000064_D_000000010000000000000062_backup_stop_sentinel.json
obj  395       2021-07-19 06:34:53.31 +0000 UTC  basebackups_005/base_000000010000000000000062/metadata.json
obj  394       2021-07-19 06:55:58.863 +0000 UTC basebackups_005/base_000000010000000000000064_D_000000010000000000000062/metadata.json
obj  35261171  2021-07-19 06:34:52.124 +0000 UTC basebackups_005/base_000000010000000000000062/tar_partitions/part_001.tar.lz4
obj  134376854 2021-07-19 06:34:53.1 +0000 UTC   basebackups_005/base_000000010000000000000062/tar_partitions/part_002.tar.lz4
obj  4048551   2021-07-19 06:34:47.02 +0000 UTC  basebackups_005/base_000000010000000000000062/tar_partitions/part_003.tar.lz4
obj  102787129 2021-07-19 06:34:50.349 +0000 UTC basebackups_005/base_000000010000000000000062/tar_partitions/part_004.tar.lz4
obj  539       2021-07-19 06:34:53.254 +0000 UTC basebackups_005/base_000000010000000000000062/tar_partitions/part_006.tar.lz4
obj  702       2021-07-19 06:34:53.17 +0000 UTC  basebackups_005/base_000000010000000000000062/tar_partitions/pg_control.tar.lz4
obj  102392041 2021-07-19 06:55:55.55 +0000 UTC  basebackups_005/base_000000010000000000000064_D_000000010000000000000062/tar_partitions/part_001.tar.lz4
obj  3781561   2021-07-19 06:55:52.659 +0000 UTC basebackups_005/base_000000010000000000000064_D_000000010000000000000062/tar_partitions/part_002.tar.lz4
obj  35803380  2021-07-19 06:55:57.54 +0000 UTC  basebackups_005/base_000000010000000000000064_D_000000010000000000000062/tar_partitions/part_003.tar.lz4
obj  134496723 2021-07-19 06:55:58.663 +0000 UTC basebackups_005/base_000000010000000000000064_D_000000010000000000000062/tar_partitions/part_004.tar.lz4
obj  538       2021-07-19 06:55:58.804 +0000 UTC basebackups_005/base_000000010000000000000064_D_000000010000000000000062/tar_partitions/part_006.tar.lz4
obj  702       2021-07-19 06:55:58.727 +0000 UTC basebackups_005/base_000000010000000000000064_D_000000010000000000000062/tar_partitions/pg_control.tar.lz4

```