### PR TITLE
Close the downloaded WAL file

### DIFF
--- a/internal/fetch_helper.go
+++ b/internal/fetch_helper.go
@@ -197,6 +197,7 @@ func DownloadFileTo(folder storage.Folder, fileName string, dstPath string) erro
 	if err != nil {
 		return err
 	}
+	defer utility.LoggedClose(file, "")
 
 	reader, err := DownloadAndDecompressStorageFile(folder, fileName)
 	if err != nil {


### PR DESCRIPTION
Add the missing `Close()` call in the` DownloadFileTo()` func. Might fix the https://github.com/wal-g/wal-g/issues/1074