### PR TITLE
all: distinguish between storage errors and no backups

### DIFF
--- a/internal/backup_list_handler.go
+++ b/internal/backup_list_handler.go
@@ -27,7 +27,11 @@ type Logging struct {
 
 func DefaultHandleBackupList(folder storage.Folder, pretty, json bool) {
 	getBackupsFunc := func() ([]BackupTime, error) {
-		return GetBackups(folder)
+		res, err := GetBackups(folder)
+		if _, ok := err.(NoBackupsFoundError); ok {
+			err = nil
+		}
+		return res, err
 	}
 	writeBackupListFunc := func(backups []BackupTime) {
 		SortBackupTimeSlices(backups)
@@ -55,11 +59,12 @@ func HandleBackupList(
 	logging Logging,
 ) {
 	backups, err := getBackupsFunc()
+	logging.ErrorLogger.FatalOnError(err)
+
 	if len(backups) == 0 {
 		logging.InfoLogger.Println("No backups found")
 		return
 	}
-	logging.ErrorLogger.FatalOnError(err)
 
 	writeBackupListFunc(backups)
 }

--- a/internal/backup_list_handler_test.go
+++ b/internal/backup_list_handler_test.go
@@ -135,7 +135,8 @@ func TestHandleBackupListLogNoBackups(t *testing.T) {
 
 	assert.Equal(t, 1, infoLogger.Stats.PrintLnCallsCount)
 	assert.Equal(t, "No backups found", infoLogger.Stats.PrintMsg)
-	assert.Equal(t, 0, errorLogger.Stats.FatalOnErrorCallsCount)
+	assert.Equal(t, 1, errorLogger.Stats.FatalOnErrorCallsCount)
+	assert.Equal(t, nil, errorLogger.Stats.Err)
 }
 
 func TestWritePrettyBackupList_LongColumnsValues(t *testing.T) {


### PR DESCRIPTION
Scripts should be able to distinguish between absence of backup and real storage/configurations errors.

In case of real errors - exit code should be 1.