### PR TITLE
Support multiple s3 storage configuration

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -666,8 +666,6 @@ func FolderFromConfig(configFile string) (storage.Folder, error) {
 	ReadConfigFromFile(config, configFile)
 	CheckAllowedSettings(config)
 
-	bindConfigToEnv(config)
-
 	var folder, err = ConfigureFolderForSpecificConfig(config)
 
 	if err != nil {


### PR DESCRIPTION
After merging https://github.com/wal-g/storages/pull/45 we are unable to configure multiple s3 storages as it needed in copy commands.

Suggested fix https://github.com/wal-g/wal-g/pull/1050 works, but it's dirty. Call to the `FolderFromConfig` pollutes the environment, making impposible to any configuration function (like `ConfigureCompressor`) after it.

Solution:
* Wal-g config file should be the first priorty configuration source.
* Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY only if they are not empty, otherwise fallback to the enviroment (and other storage dependent) configuration defaults
* Do not overwrite the environment in `FolderFromConfig`

