### PR TITLE
Fix possible panics in delete handler

### DIFF
--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -3,6 +3,7 @@ package greenplum
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -36,7 +37,7 @@ func NewDeleteHandler(folder storage.Folder) (*DeleteHandler, error) {
 		// Remove only the basebackups folder objects, do not touch the segments folders.
 		// WAL-G deals with them separately.
 		objectName := obj.GetName()
-		return objectName[:len(utility.BaseBackupPath)] != utility.BaseBackupPath
+		return !strings.HasPrefix(objectName, utility.BaseBackupPath)
 	}
 
 	return &DeleteHandler{

--- a/internal/databases/postgres/delete.go
+++ b/internal/databases/postgres/delete.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -241,8 +242,7 @@ func ExtractDeleteGarbagePredicate(args []string) func(storage.Object) bool {
 
 func storagePrefixFilter(prefix string) func(storage.Object) bool {
 	return func(object storage.Object) bool {
-		objectName := object.GetName()
-		return len(objectName) >= len(prefix) && objectName[:len(prefix)] == prefix
+		return strings.HasPrefix(object.GetName(), prefix)
 	}
 }
 

--- a/internal/databases/postgres/delete_util.go
+++ b/internal/databases/postgres/delete_util.go
@@ -1,6 +1,8 @@
 package postgres
 
 import (
+	"strings"
+
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -48,11 +50,11 @@ func GetPermanentBackupsAndWals(folder storage.Folder) (map[string]bool, map[str
 }
 
 func IsPermanent(objectName string, permanentBackups, permanentWals map[string]bool) bool {
-	if objectName[:len(utility.WalPath)] == utility.WalPath {
+	if strings.HasPrefix(objectName, utility.WalPath) {
 		wal := objectName[len(utility.WalPath) : len(utility.WalPath)+24]
 		return permanentWals[wal]
 	}
-	if objectName[:len(utility.BaseBackupPath)] == utility.BaseBackupPath {
+	if strings.HasPrefix(objectName, utility.BaseBackupPath) {
 		backup := utility.StripLeftmostBackupName(objectName[len(utility.BaseBackupPath):])
 		return permanentBackups[backup]
 	}

--- a/internal/delete_util.go
+++ b/internal/delete_util.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
@@ -35,7 +36,7 @@ func FindPermanentBackups(folder storage.Folder, metaFetcher GenericMetaFetcher)
 // IsPermanent is a generic function to determine if the storage object is permanent.
 // It does not support permanent WALs or binlogs.
 func IsPermanent(objectName string, permanentBackups map[string]bool, backupNameLength int) bool {
-	if objectName[:len(utility.BaseBackupPath)] == utility.BaseBackupPath {
+	if strings.HasPrefix(objectName, utility.BaseBackupPath) {
 		backup := objectName[len(utility.BaseBackupPath) : len(utility.BaseBackupPath)+backupNameLength]
 		return permanentBackups[backup]
 	}


### PR DESCRIPTION
If there is some unexpected object with a too short name, WAL-G delete handler logic might fail in some places. This PR should fix it.