### PR TITLE
Add --restore-point flag to Greenplum backup-fetch

### DIFF
--- a/cmd/gp/backup_fetch.go
+++ b/cmd/gp/backup_fetch.go
@@ -14,6 +14,7 @@ import (
 const (
 	backupFetchShortDescription  = "Fetches a backup from storage"
 	targetUserDataDescription    = "Fetch storage backup which has the specified user data"
+	restorePointDescription      = "Fetch storage backup w/ restore point specified by name"
 	restoreConfigPathDescription = "Path to the cluster restore configuration"
 	fetchContentIdsDescription   = "If set, WAL-G will fetch only the specified segments"
 	fetchModeDescription         = "Backup fetch mode. default: do the backup unpacking " +
@@ -22,13 +23,14 @@ const (
 )
 
 var fetchTargetUserData string
+var restorePoint string
 var restoreConfigPath string
 var fetchContentIds *[]int
 var fetchModeStr string
 var inPlaceRestore bool
 
 var backupFetchCmd = &cobra.Command{
-	Use:   "backup-fetch [backup_name | --target-user-data <data>]",
+	Use:   "backup-fetch [backup_name | --target-user-data <data> | --restore-point <name>]",
 	Short: backupFetchShortDescription, // TODO : improve description
 	Args:  cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -40,7 +42,7 @@ var backupFetchCmd = &cobra.Command{
 		if fetchTargetUserData == "" {
 			fetchTargetUserData = viper.GetString(internal.FetchTargetUserDataSetting)
 		}
-		targetBackupSelector, err := createTargetFetchBackupSelector(cmd, args, fetchTargetUserData)
+		targetBackupSelector, err := createTargetFetchBackupSelector(cmd, args, fetchTargetUserData, restorePoint)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		folder, err := internal.ConfigureFolder()
@@ -56,16 +58,24 @@ var backupFetchCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		internal.HandleBackupFetch(folder, targetBackupSelector,
-			greenplum.NewGreenplumBackupFetcher(restoreConfigPath, inPlaceRestore, logsDir, *fetchContentIds, fetchMode))
+			greenplum.NewGreenplumBackupFetcher(restoreConfigPath, inPlaceRestore, logsDir, *fetchContentIds, fetchMode, restorePoint))
 	},
 }
 
 // create the BackupSelector to select the backup to fetch
 func createTargetFetchBackupSelector(cmd *cobra.Command,
-	args []string, targetUserData string) (internal.BackupSelector, error) {
+	args []string, targetUserData, restorePoint string) (internal.BackupSelector, error) {
 	targetName := ""
 	if len(args) >= 1 {
 		targetName = args[0]
+	}
+
+	// if target restore point is provided without the backup name, then
+	// choose the latest backup up to the specified restore point name
+	if restorePoint != "" && targetUserData == "" && len(args) == 0 {
+		tracelog.InfoLogger.Printf("Restore point %s is specified without the backup name or target user data, "+
+			"will search for a matching backup", restorePoint)
+		return greenplum.NewRestorePointBackupSelector(restorePoint), nil
 	}
 
 	backupSelector, err := internal.NewTargetBackupSelector(targetUserData, targetName, greenplum.NewGenericMetaFetcher())
@@ -79,6 +89,7 @@ func createTargetFetchBackupSelector(cmd *cobra.Command,
 func init() {
 	backupFetchCmd.Flags().StringVar(&fetchTargetUserData, "target-user-data",
 		"", targetUserDataDescription)
+	backupFetchCmd.Flags().StringVar(&restorePoint, "restore-point", "", restorePointDescription)
 	backupFetchCmd.Flags().StringVar(&restoreConfigPath, "restore-config",
 		"", restoreConfigPathDescription)
 	backupFetchCmd.Flags().BoolVar(&inPlaceRestore, "in-place", false, inPlaceFlagDescription)

--- a/cmd/gp/backup_fetch.go
+++ b/cmd/gp/backup_fetch.go
@@ -72,7 +72,7 @@ func createTargetFetchBackupSelector(cmd *cobra.Command,
 
 	// if target restore point is provided without the backup name, then
 	// choose the latest backup up to the specified restore point name
-	if restorePoint != "" && targetUserData == "" && len(args) == 0 {
+	if restorePoint != "" && targetUserData == "" && targetName == "" {
 		tracelog.InfoLogger.Printf("Restore point %s is specified without the backup name or target user data, "+
 			"will search for a matching backup", restorePoint)
 		return greenplum.NewRestorePointBackupSelector(restorePoint), nil

--- a/docker/gp_tests/scripts/tests/restore_point.sh
+++ b/docker/gp_tests/scripts/tests/restore_point.sh
@@ -40,17 +40,27 @@ fi
 
 wal-g backup-push --config=${TMP_CONFIG}
 
-# should fail
+wal-g create-restore-point after_backup --config=${TMP_CONFIG}
+stop_and_delete_cluster_dir
+
 wal-g backup-fetch LATEST --restore-point rp1 --in-place --config=${TMP_CONFIG} && EXIT_STATUS=$? || EXIT_STATUS=$?
 if [ "$EXIT_STATUS" -eq 0 ] ; then
     echo "Error: backup fetched with restore point in the past"
     exit 1
 fi
 
-wal-g create-restore-point after_backup --config=${TMP_CONFIG}
+wal-g backup-fetch --restore-point rp1 --in-place --config=${TMP_CONFIG} && EXIT_STATUS=$? || EXIT_STATUS=$?
+if [ "$EXIT_STATUS" -eq 0 ] ; then
+    echo "Error: backup fetched with restore point in the past"
+    exit 1
+fi
 
 # should not fail
 wal-g backup-fetch LATEST --restore-point after_backup --in-place --config=${TMP_CONFIG}
+delete_cluster_dirs
+
+# should not fail
+wal-g backup-fetch --restore-point after_backup --in-place --config=${TMP_CONFIG}
 
 start_cluster
 

--- a/docker/gp_tests/scripts/tests/restore_point.sh
+++ b/docker/gp_tests/scripts/tests/restore_point.sh
@@ -38,5 +38,21 @@ if [ "$EXIT_STATUS" -eq 0 ] ; then
     exit 1
 fi
 
+wal-g backup-push --config=${TMP_CONFIG}
+
+# should fail
+wal-g backup-fetch LATEST --restore-point rp1 --in-place --config=${TMP_CONFIG} && EXIT_STATUS=$? || EXIT_STATUS=$?
+if [ "$EXIT_STATUS" -eq 0 ] ; then
+    echo "Error: backup fetched with restore point in the past"
+    exit 1
+fi
+
+wal-g create-restore-point after_backup --config=${TMP_CONFIG}
+
+# should not fail
+wal-g backup-fetch LATEST --restore-point after_backup --in-place --config=${TMP_CONFIG}
+
+start_cluster
+
 cleanup
 rm ${TMP_CONFIG}

--- a/docker/gp_tests/scripts/tests/test_functions/util.sh
+++ b/docker/gp_tests/scripts/tests/test_functions/util.sh
@@ -59,11 +59,15 @@ setup_wal_archiving() {
   start_cluster
 }
 
-stop_and_delete_cluster_dir() {
-  stop_cluster
+delete_cluster_dirs() {
   #remove the database files
   for elem in "${SEGMENTS_DIRS[@]}"; do
     read -a arr <<< "$elem"
     rm -rf "${arr[1]}"
   done
+}
+
+stop_and_delete_cluster_dir() {
+  stop_cluster
+  delete_cluster_dirs
 }

--- a/internal/databases/greenplum/backup_list_handler.go
+++ b/internal/databases/greenplum/backup_list_handler.go
@@ -1,0 +1,38 @@
+package greenplum
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
+)
+
+//TODO: Implement backup-list handler
+
+// ListStorageBackups returns the list of storage backups sorted by finish time (in ascending order)
+func ListStorageBackups(folder storage.Folder) ([]Backup, error) {
+	backupObjects, err := internal.GetBackups(folder.GetSubFolder(utility.BaseBackupPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch list of backups in storage: %w", err)
+	}
+
+	backups := make([]Backup, 0, len(backupObjects))
+	for _, b := range backupObjects {
+		backup := NewBackup(folder, b.BackupName)
+
+		_, err = backup.GetSentinel()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load sentinel for backup %s: %w", b.BackupName, err)
+		}
+
+		backups = append(backups, backup)
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].SentinelDto.FinishTime.Before(backups[j].SentinelDto.FinishTime)
+	})
+
+	return backups, nil
+}

--- a/internal/databases/greenplum/backup_selector.go
+++ b/internal/databases/greenplum/backup_selector.go
@@ -1,0 +1,38 @@
+package greenplum
+
+import (
+	"fmt"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type RestorePointBackupSelector struct {
+	restorePoint string
+}
+
+func NewRestorePointBackupSelector(restorePoint string) *RestorePointBackupSelector {
+	return &RestorePointBackupSelector{restorePoint: restorePoint}
+}
+
+func (s *RestorePointBackupSelector) Select(folder storage.Folder) (string, error) {
+	restorePoint, err := FetchRestorePointMetadata(folder, s.restorePoint)
+	if err != nil {
+		return "", err
+	}
+
+	backups, err := ListStorageBackups(folder)
+	if err != nil {
+		return "", err
+	}
+
+	// pick the latest (closest) backup to the restore point
+	for i := len(backups) - 1; i >= 0; i-- {
+		if backups[i].SentinelDto.FinishTime.Before(restorePoint.FinishTime) {
+			return backups[i].Name, nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"failed to find matching backup (earlier than the finish time %s of the restore point %s)",
+		restorePoint.Name, restorePoint.FinishTime)
+}

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+
 	"github.com/spf13/viper"
 
 	"github.com/blang/semver"
@@ -39,6 +41,40 @@ func (s *RestorePointMetadata) String() string {
 
 func RestorePointMetadataFileName(pointName string) string {
 	return pointName + RestorePointSuffix
+}
+
+func FetchRestorePointMetadata(folder storage.Folder, pointName string) (RestorePointMetadata, error) {
+	var restorePoint RestorePointMetadata
+	err := internal.FetchDto(folder.GetSubFolder(utility.BaseBackupPath),
+		&restorePoint, RestorePointMetadataFileName(pointName))
+	if err != nil {
+		return RestorePointMetadata{}, fmt.Errorf("failed to fetch metadata for restore point %s: %w", pointName, err)
+	}
+
+	return restorePoint, nil
+}
+
+// ValidateMatch checks that restore point is reachable from the provided backup
+func ValidateMatch(folder storage.Folder, backupName string, restorePoint string) error {
+	backup := NewBackup(folder, backupName)
+	bSentinel, err := backup.GetSentinel()
+	if err != nil {
+		return fmt.Errorf("failed to fetch %s sentinel: %w", backupName, err)
+	}
+
+	rpMeta, err := FetchRestorePointMetadata(folder, restorePoint)
+	if err != nil {
+		tracelog.WarningLogger.Printf(
+			"failed to fetch restore point %s metadata, will skip the validation check: %v", restorePoint, err)
+		return nil
+	}
+
+	if bSentinel.FinishTime.After(rpMeta.FinishTime) {
+		return fmt.Errorf("%s backup finish time (%s) is after the %s provided restore point finish time (%s)",
+			backupName, bSentinel.FinishTime, restorePoint, rpMeta.FinishTime)
+	}
+
+	return nil
 }
 
 type RestorePointCreator struct {

--- a/internal/databases/postgres/backup.go
+++ b/internal/databases/postgres/backup.go
@@ -133,7 +133,7 @@ func (backup *Backup) GetSentinelAndFilesMetadata() (BackupSentinelDto, FilesMet
 		return sentinel, filesMetadata, nil
 	}
 
-	err = backup.FetchDto(&filesMetadata, getFilesMetadataPath(backup.Name))
+	err = internal.FetchDto(backup.Folder, &filesMetadata, getFilesMetadataPath(backup.Name))
 	if err != nil {
 		// double-check that this is not V2 backup
 		sentinelV2, err2 := backup.getSentinelV2()

--- a/internal/stream_metadata.go
+++ b/internal/stream_metadata.go
@@ -23,7 +23,7 @@ type BackupStreamMetadata struct {
 
 func GetBackupStreamFetcher(backup Backup) (StreamFetcher, error) {
 	var metadata BackupStreamMetadata
-	err := backup.FetchDto(&metadata, StreamMetadataNameFromBackup(backup.Name))
+	err := FetchDto(backup.Folder, &metadata, StreamMetadataNameFromBackup(backup.Name))
 	var test storage.ObjectNotFoundError
 	if errors.As(err, &test) {
 		return DownloadAndDecompressStream, nil


### PR DESCRIPTION
Adds the ability to restore onto the provided restore point.

Usage:
```
wal-g backup-fetch --restore-point [restore_point_name]
wal-g backup-fetch [backup_name] --restore-point [restore_point_name]
wal-g backup-fetch --target-user-data=[user_data] --restore-point [restore_point_name]
```
If the backup name is not provided, WAL-G will find the most appropriate backup. Otherwise, it will also perform the check if the provided backup has been created before the restore point.