### PR TITLE
Introduce WALG_TAR_DISABLE_FSYNC to allow configuring wal-g to skip fsync

### DIFF
--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -104,6 +104,10 @@ To configure base for next delta backup (only if `WALG_DELTA_MAX_STEPS` is not e
 
 To configure the size of one backup bundle (in bytes). Smaller size causes granularity and more optimal, faster recovering. It also increases the number of storage requests, so it can costs you much money. Default size is 1 GB (`1 << 30 - 1` bytes).
 
+* `WALG_TAR_DISABLE_FSYNC`
+
+Disable calling fsync after writing files when extracting tar files.
+
 * `WALG_PG_WAL_SIZE`
 
 To configure the wal segment size if different from the postgres default of 16 MB

--- a/internal/config.go
+++ b/internal/config.go
@@ -50,6 +50,7 @@ const (
 	FetchTargetUserDataSetting   = "WALG_FETCH_TARGET_USER_DATA"
 	LogLevelSetting              = "WALG_LOG_LEVEL"
 	TarSizeThresholdSetting      = "WALG_TAR_SIZE_THRESHOLD"
+	TarDisableFsyncSetting       = "WALG_TAR_DISABLE_FSYNC"
 	CseKmsIDSetting              = "WALG_CSE_KMS_ID"
 	CseKmsRegionSetting          = "WALG_CSE_KMS_REGION"
 	LibsodiumKeySetting          = "WALG_LIBSODIUM_KEY"
@@ -142,6 +143,7 @@ var (
 		CompressionMethodSetting:     "lz4",
 		UseWalDeltaSetting:           "false",
 		TarSizeThresholdSetting:      "1073741823", // (1 << 30) - 1
+		TarDisableFsyncSetting:       "false",
 		TotalBgUploadedLimit:         "32",
 		UseReverseUnpackSetting:      "false",
 		SkipRedundantTarsSetting:     "false",
@@ -195,6 +197,7 @@ var (
 		UseWalDeltaSetting:           true,
 		LogLevelSetting:              true,
 		TarSizeThresholdSetting:      true,
+		TarDisableFsyncSetting:       true,
 		"WALG_" + GpgKeyIDSetting:    true,
 		"WALE_" + GpgKeyIDSetting:    true,
 		PgpKeySetting:                true,

--- a/internal/databases/postgres/catchup_file_unwrapper.go
+++ b/internal/databases/postgres/catchup_file_unwrapper.go
@@ -14,7 +14,7 @@ type CatchupFileUnwrapper struct {
 }
 
 func (u *CatchupFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Header,
-	file *os.File) (*FileUnwrapResult, error) {
+	file *os.File, fsync bool) (*FileUnwrapResult, error) {
 	if u.options.isIncremented {
 		targetReadWriterAt, err := NewReadWriterAtFrom(file)
 		if err != nil {
@@ -26,7 +26,7 @@ func (u *CatchupFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Heade
 		}
 		return NewCreatedFromIncrementResult(missingBlockCount), nil
 	}
-	err := u.writeLocalFile(reader, header, file)
+	err := u.writeLocalFile(reader, header, file, fsync)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (u *CatchupFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Heade
 }
 
 func (u *CatchupFileUnwrapper) UnwrapExistingFile(reader io.Reader, header *tar.Header,
-	file *os.File) (*FileUnwrapResult, error) {
+	file *os.File, fsync bool) (*FileUnwrapResult, error) {
 	if u.options.isIncremented {
 		targetReadWriterAt, err := NewReadWriterAtFrom(file)
 		if err != nil {
@@ -52,7 +52,7 @@ func (u *CatchupFileUnwrapper) UnwrapExistingFile(reader io.Reader, header *tar.
 	if err != nil {
 		return nil, err
 	}
-	err = u.writeLocalFile(reader, header, file)
+	err = u.writeLocalFile(reader, header, file, fsync)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/postgres/default_file_unwrapper.go
+++ b/internal/databases/postgres/default_file_unwrapper.go
@@ -14,7 +14,7 @@ type DefaultFileUnwrapper struct {
 }
 
 func (u *DefaultFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Header,
-	file *os.File) (*FileUnwrapResult, error) {
+	file *os.File, fsync bool) (*FileUnwrapResult, error) {
 	if u.options.isIncremented {
 		targetReadWriterAt, err := NewReadWriterAtFrom(file)
 		if err != nil {
@@ -26,7 +26,7 @@ func (u *DefaultFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Heade
 		}
 		return NewCreatedFromIncrementResult(missingBlockCount), nil
 	}
-	err := u.writeLocalFile(reader, header, file)
+	err := u.writeLocalFile(reader, header, file, fsync)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (u *DefaultFileUnwrapper) UnwrapNewFile(reader io.Reader, header *tar.Heade
 }
 
 func (u *DefaultFileUnwrapper) UnwrapExistingFile(reader io.Reader, header *tar.Header,
-	file *os.File) (*FileUnwrapResult, error) {
+	file *os.File, fsync bool) (*FileUnwrapResult, error) {
 	targetReadWriterAt, err := NewReadWriterAtFrom(file)
 	if err != nil {
 		return nil, err

--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -170,7 +170,7 @@ func convertBlocksToLocations(filePath string, blocks []uint32) ([]walparser.Blo
 }
 
 // ApplyFileIncrement changes pages according to supplied change map file
-func ApplyFileIncrement(fileName string, increment io.Reader, createNewIncrementalFiles bool) error {
+func ApplyFileIncrement(fileName string, increment io.Reader, createNewIncrementalFiles bool, fsync bool) error {
 	tracelog.DebugLogger.Printf("Incrementing %s\n", fileName)
 	err := ReadIncrementFileHeader(increment)
 	if err != nil {
@@ -207,7 +207,7 @@ func ApplyFileIncrement(fileName string, increment io.Reader, createNewIncrement
 		return errors.Wrap(err, "can't open file to increment")
 	}
 	defer utility.LoggedClose(file, "")
-	defer utility.LoggedSync(file, "")
+	defer utility.LoggedSync(file, "", fsync)
 
 	err = file.Truncate(int64(fileSize))
 	if err != nil {

--- a/internal/databases/postgres/pagefile_test.go
+++ b/internal/databases/postgres/pagefile_test.go
@@ -84,7 +84,7 @@ func postgresApplyIncrementTest(testIncrement *TestIncrement, t *testing.T) {
 	tmpFile, _ := os.OpenFile(tmpFileName, os.O_RDWR, 0666)
 	tmpFile.WriteAt(make([]byte, 12345), 477421568-12345)
 	tmpFile.Close()
-	err := postgres.ApplyFileIncrement(tmpFileName, incrementReader, false)
+	err := postgres.ApplyFileIncrement(tmpFileName, incrementReader, false, true)
 	assert.NoError(t, err)
 	_, err = incrementReader.Read(make([]byte, 1))
 	assert.Equalf(t, io.EOF, err, "Not read to the end")

--- a/internal/databases/postgres/tar_interpreter_new.go
+++ b/internal/databases/postgres/tar_interpreter_new.go
@@ -13,7 +13,8 @@ import (
 // TODO : unit tests
 func (tarInterpreter *FileTarInterpreter) unwrapRegularFileNew(fileReader io.Reader,
 	header *tar.Header,
-	targetPath string) error {
+	targetPath string,
+	fsync bool) error {
 	if tarInterpreter.FilesToUnwrap != nil {
 		if _, ok := tarInterpreter.FilesToUnwrap[header.Name]; !ok {
 			// don't have to unwrap it this time
@@ -27,13 +28,13 @@ func (tarInterpreter *FileTarInterpreter) unwrapRegularFileNew(fileReader io.Rea
 		return err
 	}
 	defer utility.LoggedClose(localFile, "")
-	defer utility.LoggedSync(localFile, "")
+	defer utility.LoggedSync(localFile, "", fsync)
 	var unwrapResult *FileUnwrapResult
 	var unwrapError error
 	if isNewFile {
-		unwrapResult, unwrapError = fileUnwrapper.UnwrapNewFile(fileReader, header, localFile)
+		unwrapResult, unwrapError = fileUnwrapper.UnwrapNewFile(fileReader, header, localFile, fsync)
 	} else {
-		unwrapResult, unwrapError = fileUnwrapper.UnwrapExistingFile(fileReader, header, localFile)
+		unwrapResult, unwrapError = fileUnwrapper.UnwrapExistingFile(fileReader, header, localFile, fsync)
 	}
 	if unwrapError != nil {
 		return unwrapError

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -30,13 +30,15 @@ func LoggedClose(c io.Closer, errmsg string) {
 	}
 }
 
-func LoggedSync(file *os.File, errmsg string) {
-	err := file.Sync()
-	if errmsg == "" {
-		errmsg = "Problem with file sync"
-	}
-	if err != nil {
-		tracelog.ErrorLogger.Printf("%s: %v", errmsg, err)
+func LoggedSync(file *os.File, errmsg string, fsync bool) {
+	if fsync {
+		err := file.Sync()
+		if errmsg == "" {
+			errmsg = "Problem with file sync"
+		}
+		if err != nil {
+			tracelog.ErrorLogger.Printf("%s: %v", errmsg, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Disabling fsync can double write throughput

fsync for tar files is only used for restoring backups,
an unexpected system crash can always be remedied by restarting the restoration

This setting only affects postgres for now, as only the postgres logic calls fsync

Fixes #1046 