### PR TITLE
DecryptAndDecompressTar: return ReadCloser instead of taking Writer

### DIFF
--- a/internal/compress_and_encrypt.go
+++ b/internal/compress_and_encrypt.go
@@ -42,7 +42,7 @@ func CompressAndEncrypt(source io.Reader, compressor compression.Compressor, cry
 
 	var compressedWriter io.WriteCloser
 	if compressor != nil {
-		writeIgnorer := &EmptyWriteIgnorer{writeCloser}
+		writeIgnorer := &utility.EmptyWriteIgnorer{Writer: writeCloser}
 		compressedWriter = compressor.NewWriter(writeIgnorer)
 	} else {
 		compressedWriter = writeCloser

--- a/internal/databases/postgres/wal_segment.go
+++ b/internal/databases/postgres/wal_segment.go
@@ -138,7 +138,7 @@ func (seg *WalSegment) processMessage(message pgproto3.BackendMessage) (ProcessM
 				messageOffset = seg.StartLSN - xld.WALStart
 			}
 			tracelog.DebugLogger.Println("XLogData =>", "WALStart", xld.WALStart, "WALEnd", walEnd,
-				"LenWALData", len(string(xld.WALData)), "ServerWALEnd", xld.ServerWALEnd,
+				"LenWALData", len(xld.WALData), "ServerWALEnd", xld.ServerWALEnd,
 				"messageOffset", messageOffset) //, "ServerTime:", xld.ServerTime)
 			if seg.StartLSN+pglogrepl.LSN(seg.writeIndex) != (xld.WALStart + messageOffset) {
 				return ProcessMessageSegmentGap, segmentError{

--- a/internal/extract_test.go
+++ b/internal/extract_test.go
@@ -4,12 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/crypto/openpgp"
@@ -42,7 +40,7 @@ func generateRandomBytes() []byte {
 		R: sb,
 		N: int64(randomBytesAmount),
 	}
-	b, _ := ioutil.ReadAll(lr)
+	b, _ := io.ReadAll(lr)
 	return b
 }
 
@@ -158,15 +156,18 @@ func TestDecryptAndDecompressTar_unencrypted(t *testing.T) {
 
 	compressedBuffer := &bytes.Buffer{}
 	_, _ = compressedBuffer.ReadFrom(compressed)
-	brm := &BufferReaderMaker{compressedBuffer, "/usr/local/test.tar.lz4"}
 
-	decompressed := &bytes.Buffer{}
-	err := internal.DecryptAndDecompressTar(decompressed, brm, nil)
-
+	reader, err := internal.DecryptAndDecompressTar(compressedBuffer, "/usr/local/test.tar.lz4", nil)
 	if err != nil {
 		t.Logf("%+v\n", err)
 	}
-	assert.Equalf(t, bCopy, decompressed.Bytes(), "decompressed tar does not match the input")
+
+	decompressed, readErr := io.ReadAll(reader)
+	if readErr != nil {
+		t.Logf("%+v\n", readErr)
+	}
+
+	assert.Equalf(t, bCopy, decompressed, "decompressed tar does not match the input")
 }
 
 func TestDecryptAndDecompressTar_encrypted(t *testing.T) {
@@ -181,17 +182,17 @@ func TestDecryptAndDecompressTar_encrypted(t *testing.T) {
 	compressor := GetLz4Compressor()
 	compressed := internal.CompressAndEncrypt(bytes.NewReader(b), compressor, crypter)
 
-	compressedBuffer, _ := ioutil.ReadAll(compressed)
-	brm := &BufferReaderMaker{bytes.NewBuffer(compressedBuffer), "/usr/local/test.tar.lz4"}
-
-	decompressed := &bytes.Buffer{}
-	err := internal.DecryptAndDecompressTar(decompressed, brm, crypter)
-
+	reader, err := internal.DecryptAndDecompressTar(compressed, "/usr/local/test.tar.lz4", crypter)
 	if err != nil {
 		t.Logf("%+v\n", err)
 	}
 
-	assert.Equalf(t, bCopy, decompressed.Bytes(), "decompressed tar does not match the input")
+	decompressed, readErr := io.ReadAll(reader)
+	if readErr != nil {
+		t.Logf("%+v\n", readErr)
+	}
+
+	assert.Equalf(t, bCopy, decompressed, "decompressed tar does not match the input")
 }
 
 func TestDecryptAndDecompressTar_noCrypter(t *testing.T) {
@@ -206,19 +207,17 @@ func TestDecryptAndDecompressTar_noCrypter(t *testing.T) {
 	compressor := GetLz4Compressor()
 	compressed := internal.CompressAndEncrypt(bytes.NewReader(b), compressor, crypter)
 
-	compressedBuffer, _ := ioutil.ReadAll(compressed)
-	brm := &BufferReaderMaker{bytes.NewBuffer(compressedBuffer), "/usr/local/test.tar.lz4"}
-
-	decompressed := &bytes.Buffer{}
-	err := internal.DecryptAndDecompressTar(decompressed, brm, nil)
-
+	reader, err := internal.DecryptAndDecompressTar(compressed, "/usr/local/test.tar.lz4", nil)
 	if err != nil {
 		t.Logf("%+v\n", err)
 	}
 
-	assert.Error(t, err)
-	originalError := errors.Cause(err)
-	assert.IsType(t, internal.DecompressionError{}, originalError)
+	_, readErr := io.ReadAll(reader)
+	if readErr != nil {
+		t.Logf("%+v\n", readErr)
+	}
+
+	assert.Error(t, readErr)
 }
 
 func TestDecryptAndDecompressTar_wrongCrypter(t *testing.T) {
@@ -233,15 +232,12 @@ func TestDecryptAndDecompressTar_wrongCrypter(t *testing.T) {
 	compressor := GetLz4Compressor()
 	compressed := internal.CompressAndEncrypt(bytes.NewReader(b), compressor, crypter)
 
-	compressedBuffer, _ := ioutil.ReadAll(compressed)
-	brm := &BufferReaderMaker{bytes.NewBuffer(compressedBuffer), "/usr/local/test.tar.lzma"}
-
-	decompressed := &bytes.Buffer{}
-	err := internal.DecryptAndDecompressTar(decompressed, brm, crypter)
+	_, err := internal.DecryptAndDecompressTar(compressed, "/usr/local/test.tar.lzma", crypter)
+	if err != nil {
+		t.Logf("%+v\n", err)
+	}
 
 	assert.Error(t, err)
-	originalError := errors.Cause(err)
-	assert.IsType(t, internal.DecompressionError{}, originalError)
 }
 
 func TestDecryptAndDecompressTar_unknownFormat(t *testing.T) {
@@ -251,11 +247,7 @@ func TestDecryptAndDecompressTar_unknownFormat(t *testing.T) {
 	bCopy := make([]byte, len(b))
 	copy(bCopy, b)
 
-	brm := &BufferReaderMaker{bytes.NewBuffer(b), "/usr/local/test.some_unsupported_file_format"}
-
-	decompressed := &bytes.Buffer{}
-	err := internal.DecryptAndDecompressTar(decompressed, brm, nil)
-
+	_, err := internal.DecryptAndDecompressTar(bytes.NewBuffer(b), "/usr/local/test.some_unsupported_file_format", nil)
 	if err != nil {
 		t.Logf("%+v\n", err)
 	}
@@ -273,15 +265,18 @@ func TestDecryptAndDecompressTar_uncompressed(t *testing.T) {
 
 	compressedBuffer := &bytes.Buffer{}
 	_, _ = compressedBuffer.ReadFrom(compressed)
-	brm := &BufferReaderMaker{compressedBuffer, "/usr/local/test.tar"}
 
-	decompressed := &bytes.Buffer{}
-	err := internal.DecryptAndDecompressTar(decompressed, brm, nil)
-
+	reader, err := internal.DecryptAndDecompressTar(compressedBuffer, "/usr/local/test.tar", nil)
 	if err != nil {
 		t.Logf("%+v\n", err)
 	}
-	assert.Equalf(t, bCopy, decompressed.Bytes(), "decompressed tar does not match the input")
+
+	decompressed, readErr := io.ReadAll(reader)
+	if readErr != nil {
+		t.Logf("%+v\n", err)
+	}
+
+	assert.Equalf(t, bCopy, decompressed, "decompressed tar does not match the input")
 }
 
 // Used to mock files in memory.
@@ -290,7 +285,7 @@ type BufferReaderMaker struct {
 	Key string
 }
 
-func (b *BufferReaderMaker) Reader() (io.ReadCloser, error) { return ioutil.NopCloser(b.Buf), nil }
+func (b *BufferReaderMaker) Reader() (io.ReadCloser, error) { return io.NopCloser(b.Buf), nil }
 func (b *BufferReaderMaker) Path() string                   { return b.Key }
 
 type NOPSleeper struct{}

--- a/internal/fetch_helper.go
+++ b/internal/fetch_helper.go
@@ -54,7 +54,7 @@ func DownloadFile(folder storage.Folder, filename, ext string, writeCloser io.Wr
 	}
 	defer utility.LoggedClose(decompressedReader, "")
 
-	_, err = utility.FastCopy(&EmptyWriteIgnorer{WriteCloser: writeCloser}, decompressedReader)
+	_, err = utility.FastCopy(&utility.EmptyWriteIgnorer{Writer: writeCloser}, decompressedReader)
 	return err
 }
 

--- a/internal/stream_fetch_helper.go
+++ b/internal/stream_fetch_helper.go
@@ -57,7 +57,7 @@ func DownloadAndDecompressStream(backup Backup, writeCloser io.WriteCloser) erro
 		}
 		defer utility.LoggedClose(decompressedReader, "")
 
-		_, err = utility.FastCopy(&EmptyWriteIgnorer{WriteCloser: writeCloser}, decompressedReader)
+		_, err = utility.FastCopy(&utility.EmptyWriteIgnorer{Writer: writeCloser}, decompressedReader)
 		if err != nil {
 			return fmt.Errorf("failed to decompress and decrypt file: %w", err)
 		}
@@ -83,7 +83,7 @@ func DownloadAndDecompressSplittedStream(backup Backup, blockSize int, extension
 	}
 
 	errorsPerWorker := make([]chan error, 0)
-	writers := splitmerge.MergeWriter(EmptyWriteIgnorer{WriteCloser: writeCloser}, partitions, blockSize)
+	writers := splitmerge.MergeWriter(utility.EmptyWriteIgnorer{Writer: writeCloser}, partitions, blockSize)
 
 	for i := 0; i < partitions; i++ {
 		fileName := GetPartitionedStreamName(backup.Name, decompressor.FileExtension(), i)

--- a/utility/empty_write_ignorer.go
+++ b/utility/empty_write_ignorer.go
@@ -1,0 +1,18 @@
+package utility
+
+import (
+	"io"
+)
+
+// EmptyWriteIgnorer handles 0 byte write in LZ4 package
+// to stop pipe reader/writer from blocking.
+type EmptyWriteIgnorer struct {
+	io.Writer
+}
+
+func (e EmptyWriteIgnorer) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return e.Writer.Write(p)
+}


### PR DESCRIPTION
This allows tryExtractFiles to drop io.Pipe in favor of feeding the decompression reader directly into the tar interpreter

In production we've seen a few databases which'll continuously fail to download some parts from their base backups. This issue persists across base backups & forks

This issue has been reproduced across:
- Before & after decompression refactor
- With lz4, lz4/v4, & brotli
- Before & after azure sdk update

The issue is currently mitigated using curl & tar to complete missing parts

After this change the issue was resolved