### PR TITLE
sqlserver compression / encryption

### DIFF
--- a/cmd/sqlserver/backup_push.go
+++ b/cmd/sqlserver/backup_push.go
@@ -8,14 +8,13 @@ import (
 const backupPushShortDescription = "Creates new backup and pushes it to the storage"
 
 var backupPushDatabases []string
-var backupCompression bool
 var backupUpdateLatest bool
 
 var backupPushCmd = &cobra.Command{
 	Use:   "backup-push",
 	Short: backupPushShortDescription,
 	Run: func(cmd *cobra.Command, args []string) {
-		sqlserver.HandleBackupPush(backupPushDatabases, backupUpdateLatest, backupCompression)
+		sqlserver.HandleBackupPush(backupPushDatabases, backupUpdateLatest)
 	},
 }
 
@@ -24,7 +23,5 @@ func init() {
 		"List of databases to backup. All not-system databases as default")
 	backupPushCmd.PersistentFlags().BoolVarP(&backupUpdateLatest, "update-latest", "u", false,
 		"Update latest backup instead of creating new one")
-	backupPushCmd.PersistentFlags().BoolVarP(&backupCompression, "compression", "c", true,
-		"Use built-in backup compression. Enabled by default")
 	cmd.AddCommand(backupPushCmd)
 }

--- a/cmd/sqlserver/log_push.go
+++ b/cmd/sqlserver/log_push.go
@@ -8,22 +8,19 @@ import (
 const logPushShortDescription = "Creates new log backup and pushes it to the storage"
 
 var logPushDatabases []string
-var logCompression bool
 var logNoRecovery bool
 
 var logPushCmd = &cobra.Command{
 	Use:   "log-push",
 	Short: logPushShortDescription,
 	Run: func(cmd *cobra.Command, args []string) {
-		sqlserver.HandleLogPush(logPushDatabases, logCompression, logNoRecovery)
+		sqlserver.HandleLogPush(logPushDatabases, logNoRecovery)
 	},
 }
 
 func init() {
 	logPushCmd.PersistentFlags().StringSliceVarP(&logPushDatabases, "databases", "d", []string{},
 		"List of databases to log. All not-system databases as default")
-	logPushCmd.PersistentFlags().BoolVarP(&logCompression, "compression", "c", true,
-		"Use built-in log compression. Enabled by default")
 	logPushCmd.PersistentFlags().BoolVarP(&logNoRecovery, "no-recovery", "n", false,
 		"Do a tail-log backup leaving database closed for further modifications")
 	cmd.AddCommand(logPushCmd)

--- a/internal/databases/sqlserver/blob/blob.go
+++ b/internal/databases/sqlserver/blob/blob.go
@@ -26,13 +26,15 @@ const BgSaveInterval = 30 * time.Second
 
 type Index struct {
 	sync.Mutex
-	folder    storage.Folder
-	Size      uint64            `json:"size"`
-	Blocks    []*Block          `json:"blocks"`
-	icache    map[string]*Block // cache by id's
-	ocache    []*Block          // cache by offset, ordered, only committed
-	needSave  bool
-	readCache *lru.Cache
+	folder      storage.Folder
+	Size        uint64            `json:"size"`
+	Blocks      []*Block          `json:"blocks"`
+	Compression string            `json:"compression"`
+	Encryption  string            `json:"encryption"`
+	icache      map[string]*Block // cache by id's
+	ocache      []*Block          // cache by offset, ordered, only committed
+	needSave    bool
+	readCache   *lru.Cache
 }
 
 type Block struct {

--- a/internal/databases/sqlserver/blob/util.go
+++ b/internal/databases/sqlserver/blob/util.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
 )
 
 var ErrNoLease = errors.New("no lease")
@@ -63,4 +65,11 @@ func (r *SkipReader) Read(s []byte) (int, error) {
 		r.offset = 0
 	}
 	return r.reader.Read(s)
+}
+
+const SQLServerCompressionMethod = "sqlserver"
+
+func UseBuiltinCompression() bool {
+	method, _ := internal.GetSetting(internal.CompressionMethodSetting)
+	return strings.EqualFold(method, SQLServerCompressionMethod)
 }

--- a/internal/databases/sqlserver/log_push_handler.go
+++ b/internal/databases/sqlserver/log_push_handler.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/wal-g/wal-g/internal/databases/sqlserver/blob"
+
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/utility"
 )
 
-func HandleLogPush(dbnames []string, compression bool, norecovery bool) {
+func HandleLogPush(dbnames []string, norecovery bool) {
 	ctx, cancel := context.WithCancel(context.Background())
 	signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 	defer func() { _ = signalHandler.Close() }()
@@ -32,16 +34,17 @@ func HandleLogPush(dbnames []string, compression bool, norecovery bool) {
 	tracelog.ErrorLogger.FatalOnError(err)
 	defer lock.Close()
 
+	builtinCompression := blob.UseBuiltinCompression()
 	logBackupName := generateLogBackupName()
 	err = runParallel(func(i int) error {
-		return backupSingleLog(ctx, db, logBackupName, dbnames[i], compression, norecovery)
+		return backupSingleLog(ctx, db, logBackupName, dbnames[i], builtinCompression, norecovery)
 	}, len(dbnames), getDBConcurrency())
 	tracelog.ErrorLogger.FatalfOnError("overall log backup failed: %v", err)
 
 	tracelog.InfoLogger.Printf("log backup finished")
 }
 
-func backupSingleLog(ctx context.Context, db *sql.DB, backupName string, dbname string, compression bool, noRecovery bool) error {
+func backupSingleLog(ctx context.Context, db *sql.DB, backupName string, dbname string, builtinCompression bool, noRecovery bool) error {
 	baseURL := getLogBackupURL(backupName, dbname)
 	size, blobCount, err := estimateLogSize(db, dbname)
 	if err != nil {
@@ -51,7 +54,7 @@ func backupSingleLog(ctx context.Context, db *sql.DB, backupName string, dbname 
 	urls := buildBackupUrls(baseURL, blobCount)
 	sql := fmt.Sprintf("BACKUP LOG %s TO %s", quoteName(dbname), urls)
 	sql += fmt.Sprintf(" WITH FORMAT, MAXTRANSFERSIZE=%d", MaxTransferSize)
-	if compression {
+	if builtinCompression {
 		sql += ", COMPRESSION"
 	}
 	if noRecovery {

--- a/internal/fetch_helper.go
+++ b/internal/fetch_helper.go
@@ -75,6 +75,10 @@ func DecompressDecryptBytes(archiveReader io.Reader, decompressor compression.De
 	if err != nil {
 		return nil, err
 	}
+	if decompressor == nil {
+		tracelog.DebugLogger.Printf("No decompressor has been selected")
+		return ioutil.NopCloser(decryptReader), nil
+	}
 	return decompressor.Decompress(decryptReader)
 }
 


### PR DESCRIPTION
### SQLServer

Enables WAL-G standard compression and encryption methods for SQLServer.
Option `WALG_COMPRESSION_METHOD=sqlserver`  has special meaning: WAL-G will request SQLServer to compress data itself.