### PR TITLE
sqlserver: fix blob index race

### DIFF
--- a/internal/databases/sqlserver/blob/server.go
+++ b/internal/databases/sqlserver/blob/server.go
@@ -624,12 +624,15 @@ func (bs *Server) HandleBlobPut(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 	}
+	bs.indexesMutex.Lock()
+	defer bs.indexesMutex.Unlock()
 	err = idx.Save()
 	if err != nil {
 		bs.returnError(w, req, err)
 		return
 	}
-	bs.deleteGarbage(folder, garbage)
+	bs.indexes[folder.GetPath()] = idx
+	go bs.deleteGarbage(folder, garbage)
 	w.WriteHeader(http.StatusCreated)
 }
 


### PR DESCRIPTION
After creating new blob with PUT, SQLServer checks it with HEAD.
If storage is not read-after-write capable, we could get NotFound error and return 404 to SQLServer. It will break backup process.

Fix: cache newly created blob indexes in in-memory cache
