### PR TITLE
fix: AWS auth fixes

### DIFF
--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -22,11 +22,11 @@ const (
 	EndpointSetting          = "AWS_ENDPOINT"
 	RegionSetting            = "AWS_REGION"
 	ForcePathStyleSetting    = "AWS_S3_FORCE_PATH_STYLE"
-	AccessKeyIdSetting       = "AWS_ACCESS_KEY_ID"     // deprecated
-	AccessKeySetting         = "AWS_ACCESS_KEY"        // deprecated
-	SecretAccessKeySetting   = "AWS_SECRET_ACCESS_KEY" // deprecated
-	SecretKeySetting         = "AWS_SECRET_KEY"        // deprecated
-	SessionTokenSetting      = "AWS_SESSION_TOKEN"     // deprecated
+	AccessKeyIdSetting       = "AWS_ACCESS_KEY_ID"
+	AccessKeySetting         = "AWS_ACCESS_KEY"
+	SecretAccessKeySetting   = "AWS_SECRET_ACCESS_KEY"
+	SecretKeySetting         = "AWS_SECRET_KEY"
+	SessionTokenSetting      = "AWS_SESSION_TOKEN"
 	SseSetting               = "S3_SSE"
 	SseCSetting              = "S3_SSE_C"
 	SseKmsIdSetting          = "S3_SSE_KMS_ID"

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -22,11 +22,11 @@ const (
 	EndpointSetting          = "AWS_ENDPOINT"
 	RegionSetting            = "AWS_REGION"
 	ForcePathStyleSetting    = "AWS_S3_FORCE_PATH_STYLE"
-	AccessKeyIdSetting       = "AWS_ACCESS_KEY_ID"
-	AccessKeySetting         = "AWS_ACCESS_KEY"
-	SecretAccessKeySetting   = "AWS_SECRET_ACCESS_KEY"
-	SecretKeySetting         = "AWS_SECRET_KEY"
-	SessionTokenSetting      = "AWS_SESSION_TOKEN"
+	AccessKeyIdSetting       = "AWS_ACCESS_KEY_ID"     // deprecated
+	AccessKeySetting         = "AWS_ACCESS_KEY"        // deprecated
+	SecretAccessKeySetting   = "AWS_SECRET_ACCESS_KEY" // deprecated
+	SecretKeySetting         = "AWS_SECRET_KEY"        // deprecated
+	SessionTokenSetting      = "AWS_SESSION_TOKEN"     // deprecated
 	SseSetting               = "S3_SSE"
 	SseCSetting              = "S3_SSE_C"
 	SseKmsIdSetting          = "S3_SSE_KMS_ID"

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -92,17 +92,27 @@ func getFirstSettingOf(settings map[string]string, keys []string) string {
 	return ""
 }
 
-func getDefaultConfig(settings map[string]string, maxRetries int) *aws.Config {
+func configWithSettings(config *aws.Config, bucket string, settings map[string]string) (*aws.Config, error) {
 	// DefaultRetryer implements basic retry logic using exponential backoff for
 	// most services. If you want to implement custom retry logic, you can implement the
 	// request.Retryer interface.
-	config := defaults.Get().Config.WithRegion(settings[RegionSetting])
-	config = request.WithRetryer(config, NewConnResetRetryer(client.DefaultRetryer{NumMaxRetries: maxRetries}))
+	maxRetriesCount := MaxRetriesDefault
+	if maxRetriesRaw, ok := settings[MaxRetriesSetting]; ok {
+		maxRetriesInt, err := strconv.Atoi(maxRetriesRaw)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse %s", MaxRetriesSetting)
+		}
+
+		maxRetriesCount = maxRetriesInt
+	}
+	config = request.WithRetryer(config, NewConnResetRetryer(client.DefaultRetryer{NumMaxRetries: maxRetriesCount}))
 
 	accessKeyId := getFirstSettingOf(settings, []string{AccessKeyIdSetting, AccessKeySetting})
 	secretAccessKey := getFirstSettingOf(settings, []string{SecretAccessKeySetting, SecretKeySetting})
 	sessionToken := settings[SessionTokenSetting]
 	if accessKeyId != "" && secretAccessKey != "" {
+		tracelog.WarningLogger.Println("Using deprecated method of setting AWS credentials.")
+		tracelog.WarningLogger.Println("Consider not setting access key id, secret access key, and session token explicitly, but setting them in environment variables or relying on default credentials provider chain to infer them.")
 		provider := &credentials.StaticProvider{Value: credentials.Value{
 			AccessKeyID:     accessKeyId,
 			SecretAccessKey: secretAccessKey,
@@ -133,25 +143,6 @@ func getDefaultConfig(settings map[string]string, maxRetries int) *aws.Config {
 	if endpoint, ok := settings[EndpointSetting]; ok {
 		config = config.WithEndpoint(endpoint)
 	}
-	return config
-}
-
-// TODO : unit tests
-func createSession(bucket string, settings map[string]string) (*session.Session, error) {
-	maxRetriesCount := MaxRetriesDefault
-	if maxRetriesRaw, ok := settings[MaxRetriesSetting]; ok {
-		maxRetriesInt, err := strconv.Atoi(maxRetriesRaw)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse %s", MaxRetriesSetting)
-		}
-
-		maxRetriesCount = maxRetriesInt
-	}
-	config := getDefaultConfig(settings, maxRetriesCount)
-	config.MaxRetries = aws.Int(maxRetriesCount)
-	if _, err := config.Credentials.Get(); err != nil {
-		return nil, errors.Wrapf(err, "failed to get AWS credentials; please specify %s and %s", AccessKeyIdSetting, SecretAccessKeySetting)
-	}
 
 	if s3ForcePathStyleStr, ok := settings[ForcePathStyleSetting]; ok {
 		s3ForcePathStyle, err := strconv.ParseBool(s3ForcePathStyleStr)
@@ -167,34 +158,45 @@ func createSession(bucket string, settings map[string]string) (*session.Session,
 	}
 	config = config.WithRegion(region)
 
+	return config, nil
+}
+
+// TODO : unit tests
+func createSession(bucket string, settings map[string]string) (*session.Session, error) {
+	s, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := configWithSettings(s.Config, bucket, settings)
+	if err != nil {
+		return nil, err
+	}
+	s.Config = c
+
 	filePath := settings[s3CertFile]
 	if filePath != "" {
 		if file, err := os.Open(filePath); err == nil {
 			defer file.Close()
-			s, err := session.NewSessionWithOptions(session.Options{Config: *config, CustomCABundle: file})
+			s, err := session.NewSessionWithOptions(session.Options{Config: *s.Config, CustomCABundle: file})
 			return s, err
 		} else {
 			return nil, err
 		}
 	}
 
-	s, err := session.NewSession(config)
-
-	if err != nil {
-		return nil, err
-	}
 	if endpointSource, ok := settings[EndpointSourceSetting]; ok {
 		s.Handlers.Validate.PushBack(func(request *request.Request) {
 			src := setupReqProxy(endpointSource, getEndpointPort(settings))
 			if src != nil {
 				tracelog.DebugLogger.Printf("using endpoint %s", *src)
-				host := strings.TrimPrefix(*config.Endpoint, "https://")
+				host := strings.TrimPrefix(*s.Config.Endpoint, "https://")
 				request.HTTPRequest.Host = host
 				request.HTTPRequest.Header.Add("Host", host)
 				request.HTTPRequest.URL.Host = *src
 				request.HTTPRequest.URL.Scheme = HTTP
 			} else {
-				tracelog.DebugLogger.Printf("using endpoint %s", *config.Endpoint)
+				tracelog.DebugLogger.Printf("using endpoint %s", *s.Config.Endpoint)
 			}
 		})
 	}

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -111,8 +111,6 @@ func configWithSettings(config *aws.Config, bucket string, settings map[string]s
 	secretAccessKey := getFirstSettingOf(settings, []string{SecretAccessKeySetting, SecretKeySetting})
 	sessionToken := settings[SessionTokenSetting]
 	if accessKeyId != "" && secretAccessKey != "" {
-		tracelog.WarningLogger.Println("Using deprecated method of setting AWS credentials.")
-		tracelog.WarningLogger.Println("Consider not setting access key id, secret access key, and session token explicitly, but setting them in environment variables or relying on default credentials provider chain to infer them.")
 		provider := &credentials.StaticProvider{Value: credentials.Value{
 			AccessKeyID:     accessKeyId,
 			SecretAccessKey: secretAccessKey,


### PR DESCRIPTION
### Database name
Any

# Pull request description
Fixes #886, #562 

### Describe what this PR fix
wal-g supports a very limited number of methods of authenticating with AWS. This PR does 2 things:
- ~it deprecates explicitly passing in aws credentials~
- it makes use of aws.credentials.ChainProvider to quack the same as e.g. aws cli.

It's a remake of [this PR from a now deprecated repo](https://github.com/wal-g/storages/pull/15).