### PR TITLE
Fix Greenplum log file init logic

### DIFF
--- a/internal/databases/greenplum/configure.go
+++ b/internal/databases/greenplum/configure.go
@@ -34,8 +34,8 @@ func ConfigureSegContentID(contentIDFlag string) (int, error) {
 
 //initGpLog is required for gp-common-go library to function properly
 func initGpLog(logsDir string) {
-	gplog.InitializeLogging("wal-g", logsDir)
 	gplog.SetLogFileNameFunc(func(program, logdir string) string {
 		return fmt.Sprintf("%s/%s-gplog.log", logdir, program)
 	})
+	gplog.InitializeLogging("wal-g", logsDir)
 }


### PR DESCRIPTION
This PR is intended to fix a flaw in the logger initialization logic (see https://github.com/wal-g/wal-g/pull/1222).