### PR TITLE
Fix dead lock in DownloadAndDecompressSplittedStream

### DIFF
--- a/internal/stream_fetch_helper.go
+++ b/internal/stream_fetch_helper.go
@@ -67,7 +67,7 @@ func DownloadAndDecompressStream(backup Backup, writeCloser io.WriteCloser) erro
 }
 
 // TODO : unit tests
-// DownloadAndDecompressStream downloads, decompresses and writes stream to stdout
+// DownloadAndDecompressSplittedStream downloads, decompresses and writes stream to stdout
 func DownloadAndDecompressSplittedStream(backup Backup, blockSize int, extension string, writeCloser io.WriteCloser) error {
 	defer utility.LoggedClose(writeCloser, "")
 
@@ -100,21 +100,20 @@ func DownloadAndDecompressSplittedStream(backup Backup, blockSize int, extension
 			}
 			if !exists {
 				errCh <- writer.Close()
-				tracelog.InfoLogger.PrintOnError(writer.Close())
 				return
 			}
 			tracelog.DebugLogger.Printf("Found file: %s", fileName)
 			decompressedReader, err := DecompressDecryptBytes(archiveReader, decompressor)
 			if err != nil {
-				errCh <- fmt.Errorf("failed to decompress/decrypt file %v: %w", fileName, err)
 				tracelog.ErrorLogger.PrintOnError(writer.Close())
+				errCh <- fmt.Errorf("failed to decompress/decrypt file %v: %w", fileName, err)
 				return
 			}
 			defer utility.LoggedClose(decompressedReader, "")
 			_, err = utility.FastCopy(writer, decompressedReader)
 			if err != nil {
-				errCh <- fmt.Errorf("failed to decompress/decrypt file %v: %w", fileName, err)
 				tracelog.ErrorLogger.PrintOnError(writer.Close())
+				errCh <- fmt.Errorf("failed to decompress/decrypt/pipe file %v: %w", fileName, err)
 				return
 			}
 			errCh <- writer.Close()


### PR DESCRIPTION
 close writers before blocking in error-handling, so MergeWriter will be able to have progress.
