### PR TITLE
sqlserver: backup import and export to the external storage

### DIFF
--- a/cmd/sqlserver/backup_export.go
+++ b/cmd/sqlserver/backup_export.go
@@ -1,0 +1,27 @@
+package sqlserver
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/wal-g/internal/databases/sqlserver"
+)
+
+const backupExportShortDescription = "Export backups to the external storage"
+
+var externalConfigFileExport string
+var exportDatabases = make(map[string]string)
+
+var backupExportCmd = &cobra.Command{
+	Use:   "backup-export",
+	Short: backupExportShortDescription,
+	Run: func(cmd *cobra.Command, args []string) {
+		sqlserver.HandleBackupExport(externalConfigFileExport, exportDatabases)
+	},
+}
+
+func init() {
+	backupExportCmd.Flags().StringVarP(&externalConfigFileExport, "external-config", "e", "", "wal-g config file for external storage")
+	backupExportCmd.Flags().StringToStringVarP(&exportDatabases, "databases", "d", nil,
+		"list of databases to export, mapped to the prefixes of .bak files in the external storage, "+
+			"eg. -d db1=db1 -d db2=db2copy")
+	cmd.AddCommand(backupExportCmd)
+}

--- a/cmd/sqlserver/backup_import.go
+++ b/cmd/sqlserver/backup_import.go
@@ -1,0 +1,27 @@
+package sqlserver
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/wal-g/internal/databases/sqlserver"
+)
+
+const backupImportShortDescription = "Import backups from the external storage"
+
+var externalConfigFileImport string
+var importDatabases = make(map[string]string)
+
+var backupImportCmd = &cobra.Command{
+	Use:   "backup-import",
+	Short: backupImportShortDescription,
+	Run: func(cmd *cobra.Command, args []string) {
+		sqlserver.HandleBackupImport(externalConfigFileImport, importDatabases)
+	},
+}
+
+func init() {
+	backupImportCmd.Flags().StringVarP(&externalConfigFileImport, "external-config", "e", "", "wal-g config file for external storage")
+	backupImportCmd.Flags().StringToStringVarP(&importDatabases, "databases", "d", nil,
+		"list of databases to import, mapped to the list of .bak files in the external storage, "+
+			"eg. -d db1=db1_1.bak,db1_2.bak -d db2=old.bak")
+	cmd.AddCommand(backupImportCmd)
+}

--- a/internal/databases/sqlserver/backup_export_handler.go
+++ b/internal/databases/sqlserver/backup_export_handler.go
@@ -1,0 +1,116 @@
+package sqlserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"syscall"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/utility"
+)
+
+func prepareBackupExportSpec(d map[string]string) (dbnames []string, mapping map[string]string) {
+	mapping = make(map[string]string, len(d))
+	for k, v := range d {
+		dbnames = append(dbnames, k)
+		if v == "" {
+			v = k
+		}
+		mapping[k] = v
+	}
+	return
+}
+
+func HandleBackupExport(externalConfig string, exportPrefixes map[string]string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
+	defer func() { _ = signalHandler.Close() }()
+
+	folder, err := internal.ConfigureFolder()
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	externalFolder, err := internal.FolderFromConfig(externalConfig)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	dbnames, exportPrefixes := prepareBackupExportSpec(exportPrefixes)
+	_, err = resolveExternalStorageFiles(externalFolder, nil)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	lock, err := RunOrReuseProxy(ctx, cancel, folder)
+	tracelog.ErrorLogger.FatalOnError(err)
+	defer lock.Close()
+
+	var backupName string
+	var sentinel *SentinelDto
+	backup, err := internal.GetBackupByName(internal.LatestString, utility.BaseBackupPath, folder)
+	tracelog.ErrorLogger.FatalfOnError("can't find latest backup: %v", err)
+	backupName = backup.Name
+	sentinel = new(SentinelDto)
+	err = backup.FetchSentinel(sentinel)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	err = runParallel(func(i int) error {
+		return exportSingleDatabaseBackup(ctx, folder, backupName, dbnames[i], externalFolder, exportPrefixes[dbnames[i]])
+	}, len(dbnames), getDBConcurrency())
+	tracelog.ErrorLogger.FatalfOnError("overall export failed: %v", err)
+
+	sentinel.Databases = uniq(append(sentinel.Databases, dbnames...))
+	uploader := internal.NewUploader(nil, folder.GetSubFolder(utility.BaseBackupPath))
+	tracelog.InfoLogger.Printf("uploading sentinel: %s", sentinel)
+	err = internal.UploadSentinel(uploader, sentinel, backupName)
+	tracelog.ErrorLogger.FatalfOnError("failed to save sentinel: %v", err)
+
+	tracelog.InfoLogger.Printf("export finished")
+}
+
+func exportSingleDatabaseBackup(ctx context.Context, folder storage.Folder, backupName string,
+	dbname string, externalFolder storage.Folder, prefix string) error {
+	baseURL := getDatabaseBackupURL(backupName, dbname)
+	basePath := getDatabaseBackupPath(backupName, dbname)
+	blobs, err := listBackupBlobs(folder.GetSubFolder(basePath))
+	if err != nil {
+		tracelog.ErrorLogger.Printf("database %v doesn't exist in backup %v", dbname, backupName)
+		return err
+	}
+	urls := buildRestoreUrlsList(baseURL, blobs)
+	tracelog.InfoLogger.Printf("starting exporting backup files for %v from %v", dbname, blobs)
+	for i := 0; i < len(urls); i++ {
+		backupFileName := fmt.Sprintf("%s_%03d.bak", prefix, i)
+		err := exportSingleDatabaseBlob(ctx, urls[i], externalFolder, backupFileName)
+		if err != nil {
+			tracelog.ErrorLogger.Printf("failed to export backup %v: %v", backupFileName, err)
+			return err
+		}
+		tracelog.InfoLogger.Printf("backup file %v exported", backupFileName)
+	}
+	tracelog.InfoLogger.Printf("all backup files for %v are exported successfully", dbname)
+	return nil
+}
+
+func exportSingleDatabaseBlob(ctx context.Context, blobURL string, externalFolder storage.Folder, backupFile string) error {
+	client := getProxyHTTPClient()
+	lease, err := acquireLease(ctx, client, blobURL)
+	if err != nil {
+		return err
+	}
+	defer releaseLeasePrintError(ctx, client, blobURL, lease)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Ms-Lease-Id", lease)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected proxy GET response: %d %s", resp.StatusCode, resp.Status)
+	}
+	defer resp.Body.Close()
+	return externalFolder.PutObject(backupFile, resp.Body)
+}

--- a/internal/databases/sqlserver/backup_import_handler.go
+++ b/internal/databases/sqlserver/backup_import_handler.go
@@ -1,0 +1,200 @@
+package sqlserver
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/utility"
+)
+
+func prepareBackupImportSpec(externalStorage storage.Folder, d map[string]string) ([]string, map[string][]storage.Object, error) {
+	dbnames := make([]string, 0, len(d))
+	fileNames := make([]string, 0, len(d))
+	fileNameMapping := make(map[string][]string, len(d))
+	for dbname, v := range d {
+		dbnames = append(dbnames, dbname)
+		fileNameMapping[dbname] = strings.Split(v, ExternalBackupFilenameSeparator)
+		fileNames = append(fileNames, fileNameMapping[dbname]...)
+	}
+	objects, err := resolveExternalStorageFiles(externalStorage, fileNames)
+	if err != nil {
+		return nil, nil, err
+	}
+	fileMapping := make(map[string][]storage.Object, len(d))
+	for dbname, names := range fileNameMapping {
+		for _, fileName := range names {
+			fileMapping[dbname] = append(fileMapping[dbname], objects[fileName])
+		}
+	}
+	return dbnames, fileMapping, nil
+}
+
+func resolveExternalStorageFiles(externalFolder storage.Folder, fileNames []string) (map[string]storage.Object, error) {
+	objs, _, err := externalFolder.ListFolder()
+	if err != nil {
+		return nil, fmt.Errorf("failed to access external storage: %w", err)
+	}
+	allObjects := make(map[string]storage.Object)
+	for _, obj := range objs {
+		allObjects[obj.GetName()] = obj
+	}
+	objects := make(map[string]storage.Object, len(fileNames))
+	notFound := make([]string, 0)
+	for _, n := range fileNames {
+		if obj, ok := allObjects[n]; ok {
+			objects[n] = obj
+		} else {
+			notFound = append(notFound, n)
+		}
+	}
+	if len(notFound) > 0 {
+		return nil, fmt.Errorf("backup files %v not found in the external storage", notFound)
+	}
+	return objects, nil
+}
+
+func HandleBackupImport(externalConfig string, importDatabases map[string]string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
+	defer func() { _ = signalHandler.Close() }()
+
+	folder, err := internal.ConfigureFolder()
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	externalFolder, err := internal.FolderFromConfig(externalConfig)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	dbnames, databaseFiles, err := prepareBackupImportSpec(externalFolder, importDatabases)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	lock, err := RunOrReuseProxy(ctx, cancel, folder)
+	tracelog.ErrorLogger.FatalOnError(err)
+	defer lock.Close()
+
+	var backupName string
+	var sentinel *SentinelDto
+	backup, err := internal.GetBackupByName(internal.LatestString, utility.BaseBackupPath, folder)
+	tracelog.ErrorLogger.FatalfOnError("can't find latest backup: %v", err)
+	backupName = backup.Name
+	sentinel = new(SentinelDto)
+	err = backup.FetchSentinel(sentinel)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	err = runParallel(func(i int) error {
+		return importSingleDatabaseBackup(ctx, backupName, dbnames[i], externalFolder, databaseFiles[dbnames[i]])
+	}, len(dbnames), getDBConcurrency())
+	tracelog.ErrorLogger.FatalfOnError("overall import failed: %v", err)
+
+	sentinel.Databases = uniq(append(sentinel.Databases, dbnames...))
+	uploader := internal.NewUploader(nil, folder.GetSubFolder(utility.BaseBackupPath))
+	tracelog.InfoLogger.Printf("uploading sentinel: %s", sentinel)
+	err = internal.UploadSentinel(uploader, sentinel, backupName)
+	tracelog.ErrorLogger.FatalfOnError("failed to save sentinel: %v", err)
+
+	tracelog.InfoLogger.Printf("import finished")
+}
+
+func importSingleDatabaseBackup(ctx context.Context, backupName string, dbname string,
+	externalFolder storage.Folder, backupFiles []storage.Object) error {
+	baseURL := getDatabaseBackupURL(backupName, dbname)
+	urls := buildBackupUrlsList(baseURL, len(backupFiles))
+	tracelog.InfoLogger.Printf("starting importing backup files for %v from %v", dbname, backupFiles)
+	for i := 0; i < len(backupFiles); i++ {
+		err := importSingleDatabaseBlob(ctx, externalFolder, backupFiles[i], urls[i])
+		if err != nil {
+			tracelog.ErrorLogger.Printf("failed to import backup %v: %v", backupFiles[i], err)
+			return err
+		}
+		tracelog.InfoLogger.Printf("backup file %v imported", backupFiles[i])
+	}
+	tracelog.InfoLogger.Printf("all backup files for %v are imported successfully", dbname)
+	return nil
+}
+
+func getProxyHTTPClient() *http.Client {
+	config := &tls.Config{InsecureSkipVerify: true}
+	tr := &http.Transport{TLSClientConfig: config}
+	client := &http.Client{Transport: tr}
+	return client
+}
+
+func acquireLease(ctx context.Context, client *http.Client, blobURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL+"?comp=lease", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-Ms-Lease-Action", "Acquire")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("unexpected proxy acquire lease response: %d %s", resp.StatusCode, resp.Status)
+	}
+	return resp.Header.Get("X-Ms-Lease-Id"), nil
+}
+
+func releaseLease(ctx context.Context, client *http.Client, blobURL string, lease string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL+"?comp=lease", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Ms-Lease-Action", "Release")
+	req.Header.Set("X-Ms-Lease-Id", lease)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected proxy acquire lease response: %d %s", resp.StatusCode, resp.Status)
+	}
+	return nil
+}
+
+func releaseLeasePrintError(ctx context.Context, client *http.Client, blobURL string, lease string) {
+	err := releaseLease(ctx, client, blobURL, lease)
+	if err != nil {
+		tracelog.ErrorLogger.Printf("failed to release lease %s: %v", lease, err)
+	}
+}
+
+func importSingleDatabaseBlob(ctx context.Context, externalFolder storage.Folder, backupFile storage.Object, blobURL string) error {
+	rc, err := externalFolder.ReadObject(backupFile.GetName())
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	client := getProxyHTTPClient()
+	lease, err := acquireLease(ctx, client, blobURL)
+	if err != nil {
+		return err
+	}
+	defer releaseLeasePrintError(ctx, client, blobURL, lease)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, blobURL, rc)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", backupFile.GetSize()))
+	req.Header.Set("X-Ms-Lease-Id", lease)
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected proxy PUT response: %d %s", resp.StatusCode, resp.Status)
+	}
+	return nil
+}

--- a/internal/databases/sqlserver/backup_push_handler.go
+++ b/internal/databases/sqlserver/backup_push_handler.go
@@ -43,7 +43,7 @@ func HandleBackupPush(dbnames []string, updateLatest bool) {
 		tracelog.ErrorLogger.FatalfOnError("can't find latest backup: %v", err)
 		backupName = backup.Name
 		sentinel = new(SentinelDto)
-		err = backup.FetchSentinel(&sentinel)
+		err = backup.FetchSentinel(sentinel)
 		tracelog.ErrorLogger.FatalOnError(err)
 		sentinel.Databases = uniq(append(sentinel.Databases, dbnames...))
 	} else {
@@ -60,7 +60,9 @@ func HandleBackupPush(dbnames []string, updateLatest bool) {
 	}, len(dbnames), getDBConcurrency())
 	tracelog.ErrorLogger.FatalfOnError("overall backup failed: %v", err)
 
-	sentinel.StopLocalTime = utility.TimeNowCrossPlatformLocal()
+	if !updateLatest {
+		sentinel.StopLocalTime = utility.TimeNowCrossPlatformLocal()
+	}
 	uploader := internal.NewUploader(nil, folder.GetSubFolder(utility.BaseBackupPath))
 	tracelog.InfoLogger.Printf("uploading sentinel: %s", sentinel)
 	err = internal.UploadSentinel(uploader, sentinel, backupName)

--- a/internal/databases/sqlserver/backup_restore_handler.go
+++ b/internal/databases/sqlserver/backup_restore_handler.go
@@ -26,7 +26,7 @@ func HandleBackupRestore(backupName string, dbnames []string, fromnames []string
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	sentinel := new(SentinelDto)
-	err = backup.FetchSentinel(&sentinel)
+	err = backup.FetchSentinel(sentinel)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	db, err := getSQLServerConnection()
@@ -72,17 +72,15 @@ func restoreSingleDatabase(ctx context.Context,
 	}
 	urls := buildRestoreUrls(baseURL, blobs)
 	sql := fmt.Sprintf("RESTORE DATABASE %s FROM %s WITH REPLACE, NORECOVERY", quoteName(dbname), urls)
-	if dbname != fromName {
-		files, err := listDatabaseFiles(db, urls)
-		if err != nil {
-			return err
-		}
-		move, err := buildPhysicalFileMove(files, dbname)
-		if err != nil {
-			return err
-		}
-		sql += ", " + move
+	files, err := listDatabaseFiles(db, urls)
+	if err != nil {
+		return err
 	}
+	move, err := buildPhysicalFileMove(files, dbname)
+	if err != nil {
+		return err
+	}
+	sql += ", " + move
 	tracelog.InfoLogger.Printf("starting restore database [%s] from %s", dbname, urls)
 	tracelog.DebugLogger.Printf("SQL: %s", sql)
 	_, err = db.ExecContext(ctx, sql)

--- a/internal/databases/sqlserver/blob/server.go
+++ b/internal/databases/sqlserver/blob/server.go
@@ -1,6 +1,7 @@
 package blob
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -588,6 +589,34 @@ func (bs *Server) HandleBlobGet(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (bs *Server) blobPut(r io.Reader, idx *Index) ([]string, error) {
+	const blockSize = 4 * 1024 * 1024
+	buf := make([]byte, blockSize)
+	xblocklist := &XBlockListIn{Blocks: []XBlockIn{}}
+	for i, last := 0, false; !last; i++ {
+		n, err := io.ReadFull(r, buf)
+		if err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				last = true
+			} else {
+				return nil, err
+			}
+		}
+		if n == 0 {
+			continue
+		}
+		id := fmt.Sprintf("data_%05d", i)
+		name := idx.PutBlock(id, uint64(n))
+		encryptedReader := internal.CompressAndEncrypt(bytes.NewReader(buf[:n]), bs.compressor, bs.crypter)
+		err = idx.folder.PutObject(name, encryptedReader)
+		if err != nil {
+			return nil, err
+		}
+		xblocklist.Blocks = append(xblocklist.Blocks, XBlockIn{ID: id, Mode: BlockLatest})
+	}
+	return idx.PutBlockList(xblocklist)
+}
+
 func (bs *Server) HandleBlobPut(w http.ResponseWriter, req *http.Request) {
 	folder := bs.getBlobFolder(req.URL.Path)
 	idx, err := bs.loadBlobIndex(folder)
@@ -599,41 +628,40 @@ func (bs *Server) HandleBlobPut(w http.ResponseWriter, req *http.Request) {
 		bs.returnError(w, req, err)
 		return
 	}
+	if idx.Compression != "" || idx.Encryption != "" {
+		err = bs.validateBlobCompressionEncryption(idx)
+		if err != nil {
+			tracelog.ErrorLogger.Printf("proxy: misconfiguration: %v", err)
+			bs.returnError(w, req, err)
+			return
+		}
+	}
 	if err := bs.checkLease(req, folder); err != nil {
 		bs.returnError(w, req, err)
 		return
 	}
 	blobSizeStr := req.Header.Get("Content-Length")
-	blobSize, err := strconv.ParseUint(blobSizeStr, 10, 64)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-	garbage := idx.Clear()
-	if blobSize > 0 {
-		name := idx.PutBlock("data", blobSize)
-		encryptedReader := internal.CompressAndEncrypt(req.Body, bs.compressor, bs.crypter)
-		err := folder.PutObject(name, encryptedReader)
-		req.Body.Close()
-		if err != nil {
-			bs.returnError(w, req, err)
-			return
-		}
-		_, err = idx.PutBlockList(&XBlockListIn{Blocks: []XBlockIn{{ID: "data", Mode: BlockLatest}}})
+	var garbage []string
+	if blobSizeStr == "0" {
+		garbage = idx.Clear()
+	} else {
+		defer req.Body.Close()
+		garbage, err = bs.blobPut(req.Body, idx)
 		if err != nil {
 			bs.returnError(w, req, err)
 			return
 		}
 	}
 	bs.indexesMutex.Lock()
-	defer bs.indexesMutex.Unlock()
 	err = idx.Save()
 	if err != nil {
+		bs.indexesMutex.Unlock()
 		bs.returnError(w, req, err)
 		return
 	}
 	bs.indexes[folder.GetPath()] = idx
-	go bs.deleteGarbage(folder, garbage)
+	bs.indexesMutex.Unlock()
+	bs.deleteGarbage(folder, garbage)
 	w.WriteHeader(http.StatusCreated)
 }
 

--- a/internal/databases/sqlserver/database_list_handler.go
+++ b/internal/databases/sqlserver/database_list_handler.go
@@ -22,7 +22,7 @@ func HandleDatabaseList(backupName string) {
 		tracelog.ErrorLogger.Fatalf("can't find backup %s: %v", backupName, err)
 	}
 	sentinel := new(SentinelDto)
-	err = backup.FetchSentinel(&sentinel)
+	err = backup.FetchSentinel(sentinel)
 	tracelog.ErrorLogger.FatalOnError(err)
 	for _, name := range sentinel.Databases {
 		fmt.Println(name)

--- a/internal/databases/sqlserver/log_restore_handler.go
+++ b/internal/databases/sqlserver/log_restore_handler.go
@@ -27,7 +27,7 @@ func HandleLogRestore(backupName string, untilTS string, dbnames []string, fromn
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	sentinel := new(SentinelDto)
-	err = backup.FetchSentinel(&sentinel)
+	err = backup.FetchSentinel(sentinel)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	db, err := getSQLServerConnection()


### PR DESCRIPTION
### SQLServer

Export/import backups to/from external storage.

Backups blobs are stored as a set of blocks with index in default storage.
During export to external storage, backup blobs are serialized to single .bak files, suitable for downloading and manual restoring using `RESTORE DATABASE FROM DISK='filename.bak'`.
During import from external storage, backup blobs are sliced into the set of blocks appropriate to be restored with wal-g.
