### PR TITLE
[SQLSERVER] fixing int overflow by big LSN numbers in IsLogAlreadyApplied

### DIFF
--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -569,18 +569,17 @@ func IsLogAlreadyApplied(db *sql.DB, databaseName string, logBackupFilePropertie
 	if err != nil {
 		return false, err
 	}
-
-	dbRestoreLSN_int := new(big.Int)
-	dbRestoreLSN_int, ok := dbRestoreLSN_int.SetString(dbRestoreLSN, 10)
+	dbRestoreLSNInt := new(big.Int)
+	dbRestoreLSNInt, ok := dbRestoreLSNInt.SetString(dbRestoreLSN, 10)
 	if !ok {
 		return false, xerrors.Errorf("dbRestoreLSN not recognized")
 	}
-	lastLSN_int := new(big.Int)
-	lastLSN_int, ok = lastLSN_int.SetString(logBackupFileProperties.LastLSN, 10)
+	lastLSNInt := new(big.Int)
+	lastLSNInt, ok = lastLSNInt.SetString(logBackupFileProperties.LastLSN, 10)
 	if !ok {
 		return false, xerrors.Errorf("lastLSN not recognized")
 	}
-	if dbRestoreLSN_int.Cmp(lastLSN_int) == -1 {
+	if dbRestoreLSNInt.Cmp(lastLSNInt) == -1 {
 		return false, nil
 	}
 	return true, nil

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -553,11 +553,11 @@ func RunOrReuseProxy(ctx context.Context, cancel context.CancelFunc, folder stor
 	return &LockWrapper{lock}, nil
 }
 
-func GetDBRestoreLSN(db *sql.DB, databaseName string) (int64, error) {
+func GetDBRestoreLSN(db *sql.DB, databaseName string) (uint64, error) {
 	query := `SELECT MAX(redo_start_lsn) 
         FROM sys.master_files
         WHERE database_id=DB_ID(@dbname) `
-	var res int64
+	var res uint64
 	if err := db.QueryRow(query, sql.Named("dbname", databaseName)).Scan(&res); err != nil {
 		return 0, err
 	}
@@ -565,7 +565,7 @@ func GetDBRestoreLSN(db *sql.DB, databaseName string) (int64, error) {
 }
 
 func IsLogAlreadyApplied(db *sql.DB, databaseName string, logBackupFileProperties *BackupProperties) (bool, error) {
-	lastLSN, err := strconv.ParseInt(logBackupFileProperties.LastLSN, 10, 64)
+	lastLSN, err := strconv.ParseUint(logBackupFileProperties.LastLSN, 10, 64)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
### Database name
SQL Server
# Pull request description

### Describe what this PR fix
fixing int overflow by big LSN numbers in IsLogAlreadyApplied

### Please provide steps to reproduce (if it's a bug)
Try restoring log for old enough database which LSN is 20 digits long.

### Please add config and wal-g stdout/stderr logs for debug purpose

>.\wal-g-sqlserver.exe --config C:\\ProgramData\\wal-g\\wal-g.yaml log-restore --from db1
 --databases db2 --since base_20211225T221500Z --until 2021-12-25T22:17:23Z
INFO: 2021/12/29 13:38:18.399931 running proxy at backup.local:443
ERROR: 2021/12/29 13:38:21.713942 overall log restore failed: strconv.ParseInt: parsing "33427000000196000001": value out of range