### PR TITLE
Libsodium Crypto Reader: Fix Crash if Read called after previous Read indicated EOF

### DIFF
--- a/internal/crypto/libsodium/crypter_test.go
+++ b/internal/crypto/libsodium/crypter_test.go
@@ -71,6 +71,12 @@ func EncryptionCycle(t *testing.T, crypter crypto.Crypter) {
 	assert.NoErrorf(t, err, "decryption read error: %v", err)
 
 	assert.Equal(t, secret, string(decrypted), "decrypted text not equals to open text")
+
+	// decrypter should keep returning EOF with no data
+	var buf [8]byte
+	n, err := decrypt.Read(buf[:])
+	assert.Equal(t, n, 0, "decryptor should not read any more data after ReadAll")
+	assert.Error(t, io.EOF, "decryptor should keep returning EOF error")
 }
 
 func TestEncryptionCycleFromKey(t *testing.T) {

--- a/internal/crypto/libsodium/reader.go
+++ b/internal/crypto/libsodium/reader.go
@@ -88,8 +88,6 @@ func (reader *Reader) Read(p []byte) (n int, err error) {
 func (reader *Reader) readNextChunk() (err error) {
 	n, err := io.ReadFull(reader.Reader, reader.in)
 
-	reader.in = reader.in[:n]
-
 	if err != nil && err != io.ErrUnexpectedEOF {
 		return
 	}


### PR DESCRIPTION
## Summary
The libsodium cryptographic reader will panic if the `Read()` method is invoked after a previous `Read()` call returns `io.EOF`.

This pull request:
- Modifies the reader to prevent the crash
- Adds a testcase which tests the behaviour of `Read()` after `io.EOF`.

Fixes #1226


## Details
In order to resolve this issue, it is enough to remove the input buffer truncation in the `readNextChunk` call. The truncation doesn't seem to serve any practical purpose.

The issue with the truncation was that the input buffer (reader.in) was truncated to zero-length. A `io.ReadFull` with a zero-length buffer always succeeds (returns 0, nil) - which causes the panic later on when attempting to evaluate `&reader.in[0]`. 

Without the truncation, `io.ReadFull` will now return the error of the underlying reader (which is likely `io.EOF` if it previously returned `io.EOF`).

## Further Information
In previous versions (before def83ac469b47e44c6c5769c0de321a7c9669a1e or a609be7e6a2d0d11241a9b277bc0cc1973d7f22a), this behaviour didn't cause an issue. In newer versions a backup restore will call `Read(..)` even if a previous `Read(..)` resulted in a `EOF` and panic.