### PR TITLE
Use the regular modification time in Greenplum delete handler

### DIFF
--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -118,7 +118,7 @@ func (h *DeleteHandler) DeleteBeforeTarget(target internal.BackupObject, confirm
 		segFolder := h.Folder.GetSubFolder(FormatSegmentStoragePrefix(meta.ContentID))
 		permanentBackups, permanentWals := postgres.GetPermanentBackupsAndWals(segFolder)
 
-		segDeleteHandler, err := postgres.NewDeleteHandler(segFolder, permanentBackups, permanentWals, true)
+		segDeleteHandler, err := postgres.NewDeleteHandler(segFolder, permanentBackups, permanentWals, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fallback to the default delete behavior since WAL-G fails to delete the garbage when the delete handler uses the backup sentinel time.