### PR TITLE
Add `--until-binlog-last-modified-time` option to `wal-g-mysql binlog…

### DIFF
--- a/cmd/mysql/binlog_fetch.go
+++ b/cmd/mysql/binlog_fetch.go
@@ -12,9 +12,12 @@ import (
 
 const fetchSinceFlagShortDescr = "backup name starting from which you want to fetch binlogs"
 const fetchUntilFlagShortDescr = "time in RFC3339 for PITR"
+const fetchUntilBinlogLastModifiedFlagShortDescr = "time in RFC3339 that is used to prevent wal-g from replaying" +
+	" binlogs that was created/modified after this time"
 
 var fetchBackupName string
 var fetchUntilTS string
+var fetchUntilBinlogLastModifiedTS string
 
 // binlogPushCmd represents the cron command
 var binlogFetchCmd = &cobra.Command{
@@ -24,7 +27,7 @@ var binlogFetchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
-		mysql.HandleBinlogFetch(folder, fetchBackupName, fetchUntilTS)
+		mysql.HandleBinlogFetch(folder, fetchBackupName, fetchUntilTS, fetchUntilBinlogLastModifiedTS)
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		internal.RequiredSettings[internal.MysqlBinlogDstSetting] = true
@@ -39,5 +42,9 @@ func init() {
 		"until",
 		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339),
 		fetchUntilFlagShortDescr)
+	binlogReplayCmd.PersistentFlags().StringVar(&fetchUntilBinlogLastModifiedTS,
+		"until-binlog-last-modified-time",
+		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339),
+		fetchUntilBinlogLastModifiedFlagShortDescr)
 	cmd.AddCommand(binlogFetchCmd)
 }

--- a/cmd/mysql/binlog_fetch.go
+++ b/cmd/mysql/binlog_fetch.go
@@ -44,7 +44,7 @@ func init() {
 		fetchUntilFlagShortDescr)
 	binlogFetchCmd.PersistentFlags().StringVar(&fetchUntilBinlogLastModifiedTS,
 		"until-binlog-last-modified-time",
-		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339),
+		"",
 		fetchUntilBinlogLastModifiedFlagShortDescr)
 	cmd.AddCommand(binlogFetchCmd)
 }

--- a/cmd/mysql/binlog_fetch.go
+++ b/cmd/mysql/binlog_fetch.go
@@ -42,7 +42,7 @@ func init() {
 		"until",
 		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339),
 		fetchUntilFlagShortDescr)
-	binlogReplayCmd.PersistentFlags().StringVar(&fetchUntilBinlogLastModifiedTS,
+	binlogFetchCmd.PersistentFlags().StringVar(&fetchUntilBinlogLastModifiedTS,
 		"until-binlog-last-modified-time",
 		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339),
 		fetchUntilBinlogLastModifiedFlagShortDescr)

--- a/cmd/mysql/binlog_replay.go
+++ b/cmd/mysql/binlog_replay.go
@@ -40,6 +40,6 @@ func init() {
 	binlogReplayCmd.PersistentFlags().StringVar(&replayUntilTS, "until",
 		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339), replayUntilFlagShortDescr)
 	binlogReplayCmd.PersistentFlags().StringVar(&replayUntilBinlogLastModifiedTS, "until-binlog-last-modified-time",
-		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339), replayUntilBinlogLastModifiedFlagShortDescr)
+		"", replayUntilBinlogLastModifiedFlagShortDescr)
 	cmd.AddCommand(binlogReplayCmd)
 }

--- a/cmd/mysql/binlog_replay.go
+++ b/cmd/mysql/binlog_replay.go
@@ -12,9 +12,12 @@ import (
 
 const replaySinceFlagShortDescr = "backup name starting from which you want to fetch binlogs"
 const replayUntilFlagShortDescr = "time in RFC3339 for PITR"
+const replayUntilBinlogLastModifiedFlagShortDescr = "time in RFC3339 that is used to prevent wal-g from replaying" +
+	" binlogs that was created/modified after this time"
 
 var replayBackupName string
 var replayUntilTS string
+var replayUntilBinlogLastModifiedTS string
 
 var binlogReplayCmd = &cobra.Command{
 	Use:   "binlog-replay",
@@ -23,7 +26,7 @@ var binlogReplayCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
-		mysql.HandleBinlogReplay(folder, replayBackupName, replayUntilTS)
+		mysql.HandleBinlogReplay(folder, replayBackupName, replayUntilTS, replayUntilBinlogLastModifiedTS)
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		internal.RequiredSettings[internal.MysqlBinlogReplayCmd] = true
@@ -36,5 +39,7 @@ func init() {
 	binlogReplayCmd.PersistentFlags().StringVar(&replayBackupName, "since", "LATEST", replaySinceFlagShortDescr)
 	binlogReplayCmd.PersistentFlags().StringVar(&replayUntilTS, "until",
 		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339), replayUntilFlagShortDescr)
+	binlogReplayCmd.PersistentFlags().StringVar(&replayUntilBinlogLastModifiedTS, "until-binlog-last-modified-time",
+		utility.TimeNowCrossPlatformUTC().Format(time.RFC3339), replayUntilBinlogLastModifiedFlagShortDescr)
 	cmd.AddCommand(binlogReplayCmd)
 }

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -140,6 +140,13 @@ or
 wal-g binlog-fetch --since LATEST --until "2006-01-02T15:04:05Z07:00"
 ```
 
+You can stop wal-g from fetching newly created/modified binlogs by specifying `--until-binlog-last-modified-time` option.
+This may be useful to achieve exact clones of the same database in scenarios when new binlogs are uploaded concurrently whith your restore process.
+
+```bash
+wal-g binlog-replay --since LATEST --until "2006-01-02T15:04:05Z07:00" --until-binlog-last-modified-time "2006-01-02T15:04:05Z07:00"
+```
+
 ### ``binlog-replay``
 
 Fetches binlogs from storage and passes them to `WALG_MYSQL_BINLOG_REPLAY_COMMAND` to replay on running MySQL server.
@@ -161,6 +168,12 @@ or
 wal-g binlog-replay --since LATEST --until "2006-01-02T15:04:05Z07:00"
 ```
 
+You can stop wal-g from applying newly created/modified  binlogs by specifying `--until-binlog-last-modified-time` option.
+This may be useful to achieve exact clones of the same database in scenarios when new binlogs are uploaded concurrently whith your restore process.
+
+```bash
+wal-g binlog-replay --since LATEST --until "2006-01-02T15:04:05Z07:00" --until-binlog-last-modified-time "2006-01-02T15:04:05Z07:00"
+```
 
 Typical configurations
 -----

--- a/internal/databases/mysql/binlog_fetch_handler.go
+++ b/internal/databases/mysql/binlog_fetch_handler.go
@@ -41,17 +41,17 @@ func (ih *indexHandler) createIndexFile() error {
 	return nil
 }
 
-func HandleBinlogFetch(folder storage.Folder, backupName string, untilTS string) {
+func HandleBinlogFetch(folder storage.Folder, backupName string, untilTS string, untilBinlogLastModifiedTS string) {
 	dstDir, err := internal.GetLogsDstSettings(internal.MysqlBinlogDstSetting)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	startTS, endTS, err := getTimestamps(folder, backupName, untilTS)
+	startTS, endTS, endBinlogTS, err := getTimestamps(folder, backupName, untilTS, untilBinlogLastModifiedTS)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	handler := newIndexHandler(dstDir)
 
 	tracelog.InfoLogger.Printf("Fetching binlogs since %s until %s", startTS, endTS)
-	err = fetchLogs(folder, dstDir, startTS, endTS, handler)
+	err = fetchLogs(folder, dstDir, startTS, endTS, endBinlogTS, handler)
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch binlogs: %v", err)
 
 	err = handler.createIndexFile()


### PR DESCRIPTION
 Add `--until-binlog-last-modified-time` option to `wal-g-mysql binlog-replay`  this may be useful to achieve exact clones of the same database in scenarios when  new binlogs are uploaded during replay process of different hosts.
