### PR TITLE
[draft / prototype] daemon mode for wal-push

### DIFF
--- a/cmd/pg/wal_push.go
+++ b/cmd/pg/wal_push.go
@@ -1,6 +1,12 @@
 package pg
 
 import (
+	"net"
+	"os"
+	"path"
+
+	"github.com/wal-g/wal-g/utility"
+
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -9,6 +15,43 @@ import (
 )
 
 const WalPushShortDescription = "Uploads a WAL file to storage"
+const WalPushSocketName = "/tmp/wal-push.sock"
+
+func handleConn(c net.Conn, f func(string) error) {
+	defer c.Close()
+	buf := make([]byte, 512)
+	nr, err := c.Read(buf)
+	if err != nil {
+		tracelog.ErrorLogger.Printf("Failed to read message from client %s, err: %v\n", c.RemoteAddr(), err)
+		_, _ = c.Write([]byte("READ_FAILED"))
+		return
+	}
+
+	if nr < 24 {
+		if nr > 0 {
+			tracelog.ErrorLogger.Printf("Received incorrect message %s from %s", buf[0:nr], c.RemoteAddr())
+		} else {
+			tracelog.ErrorLogger.Printf("Received empty message from %s", c.RemoteAddr())
+		}
+		_, _ = c.Write([]byte("BAD_MSG"))
+		return
+	}
+
+	data := buf[0:24]
+	tracelog.InfoLogger.Printf("wal file name: %s\n", string(data))
+
+	err = f(string(data))
+	if err != nil {
+		tracelog.ErrorLogger.Printf("wal-push failed: %v\n", err)
+		_, _ = c.Write([]byte("FAIL"))
+		return
+	}
+
+	_, err = c.Write([]byte("OK"))
+	if err != nil {
+		tracelog.ErrorLogger.Println("OK write fail: ", err)
+	}
+}
 
 // walPushCmd represents the walPush command
 var walPushCmd = &cobra.Command{
@@ -35,10 +78,36 @@ var walPushCmd = &cobra.Command{
 			uploader.PGArchiveStatusManager = asm.NewNopASM()
 		}
 
-		postgres.HandleWALPush(uploader, args[0])
+		uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.WalPath)
+
+		if !daemonMode {
+			tracelog.ErrorLogger.FatalOnError(postgres.HandleWALPush(uploader, args[0]))
+			return
+		}
+
+		_ = os.Remove(WalPushSocketName)
+		l, err := net.Listen("unix", WalPushSocketName)
+		if err != nil {
+			tracelog.ErrorLogger.Fatal("listen error:", err)
+		}
+		for {
+			fd, err := l.Accept()
+			if err != nil {
+				tracelog.ErrorLogger.Println("accept error:", err)
+			}
+
+			go handleConn(fd, func(walFileName string) error {
+				fullPath := path.Join(args[0], walFileName)
+				tracelog.InfoLogger.Printf("starting wal-push for %s\n", fullPath)
+				return postgres.HandleWALPush(uploader, fullPath)
+			})
+		}
 	},
 }
 
+var daemonMode = false
+
 func init() {
 	Cmd.AddCommand(walPushCmd)
+	walPushCmd.Flags().BoolVar(&daemonMode, "daemon", false, "Run in daemon mode")
 }

--- a/internal/databases/mysql/mysql_binlog_test.go
+++ b/internal/databases/mysql/mysql_binlog_test.go
@@ -1,9 +1,10 @@
 package mysql
 
 import (
-	"github.com/go-mysql-org/go-mysql/mysql"
 	"testing"
 	"time"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
 const testFilenameSmall = "testdata/binlog_small_test"

--- a/internal/databases/postgres/wal_push_handler_test.go
+++ b/internal/databases/postgres/wal_push_handler_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/wal-g/wal-g/utility"
+
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 
 	"github.com/spf13/viper"
@@ -29,6 +31,7 @@ func generateAndUploadWalFile(t *testing.T, fileFormat string) (postgres.WalUplo
 	uploader := testtools.NewMockWalDirUploader(false, false)
 	fakeASM := asm.NewFakeASM()
 	uploader.ArchiveStatusManager = fakeASM
+	uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.WalPath)
 	postgres.HandleWALPush(uploader, filepath.Join(dirName, testFileName))
 	return *uploader, fakeASM, dir, testFileName
 }


### PR DESCRIPTION
This PR is intended to compare the wal-push effectiveness when using wal-push in daemon mode. 

Usage:
```bash
wal-g wal-push /path/to/pg_wal --config /path/to/config/wal-g.yaml --daemon

# some sort of archive_command
[[ $(nc -U /tmp/wal-push.sock <<< 'WAL_FILE_NAME') == "OK" ]] && exit 0 || exit 127`
```

Binary with this draft is available here https://github.com/usernamedt/wal-g/releases/tag/v0-test-daemon-mode