### PR TITLE
Improve greenplum logging

### DIFF
--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
-
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -65,7 +63,7 @@ func NewFetchHandler(
 ) *FetchHandler {
 	backupIDByContentID := make(map[int]string)
 	segmentConfigs := make([]cluster.SegConfig, 0)
-	gplog.InitializeLogging("wal-g", logsDir)
+	initGpLog(logsDir)
 
 	for _, segMeta := range sentinel.Segments {
 		// currently, WAL-G does not restore the mirrors

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -260,8 +260,12 @@ func (bh *BackupHandler) pollSegmentStates() (map[int]SegBackupState, error) {
 	}, true)
 
 	for _, command := range remoteOutput.Commands {
-		tracelog.InfoLogger.Printf("Poll segment backup-push state STDERR (segment %d):\n%s\n", command.Content, command.Stderr)
-		tracelog.InfoLogger.Printf("Poll segment backup-push state STDOUT (segment %d):\n%s\n", command.Content, command.Stdout)
+		logger := tracelog.DebugLogger
+		if command.Stderr != "" {
+			logger = tracelog.WarningLogger
+		}
+		logger.Printf("Poll segment backup-push state STDERR (segment %d):\n%s\n", command.Content, command.Stderr)
+		logger.Printf("Poll segment backup-push state STDOUT (segment %d):\n%s\n", command.Content, command.Stdout)
 	}
 
 	if remoteOutput.NumErrors > 0 {

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -136,7 +136,7 @@ func (bh *BackupHandler) buildBackupPushCommand(contentID int) string {
 func (bh *BackupHandler) HandleBackupPush() {
 	bh.currBackupInfo.backupName = BackupNamePrefix + time.Now().Format(utility.BackupTimeFormat)
 	bh.currBackupInfo.startTime = utility.TimeNowCrossPlatformUTC()
-	gplog.InitializeLogging("wal-g", bh.arguments.logsDir)
+	initGpLog(bh.arguments.logsDir)
 
 	err := bh.checkPrerequisites()
 	tracelog.ErrorLogger.FatalfOnError("Backup prerequisites check failed: %v\n", err)

--- a/internal/databases/greenplum/configure.go
+++ b/internal/databases/greenplum/configure.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+
 	"github.com/spf13/viper"
 	"github.com/wal-g/wal-g/internal"
 )
@@ -28,4 +30,12 @@ func ConfigureSegContentID(contentIDFlag string) (int, error) {
 	}
 
 	return contentID, nil
+}
+
+//initGpLog is required for gp-common-go library to function properly
+func initGpLog(logsDir string) {
+	gplog.InitializeLogging("wal-g", logsDir)
+	gplog.SetLogFileNameFunc(func(program, logdir string) string {
+		return fmt.Sprintf("%s/%s-gplog.log", logdir, program)
+	})
 }

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/blang/semver"
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/jackc/pgx"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -122,7 +121,7 @@ func NewRestorePointCreator(pointName string) (rpc *RestorePointCreator, err err
 // Create creates cluster-wide consistent restore point
 func (rpc *RestorePointCreator) Create() {
 	rpc.startTime = utility.TimeNowCrossPlatformUTC()
-	gplog.InitializeLogging("wal-g", rpc.logsDir)
+	initGpLog(rpc.logsDir)
 
 	err := rpc.checkExists()
 	tracelog.ErrorLogger.FatalOnError(err)


### PR DESCRIPTION
Set permanent log file name `wal-g-gplog.log` for easier log rotation configuration.