### PR TITLE
Fix old version delta unpack

### DIFF
--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -548,7 +548,7 @@ func (bh *BackupHandler) configureDeltaBackup() (err error) {
 		*prevBackupSentinelDto.BackupStartLSN)
 	bh.prevBackupInfo.name = previousBackupName
 	bh.prevBackupInfo.sentinelDto = prevBackupSentinelDto
-	bh.prevBackupInfo.filesMetadataDto, err = previousBackup.GetFilesMetadata()
+	_, bh.prevBackupInfo.filesMetadataDto, err = previousBackup.GetSentinelAndFilesMetadata()
 	return err
 }
 


### PR DESCRIPTION
https://github.com/wal-g/wal-g/pull/1114 introduced the new sentinel format. However, there still was a problem fetching the old version delta backup with the new WAL-G version. This PR should fix it.