### PR TITLE
Config flags shell completions

### DIFF
--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -87,7 +87,7 @@ func Init(cmd *cobra.Command, dbName string) {
 	// Don't run PersistentPreRun when shell autocompleting
 	preRun := cmd.PersistentPreRun
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		if strings.Index(cmd.Use, "__complete") == 0 {
+		if strings.Index(cmd.Use, cobra.ShellCompRequestCmd) == 0 {
 			return
 		}
 		preRun(cmd, args)

--- a/cmd/common/flags.go
+++ b/cmd/common/flags.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // FlagsCmd represents the flags command
@@ -16,22 +15,8 @@ var FlagsCmd = &cobra.Command{
 }
 
 func init() {
-	defaultUsageFn := (&cobra.Command{}).UsageFunc()
-	defaultHelpFn := (&cobra.Command{}).HelpFunc()
-
 	FlagsCmd.SetUsageTemplate(flagsUsageTemplate)
 	FlagsCmd.SetHelpTemplate(flagsHelpTemplate)
-
-	FlagsCmd.SetUsageFunc(func(cmd *cobra.Command) error {
-		cmd.Parent().PersistentFlags().VisitAll(func(f *pflag.Flag) { f.Hidden = false })
-
-		return defaultUsageFn(cmd)
-	})
-	FlagsCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		cmd.Parent().PersistentFlags().VisitAll(func(f *pflag.Flag) { f.Hidden = false })
-
-		defaultHelpFn(cmd, args)
-	})
 
 	// fix to disable the required settings check for the help subcommand
 	FlagsCmd.PersistentPreRun = func(*cobra.Command, []string) {}

--- a/internal/config.go
+++ b/internal/config.go
@@ -142,6 +142,8 @@ const (
 	YcSaKeyFileSetting = "YC_SERVICE_ACCOUNT_KEY_FILE"
 
 	PgBackRestStanza = "PGBACKREST_STANZA"
+
+	HiddenConfigFlagAnnotation = "HIDDEN_CONFIG_FLAG_ANNOTATION"
 )
 
 var (
@@ -569,8 +571,12 @@ func AddConfigFlags(Cmd *cobra.Command) {
 		cfgFlags.String(flagName, "", flagUsage)
 		_ = viper.BindPFlag(k, cfgFlags.Lookup(flagName))
 	}
-	cfgFlags.VisitAll(func(f *pflag.Flag) { f.Hidden = true })
-
+	cfgFlags.VisitAll(func(f *pflag.Flag) {
+		if f.Annotations == nil {
+			f.Annotations = map[string][]string{}
+		}
+		f.Annotations[HiddenConfigFlagAnnotation] = []string{"true"}
+	})
 	Cmd.PersistentFlags().AddFlagSet(cfgFlags)
 }
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -142,8 +142,6 @@ const (
 	YcSaKeyFileSetting = "YC_SERVICE_ACCOUNT_KEY_FILE"
 
 	PgBackRestStanza = "PGBACKREST_STANZA"
-
-	HiddenConfigFlagAnnotation = "HIDDEN_CONFIG_FLAG_ANNOTATION"
 )
 
 var (
@@ -558,7 +556,7 @@ func ConfigureAndRunDefaultWebServer() error {
 	return nil
 }
 
-func AddConfigFlags(Cmd *cobra.Command) {
+func AddConfigFlags(Cmd *cobra.Command, hiddenCfgFlagAnnotation string) {
 	cfgFlags := &pflag.FlagSet{}
 	for k := range AllowedSettings {
 		flagName := toFlagName(k)
@@ -575,7 +573,7 @@ func AddConfigFlags(Cmd *cobra.Command) {
 		if f.Annotations == nil {
 			f.Annotations = map[string][]string{}
 		}
-		f.Annotations[HiddenConfigFlagAnnotation] = []string{"true"}
+		f.Annotations[hiddenCfgFlagAnnotation] = []string{"true"}
 	})
 	Cmd.PersistentFlags().AddFlagSet(cfgFlags)
 }


### PR DESCRIPTION
Now wal-g can autocomplete flags described in `wal-g flags` command. Just type `--` and hit `<tab><tab>`