### PR TITLE
MySQL > Check binlog GTIDs before pushing binlogs to S3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cyberdelia/lzo v0.0.0-20171006181345-d85071271a6f
 	github.com/denisenkom/go-mssqldb v0.10.0
 	github.com/docker/docker v1.13.1
-	github.com/go-mysql-org/go-mysql v1.3.0
+	github.com/go-mysql-org/go-mysql v1.4.1-0.20220112102103-b3f1a27311d8
 	github.com/go-redis/redis v6.15.6+incompatible
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gofrs/flock v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cyberdelia/lzo v0.0.0-20171006181345-d85071271a6f
 	github.com/denisenkom/go-mssqldb v0.10.0
 	github.com/docker/docker v1.13.1
-	github.com/go-mysql-org/go-mysql v1.4.1-0.20220112102103-b3f1a27311d8
+	github.com/go-mysql-org/go-mysql v1.4.1-0.20220126055159-3566d1e608ea
 	github.com/go-redis/redis v6.15.6+incompatible
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gofrs/flock v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-mysql-org/go-mysql v1.3.0 h1:lpNqkwdPzIrYSZGdqt8HIgAXZaK6VxBNfr8f7Z4FgGg=
 github.com/go-mysql-org/go-mysql v1.3.0/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
+github.com/go-mysql-org/go-mysql v1.4.1-0.20220112102103-b3f1a27311d8 h1:ViPrQui89RKKSFi0FwonSGGCMksRaYFZm+mu8nQpM84=
+github.com/go-mysql-org/go-mysql v1.4.1-0.20220112102103-b3f1a27311d8/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
 github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
 github.com/go-openapi/errors v0.19.3 h1:7MGZI1ibQDLasvAz8HuhvYk9eNJbJkCOXWsSjjMS+Zc=
 github.com/go-openapi/errors v0.19.3/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/go-mysql-org/go-mysql v1.3.0 h1:lpNqkwdPzIrYSZGdqt8HIgAXZaK6VxBNfr8f7
 github.com/go-mysql-org/go-mysql v1.3.0/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
 github.com/go-mysql-org/go-mysql v1.4.1-0.20220112102103-b3f1a27311d8 h1:ViPrQui89RKKSFi0FwonSGGCMksRaYFZm+mu8nQpM84=
 github.com/go-mysql-org/go-mysql v1.4.1-0.20220112102103-b3f1a27311d8/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
+github.com/go-mysql-org/go-mysql v1.4.1-0.20220126055159-3566d1e608ea h1:0UJhOgGN1smCz5xfXoGrUHJlLoBZ5/LQArOewYCRFQY=
+github.com/go-mysql-org/go-mysql v1.4.1-0.20220126055159-3566d1e608ea/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
 github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
 github.com/go-openapi/errors v0.19.3 h1:7MGZI1ibQDLasvAz8HuhvYk9eNJbJkCOXWsSjjMS+Zc=
 github.com/go-openapi/errors v0.19.3/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-mysql-org/go-mysql v1.3.0 h1:lpNqkwdPzIrYSZGdqt8HIgAXZaK6VxBNfr8f7Z4FgGg=
 github.com/go-mysql-org/go-mysql v1.3.0/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
-github.com/go-mysql-org/go-mysql v1.4.1-0.20220112102103-b3f1a27311d8 h1:ViPrQui89RKKSFi0FwonSGGCMksRaYFZm+mu8nQpM84=
-github.com/go-mysql-org/go-mysql v1.4.1-0.20220112102103-b3f1a27311d8/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
 github.com/go-mysql-org/go-mysql v1.4.1-0.20220126055159-3566d1e608ea h1:0UJhOgGN1smCz5xfXoGrUHJlLoBZ5/LQArOewYCRFQY=
 github.com/go-mysql-org/go-mysql v1.4.1-0.20220126055159-3566d1e608ea/go.mod h1:3lFZKf7l95Qo70+3XB2WpiSf9wu2s3na3geLMaIIrqQ=
 github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=


### PR DESCRIPTION
 * use strict GTID sets math during binlog upload check. This patch fixes
   possible transaction loss due to coarse GTIDs handling in previous algo.
   Also, it fixes an issue with different sets of `server_id`s in
   binlogs's PREVIOUS_GTIDS event on different servers.
