### PR TITLE
Fix missing unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,25 +188,9 @@ st_integration_test: load_docker_common
 
 unittest:
 	go list ./... | grep -Ev 'vendor|submodules|tmp' | xargs go vet
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/compression/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/openpgp/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/awskms/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/abool
-	@if [ ! -z "${USE_LIBSODIUM}" ]; then\
-		go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/crypto/libsodium/;\
-	fi
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/mysql
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/mongo/...
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/databases/postgres
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/walparser/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./utility
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./pkg/storages/azure/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./pkg/storages/fs/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./pkg/storages/gcs/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./pkg/storages/s3/
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./pkg/storages/storage
-	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./pkg/storages/swift/
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./internal/...
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./pkg/...
+	go test -mod vendor -v $(TEST_MODIFIER) -tags "$(BUILD_TAGS)" ./utility/...
 
 coverage:
 	go list ./... | grep -Ev 'vendor|submodules|tmp' | xargs go test -v $(TEST_MODIFIER) -coverprofile=$(COVERAGE_FILE) | grep -v 'no test files'

--- a/internal/compression/lzo/lzo_test.go
+++ b/internal/compression/lzo/lzo_test.go
@@ -1,7 +1,7 @@
 //go:build lzo
 // +build lzo
 
-package lzo
+package lzo_test
 
 import (
 	"bufio"
@@ -14,6 +14,7 @@ import (
 	"github.com/cyberdelia/lzo"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
+	walg_lzo "github.com/wal-g/wal-g/internal/compression/lzo"
 	"github.com/wal-g/wal-g/testtools"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -43,7 +44,7 @@ func testLzopRoundTrip(t *testing.T, stride, nBytes int) {
 	go func() {
 		defer utility.LoggedClose(lzow, "")
 		defer utility.LoggedClose(w, "")
-		bw := bufio.NewWriterSize(lzow, LzopBlockSize)
+		bw := bufio.NewWriterSize(lzow, walg_lzo.LzopBlockSize)
 		defer func() {
 			if err := bw.Flush(); err != nil {
 				panic(err)
@@ -73,7 +74,7 @@ func testLzopRoundTrip(t *testing.T, stride, nBytes int) {
 }
 
 func TestLzopUncompressableBytes(t *testing.T) {
-	testLzopRoundTrip(t, LzopBlockSize*2, LzopBlockSize*2)
+	testLzopRoundTrip(t, walg_lzo.LzopBlockSize*2, walg_lzo.LzopBlockSize*2)
 }
 func TestLzop1Byte(t *testing.T)   { testLzopRoundTrip(t, 7924, 1) }
 func TestLzop1MByte(t *testing.T)  { testLzopRoundTrip(t, 7924, 1024*1024) }
@@ -141,3 +142,9 @@ type BufferReaderMaker struct {
 
 func (b *BufferReaderMaker) Reader() (io.ReadCloser, error) { return ioutil.NopCloser(b.Buf), nil }
 func (b *BufferReaderMaker) Path() string                   { return b.Key }
+
+func init() {
+	internal.ConfigureSettings("")
+	internal.InitConfig()
+	internal.Configure()
+}


### PR DESCRIPTION
Currently, there are some explicit paths configured in the `make unittests` Makefile target. This results in some missing tests. I propose to run all of the `_test.go` files by default.