### PR TITLE
Greenplum backup-fetch: add --content-ids, --mode flags

### DIFF
--- a/cmd/gp/backup_fetch.go
+++ b/cmd/gp/backup_fetch.go
@@ -19,10 +19,12 @@ const (
 	backupFetchShortDescription  = "Fetches a backup from storage"
 	targetUserDataDescription    = "Fetch storage backup which has the specified user data"
 	restoreConfigPathDescription = "Path to the cluster restore configuration"
+	fetchContentIdsDescription   = "If set, WAL-G will fetch only the specified segments"
 )
 
 var fetchTargetUserData string
 var restoreConfigPath string
+var fetchContentIds *[]int
 
 var backupFetchCmd = &cobra.Command{
 	Use:   "backup-fetch [backup_name | --target-user-data <data>]",
@@ -46,7 +48,7 @@ var backupFetchCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalfOnError("Failed to unmarshal the provided restore config file: %v", err)
 
 		logsDir := viper.GetString(internal.GPLogsDirectory)
-		internal.HandleBackupFetch(folder, targetBackupSelector, greenplum.NewGreenplumBackupFetcher(restoreCfg, logsDir))
+		internal.HandleBackupFetch(folder, targetBackupSelector, greenplum.NewGreenplumBackupFetcher(restoreCfg, logsDir, *fetchContentIds))
 	},
 }
 
@@ -71,6 +73,7 @@ func init() {
 		"", targetUserDataDescription)
 	backupFetchCmd.Flags().StringVar(&restoreConfigPath, "restore-config",
 		"", restoreConfigPathDescription)
+	fetchContentIds = backupFetchCmd.Flags().IntSlice("content-ids", []int{}, fetchContentIdsDescription)
 	_ = backupFetchCmd.MarkFlagRequired("restore-config")
 
 	cmd.AddCommand(backupFetchCmd)

--- a/cmd/gp/backup_fetch.go
+++ b/cmd/gp/backup_fetch.go
@@ -52,6 +52,10 @@ var backupFetchCmd = &cobra.Command{
 
 		logsDir := viper.GetString(internal.GPLogsDirectory)
 
+		if len(*fetchContentIds) > 0 {
+			tracelog.InfoLogger.Printf("Will perform fetch operations only on the specified segments: %v", *fetchContentIds)
+		}
+
 		fetchMode, err := greenplum.NewBackupFetchMode(fetchModeStr)
 		tracelog.ErrorLogger.FatalOnError(err)
 


### PR DESCRIPTION
I propose to add the two new flags for the Greenplum `backup-fetch`:

`--content-ids` allows to perform the fetch operations only on some specific segments. This might be useful when the backup-fetch operation completed successfully on all segments except the few ones so the DBA or script can semi-automatically complete the failed backup fetch. For example:
```
wal-g backup-fetch LATEST --content-ids=3,5,7 --restore-config=restore-config.json --config=/etc/wal-g/wal-g.yaml 
```

`--mode` allows to specify the desired mode of the backup-fetching.

- Default: do the backup unpacking and prepare the configs [unpack+prepare]
- Unpack: backup unpacking only
- Prepare: config preparation only.