### PR TITLE
Make wal-g-mysql profilable again

### DIFF
--- a/cmd/mysql/backup_fetch.go
+++ b/cmd/mysql/backup_fetch.go
@@ -19,7 +19,7 @@ var (
 		Use:   "backup-fetch backup-name",
 		Short: backupFetchShortDescription,
 		Args:  cobra.RangeArgs(0, 1),
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(cmd *cobra.Command, args []string) {
 			internal.RequiredSettings[internal.NameStreamRestoreCmd] = true
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)

--- a/cmd/mysql/backup_push.go
+++ b/cmd/mysql/backup_push.go
@@ -20,7 +20,7 @@ var (
 	backupPushCmd = &cobra.Command{
 		Use:   "backup-push",
 		Short: backupPushShortDescription,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(cmd *cobra.Command, args []string) {
 			internal.RequiredSettings[internal.NameStreamCreateCmd] = true
 			internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
 			err := internal.AssertRequiredSettingsSet()

--- a/cmd/mysql/binlog_fetch.go
+++ b/cmd/mysql/binlog_fetch.go
@@ -26,7 +26,7 @@ var binlogFetchCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 		mysql.HandleBinlogFetch(folder, fetchBackupName, fetchUntilTS)
 	},
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PreRun: func(cmd *cobra.Command, args []string) {
 		internal.RequiredSettings[internal.MysqlBinlogDstSetting] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)

--- a/cmd/mysql/binlog_push.go
+++ b/cmd/mysql/binlog_push.go
@@ -22,7 +22,7 @@ var binlogPushCmd = &cobra.Command{
 		checkGTIDs, _ := internal.GetBoolSettingDefault(internal.MysqlCheckGTIDs, false)
 		mysql.HandleBinlogPush(uploader, untilBinlog, checkGTIDs)
 	},
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PreRun: func(cmd *cobra.Command, args []string) {
 		internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)

--- a/cmd/mysql/binlog_replay.go
+++ b/cmd/mysql/binlog_replay.go
@@ -25,7 +25,7 @@ var binlogReplayCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 		mysql.HandleBinlogReplay(folder, replayBackupName, replayUntilTS)
 	},
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PreRun: func(cmd *cobra.Command, args []string) {
 		internal.RequiredSettings[internal.MysqlBinlogReplayCmd] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)

--- a/cmd/mysql/mysql.go
+++ b/cmd/mysql/mysql.go
@@ -28,6 +28,8 @@ var cmd = &cobra.Command{
 		if err != nil {
 			tracelog.WarningLogger.PrintError(err)
 		}
+		err = internal.ConfigureAndRunDefaultWebServer()
+		tracelog.ErrorLogger.FatalOnError(err)
 	},
 }
 


### PR DESCRIPTION
### MySQL
Allow users to connect to wal-g and collect profiles and stacktraces.


### Usage:
1. Configure wal-g
```
HTTP_LISTEN: localhost:9876
HTTP_EXPOSE_PPROF: True
```
2. Start wal-g.
3. Collect data:
```
go tool pprof http://localhost:9876/debug/pprof/profile?seconds=30
```