### PR TITLE
mysql: backups on cascade replicas

### DIFF
--- a/cmd/mysql/backup_push.go
+++ b/cmd/mysql/backup_push.go
@@ -29,8 +29,9 @@ var (
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			uploader, err := internal.ConfigureSplitUploader()
-			uploader.ChangeDirectory(utility.BaseBackupPath)
 			tracelog.ErrorLogger.FatalOnError(err)
+			folder := uploader.Folder()
+			uploader.ChangeDirectory(utility.BaseBackupPath)
 			backupCmd, err := internal.GetCommandSetting(internal.NameStreamCreateCmd)
 			tracelog.ErrorLogger.FatalOnError(err)
 
@@ -38,7 +39,7 @@ var (
 				userData = viper.GetString(internal.SentinelUserDataSetting)
 			}
 
-			mysql.HandleBackupPush(uploader, backupCmd, permanent, userData)
+			mysql.HandleBackupPush(folder, uploader, backupCmd, permanent, userData)
 		},
 	}
 	permanent = false

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -4,18 +4,22 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/limiters"
 	"github.com/wal-g/wal-g/utility"
 )
 
-func HandleBackupPush(uploader internal.UploaderProvider, backupCmd *exec.Cmd, isPermanent bool, userDataRaw string) {
+func HandleBackupPush(folder storage.Folder, uploader internal.UploaderProvider,
+	backupCmd *exec.Cmd, isPermanent bool, userDataRaw string) {
 	db, err := getMySQLConnection()
 	tracelog.ErrorLogger.FatalOnError(err)
 	defer utility.LoggedClose(db, "")
 
-	binlogStart := getMySQLCurrentBinlogFile(db)
+	binlogStart, err := getLastUploadedBinlog(folder)
+	tracelog.ErrorLogger.FatalfOnError("failed to get last uploaded binlog: %v", err)
 	timeStart := utility.TimeNowCrossPlatformLocal()
 
 	stdout, stderr, err := utility.StartCommandWithStdoutStderr(backupCmd)
@@ -30,7 +34,8 @@ func HandleBackupPush(uploader internal.UploaderProvider, backupCmd *exec.Cmd, i
 		tracelog.ErrorLogger.Fatalf("backup create command failed: %v", err)
 	}
 
-	binlogEnd := getMySQLCurrentBinlogFile(db)
+	binlogEnd, err := getLastUploadedBinlog(folder)
+	tracelog.ErrorLogger.FatalfOnError("failed to get last uploaded binlog (after): %v", err)
 	timeStop := utility.TimeNowCrossPlatformLocal()
 	hostname, err := os.Hostname()
 	if err != nil {


### PR DESCRIPTION
### MySQL

Before taking backup Wal-G determines the current binlog file and saves it to the sentinel.
Wal-G do this using `SHOW MASTER STATUS` or `SHOW REPLICA STATUS` (if backup is taken from replica).
This does not work for second-level (cascade) replica, as it does not connect directly to master.
```
primary <== replica <== replica2 (backup)
```

## Fix
We can find last binlog uploaded to storage instead of the current binlog on master. The last uploaded binlog is behind the current one, so we do not loose the data.
