### PR TITLE
Returns error code 74 on WAL fetch when WAL file does not exist

### DIFF
--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -329,6 +329,11 @@ WAL-G will also prefetch WAL files ahead of asked WAL file. These files will be 
 wal-g wal-fetch example-archive new-file-name
 ```
 
+Note: ``wal-fetch`` will exit with errorcode 74 (EX_IOERR: input/output error, see sysexits.h for more info) if the WAL-file is not available in the repository.
+All other errors end in exit code 1, and should stop PostgreSQL rather than ending PostgreSQL recovery.
+For PostgreSQL that should be any error code between 126 and 255, which can be achieved with a simple wrapper script.
+Please see https://github.com/wal-g/wal-g/pull/1195 for more information.
+
 ### ``wal-push``
 
 When uploading WAL archives to S3, the user should pass in the absolute path to where the archive is located.

--- a/internal/databases/postgres/wal_fetch_handler.go
+++ b/internal/databases/postgres/wal_fetch_handler.go
@@ -17,6 +17,9 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
+// Looking at sysexits.h, EX_IOERR (74) is defined as a generic exit code for input/output errors
+const exIoError = 74
+
 type InvalidWalFileMagicError struct {
 	error
 }
@@ -98,7 +101,7 @@ func HandleWALFetch(folder storage.Folder, walFileName string, location string, 
 	err := internal.DownloadFileTo(folder, walFileName, location)
 	if _, isArchNonExistErr := err.(internal.ArchiveNonExistenceError); isArchNonExistErr {
 		tracelog.ErrorLogger.Print(err.Error())
-		os.Exit(74)
+		os.Exit(exIoError)
 	} else {
 		tracelog.ErrorLogger.FatalOnError(err)
 	}

--- a/internal/databases/postgres/wal_fetch_handler.go
+++ b/internal/databases/postgres/wal_fetch_handler.go
@@ -96,7 +96,12 @@ func HandleWALFetch(folder storage.Folder, walFileName string, location string, 
 	}
 
 	err := internal.DownloadFileTo(folder, walFileName, location)
-	tracelog.ErrorLogger.FatalOnError(err)
+	if _, isArchNonExistErr := err.(internal.ArchiveNonExistenceError); isArchNonExistErr {
+		tracelog.ErrorLogger.Print(err.Error())
+		os.Exit(74)
+	} else {
+		tracelog.ErrorLogger.FatalOnError(err)
+	}
 }
 
 // TODO : unit tests


### PR DESCRIPTION
### Database name
Postgres

# Pull request description

### Describe what this PR fix
When running wal-g in restore_command, postgres has 3 ways to handle a exit code:
0: No problem, next WAL file...
1 - 125: End of timeline? Ok, lets stop recovery and go online
>=126: Ouch, big problem. Better not proceed, but error out with a FAIL instead

It would be great if wal-g would be able to distinguish between these cases with a proper exit code too.
Mostly it is so, but config errors, tcp errors, dns errors, etc have the same error code as 'archive does not exist (both 1).

This small change will allow wal-g to return exit code 74 when the wal file does not exist.

### Please provide steps to reproduce (if it's a bug)
* create a postgres backup with wal archive backups
* restore a file that already exists and print the exit code `wal-g wal-fetch 000000010000000300000099 /tmp/000000010000000300000099`. It is 1.
* restore a file with missing config: `WALG_S3_PREFIX=123 wal-g wal-fetch 000000010000000300000099 /tmp/000000010000000300000099`. It is also 1. We should distinguish, but this not different to Postgres either...
* restore a file that does not exist int the backupset `wal-g wal-fetch 00000001000000030000009A /tmp/00000001000000030000009A`and print the exit code. It is also 1, but should be distinguishable

Please see #1126 for more info.

Even with this fix, we still need Postgres to act differently too.
We have requested a change but it is not considered by the PG community yet.
For now we could make this work with a bash script:
```bash
#!/bin/bash
wal-g wal-fetch "$2" "$3"
RET=$?
if [ $RET -eq 1 ]; then
  # whoops, no good. exit code 254 halts postgres with a FAILURE state
  exit 254
fi
exit $RET
```
