### PR TITLE
change that made some correction for checksum verification

### DIFF
--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -107,7 +107,6 @@ func isPagedFile(info os.FileInfo, filePath string) bool {
 	if info.IsDir() ||
 		((!strings.Contains(filePath, DefaultTablespace)) && (!strings.Contains(filePath, NonDefaultTablespace))) ||
 		info.Size() == 0 ||
-		info.Size()%DatabasePageSize != 0 ||
 		!pagedFilenameRegexp.MatchString(path.Base(filePath)) {
 		return false
 	}


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description
Some change in 3 go files for issues #1140 
**new output logs (Before creating a backup, three files were corrupted. Data inserts were done in each of them in different places)**
- echo -n "Hello!" | dd conv=notrunc oflag=seek_bytes seek=8189 bs=6 count=1 of=/data/pg_data/postgres/base/16493/16511
- echo -n "Hello!" | dd conv=notrunc oflag=seek_bytes seek=49134 bs=6 count=1 of=/data/pg_data/postgres/base/16493/16530
- echo -n "Hello!" | dd conv=notrunc oflag=seek_bytes seek=7928000 bs=6 count=1 of=/data/pg_data/postgres/base/16493/16529
- 

_INFO: 2021/11/11 14:14:35.873969 Selecting the latest backup as the base for the current delta backup...
INFO: 2021/11/11 14:14:35.886016 Doing full backup.
INFO: 2021/11/11 14:14:35.894429 Calling pg_start_backup()
INFO: 2021/11/11 14:14:36.134987 Starting a new tar bundle
INFO: 2021/11/11 14:14:36.135038 Walking ...
INFO: 2021/11/11 14:14:36.135635 Starting part 1 ...
INFO: 2021/11/11 14:14:36.145365 Starting part 2 ...
WARNING: 2021/11/11 14:14:37.315689 Corruption found in /data/pg_data/postgres/base/16493/16511/[0], expected f2e4, found ff7
WARNING: 2021/11/11 14:14:37.316085 verifyPageBlocks: /data/pg_data/postgres/base/16493/16511 invalid file size 8195
WARNING: 2021/11/11 14:14:37.347120 Invalid page header encountered: blockNo 1, path /data/pg_data/postgres/base/16493/16530
WARNING: 2021/11/11 14:14:37.347144 Invalid page header encountered: blockNo 2, path /data/pg_data/postgres/base/16493/16530
WARNING: 2021/11/11 14:14:37.347152 Invalid page header encountered: blockNo 3, path /data/pg_data/postgres/base/16493/16530
WARNING: 2021/11/11 14:14:37.348574 Invalid page header encountered: blockNo 4, path /data/pg_data/postgres/base/16493/16530
WARNING: 2021/11/11 14:14:37.349118 verifyPageBlocks: /data/pg_data/postgres/base/16493/16530 invalid file size 49140
WARNING: 2021/11/11 14:14:37.730442 Corruption found in /data/pg_data/postgres/base/16493/16529/[967], expected 7a4c, found c88b
INFO: 2021/11/11 14:14:44.131827 Packing ...
INFO: 2021/11/11 14:14:49.855011 Finished writing part 2.
INFO: 2021/11/11 14:14:51.127124 Finished writing part 1.
INFO: 2021/11/11 14:14:52.302761 Starting part 3 ...
INFO: 2021/11/11 14:14:52.305401 /global/pg_control
INFO: 2021/11/11 14:14:52.306677 Finished writing part 3.
INFO: 2021/11/11 14:14:52.307615 Calling pg_stop_backup()
INFO: 2021/11/11 14:14:53.375753 Starting part 4 ...
INFO: 2021/11/11 14:14:53.385576 backup_label
INFO: 2021/11/11 14:14:53.385602 tablespace_map
INFO: 2021/11/11 14:14:53.387831 Finished writing part 4.
INFO: 2021/11/11 14:14:53.560000 Wrote backup with name base_000000010000000000000025_

P.S. 
Also in paged_file_verifier.go there is no need to use check """!isPagedFile(fileInfo, path) """ in func verifyPageBlocks, because this check performed earlier.
Maybed we should make a change  like this:
	//if _, ignored := ignoredFileNames[fileInfo.Name()]; ignored || !isPagedFile(fileInfo, path) { ...
	if _, ignored := ignoredFileNames[fileInfo.Name()]; ignored { ...


