### PR TITLE
Introduce sampled pprof profiler

### DIFF
--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/cmd/common/st"
 	"github.com/wal-g/wal-g/internal"
 )
@@ -57,4 +58,29 @@ func Init(cmd *cobra.Command, dbName string) {
 
 	// Add storage tools
 	cmd.AddCommand(st.StorageToolsCmd)
+
+	// profiler
+	var persistentPreRun, persistentPostRun func(*cobra.Command, []string)
+	persistentPreRun = cmd.PersistentPreRun
+	persistentPostRun = cmd.PersistentPostRun
+
+	var p internal.ProfileStopper
+	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if persistentPreRun != nil {
+			persistentPreRun(cmd, args)
+		}
+
+		var err error
+		p, err = internal.Profile()
+		tracelog.ErrorLogger.FatalOnError(err)
+	}
+	cmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
+		if persistentPostRun != nil {
+			persistentPostRun(cmd, args)
+		}
+
+		if p != nil {
+			p.Stop()
+		}
+	}
 }

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -60,9 +60,8 @@ func Init(cmd *cobra.Command, dbName string) {
 	cmd.AddCommand(st.StorageToolsCmd)
 
 	// profiler
-	var persistentPreRun, persistentPostRun func(*cobra.Command, []string)
-	persistentPreRun = cmd.PersistentPreRun
-	persistentPostRun = cmd.PersistentPostRun
+	persistentPreRun := cmd.PersistentPreRun
+	persistentPostRun := cmd.PersistentPostRun
 
 	var p internal.ProfileStopper
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,7 +98,23 @@ Similar to `WALG_PGP_KEY`, but value is the path to the key on file system.
 
 If your *private key* is encrypted with a *passphrase*, you should set *passphrase* for decrypt.
 
-### Database-specific options 
+### Profiling
+
+Profiling is useful for identifying bottlenecks within WAL-G.
+
+* `PROFILE_SAMPLING_RATIO`
+
+A float value between 0 and 1, defines likelihood of the profiler getting enabled. When set to 1, it will always run. This allows probabilistic sampling of invocations. Since WAL-G processes may get created several times per second (e.g. wal-g wal-push), we do not want to profile all of them.
+
+* `PROFILE_MODE`
+
+The type of pprof profiler to use. Can be one of `cpu`, `mem`, `mutex`, `block`, `threadcreation`, `trace`, `goroutine`. See the [runtime/pprof docs](https://pkg.go.dev/runtime/pprof) for more information. Defaults to `cpu`.
+
+* `PROFILE_PATH`
+
+The directory to store profiles in. Defaults to `$TMPDIR`.
+
+### Database-specific options
 **More options are available for the chosen database. See it in [Databases](#databases)**
 
 Usage

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.1 // indirect
 	github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf // indirect
+	github.com/google/brotli/go/cbrotli v0.0.0-20220110100810-f4153a09f87c // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.0.0 // indirect
@@ -107,6 +108,7 @@ require (
 	github.com/pelletier/go-toml v1.7.0 // indirect
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3 // indirect
+	github.com/pkg/profile v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,7 @@ github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -225,6 +226,8 @@ github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf h1:gFVkHXmVAhEbxZV
 github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/brotli v1.0.9 h1:vgeehFs4lfG6xStg/Tr5Kjt4nEHhly0I8te7HKwPUfY=
 github.com/google/brotli v1.0.9/go.mod h1:XpGqLY1HgMKTQI5TU8iAKE/okaKqS9h1e6KRlRztlOU=
+github.com/google/brotli/go/cbrotli v0.0.0-20220110100810-f4153a09f87c h1:r47YgJ24CPvKxwxxHYPuE+FX1GgNtV93E7uaknKW0HU=
+github.com/google/brotli/go/cbrotli v0.0.0-20220110100810-f4153a09f87c/go.mod h1:nOPhAkwVliJdNTkj3gXpljmWhjc4wCaVqbMJcPKWP4s=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -415,6 +418,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=
+github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.11.0 h1:4Zv0OGbpkg4yNuUtH0s8rvoYxRCNyT29NVUo6pgPmxI=
 github.com/pkg/sftp v1.11.0/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -617,6 +622,7 @@ golang.org/x/net v0.0.0-20200320220750-118fecf932d8/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=

--- a/internal/config.go
+++ b/internal/config.go
@@ -82,6 +82,10 @@ const (
 	StreamSplitterPartitions     = "WALG_STREAM_SPLITTER_PARTITIONS"
 	StreamSplitterBlockSize      = "WALG_STREAM_SPLITTER_BLOCK_SIZE"
 
+	ProfileSamplingRatio = "PROFILE_SAMPLING_RATIO"
+	ProfileMode          = "PROFILE_MODE"
+	ProfilePath          = "PROFILE_PATH"
+
 	MongoDBUriSetting               = "MONGODB_URI"
 	MongoDBLastWriteUpdateInterval  = "MONGODB_LAST_WRITE_UPDATE_INTERVAL"
 	OplogArchiveAfterSize           = "OPLOG_ARCHIVE_AFTER_SIZE"
@@ -246,6 +250,10 @@ var (
 		DeltaFromUserDataSetting:     true,
 		FetchTargetUserDataSetting:   true,
 		SerializerTypeSetting:        true,
+
+		ProfileSamplingRatio: true,
+		ProfileMode:          true,
+		ProfilePath:          true,
 
 		// Swift
 		"WALG_SWIFT_PREFIX": true,

--- a/internal/profile.go
+++ b/internal/profile.go
@@ -1,13 +1,11 @@
 package internal
 
 import (
-	"fmt"
 	"math/rand"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/pkg/profile"
+	"github.com/spf13/viper"
 )
 
 type ProfileStopper interface {
@@ -15,15 +13,11 @@ type ProfileStopper interface {
 }
 
 func Profile() (ProfileStopper, error) {
-	envSamplingRatio := os.Getenv("PROFILE_SAMPLING_RATIO")
-	if envSamplingRatio == "" {
+	if !viper.IsSet(ProfileSamplingRatio) {
 		return nil, nil
 	}
 
-	samplingRatio, err := strconv.ParseFloat(envSamplingRatio, 64)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse PROFILE_SAMPLING_RATIO as float: %v", err)
-	}
+	samplingRatio := viper.GetFloat64(ProfileSamplingRatio)
 
 	// sample profiling invoked commands
 	rand.Seed(time.Now().UnixNano())
@@ -33,7 +27,7 @@ func Profile() (ProfileStopper, error) {
 
 	var opts []func(*profile.Profile)
 
-	profileMode := os.Getenv("PROFILE_MODE")
+	profileMode := viper.GetString(ProfileMode)
 	switch profileMode {
 	case "cpu":
 		opts = append(opts, profile.CPUProfile)
@@ -51,7 +45,7 @@ func Profile() (ProfileStopper, error) {
 		opts = append(opts, profile.GoroutineProfile)
 	}
 
-	profilePath := os.Getenv("PROFILE_PATH")
+	profilePath := viper.GetString(ProfilePath)
 	if profilePath != "" {
 		opts = append(opts, profile.ProfilePath(profilePath))
 	}

--- a/internal/profile.go
+++ b/internal/profile.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/pkg/profile"
+)
+
+type ProfileStopper interface {
+	Stop()
+}
+
+func Profile() (ProfileStopper, error) {
+	envSamplingRatio := os.Getenv("PROFILE_SAMPLING_RATIO")
+	if envSamplingRatio == "" {
+		return nil, nil
+	}
+
+	samplingRatio, err := strconv.ParseFloat(envSamplingRatio, 64)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse PROFILE_SAMPLING_RATIO as float: %v", err)
+	}
+
+	// sample profiling invoked commands
+	rand.Seed(time.Now().UnixNano())
+	if rand.Float64() >= samplingRatio {
+		return nil, nil
+	}
+
+	var opts []func(*profile.Profile)
+
+	profileMode := os.Getenv("PROFILE_MODE")
+	switch profileMode {
+	case "cpu":
+		opts = append(opts, profile.CPUProfile)
+	case "mem":
+		opts = append(opts, profile.MemProfile)
+	case "mutex":
+		opts = append(opts, profile.MutexProfile)
+	case "block":
+		opts = append(opts, profile.BlockProfile)
+	case "threadcreation":
+		opts = append(opts, profile.ThreadcreationProfile)
+	case "trace":
+		opts = append(opts, profile.TraceProfile)
+	case "goroutine":
+		opts = append(opts, profile.GoroutineProfile)
+	}
+
+	profilePath := os.Getenv("PROFILE_PATH")
+	if profilePath != "" {
+		opts = append(opts, profile.ProfilePath(profilePath))
+	}
+
+	p := profile.Start(opts...)
+
+	return p, nil
+}


### PR DESCRIPTION
This patch allows WAL-G runs to be profiled with golang's pprof profiler.

Options:

- `PROFILE_SAMPLING_RATIO`: A float value between 0 and 1, defines likelihood of the profiler getting enabled. When set to 1, it will always run. This allows probabilistic sampling of invocations. Since WAL-G processes may get created several times per second (e.g. wal-g wal-push), we do not want to profile all of them.
- `PROFILE_MODE`: The type of pprof profiler to use. Can be one of `cpu`, `mem`, `mutex`, `block`, `threadcreation`, `trace`, `goroutine`. Defaults to `cpu`.
- `PROFILE_PATH`: The directory to store profiles in. Defaults to `$TMPDIR`.

Sample invocation:

```bash
$ PROFILE_SAMPLING_RATIO=1 WALG_FILE_PREFIX=tmp ./main/pg/wal-g wal-push bar

2022/03/28 14:21:57 profile: cpu profiling enabled, /var/folders/7z/l7bjk65s5159bp_k60h6hr940000gn/T/profile357452575/cpu.pprof
INFO: 2022/03/28 14:21:57.413146 FILE PATH: bar.lz4
2022/03/28 14:21:57 profile: cpu profiling disabled, /var/folders/7z/l7bjk65s5159bp_k60h6hr940000gn/T/profile357452575/cpu.pprof
```

Sample pprof analysis:

```bash
$ go tool pprof /var/folders/7z/l7bjk65s5159bp_k60h6hr940000gn/T/profile3628604213/cpu.pprof

Type: cpu
Time: Mar 28, 2022 at 2:22pm (CEST)
Duration: 203.34ms, Total samples = 10ms ( 4.92%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 10ms, 100% of 10ms total
      flat  flat%   sum%        cum   cum%
      10ms   100%   100%       10ms   100%  runtime.scanobject
         0     0%   100%       10ms   100%  runtime.gcBgMarkWorker
         0     0%   100%       10ms   100%  runtime.gcBgMarkWorker.func2
         0     0%   100%       10ms   100%  runtime.gcDrain
         0     0%   100%       10ms   100%  runtime.systemstack
```