### PR TITLE
Add tests for Greenplum generic meta interactor

### DIFF
--- a/internal/databases/greenplum/generic_meta_interactor_test.go
+++ b/internal/databases/greenplum/generic_meta_interactor_test.go
@@ -17,21 +17,32 @@ func init() {
 
 func TestFetch(t *testing.T) {
 	backupName := "test"
+	data := "Data"
 	hostName := "TestHost"
 	compressedSize := int64(100)
+	uncompressedSize := int64(10)
+	restorePoint := new(string)
+	*restorePoint = "restorePoint"
+	var segments []greenplum.SegmentMetadata
+	timeNow := time.Now()
+	format := greenplum.MetadataDatetimeFormat
+	version := "version"
+	isPermanent := false
+	systemIdentifier := new(uint64)
+	*systemIdentifier = 20
 
 	testObject := greenplum.BackupSentinelDto{
-		RestorePoint:     nil,
-		Segments:         nil,
-		UserData:         nil,
-		StartTime:        time.Now(),
-		FinishTime:       time.Now(),
-		DatetimeFormat:   greenplum.MetadataDatetimeFormat,
+		RestorePoint:     restorePoint,
+		Segments:         segments,
+		UserData:         data,
+		StartTime:        timeNow,
+		FinishTime:       timeNow,
+		DatetimeFormat:   format,
 		Hostname:         hostName,
-		GpVersion:        "",
-		IsPermanent:      false,
-		SystemIdentifier: nil,
-		UncompressedSize: 0,
+		GpVersion:        version,
+		IsPermanent:      isPermanent,
+		SystemIdentifier: systemIdentifier,
+		UncompressedSize: uncompressedSize,
 		CompressedSize:   compressedSize,
 	}
 
@@ -42,7 +53,10 @@ func TestFetch(t *testing.T) {
 	backup, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
 	assert.NoError(t, err)
 	assert.Equal(t, backupName, backup.BackupName)
+	assert.Equal(t, data, backup.UserData)
 	assert.Equal(t, hostName, backup.Hostname)
+	assert.Equal(t, isPermanent, backup.IsPermanent)
+	assert.Equal(t, uncompressedSize, backup.UncompressedSize)
 	assert.Equal(t, compressedSize, backup.CompressedSize)
 }
 

--- a/internal/databases/greenplum/generic_meta_interactor_test.go
+++ b/internal/databases/greenplum/generic_meta_interactor_test.go
@@ -21,18 +21,14 @@ func TestFetch(t *testing.T) {
 	hostName := "TestHost"
 	compressedSize := int64(100)
 	uncompressedSize := int64(10)
-	restorePoint := new(string)
-	*restorePoint = "restorePoint"
 	var segments []greenplum.SegmentMetadata
 	timeNow := time.Now()
 	format := greenplum.MetadataDatetimeFormat
 	version := "version"
 	isPermanent := false
-	systemIdentifier := new(uint64)
-	*systemIdentifier = 20
 
 	testObject := greenplum.BackupSentinelDto{
-		RestorePoint:     restorePoint,
+		RestorePoint:     nil,
 		Segments:         segments,
 		UserData:         data,
 		StartTime:        timeNow,
@@ -41,7 +37,7 @@ func TestFetch(t *testing.T) {
 		Hostname:         hostName,
 		GpVersion:        version,
 		IsPermanent:      isPermanent,
-		SystemIdentifier: systemIdentifier,
+		SystemIdentifier: nil,
 		UncompressedSize: uncompressedSize,
 		CompressedSize:   compressedSize,
 	}

--- a/internal/databases/greenplum/generic_meta_interactor_test.go
+++ b/internal/databases/greenplum/generic_meta_interactor_test.go
@@ -68,11 +68,9 @@ func TestFetch(t *testing.T) {
 	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
 	assert.True(t, isEqualTimeFinish)
 
-	expectedResult.StartTime = time.Time{}
-	actualResult.StartTime = time.Time{}
-
-	expectedResult.FinishTime = time.Time{}
-	actualResult.FinishTime = time.Time{}
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time  
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, actualResult)

--- a/internal/databases/greenplum/generic_meta_interactor_test.go
+++ b/internal/databases/greenplum/generic_meta_interactor_test.go
@@ -38,7 +38,7 @@ func TestFetch(t *testing.T) {
 	folder := testtools.MakeDefaultInMemoryStorageFolder()
 	marshaller, _ := internal.NewDtoSerializer()
 	file, _ := marshaller.Marshal(testObject)
-	folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
 	backup, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
 	assert.NoError(t, err)
 	assert.Equal(t, backupName, backup.BackupName)
@@ -66,9 +66,9 @@ func TestSetIsPermanent(t *testing.T) {
 	folder := testtools.MakeDefaultInMemoryStorageFolder()
 	marshaller, _ := internal.NewDtoSerializer()
 	file, _ := marshaller.Marshal(testObject)
-	folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
 
-	greenplum.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	_ = greenplum.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
 	backup, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
 
 	assert.NoError(t, err)
@@ -97,9 +97,9 @@ func TestSetUserData(t *testing.T) {
 	folder := testtools.MakeDefaultInMemoryStorageFolder()
 	marshaller, _ := internal.NewDtoSerializer()
 	file, _ := marshaller.Marshal(testObject)
-	folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
 
-	greenplum.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+	_ = greenplum.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
 
 	backup, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
 

--- a/internal/databases/greenplum/generic_meta_interactor_test.go
+++ b/internal/databases/greenplum/generic_meta_interactor_test.go
@@ -1,0 +1,108 @@
+package greenplum_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+	"github.com/wal-g/wal-g/testtools"
+	"testing"
+	"time"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	internal.InitConfig()
+	internal.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	hostName := "TestHost"
+	compressedSize := int64(100)
+
+	testObject := greenplum.BackupSentinelDto{
+		RestorePoint:     nil,
+		Segments:         nil,
+		UserData:         nil,
+		StartTime:        time.Now(),
+		FinishTime:       time.Now(),
+		DatetimeFormat:   greenplum.MetadataDatetimeFormat,
+		Hostname:         hostName,
+		GpVersion:        "",
+		IsPermanent:      false,
+		SystemIdentifier: nil,
+		UncompressedSize: 0,
+		CompressedSize:   compressedSize,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	backup, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
+	assert.NoError(t, err)
+	assert.Equal(t, backupName, backup.BackupName)
+	assert.Equal(t, hostName, backup.Hostname)
+	assert.Equal(t, compressedSize, backup.CompressedSize)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := greenplum.BackupSentinelDto{
+		RestorePoint:     nil,
+		Segments:         nil,
+		UserData:         nil,
+		StartTime:        time.Now(),
+		FinishTime:       time.Now(),
+		DatetimeFormat:   greenplum.MetadataDatetimeFormat,
+		Hostname:         "",
+		GpVersion:        "",
+		IsPermanent:      false,
+		SystemIdentifier: nil,
+		UncompressedSize: 0,
+		CompressedSize:   0,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	greenplum.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	backup, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := greenplum.BackupSentinelDto{
+		RestorePoint:     nil,
+		Segments:         nil,
+		UserData:         oldData,
+		StartTime:        time.Now(),
+		FinishTime:       time.Now(),
+		DatetimeFormat:   greenplum.MetadataDatetimeFormat,
+		Hostname:         "",
+		GpVersion:        "",
+		IsPermanent:      false,
+		SystemIdentifier: nil,
+		UncompressedSize: 0,
+		CompressedSize:   0,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	greenplum.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+
+	backup, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/greenplum/generic_meta_interactor_test.go
+++ b/internal/databases/greenplum/generic_meta_interactor_test.go
@@ -22,7 +22,7 @@ func TestFetch(t *testing.T) {
 	compressedSize := int64(100)
 	uncompressedSize := int64(10)
 	var segments []greenplum.SegmentMetadata
-	timeNow := time.Time{}
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
 	format := greenplum.MetadataDatetimeFormat
 	version := "version"
 	isPermanent := false
@@ -31,8 +31,8 @@ func TestFetch(t *testing.T) {
 		RestorePoint:     nil,
 		Segments:         segments,
 		UserData:         data,
-		StartTime:        timeNow,
-		FinishTime:       timeNow,
+		StartTime:        date,
+		FinishTime:       date,
 		DatetimeFormat:   format,
 		Hostname:         hostName,
 		GpVersion:        version,
@@ -47,8 +47,8 @@ func TestFetch(t *testing.T) {
 		UncompressedSize: uncompressedSize,
 		CompressedSize:   compressedSize,
 		Hostname:         hostName,
-		StartTime:        timeNow,
-		FinishTime:       timeNow,
+		StartTime:        date,
+		FinishTime:       date,
 		IsPermanent:      isPermanent,
 		IsIncremental:    false,
 		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
@@ -59,9 +59,23 @@ func TestFetch(t *testing.T) {
 	marshaller, _ := internal.NewDtoSerializer()
 	file, _ := marshaller.Marshal(testObject)
 	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
-	backup, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
+	actualResult, err := greenplum.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	expectedResult.StartTime = time.Time{}
+	actualResult.StartTime = time.Time{}
+
+	expectedResult.FinishTime = time.Time{}
+	actualResult.FinishTime = time.Time{}
+
 	assert.NoError(t, err)
-	assert.Equal(t, expectedResult, backup)
+	assert.Equal(t, expectedResult, actualResult)
 }
 
 func TestSetIsPermanent(t *testing.T) {


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fix
problem is Add tests for generic meta interactor

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
