### PR TITLE
Add WALG_S3_MAX_RETRIES setting

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -55,11 +55,15 @@ Set to TRUE to allow wal-g in case of network problems to continue downloading f
 
 If `WALG_S3_RANGE_BATCH_ENABLED` enabled, wal-g will try to reconnect N times, by default 10 times
 
-* `S3_USE_LIST_OBJECTS_V1`
+* `WALG_S3_USE_LIST_OBJECTS_V1`
 
 By default, WAL-G uses [ListObjectsV2](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html) to fetch S3 storage folder listings.
 However, some S3-compatible storages may not support it.
 Set this setting to `true` to use [ListObjects](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html) instead.
+
+* `WALG_S3_MAX_RETRIES`
+
+Overrides the default request retry limit while interacting with S3. Default is 15.
 
 GCS
 -----------

--- a/internal/config.go
+++ b/internal/config.go
@@ -254,6 +254,7 @@ var (
 		"S3_USE_LIST_OBJECTS_V1":      true,
 		"S3_RANGE_BATCH_ENABLED":      true,
 		"S3_RANGE_MAX_RETRIES":        true,
+		"S3_MAX_RETRIES":              true,
 
 		// Azure
 		"WALG_AZ_PREFIX":           true,

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -72,6 +72,7 @@ var (
 		UseListObjectsV1,
 		RangeBatchEnabled,
 		RangeQueriesMaxRetries,
+		MaxRetriesSetting,
 	}
 )
 

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -40,16 +40,17 @@ const (
 	UseListObjectsV1         = "S3_USE_LIST_OBJECTS_V1"
 	RangeBatchEnabled        = "S3_RANGE_BATCH_ENABLED"
 	RangeQueriesMaxRetries   = "S3_RANGE_MAX_RETRIES"
+	// MaxRetriesSetting limits retries during interaction with S3
+	MaxRetriesSetting = "S3_MAX_RETRIES"
 
 	RangeBatchEnabledDefault = false
 	RangeMaxRetriesDefault   = 10
 	RangeQueryMinRetryDelay  = 30 * time.Millisecond
 	RangeQueryMaxRetryDelay  = 300 * time.Second
+	MaxRetriesDefault        = 15
 )
 
 var (
-	// MaxRetries limit upload and download retries during interaction with S3
-	MaxRetries  = 15
 	SettingList = []string{
 		EndpointPortSetting,
 		EndpointSetting,


### PR DESCRIPTION
Add `WALG_S3_MAX_RETRIES` to control the WAL-G S3 request retries limit. Default value (15) is unchanged.