### PR TITLE
MySQL > Check binlog GTIDs before pushing binlogs to S3

### DIFF
--- a/cmd/mysql/binlog.go
+++ b/cmd/mysql/binlog.go
@@ -1,0 +1,34 @@
+package mysql
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/mysql"
+)
+
+var binlogToolboxCmd = &cobra.Command{
+	Use:   "binlog",
+	Short: "binlog-related toolbox",
+}
+
+var forgetBinlogGtidsCmd = &cobra.Command{
+	Use:   "forget-gtids",
+	Short: "remove GTIDs from binlog sentinel",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		uploader, err := internal.ConfigureUploaderWithoutCompressMethod()
+		tracelog.ErrorLogger.FatalOnError(err)
+		mysql.HandleBinlogForgetGtids(uploader)
+	},
+	PreRun: func(cmd *cobra.Command, args []string) {
+		internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
+		err := internal.AssertRequiredSettingsSet()
+		tracelog.ErrorLogger.FatalOnError(err)
+	},
+}
+
+func init() {
+	cmd.AddCommand(binlogToolboxCmd)
+	binlogToolboxCmd.AddCommand(forgetBinlogGtidsCmd)
+}

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -114,12 +114,22 @@ Sends (not yet archived) binlogs to storage. Typically run in CRON.
 wal-g binlog-push
 ```
 
-
 When `WALG_MYSQL_CHECK_GTIDS` is set wal-g will try to be upload only binlogs which GTID sets contains events that
 wasn't seen before. This is done by parsing binlogs and peeking first PREVIOUS_GTIDS_EVENT that holds GTID set of
 all executed transactions at the moment this particular binlog file created.
 This feature may be useful when you are uploading binlogs from different hosts (e.g. after master switchower)
 Note: Don't use `WALG_MYSQL_CHECK_GTIDS` when GTIDs are not used - it will slow down binlog upload.
+
+### ``binlog``
+
+This is toolbox that contains useful commands to manipulate archived binlogs.
+
+Available commands:
+
+- ``forget-gtids`` resets wal-g's knowledge about uploaded GITDs.
+  ```bash
+  wal-g binlog forget-gtid
+  ```
 
 ### ``binlog-fetch``
 

--- a/internal/databases/mysql/binlog_handler.go
+++ b/internal/databases/mysql/binlog_handler.go
@@ -1,0 +1,27 @@
+package mysql
+
+import (
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+)
+
+func HandleBinlogForgetGtids(uploader internal.UploaderProvider) {
+	rootFolder := uploader.Folder()
+	uploader.ChangeDirectory(BinlogPath)
+
+	// Remove GTIDs from remote sentinel
+	var binlogSentinelDto BinlogSentinelDto
+	err := FetchBinlogSentinel(rootFolder, &binlogSentinelDto)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	binlogSentinelDto.GTIDArchived = ""
+
+	err = UploadBinlogSentinel(rootFolder, &binlogSentinelDto)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	// clean local cache:
+	cache := getCache()
+	cache.GTIDArchived = ""
+	putCache(cache)
+	tracelog.InfoLogger.Printf("Binlog sentinel: %s, cache: %+v", binlogSentinelDto.String(), cache)
+}


### PR DESCRIPTION
* allow users to reset wal-g's knowledge about uploaded binlog GTID set

