### PR TITLE
Enable greenplum wal-prefetch

### DIFF
--- a/cmd/gp/gp.go
+++ b/cmd/gp/gp.go
@@ -55,4 +55,11 @@ func init() {
 		wrappedPreRun(cmd, args)
 	}
 	cmd.AddCommand(wrappedPgCmd)
+
+	// Add the hidden prefetch command to the root command since there is no "pg" prefix in the WAL-G prefetch fork logic
+	pg.WalPrefetchCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		internal.RequiredSettings[internal.StoragePrefixSetting] = true
+		tracelog.ErrorLogger.FatalOnError(internal.AssertRequiredSettingsSet())
+	}
+	cmd.AddCommand(pg.WalPrefetchCmd)
 }

--- a/cmd/gp/gp.go
+++ b/cmd/gp/gp.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/spf13/viper"
+	"github.com/wal-g/wal-g/internal/databases/postgres"
+
 	"github.com/wal-g/wal-g/cmd/common"
 
 	"github.com/wal-g/wal-g/cmd/pg"
@@ -26,6 +29,8 @@ var cmd = &cobra.Command{
 	Short:   dbShortDescription, // TODO : improve description
 	Version: strings.Join([]string{walgVersion, gitRevision, buildDate, "GreenplumDB"}, "\t"),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Greenplum uses the 64MB WAL segment size by default
+		postgres.SetWalSize(viper.GetUint64(internal.PgWalSize))
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
@@ -57,7 +62,7 @@ func init() {
 	cmd.AddCommand(wrappedPgCmd)
 
 	// Add the hidden prefetch command to the root command since there is no "pg" prefix in the WAL-G prefetch fork logic
-	pg.WalPrefetchCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+	pg.WalPrefetchCmd.PreRun = func(cmd *cobra.Command, args []string) {
 		internal.RequiredSettings[internal.StoragePrefixSetting] = true
 		tracelog.ErrorLogger.FatalOnError(internal.AssertRequiredSettingsSet())
 	}

--- a/cmd/pg/wal_prefetch.go
+++ b/cmd/pg/wal_prefetch.go
@@ -9,8 +9,8 @@ import (
 const WalPrefetchShortDescription = `Used for prefetching process forking
 and should not be called by user.`
 
-// walPrefetchCmd represents the walPrefetch command
-var walPrefetchCmd = &cobra.Command{
+// WalPrefetchCmd represents the walPrefetch command
+var WalPrefetchCmd = &cobra.Command{
 	Use:    "wal-prefetch wal_name prefetch_location",
 	Short:  WalPrefetchShortDescription,
 	Args:   cobra.ExactArgs(2),
@@ -23,5 +23,5 @@ var walPrefetchCmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.AddCommand(walPrefetchCmd)
+	Cmd.AddCommand(WalPrefetchCmd)
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -185,6 +185,7 @@ var (
 
 	GPDefaultSettings = map[string]string{
 		GPLogsDirectory: "",
+		PgWalSize:       "64",
 	}
 
 	AllowedSettings map[string]bool

--- a/internal/databases/postgres/prefetch.go
+++ b/internal/databases/postgres/prefetch.go
@@ -248,6 +248,10 @@ func forkPrefetch(walFileName string, location string) {
 	if internal.CfgFile != "" {
 		prefetchArgs = append(prefetchArgs, "--config", internal.CfgFile)
 	}
+	storagePrefix := viper.GetString(internal.StoragePrefixSetting)
+	if storagePrefix != "" {
+		prefetchArgs = append(prefetchArgs, "--walg-storage-prefix", storagePrefix)
+	}
 	cmd := exec.Command(os.Args[0], prefetchArgs...)
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Currently, `wal-prefetch` does not work in WAL-G for Greenplum. This PR enables this functionality.