### PR TITLE
Added tests for GetLatestBackupName func

### DIFF
--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -39,7 +39,6 @@ func (err NoBackupsFoundError) Error() string {
 	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
 }
 
-// TODO : unit tests
 func GetLatestBackupName(folder storage.Folder) (string, error) {
 	backupTimes, err := GetBackups(folder)
 	SortBackupTimeSlices(backupTimes)

--- a/internal/backup_util_test.go
+++ b/internal/backup_util_test.go
@@ -58,6 +58,21 @@ func TestGetBackupTimeSlices_OrderCheck(t *testing.T) {
 	assert.True(t, result[0].Time.Before(result[1].Time), "GetBackupTimeSlices returned bad time ordering: order should be Ascending")
 }
 
+func TestGetLastBackupName(t *testing.T) {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	b1 := testStreamBackup.BackupName + ".1" + utility.SentinelSuffix
+	b2 := testStreamBackup.BackupName + ".2" + utility.SentinelSuffix
+	_, _ = folder.PutObject(b1, &bytes.Buffer{}), folder.PutObject(b2, &bytes.Buffer{})
+	lastB, _ := internal.GetLatestBackupName(folder)
+	assert.Equalf(t, lastB+utility.SentinelSuffix, b2, "Last Backup is not b2")
+}
+
+func TestGetLatestBackupName_EmptyWhenNoBackups(t *testing.T) {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	lastB, _ := internal.GetLatestBackupName(folder)
+	assert.Equal(t, "", lastB)
+}
+
 func TestGetGarbageFromPrefix(t *testing.T) {
 	backupNames := []string{"backup", "garbage", "garbage_0"}
 	folders := make([]storage.Folder, 0)


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fix
Added tests for GetLatestBackupName func

### Please provide steps to reproduce (if it's a bug)
--

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
