### PR TITLE
Greenplum backup-push: split the segment backup push states into different dirs to avoid races

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -112,6 +112,7 @@ const (
 	GPSegmentsPollInterval = "WALG_GP_SEG_POLL_INTERVAL"
 	GPSegmentsPollRetries  = "WALG_GP_SEG_POLL_RETRIES"
 	GPSegmentsUpdInterval  = "WALG_GP_SEG_UPD_INTERVAL"
+	GPSegmentStatesDir     = "WALG_GP_SEG_STATES_DIR"
 
 	GoMaxProcs = "GOMAXPROCS"
 
@@ -195,6 +196,7 @@ var (
 		GPSegmentsPollInterval: "5m",
 		GPSegmentsUpdInterval:  "10s",
 		GPSegmentsPollRetries:  "5",
+		GPSegmentStatesDir:     "/tmp",
 	}
 
 	AllowedSettings map[string]bool
@@ -386,6 +388,7 @@ var (
 		GPSegmentsPollRetries:  true,
 		GPSegmentsPollInterval: true,
 		GPSegmentsUpdInterval:  true,
+		GPSegmentStatesDir:     true,
 	}
 
 	RequiredSettings       = make(map[string]bool)

--- a/internal/databases/greenplum/segment_backup_runner.go
+++ b/internal/databases/greenplum/segment_backup_runner.go
@@ -42,8 +42,9 @@ func (r *SegBackupRunner) Run() {
 		cmdArgs = append(cmdArgs, "--config", internal.CfgFile)
 	}
 
-	tracelog.ErrorLogger.FatalOnError(os.RemoveAll(stateFilesDirPath))
-	tracelog.ErrorLogger.FatalOnError(os.MkdirAll(stateFilesDirPath, os.ModePerm))
+	segBackupStatesPath := FormatSegmentStateFolderPath(r.contentID)
+	tracelog.ErrorLogger.FatalOnError(os.RemoveAll(segBackupStatesPath))
+	tracelog.ErrorLogger.FatalOnError(os.MkdirAll(segBackupStatesPath, os.ModePerm))
 
 	cmd := exec.Command(os.Args[0], cmdArgs...)
 	cmd.Env = os.Environ()

--- a/internal/databases/greenplum/segment_backup_state.go
+++ b/internal/databases/greenplum/segment_backup_state.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"path"
 	"time"
+
+	"github.com/spf13/viper"
+	"github.com/wal-g/wal-g/internal"
 )
 
-const stateFilesDirPath = "/tmp/walg_seg_states/"
+const stateFilesDirPrefix = "walg_seg_states"
 const backupStatePrefix = "backup_push_state"
 
 func FormatBackupStateName(contentID int, backupName string) string {
@@ -14,7 +17,13 @@ func FormatBackupStateName(contentID int, backupName string) string {
 }
 
 func FormatBackupStatePath(contentID int, backupName string) string {
-	return path.Join(stateFilesDirPath, FormatBackupStateName(contentID, backupName))
+	return path.Join(FormatSegmentStateFolderPath(contentID), FormatBackupStateName(contentID, backupName))
+}
+
+func FormatSegmentStateFolderPath(contentID int) string {
+	segStatesDirPath := viper.GetString(internal.GPSegmentStatesDir)
+	currSegmentStatePath := fmt.Sprintf("%s_seg%d", stateFilesDirPrefix, contentID)
+	return path.Join(segStatesDirPath, currSegmentStatePath)
 }
 
 type SegBackupStatus string


### PR DESCRIPTION
Currently, there might be multiple WAL-G processes concurrently trying to create the backup states directory (if the number of segments per host is >1). This PR should help to avoid races. Also, it adds the `WALG_GP_SEG_STATES_DIR` option for easier control over the state files location.