### PR TITLE
'delete retain xx' : do not treat 'not found' as an error

### DIFF
--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -248,6 +248,7 @@ func (h *DeleteHandler) FindTargetRetain(retentionCount, modifier int) (BackupOb
 		return nil, utility.NewForbiddenActionError("Not allowed modifier for 'delete retain'")
 	}
 	target, err := findTarget(h.backups, h.greater, choiceFunc)
+	// it is OK to have no backups found outside of the specified retain window, skip this error
 	if err != nil && err != errNotFound {
 		return nil, err
 	}


### PR DESCRIPTION
### Database name
changes a behavior in `wal-g delete`, this should impact all database engines.

# Pull request description

fixes #1124 
