### PR TITLE
fixing LATEST keyword handling

### DIFF
--- a/internal/databases/sqlserver/log_restore_handler.go
+++ b/internal/databases/sqlserver/log_restore_handler.go
@@ -59,7 +59,7 @@ func HandleLogRestore(backupName string, untilTS string, dbnames []string, fromn
 		if err != nil {
 			return err
 		}
-		backupMetadata, err := GetBackupProperties(db, folder, false, backupName, fromname)
+		backupMetadata, err := GetBackupProperties(db, folder, false, backup.Name, fromname)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Database name
SQL Server

# Pull request description
changed handling of "since" argument in log-restore operation to respect LATEST keyword in GetBackupProperties function.

### Describe what this PR fix
If we pass LATEST as "since" argument to log-restore the restore operation fails. This happens because this keyword gets passed and backupname argument to the GetBackupProperties helper function which is not expected there.

### Please provide steps to reproduce (if it's a bug)
If we pass LATEST as "since" argument to log-restore the restore operation fails. 
