### PR TITLE
[greenplum] Gracefully handle the backup failure

### DIFF
--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -135,6 +135,8 @@ func (bh *BackupHandler) HandleBackupPush() {
 	}, true)
 
 	if remoteOutput.NumErrors > 0 {
+		tracelog.InfoLogger.Printf("Encountered one or more errors during the backup-push. See %s for a complete list of errors.",
+			gplog.GetLogFilePath())
 		// handle the backup failure and exit
 		err := bh.handleBackupError()
 		if err != nil {

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -132,7 +132,16 @@ func (bh *BackupHandler) HandleBackupPush() {
 		})
 	bh.globalCluster.CheckClusterError(remoteOutput, "Unable to run wal-g", func(contentID int) string {
 		return "Unable to run wal-g"
-	})
+	}, true)
+
+	if remoteOutput.NumErrors > 0 {
+		// handle the backup failure and exit
+		err := bh.handleBackupError()
+		if err != nil {
+			tracelog.WarningLogger.Printf("Non-critical error during terminating of the failed backup: %v", err)
+		}
+		return
+	}
 
 	for _, command := range remoteOutput.Commands {
 		tracelog.InfoLogger.Printf("WAL-G output (segment %d):\n%s\n", command.Content, command.Stderr)
@@ -187,6 +196,22 @@ func (bh *BackupHandler) checkPrerequisites() (err error) {
 	return nil
 }
 
+func (bh *BackupHandler) handleBackupError() error {
+	// Abort the non-finished exclusive backups on the segments.
+	// WAL-G in GP7+ uses the non-exclusive backups, that are terminated on connection close, so this is unnecessary.
+	if bh.currBackupInfo.gpVersion.Major < 7 {
+		tracelog.InfoLogger.Println("Terminating the running exclusive backups...")
+		bh.checkConn()
+		queryRunner, err := NewGpQueryRunner(bh.workers.Conn)
+		if err != nil {
+			return err
+		}
+		return queryRunner.AbortBackup()
+	}
+
+	return nil
+}
+
 func (bh *BackupHandler) uploadSentinel(sentinelDto BackupSentinelDto) (err error) {
 	tracelog.InfoLogger.Println("Uploading sentinel file")
 	tracelog.InfoLogger.Println(sentinelDto.String())
@@ -205,13 +230,16 @@ func (bh *BackupHandler) connect() (err error) {
 	return
 }
 
-func (bh *BackupHandler) createRestorePoint(restorePointName string) (restoreLSNs map[int]string, err error) {
-	tracelog.InfoLogger.Printf("Creating restore point with name %s", restorePointName)
+func (bh *BackupHandler) checkConn() {
 	if !bh.workers.Conn.IsAlive() {
 		tracelog.InfoLogger.Printf("Looks like the connection to the greenplum master is dead, reconnecting...")
 		tracelog.ErrorLogger.FatalOnError(bh.connect())
 	}
+}
 
+func (bh *BackupHandler) createRestorePoint(restorePointName string) (restoreLSNs map[int]string, err error) {
+	tracelog.InfoLogger.Printf("Creating restore point with name %s", restorePointName)
+	bh.checkConn()
 	queryRunner, err := NewGpQueryRunner(bh.workers.Conn)
 	if err != nil {
 		return

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -135,14 +135,13 @@ func (bh *BackupHandler) HandleBackupPush() {
 	}, true)
 
 	if remoteOutput.NumErrors > 0 {
-		tracelog.InfoLogger.Printf("Encountered one or more errors during the backup-push. See %s for a complete list of errors.",
-			gplog.GetLogFilePath())
 		// handle the backup failure and exit
 		err := bh.handleBackupError()
 		if err != nil {
 			tracelog.WarningLogger.Printf("Non-critical error during terminating of the failed backup: %v", err)
 		}
-		return
+		tracelog.InfoLogger.Fatalf("Encountered one or more errors during the backup-push. See %s for a complete list of errors.",
+			gplog.GetLogFilePath())
 	}
 
 	for _, command := range remoteOutput.Commands {


### PR DESCRIPTION
In GP6X, wal-g performs the exclusive backup on each segment. The problem is that it does not terminates after the connection close:
```
host ~ # psql
could not change directory to "/root": Permission denied
psql (9.4.24)
Type "help" for help.

postgres=# select pg_start_backup('test')
postgres-# ;
NOTICE:  pg_start_backup() is not supported in Greenplum Database
HINT:  Contact support to get more information and resolve the issue
 pg_start_backup
-----------------
 B/F4000028
(1 row)

postgres=#
postgres=# \q
host ~ # psql
could not change directory to "/root": Permission denied
psql (9.4.24)
Type "help" for help.

postgres=# select pg_is_in_backup();
 pg_is_in_backup
-----------------
 t
(1 row)

postgres=# \q
```
It means that if backup has failed for some reason, WAL-G should manually call the `pg_stop_backup()` on all segments.

In this PR, I implemented the manual pg_stop_backup() call on all segments in case of the backup failure.