### PR TITLE
sqlserver: add norecovery option for backup log command

### DIFF
--- a/cmd/sqlserver/log_push.go
+++ b/cmd/sqlserver/log_push.go
@@ -9,12 +9,13 @@ const logPushShortDescription = "Creates new log backup and pushes it to the sto
 
 var logPushDatabases []string
 var logCompression bool
+var logNoRecovery bool
 
 var logPushCmd = &cobra.Command{
 	Use:   "log-push",
 	Short: logPushShortDescription,
 	Run: func(cmd *cobra.Command, args []string) {
-		sqlserver.HandleLogPush(logPushDatabases, logCompression)
+		sqlserver.HandleLogPush(logPushDatabases, logCompression, logNoRecovery)
 	},
 }
 
@@ -23,5 +24,7 @@ func init() {
 		"List of databases to log. All not-system databases as default")
 	logPushCmd.PersistentFlags().BoolVarP(&logCompression, "compression", "c", true,
 		"Use built-in log compression. Enabled by default")
+	logPushCmd.PersistentFlags().BoolVarP(&logNoRecovery, "no-recovery", "n", false,
+		"Do a tail-log backup leaving database closed for further modifications")
 	cmd.AddCommand(logPushCmd)
 }

--- a/internal/databases/sqlserver/log_push_handler.go
+++ b/internal/databases/sqlserver/log_push_handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-func HandleLogPush(dbnames []string, compression bool) {
+func HandleLogPush(dbnames []string, compression bool, norecovery bool) {
 	ctx, cancel := context.WithCancel(context.Background())
 	signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 	defer func() { _ = signalHandler.Close() }()
@@ -34,14 +34,14 @@ func HandleLogPush(dbnames []string, compression bool) {
 
 	logBackupName := generateLogBackupName()
 	err = runParallel(func(i int) error {
-		return backupSingleLog(ctx, db, logBackupName, dbnames[i], compression)
+		return backupSingleLog(ctx, db, logBackupName, dbnames[i], compression, norecovery)
 	}, len(dbnames), getDBConcurrency())
 	tracelog.ErrorLogger.FatalfOnError("overall log backup failed: %v", err)
 
 	tracelog.InfoLogger.Printf("log backup finished")
 }
 
-func backupSingleLog(ctx context.Context, db *sql.DB, backupName string, dbname string, compression bool) error {
+func backupSingleLog(ctx context.Context, db *sql.DB, backupName string, dbname string, compression bool, noRecovery bool) error {
 	baseURL := getLogBackupURL(backupName, dbname)
 	size, blobCount, err := estimateLogSize(db, dbname)
 	if err != nil {
@@ -53,6 +53,9 @@ func backupSingleLog(ctx context.Context, db *sql.DB, backupName string, dbname 
 	sql += fmt.Sprintf(" WITH FORMAT, MAXTRANSFERSIZE=%d", MaxTransferSize)
 	if compression {
 		sql += ", COMPRESSION"
+	}
+	if noRecovery {
+		sql += ", NORECOVERY"
 	}
 	tracelog.InfoLogger.Printf("starting backup database [%s] log to %s", dbname, urls)
 	tracelog.DebugLogger.Printf("SQL: %s", sql)


### PR DESCRIPTION
SQLServer

--no-recovery option added for log-push command.

When specified, this adds NORECOVERY flag to BACKUP LOG call.
