### PR TITLE
fix mysql backup of a lagging replica

### DIFF
--- a/cmd/mysql/find_binlog.go
+++ b/cmd/mysql/find_binlog.go
@@ -1,0 +1,35 @@
+package mysql
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/mysql"
+)
+
+const (
+	findBinlogShortDescription = "Find the last uploaded binlog before specified GTID"
+)
+
+var (
+	findGtid      = ""
+	findBinlogCmd = &cobra.Command{
+		Use:   "binlog-find",
+		Short: findBinlogShortDescription,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
+			err := internal.AssertRequiredSettingsSet()
+			tracelog.ErrorLogger.FatalOnError(err)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			folder, err := internal.ConfigureFolder()
+			tracelog.ErrorLogger.FatalOnError(err)
+			mysql.HandleBinlogFind(folder, findGtid)
+		},
+	}
+)
+
+func init() {
+	cmd.AddCommand(findBinlogCmd)
+	findBinlogCmd.Flags().StringVarP(&findGtid, "--gtid", "g", "", "GTID to find. Default is @@GTID_EXECUTED on current server")
+}

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -18,7 +18,13 @@ func HandleBackupPush(folder storage.Folder, uploader internal.UploaderProvider,
 	tracelog.ErrorLogger.FatalOnError(err)
 	defer utility.LoggedClose(db, "")
 
-	binlogStart, err := getLastUploadedBinlog(folder)
+	flavor, err := getMySQLFlavor(db)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	gtidStart, err := getMySQLGTIDExecuted(db, flavor)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	binlogStart, err := getLastUploadedBinlogBeforeGTID(folder, gtidStart, flavor)
 	tracelog.ErrorLogger.FatalfOnError("failed to get last uploaded binlog: %v", err)
 	timeStart := utility.TimeNowCrossPlatformLocal()
 

--- a/internal/databases/mysql/binlog_find_handler.go
+++ b/internal/databases/mysql/binlog_find_handler.go
@@ -1,0 +1,23 @@
+package mysql
+
+import (
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
+
+	"github.com/wal-g/tracelog"
+)
+
+func HandleBinlogFind(folder storage.Folder, gtid string) {
+	db, err := getMySQLConnection()
+	tracelog.ErrorLogger.FatalOnError(err)
+	defer utility.LoggedClose(db, "")
+	flavor, err := getMySQLFlavor(db)
+	tracelog.ErrorLogger.FatalOnError(err)
+	if gtid == "" {
+		gtid, err = getMySQLGTIDExecuted(db, flavor)
+		tracelog.ErrorLogger.FatalOnError(err)
+	}
+	name, err := getLastUploadedBinlogBeforeGTID(folder, gtid, flavor)
+	tracelog.ErrorLogger.FatalOnError(err)
+	tracelog.InfoLogger.Println(name)
+}

--- a/internal/databases/mysql/mysql.go
+++ b/internal/databases/mysql/mysql.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/wal-g/wal-g/internal/compression"
 
-	flavors "github.com/go-mysql-org/go-mysql/mysql"
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-sql-driver/mysql"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -26,25 +26,20 @@ const BinlogPath = "binlog_" + utility.VersionStr + "/"
 
 const TimeMysqlFormat = "2006-01-02 15:04:05"
 
-func getFlavor(db *sql.DB) (string, error) {
-	rows, err := db.Query("SELECT @@version")
-	tracelog.ErrorLogger.FatalOnError(err)
-	defer utility.LoggedClose(rows, "")
-	if rows.Next() {
-		var versionComment string
-		err = rows.Scan(&versionComment)
-		if err != nil {
-			return "", err
-		}
-		// example: '10.6.4-MariaDB-1:10.6.4+maria~focal'
-		if strings.Contains(versionComment, "MariaDB") {
-			return flavors.MariaDBFlavor, nil
-		}
-		// It is possible to distinguish Percona & MySQL by checking 'version_comment',
-		// however usually we can expect that there is no difference between these distributions
-		return flavors.MySQLFlavor, nil
+func getMySQLFlavor(db *sql.DB) (string, error) {
+	row := db.QueryRow("SELECT @@version")
+	var versionComment string
+	err := row.Scan(&versionComment)
+	if err != nil {
+		return "", err
 	}
-	return "", nil
+	// example: '10.6.4-MariaDB-1:10.6.4+maria~focal'
+	if strings.Contains(versionComment, "MariaDB") {
+		return gomysql.MariaDBFlavor, nil
+	}
+	// It is possible to distinguish Percona & MySQL by checking 'version_comment',
+	// however usually we can expect that there is no difference between these distributions
+	return gomysql.MySQLFlavor, nil
 }
 
 func getMySQLCurrentBinlogFileLocal(db *sql.DB) (fileName string) {
@@ -59,6 +54,21 @@ func getMySQLCurrentBinlogFileLocal(db *sql.DB) (fileName string) {
 	}
 	tracelog.ErrorLogger.Fatalf("Failed to obtain current binlog file")
 	return ""
+}
+
+func getMySQLGTIDExecuted(db *sql.DB, flavor string) (gtid string, err error) {
+	query := ""
+	switch flavor {
+	case gomysql.MySQLFlavor:
+		query = "SELECT @@global.gtid_executed"
+	case gomysql.MariaDBFlavor:
+		query = "SELECT @@global.gtid_current_pos"
+	default:
+		return "", fmt.Errorf("unknown MySQL flavor: %s", flavor)
+	}
+	row := db.QueryRow(query)
+	err = row.Scan(&gtid)
+	return gtid, err
 }
 
 func getLastUploadedBinlog(folder storage.Folder) (string, error) {
@@ -78,6 +88,35 @@ func getLastUploadedBinlog(folder storage.Folder) (string, error) {
 		name = strings.TrimSuffix(name, ext)
 	}
 	return name, nil
+}
+
+func getLastUploadedBinlogBeforeGTID(folder storage.Folder, gtid string, flavor string) (string, error) {
+	gtidParsed, err := gomysql.ParseMysqlGTIDSet(gtid)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse server gtid: %s: %v", gtid, err)
+	}
+	folder = folder.GetSubFolder(BinlogPath)
+	logFiles, _, err := folder.ListFolder()
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(logFiles, func(i, j int) bool {
+		return logFiles[i].GetLastModified().Before(logFiles[j].GetLastModified())
+	})
+	if len(logFiles) == 0 {
+		return "", nil
+	}
+	for i := len(logFiles) - 1; i > 0; i-- {
+		prevGtid, err := GetBinlogPreviousGTIDsRemote(folder, logFiles[i].GetName(), flavor)
+		if err != nil {
+			return "", err
+		}
+		if gtidParsed.Contain(prevGtid) {
+			return utility.TrimFileExtension(logFiles[i].GetName()), nil
+		}
+	}
+	tracelog.WarningLogger.Printf("failed to find uploaded binlog behind %s", gtid)
+	return "", nil
 }
 
 func getMySQLConnection() (*sql.DB, error) {
@@ -197,7 +236,7 @@ outer:
 				tracelog.ErrorLogger.Printf("failed to download %s: %v", binlogName, err)
 				return err
 			}
-			timestamp, err := GetBinlogStartTimestamp(binlogPath)
+			timestamp, err := GetBinlogStartTimestamp(binlogPath, gomysql.MySQLFlavor)
 			if err != nil {
 				return err
 			}

--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -1,15 +1,17 @@
 package mysql
 
 import (
-	"bufio"
 	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"time"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/replication"
+	"github.com/pkg/errors"
+	"github.com/wal-g/tracelog"
 
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -17,180 +19,10 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-var BinlogMagic = [...]byte{0xfe, 0x62, 0x69, 0x6e}
-
-const BinlogMagicLength = 4
-
-const BinlogEventHeaderSize = 13
-
-func time2uint32(t time.Time) uint32 {
-	ts := t.Unix()
-	if ts > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(ts)
-}
-
-func minInt(i, j int) int {
-	if i < j {
-		return i
-	}
-	return j
-}
-
-// https://dev.mysql.com/doc/internals/en/event-structure.html
-// First 4 fields are the same in all versions
-type BinlogEventHeader struct {
-	Timestamp   uint32
-	TypeCode    uint8
-	ServerID    uint32
-	EventLength uint32
-}
-
-func ParseEventHeader(buf []byte) (header BinlogEventHeader) {
-	if len(buf) < BinlogEventHeaderSize {
-		panic("failed to parse binlog event header: buffer is too short")
-	}
-	le := binary.LittleEndian
-	header.Timestamp = le.Uint32(buf[0:])
-	header.TypeCode = buf[4]
-	header.ServerID = le.Uint32(buf[5:])
-	header.EventLength = le.Uint32(buf[9:])
-	return header
-}
-
-type BinlogReader struct {
-	reader          *bufio.Reader
-	startTS         uint32
-	endTS           uint32
-	headerBuf       []byte
-	headerSaved     bool
-	intervalEntered bool
-	intervalLeft    bool
-	tail            int
-}
-
-func NewBinlogReader(reader io.Reader, startTS time.Time, endTS time.Time) *BinlogReader {
-	return &BinlogReader{
-		reader:  bufio.NewReaderSize(reader, 10*utility.Mebibyte),
-		startTS: time2uint32(startTS),
-		endTS:   time2uint32(endTS),
-	}
-}
-
-func (bl *BinlogReader) saveMagicAndHeaderEvent() error {
-	var magic [4]byte
-	_, err := io.ReadFull(bl.reader, magic[:])
-	if err != nil {
-		return err
-	}
-	if magic != BinlogMagic {
-		return fmt.Errorf("incorrect binlog magic: %v", magic)
-	}
-	hbuf, err := bl.reader.Peek(BinlogEventHeaderSize)
-	if err != nil {
-		return err
-	}
-	header := ParseEventHeader(hbuf)
-	bl.headerBuf = make([]byte, 4+header.EventLength)
-	copy(bl.headerBuf[:4], magic[:])
-	_, err = io.ReadFull(bl.reader, bl.headerBuf[4:])
-	return err
-}
-
-func (bl *BinlogReader) readMagicAndHeaderEvent(buf []byte) int {
-	limit := minInt(len(bl.headerBuf), len(buf))
-	copy(buf, bl.headerBuf[:limit])
-	bl.headerBuf = bl.headerBuf[limit:]
-	return limit
-}
-
-func (bl *BinlogReader) readEvent(buf []byte) (int, error) {
-	limit := minInt(bl.tail, len(buf))
-	read, err := bl.reader.Read(buf[:limit])
-	bl.tail -= read
-	return read, err
-}
-
-func (bl *BinlogReader) Read(buf []byte) (int, error) {
-	blen := len(buf)
-	// save magic and first event (aka header) into the temporary buffer
-	// and keep them until first appropriate event
-	if !bl.headerSaved {
-		err := bl.saveMagicAndHeaderEvent()
-		if err != nil {
-			return 0, err
-		}
-		bl.headerSaved = true
-	}
-	// read events, checking timestamps
-	offset := 0
-	for offset < blen {
-		// pass magic and header event to client with first appropriate event
-		if bl.intervalEntered && len(bl.headerBuf) > 0 {
-			read := bl.readMagicAndHeaderEvent(buf[offset:])
-			offset += read
-			if len(bl.headerBuf) > 0 {
-				return offset, nil
-			}
-		}
-		// pass next event to client
-		if bl.tail > 0 {
-			read, err := bl.readEvent(buf[offset:])
-			offset += read
-			if err != nil || bl.tail > 0 {
-				return offset, err
-			}
-		}
-		// parse next event
-		hbuf, err := bl.reader.Peek(BinlogEventHeaderSize)
-		if err != nil {
-			// may return EOF here
-			return offset, err
-		}
-		header := ParseEventHeader(hbuf)
-		evlen := int(header.EventLength)
-		if header.Timestamp < bl.startTS {
-			_, err := bl.reader.Discard(evlen)
-			if err != nil {
-				return offset, err
-			}
-			continue
-		}
-		bl.intervalEntered = true
-		if header.Timestamp >= bl.endTS {
-			bl.intervalLeft = true
-			return offset, io.EOF
-		}
-		// set event to be read
-		bl.tail = evlen
-	}
-	return offset, nil
-}
-
-func (bl *BinlogReader) NeedAbort() bool {
-	return bl.intervalLeft
-}
-
-func GetBinlogStartTimestamp(path string) (time.Time, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return time.Time{}, err
-	}
-	defer file.Close()
-	buf := make([]byte, BinlogMagicLength+BinlogEventHeaderSize)
-	_, err = io.ReadFull(file, buf)
-	if err != nil {
-		return time.Time{}, err
-	}
-	if !bytes.Equal(BinlogMagic[:], buf[:BinlogMagicLength]) {
-		return time.Time{}, fmt.Errorf("incorrect binlog magic: %v", buf[:BinlogMagicLength])
-	}
-	header := ParseEventHeader(buf[BinlogMagicLength:])
-	return time.Unix(int64(header.Timestamp), 0), nil
-}
-
 const BinlogSentinelPath = "binlog_sentinel_" + utility.VersionStr + ".json"
+
+// 128k should be enough to parse prev_gtids event
+const BinlogReadHeaderSize = 128 * 1024
 
 type BinlogSentinelDto struct {
 	GTIDArchived string `json:"GtidArchived"`
@@ -226,4 +58,78 @@ func UploadBinlogSentinel(folder storage.Folder, sentinelDto interface{}) error 
 	}
 
 	return folder.PutObject(sentinelName, bytes.NewReader(dtoBody))
+}
+
+func GetBinlogPreviousGTIDs(filename string, flavor string) (*mysql.MysqlGTIDSet, error) {
+	var found bool
+	previousGTID := &replication.PreviousGTIDsEvent{}
+
+	parser := replication.NewBinlogParser()
+	parser.SetFlavor(flavor)
+	parser.SetVerifyChecksum(false) // the faster, the better
+	parser.SetRawMode(true)         // choose events to parse manually
+	err := parser.ParseFile(filename, 0, func(event *replication.BinlogEvent) error {
+		if event.Header.EventType == replication.PREVIOUS_GTIDS_EVENT {
+			err := previousGTID.Decode(event.RawData[replication.EventHeaderSize:])
+			if err != nil {
+				return err
+			}
+			found = true
+			return fmt.Errorf("shallow file read finished")
+		}
+		return nil
+	})
+
+	if err != nil && !found {
+		return nil, errors.Wrapf(err, "binlog-push: could not parse binlog file '%s'\n", filename)
+	}
+
+	res, err := mysql.ParseMysqlGTIDSet(previousGTID.GTIDSets)
+	if err != nil {
+		return nil, err
+	}
+	result, ok := res.(*mysql.MysqlGTIDSet)
+	if !ok {
+		tracelog.ErrorLogger.Fatalf("cannot cast nextPreviousGTIDs to MysqlGTIDSet. Should never be here. Actual type: %T\n", res)
+	}
+	return result, nil
+}
+
+func GetBinlogPreviousGTIDsRemote(folder storage.Folder, filename string, flavor string) (*mysql.MysqlGTIDSet, error) {
+	binlogName := utility.TrimFileExtension(filename)
+	fh, err := internal.DownloadAndDecompressStorageFile(folder, binlogName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read binlog %s: %w", binlogName, err)
+	}
+	defer utility.LoggedClose(fh, "failed to close binlog")
+	tmp, err := os.CreateTemp("", binlogName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer utility.LoggedClose(tmp, "failed to close temp file")
+	_, err = io.CopyN(tmp, fh, BinlogReadHeaderSize)
+	if err != nil && err != io.EOF {
+		return nil, fmt.Errorf("failed to read binlog beginning")
+	}
+	prevGtid, err := GetBinlogPreviousGTIDs(tmp.Name(), flavor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse binlog %s: %w", binlogName, err)
+	}
+	return prevGtid, nil
+}
+
+func GetBinlogStartTimestamp(filename string, flavor string) (time.Time, error) {
+	var ts uint32 = 0
+	parser := replication.NewBinlogParser()
+	parser.SetFlavor(flavor)
+	parser.SetVerifyChecksum(false) // the faster, the better
+	parser.SetRawMode(true)         // choose events to parse manually
+	err := parser.ParseFile(filename, 0, func(event *replication.BinlogEvent) error {
+		ts = event.Header.Timestamp
+		return fmt.Errorf("shallow file read finished")
+	})
+	if err != nil && ts == 0 {
+		return time.Time{}, fmt.Errorf("failed to parse binlog %s: %w", filename, err)
+	}
+	return time.Unix(int64(ts), 0), nil
 }

--- a/internal/databases/mysql/mysql_binlog_test.go
+++ b/internal/databases/mysql/mysql_binlog_test.go
@@ -1,168 +1,13 @@
 package mysql
 
 import (
-	"bytes"
-	"io"
-	"os"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"testing"
 	"time"
-
-	"github.com/wal-g/wal-g/utility"
 )
 
 const testFilenameSmall = "testdata/binlog_small_test"
 const testFilenameBig = "testdata/binlog_big_test"
-
-func TestReadWholeBinlog(t *testing.T) {
-	startTs := utility.MinTime
-	endTs := utility.MaxTime
-	binlog, err := os.Open(testFilenameBig)
-	if err != nil {
-		t.Errorf("failed to open data example: %v", err)
-	}
-	defer binlog.Close()
-	data1, err := io.ReadAll(binlog)
-	if err != nil {
-		t.Errorf("failed to read data exapmple: %v", err)
-	}
-	_, err = binlog.Seek(0, 0)
-	if err != nil {
-		t.Errorf("failed to seek data exapmple: %v", err)
-	}
-	br := NewBinlogReader(binlog, startTs, endTs)
-	data2, err := io.ReadAll(br)
-	if err != nil {
-		t.Errorf("failed to read whole binlog through BinlogReader: %v", err)
-	}
-	if bytes.Compare(data1, data2) != 0 {
-		t.Errorf("binlog differs from orriginal one")
-	}
-	if br.NeedAbort() {
-		t.Errorf("binlog reader unexpected marked as needed abort")
-	}
-}
-
-func TestReadBinlogAfterInterval(t *testing.T) {
-	startTs := utility.MinTime
-	endTs := utility.MinTime.Add(time.Second)
-	binlog, err := os.Open(testFilenameBig)
-	if err != nil {
-		t.Errorf("failed to open data example: %v", err)
-	}
-	defer binlog.Close()
-	br := NewBinlogReader(binlog, startTs, endTs)
-	data, err := io.ReadAll(br)
-	if err != nil {
-		t.Errorf("failed to read binlog through BinlogReader: %v", err)
-	}
-	if bytes.Compare(data, []byte{}) != 0 {
-		t.Errorf("binlog should be empty due to interval, but got %v", data[:1000])
-	}
-	if !br.NeedAbort() {
-		t.Errorf("binlog reader should be marked as needed abort")
-	}
-}
-
-func TestReadBinlogBeforeInterval(t *testing.T) {
-	startTs := utility.MaxTime
-	endTs := utility.MaxTime.Add(-time.Second)
-	binlog, err := os.Open(testFilenameBig)
-	if err != nil {
-		t.Errorf("failed to open data example: %v", err)
-	}
-	defer binlog.Close()
-	br := NewBinlogReader(binlog, startTs, endTs)
-	data, err := io.ReadAll(br)
-	if err != nil {
-		t.Errorf("failed to read binlog through BinlogReader: %v", err)
-	}
-	if bytes.Compare(data, []byte{}) != 0 {
-		t.Errorf("binlog should be empty due to interval, but got %v", data[:1000])
-	}
-	if br.NeedAbort() {
-		t.Errorf("binlog reader should not be marked as needed abort")
-	}
-}
-
-func TestReadPartOfBinlog(t *testing.T) {
-	startTs := utility.MinTime
-	endTs := time.Unix(1565531903, 0) // corresponds to the middle of the binlog
-	binlog, err := os.Open(testFilenameBig)
-	if err != nil {
-		t.Errorf("failed to open data example: %v", err)
-	}
-	defer binlog.Close()
-	data1, err := io.ReadAll(binlog)
-	if err != nil {
-		t.Errorf("failed to read data exapmple: %v", err)
-	}
-	_, err = binlog.Seek(0, 0)
-	if err != nil {
-		t.Errorf("failed to seek data exapmple: %v", err)
-	}
-	br := NewBinlogReader(binlog, startTs, endTs)
-	data2, err := io.ReadAll(br)
-	if err != nil {
-		t.Errorf("failed to read whole binlog through BinlogReader: %v", err)
-	}
-	if bytes.Compare(data1[:len(data2)], data2) != 0 {
-		t.Errorf("binlog differs from orriginal one (at read prefix)")
-	}
-	if !br.NeedAbort() {
-		t.Errorf("binlog reader should be marked as needed abort")
-	}
-}
-
-// stupid reader that reads by small chunks
-type antiBufReader struct {
-	Reader io.Reader
-	Limit  int
-}
-
-func (abr *antiBufReader) Read(buf []byte) (int, error) {
-	limit := abr.Limit
-	if len(buf) < limit {
-		limit = len(buf)
-	}
-	return abr.Reader.Read(buf[:limit])
-}
-
-func TestReadWholeBinlogWithDifferentChunks(t *testing.T) {
-	startTs := utility.MinTime
-	endTs := utility.MaxTime
-	binlog, err := os.Open(testFilenameBig)
-	if err != nil {
-		t.Errorf("failed to open data example: %v", err)
-	}
-	defer binlog.Close()
-	data1, err := io.ReadAll(binlog)
-	if err != nil {
-		t.Errorf("failed to read data exapmple: %v", err)
-	}
-	// read binlog through binlog reader with different input and output chunk combinations
-	variants := []int{3, 13, 967, 11087}
-	for _, underChunk := range variants {
-		for _, overChunk := range variants {
-			_, err = binlog.Seek(0, 0)
-			if err != nil {
-				t.Errorf("failed to seek data exapmple: %v", err)
-			}
-			ur := &antiBufReader{binlog, underChunk}
-			br := NewBinlogReader(ur, startTs, endTs)
-			or := &antiBufReader{br, overChunk}
-			data2, err := io.ReadAll(or)
-			if err != nil {
-				t.Errorf("failed to read whole binlog through BinlogReader: %v", err)
-			}
-			if bytes.Compare(data1, data2) != 0 {
-				t.Errorf("binlog differs from orriginal one, underChunk=%d overChunk=%d", underChunk, overChunk)
-			}
-			if br.NeedAbort() {
-				t.Errorf("binlog reader unexpected marked as needed abort")
-			}
-		}
-	}
-}
 
 func TestGetBinlogStartTimestamp(t *testing.T) {
 	var tests = []struct {
@@ -175,7 +20,7 @@ func TestGetBinlogStartTimestamp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetBinlogStartTimestamp(tt.testLogPath)
+			got, err := GetBinlogStartTimestamp(tt.testLogPath, mysql.MySQLFlavor)
 			if err != nil {
 				t.Errorf("parseFirstTimestampFromHeader(%s) error %v", tt.testLogPath, err)
 			}


### PR DESCRIPTION
# fix MySQL backup of a lagging replica

### Describe what this PR fix
Suppose we have a standard primary => secodary replication schema.
Primary works fine, and wal-g have uploaded `primary.0001` - `primary.0099` binlogs to storage.
Secondary instance is lagging and 5 hours behind the master, it's currently applying transactions from `primary.0050` binlog.
When we're making a full backup of a secondary, we should mark that it corresponds to `primary.0050` (currently applying) not `primary.0099` (last uploaded) binlog.
Otherwise, PITR will not work due to gap in transactions.
  
</p>
</details>
