### PR TITLE
[draft] Fix S3_LOG_LEVEL setting

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -256,6 +256,7 @@ var (
 		"S3_ENDPOINT_SOURCE":          true,
 		"S3_ENDPOINT_PORT":            true,
 		"S3_USE_LIST_OBJECTS_V1":      true,
+		"S3_LOG_LEVEL":					true,
 		"S3_RANGE_BATCH_ENABLED":      true,
 		"S3_RANGE_MAX_RETRIES":        true,
 		"S3_MAX_RETRIES":              true,

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -70,6 +70,7 @@ var (
 		s3CertFile,
 		MaxPartSize,
 		UseListObjectsV1,
+		LogLevel,
 		RangeBatchEnabled,
 		RangeQueriesMaxRetries,
 		MaxRetriesSetting,


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fix
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
