### PR TITLE
Restore release checksums generation in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,20 @@ jobs:
       - name: Compress WAL-G binary
         run: tar --owner=0 --group=0 -zcvf wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.tar.gz wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64
 
+      - name: Calculate checksum
+        run: sha256sum wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64 > wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.sha256
+
+      - name: Calculate checksum for the compressed binary
+        run: sha256sum wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.tar.gz > wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.tar.gz.sha256
+
       - name: Upload WAL-G binary
         uses: softprops/action-gh-release@v1
         with:
           files: |
             wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64
             wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.tar.gz
+            wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.sha256
+            wal-g-${{ matrix.db }}-${{ matrix.os }}-amd64.tar.gz.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:


### PR DESCRIPTION
Should fix the https://github.com/wal-g/wal-g/issues/1123