### PR TITLE
[greenplum] fix dead connection after backup creation

### DIFF
--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -207,6 +207,11 @@ func (bh *BackupHandler) connect() (err error) {
 
 func (bh *BackupHandler) createRestorePoint(restorePointName string) (restoreLSNs map[int]string, err error) {
 	tracelog.InfoLogger.Printf("Creating restore point with name %s", restorePointName)
+	if !bh.workers.Conn.IsAlive() {
+		tracelog.InfoLogger.Printf("Looks like the connection to the greenplum master is dead, reconnecting...")
+		tracelog.ErrorLogger.FatalOnError(bh.connect())
+	}
+
 	queryRunner, err := NewGpQueryRunner(bh.workers.Conn)
 	if err != nil {
 		return


### PR DESCRIPTION
Currently, the greenplum backup may fail with the following message:
```
INFO: 2021/09/30 06:41:32.166480 Wrote backup with name base_00000005000001E80000002C

INFO: 2021/09/30 07:15:13.596143 Creating restore point with name backup_20210929T220001Z
ERROR: 2021/09/30 07:15:13.596283 GetVersion: getting Postgres version failed: write tcp [::1]:55700->[::1]:5432: write: broken pipe
```
This happens because there is a big timeframe between starting the backup and finishing it, so the connection between wal-g and greenplum master instance might be dropped. This PR adds a reconnect attempt.