### PR TITLE
Improve error handling in Split-Merge fetcher

### DIFF
--- a/internal/splitmerge/splitmerge_test.go
+++ b/internal/splitmerge/splitmerge_test.go
@@ -8,8 +8,31 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal/abool"
 	"golang.org/x/sync/errgroup"
 )
+
+type BufferCloser struct {
+	bytes.Buffer
+	io.Closer
+	closed abool.AtomicBool
+}
+
+func (b *BufferCloser) Write(p []byte) (n int, err error) {
+	if b.closed.IsSet() {
+		return 0, io.ErrClosedPipe
+	}
+	return b.Buffer.Write(p)
+}
+
+func (b *BufferCloser) Close() error {
+	if !b.closed.SetToIf(false, true) {
+		// The behavior of Close after the first call is undefined.
+		// Specific implementations may document their own behavior.
+		panic("UB")
+	}
+	return nil
+}
 
 //               ┌─> copy data per 1 byte    ─>┐
 // data ─> split ├─> copy data per ... bytes ─>├─> merge
@@ -26,7 +49,7 @@ func TestSplitMerge(t *testing.T) {
 	var readers = SplitReader(dataReader, partitions, blockSize)
 
 	// out:
-	var sink bytes.Buffer
+	var sink BufferCloser
 	writers := MergeWriter(&sink, partitions, blockSize)
 
 	errGroup := new(errgroup.Group)

--- a/internal/stream_fetch_helper.go
+++ b/internal/stream_fetch_helper.go
@@ -83,7 +83,7 @@ func DownloadAndDecompressSplittedStream(backup Backup, blockSize int, extension
 	}
 
 	errorsPerWorker := make([]chan error, 0)
-	writers := splitmerge.MergeWriter(utility.EmptyWriteIgnorer{Writer: writeCloser}, partitions, blockSize)
+	writers := splitmerge.MergeWriter(utility.EmptyWriteCloserIgnorer{WriteCloser: writeCloser}, partitions, blockSize)
 
 	for i := 0; i < partitions; i++ {
 		fileName := GetPartitionedStreamName(backup.Name, decompressor.FileExtension(), i)

--- a/utility/empty_write_ignorer.go
+++ b/utility/empty_write_ignorer.go
@@ -2,6 +2,7 @@ package utility
 
 import (
 	"io"
+	"sync"
 )
 
 // EmptyWriteIgnorer handles 0 byte write in LZ4 package
@@ -16,3 +17,37 @@ func (e EmptyWriteIgnorer) Write(p []byte) (int, error) {
 	}
 	return e.Writer.Write(p)
 }
+
+type EmptyWriteCloserIgnorer struct {
+	io.WriteCloser
+}
+
+func (e EmptyWriteCloserIgnorer) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return e.WriteCloser.Write(p)
+}
+
+func (e EmptyWriteCloserIgnorer) Close() error {
+	return e.WriteCloser.Close()
+}
+
+// CloseOnce is a wrapper that prevents users from closing io.WriteCloser multiple times
+// Note: The behavior of Close after the first call is undefined. (proof: io.Closer comments)
+type CloseOnce struct {
+	io.WriteCloser
+	once sync.Once
+	err  error
+}
+
+func (c *CloseOnce) Close() error {
+	c.once.Do(c.close)
+	return c.err
+}
+
+func (c *CloseOnce) close() {
+	c.err = c.WriteCloser.Close()
+}
+
+var _ io.WriteCloser = &CloseOnce{WriteCloser: nil}


### PR DESCRIPTION
* This patch fixes hanging wal-g-mysql backup-fetch when some error happen in downstream processing.
* We should wait util all goroutines will be closed properly, before exiting MergeWriter. So main thread will be able to exit gracefully rather than hanging on channel receive.