### PR TITLE
Greenplum: separate storage for AO/AOCS segments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       &&  mkdir -p /export/gpdeletebeforepermanentbucket
       &&  mkdir -p /export/gpdeletebeforenamebucket
       &&  mkdir -p /export/gpdeletebeforetimebucket
+      &&  mkdir -p /export/gpaostoragetestbucket
       &&  mkdir -p /export/createrestorepointbucket
       &&  mkdir -p /export/storagetoolsbucket
       &&  mkdir -p /export/walrestorebucket

--- a/docker/gp_tests/scripts/configs/ao_storage_test_config.json
+++ b/docker/gp_tests/scripts/configs/ao_storage_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://gpaostoragetestbucket",
+"WALG_LOG_LEVEL": "DEVEL"

--- a/docker/gp_tests/scripts/tests/ao_storage_test.sh
+++ b/docker/gp_tests/scripts/tests/ao_storage_test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e -x
+CONFIG_FILE="/tmp/configs/ao_storage_test_config.json"
+
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/pg_scripts/wrap_config_file.sh ${TMP_CONFIG}
+source /tmp/tests/test_functions/util.sh
+
+bootstrap_gp_cluster
+sleep 3
+setup_wal_archiving
+enable_pitr_extension
+
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+# 1st backup (init tables heap, ao, co)
+insert_data
+run_backup_logged ${TMP_CONFIG} ${PGDATA}
+
+# 2nd backup (populate the co table)
+psql -p 6000 -d test -c "INSERT INTO co select i, i FROM generate_series(1,10)i;"
+run_backup_logged ${TMP_CONFIG} ${PGDATA}
+
+# 3rd backup (populate the ao table)
+psql -p 6000 -d test -c "INSERT INTO ao select i, i FROM generate_series(1,10)i;"
+run_backup_logged ${TMP_CONFIG} ${PGDATA}
+
+backup_name=$(wal-g --config=${TMP_CONFIG} backup-list | tail -n 1 | cut -f 1 -d " ")
+
+wal-g --config=${TMP_CONFIG} backup-list
+
+wal-g --config=${TMP_CONFIG} delete before $backup_name --confirm
+
+# show the storage objects (useful for debug)
+wal-g st ls -r --config=${TMP_CONFIG}
+
+stop_and_delete_cluster_dir
+
+wal-g backup-fetch LATEST --in-place --config=${TMP_CONFIG}
+start_cluster
+
+psql -p 6000 -d test -c "SELECT COUNT(*) FROM ao;" | grep 20 && EXIT_STATUS=$? || EXIT_STATUS=$?
+if [ "$EXIT_STATUS" -ne 0 ] ; then
+    echo "Error: Failed to read from ao table after restore"
+    exit 1
+fi
+
+psql -p 6000 -d test -c "SELECT COUNT(*) FROM co;" | grep 20 && EXIT_STATUS=$? || EXIT_STATUS=$?
+if [ "$EXIT_STATUS" -ne 0 ] ; then
+    echo "Error: Failed to read from co table after restore"
+    exit 1
+fi
+
+cleanup
+rm ${TMP_CONFIG}

--- a/internal/compression/lzo/lzo_test.go
+++ b/internal/compression/lzo/lzo_test.go
@@ -140,9 +140,10 @@ type BufferReaderMaker struct {
 }
 
 func (b *BufferReaderMaker) Reader() (io.ReadCloser, error) { return io.NopCloser(b.Buf), nil }
-func (b *BufferReaderMaker) Path() string                   { return b.Key }
+func (b *BufferReaderMaker) StoragePath() string            { return b.Key }
+func (b *BufferReaderMaker) LocalPath() string              { return b.Key }
 func (b *BufferReaderMaker) FileType() internal.FileType    { return internal.TarFileType }
-func (b *BufferReaderMaker) Mode() int                      { return 0 }
+func (b *BufferReaderMaker) Mode() int64                    { return 0 }
 
 func init() {
 	internal.ConfigureSettings("")

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -247,6 +247,8 @@ func (fh *FetchHandler) buildFetchCommand(contentID int) string {
 		fmt.Sprintf("--content-id=%d", segment.ContentID),
 		fmt.Sprintf("--target-user-data=%s", segUserData.QuotedString()),
 		fmt.Sprintf("--config=%s", internal.CfgFile),
+		// forward STDOUT& STDERR to log file
+		">>", formatSegmentLogPath(contentID), "2>&1",
 	}
 
 	cmdLine := strings.Join(cmd, " ")

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/google/uuid"
 
 	"github.com/blang/semver"
@@ -300,7 +298,7 @@ func (bh *BackupHandler) checkPrerequisites() (err error) {
 	tracelog.InfoLogger.Println("Checking for the existing running backup...")
 	queryRunner, err := NewGpQueryRunner(bh.workers.Conn)
 	if err != nil {
-		return
+		return err
 	}
 	backupStatuses, err := queryRunner.IsInBackup()
 	if err != nil {
@@ -493,9 +491,4 @@ func (bh *BackupHandler) fetchSingleMetadata(backupID string, segCfg *cluster.Se
 	}
 
 	return &meta, nil
-}
-
-func formatSegmentLogPath(contentID int) string {
-	logsDir := viper.GetString(internal.GPLogsDirectory)
-	return fmt.Sprintf("%s/%s-seg%d.log", logsDir, SegBackupLogPrefix, contentID)
 }

--- a/internal/databases/greenplum/segment_backup_runner.go
+++ b/internal/databases/greenplum/segment_backup_runner.go
@@ -34,7 +34,7 @@ func NewSegBackupRunner(contentID int, backupName, backupArgs string, updInterva
 
 func (r *SegBackupRunner) Run() {
 	contentIDArg := fmt.Sprintf("--content-id=%d", r.contentID)
-	cmdArgs := []string{"seg", "backup-push", contentIDArg}
+	cmdArgs := []string{"seg", "backup-push", contentIDArg, "--gp-composer"}
 	backupArgs := strings.Fields(r.backupArgs)
 	cmdArgs = append(cmdArgs, backupArgs...)
 

--- a/internal/databases/greenplum/util.go
+++ b/internal/databases/greenplum/util.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/spf13/viper"
+	"github.com/wal-g/wal-g/internal"
+
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -12,6 +15,11 @@ const SegmentsFolderPath = "segments_" + utility.VersionStr + "/"
 func FormatSegmentStoragePrefix(contentID int) string {
 	segmentFolderName := fmt.Sprintf("seg%d", contentID)
 	return path.Join(SegmentsFolderPath, segmentFolderName)
+}
+
+func formatSegmentLogPath(contentID int) string {
+	logsDir := viper.GetString(internal.GPLogsDirectory)
+	return fmt.Sprintf("%s/%s-seg%d.log", logsDir, SegBackupLogPrefix, contentID)
 }
 
 func FormatSegmentBackupPath(contentID int) string {

--- a/internal/databases/mysql/mysql_binlog_test.go
+++ b/internal/databases/mysql/mysql_binlog_test.go
@@ -1,9 +1,10 @@
 package mysql
 
 import (
-	"github.com/go-mysql-org/go-mysql/mysql"
 	"testing"
 	"time"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
 )
 
 const testFilenameSmall = "testdata/binlog_small_test"

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -239,7 +239,7 @@ func (bh *BackupHandler) uploadBackup() TarFileSets {
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	tarBallComposerMaker, err := NewTarBallComposerMaker(bh.arguments.tarBallComposerType, bh.workers.conn,
-		bh.workers.uploader.UploadingFolder, bh.curBackupInfo.name,
+		bh.workers.uploader.Uploader, bh.curBackupInfo.name,
 		NewTarBallFilePackerOptions(bh.arguments.verifyPageChecksums, bh.arguments.storeAllCorruptBlocks),
 		bh.arguments.withoutFilesMetadata)
 	tracelog.ErrorLogger.FatalOnError(err)
@@ -252,7 +252,7 @@ func (bh *BackupHandler) uploadBackup() TarFileSets {
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	tracelog.InfoLogger.Println("Packing ...")
-	tarFileSets, err := bundle.PackTarballs()
+	tarFileSets, err := bundle.FinishTarComposer()
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	tracelog.DebugLogger.Println("Finishing queue ...")

--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -430,8 +430,8 @@ func (bundle *Bundle) DownloadDeltaMap(folder storage.Folder, backupStartLSN uin
 	return nil
 }
 
-func (bundle *Bundle) PackTarballs() (TarFileSets, error) {
-	return bundle.TarBallComposer.PackTarballs()
+func (bundle *Bundle) FinishTarComposer() (TarFileSets, error) {
+	return bundle.TarBallComposer.FinishComposing()
 }
 
 func (bundle *Bundle) GetFiles() *sync.Map {

--- a/internal/databases/postgres/copy_tar_ball_composer.go
+++ b/internal/databases/postgres/copy_tar_ball_composer.go
@@ -230,7 +230,7 @@ func (c *CopyTarBallComposer) copyUnchangedTars() error {
 	return nil
 }
 
-func (c *CopyTarBallComposer) PackTarballs() (TarFileSets, error) {
+func (c *CopyTarBallComposer) FinishComposing() (TarFileSets, error) {
 	err := c.copyUnchangedTars()
 	if err != nil {
 		return nil, err

--- a/internal/databases/postgres/delete_util.go
+++ b/internal/databases/postgres/delete_util.go
@@ -55,6 +55,12 @@ func IsPermanent(objectName string, permanentBackups, permanentWals map[string]b
 		return permanentWals[wal]
 	}
 	if strings.HasPrefix(objectName, utility.BaseBackupPath) {
+		// Handle Greenplum AO segment backup reference
+		if strings.HasSuffix(objectName, BackupRefSuffix) {
+			backupRef := strings.SplitAfter(objectName, AoSegSuffix+"_")[1]
+			return permanentBackups[strings.TrimSuffix(backupRef, BackupRefSuffix)]
+		}
+
 		backup := utility.StripLeftmostBackupName(objectName[len(utility.BaseBackupPath):])
 		return permanentBackups[backup]
 	}

--- a/internal/databases/postgres/greenplum_ao_metadata.go
+++ b/internal/databases/postgres/greenplum_ao_metadata.go
@@ -1,0 +1,44 @@
+package postgres
+
+import (
+	"time"
+)
+
+const AOFilesMetadataName = "ao_files_metadata.json"
+
+// getAOFilesMetadataPath returns AO files metadata storage path.
+func getAOFilesMetadataPath(backupName string) string {
+	return backupName + "/" + AOFilesMetadataName
+}
+
+type BackupAOFileDesc struct {
+	StoragePath string         `json:"StoragePath"`
+	IsSkipped   bool           `json:"IsSkipped"`
+	MTime       time.Time      `json:"MTime"`
+	StorageType RelStorageType `json:"StorageType"`
+	EOF         uint32         `json:"EOF"`
+	Compressor  string         `json:"Compressor,omitempty"`
+	FileMode    int64          `json:"FileMode"`
+}
+
+type AOFilesMetadataDTO struct {
+	Files BackupAOFiles
+}
+
+type BackupAOFiles map[string]BackupAOFileDesc
+
+func NewAOFilesMetadataDTO() *AOFilesMetadataDTO {
+	return &AOFilesMetadataDTO{Files: make(BackupAOFiles)}
+}
+
+func (m *AOFilesMetadataDTO) addFile(key, storagePath string, mTime time.Time, aoMeta AoRelFileMetadata,
+	fileMode int64, isSkipped bool) {
+	m.Files[key] = BackupAOFileDesc{
+		StoragePath: storagePath,
+		IsSkipped:   isSkipped,
+		MTime:       mTime,
+		EOF:         aoMeta.eof,
+		StorageType: aoMeta.storageType,
+		FileMode:    fileMode,
+	}
+}

--- a/internal/databases/postgres/greenplum_ao_storage.go
+++ b/internal/databases/postgres/greenplum_ao_storage.go
@@ -1,0 +1,43 @@
+package postgres
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+
+	"github.com/wal-g/wal-g/internal/walparser"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+const (
+	AoStoragePath   = "aosegments"
+	BackupRefSuffix = "_ref"
+	AoSegSuffix     = "_aoseg"
+)
+
+func makeAoFileStorageKey(relNameMd5 string, modCount uint32, location *walparser.BlockLocation) string {
+	return fmt.Sprintf("%d_%d_%s_%d_%d_%d%s",
+		location.RelationFileNode.SpcNode, location.RelationFileNode.DBNode,
+		relNameMd5,
+		location.RelationFileNode.RelNode, location.BlockNo,
+		modCount, AoSegSuffix)
+}
+
+func storeBackupReference(baseBackupsFolder storage.Folder, aoFilename string, backupName string) error {
+	refName := aoFilename + "_" + backupName + BackupRefSuffix
+	return baseBackupsFolder.PutObject(path.Join(AoStoragePath, refName), &bytes.Buffer{})
+}
+
+func LoadStorageAoFiles(baseBackupsFolder storage.Folder) (map[string]struct{}, error) {
+	aoObjects, _, err := baseBackupsFolder.GetSubFolder(AoStoragePath).ListFolder()
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]struct{})
+	for _, obj := range aoObjects {
+		result[obj.GetName()] = struct{}{}
+	}
+
+	return result, nil
+}

--- a/internal/databases/postgres/greenplum_relfile_storage_map.go
+++ b/internal/databases/postgres/greenplum_relfile_storage_map.go
@@ -1,0 +1,88 @@
+package postgres
+
+import (
+	"github.com/jackc/pgx"
+	"github.com/pkg/errors"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/walparser"
+)
+
+type RelStorageType byte
+
+const (
+	AppendOptimized RelStorageType = 'a'
+	ColumnOriented  RelStorageType = 'c'
+)
+
+type AoRelFileMetadata struct {
+	relNameMd5  string
+	storageType RelStorageType
+	eof         uint32
+	modCount    uint32
+}
+
+// AoRelFileStorageMap indicates the storage type for the relfile
+type AoRelFileStorageMap map[walparser.BlockLocation]AoRelFileMetadata
+
+func (storageMap *AoRelFileStorageMap) getAOStorageMetadata(filePath string) (bool, AoRelFileMetadata, *walparser.BlockLocation) {
+	relFileNode, err := GetRelFileNodeFrom(filePath)
+	if err != nil {
+		// looks like this is not the relfile at all => false
+		return false, AoRelFileMetadata{}, nil
+	}
+	blockNo, err := GetRelFileIDFrom(filePath)
+	if err != nil {
+		// same as above, but this is some unusual / unexpected error, better log it
+		tracelog.WarningLogger.Printf("Failed to parse blockNo for path %s: %v", filePath, err)
+		return false, AoRelFileMetadata{}, nil
+	}
+
+	location := walparser.NewBlockLocation(relFileNode.SpcNode, relFileNode.DBNode, relFileNode.RelNode, uint32(blockNo))
+	storageInfo, ok := (*storageMap)[*location]
+	if !ok {
+		// Absence of the entry does not guarantee that the relfile is not append-optimized.
+		// It may have been created after the backup start.
+		// Currently, we do not need to detect an AO file with 100% precision, so it is OK.
+		return false, AoRelFileMetadata{}, nil
+	}
+
+	return true, storageInfo, location
+}
+
+func newAoRelFileStorageMap(conn *pgx.Conn) (AoRelFileStorageMap, error) {
+	databases, err := getDatabaseInfos(conn)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get database names")
+	}
+
+	result := make(AoRelFileStorageMap)
+	// collect info for each relFileNode
+	for _, db := range databases {
+		dbName := db.name
+		databaseOption := func(c *pgx.ConnConfig) error {
+			c.Database = dbName
+			return nil
+		}
+
+		dbConn, err := Connect(databaseOption)
+		if err != nil {
+			tracelog.WarningLogger.Printf("Failed to connect to database: %s\n'%v'\n", db.name, err)
+			continue
+		}
+
+		queryRunner, err := NewPgQueryRunner(dbConn)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to build query runner.")
+		}
+		rows, err := queryRunner.fetchAOStorageMetadata(db)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to fetch storage types")
+		}
+		for relFileLoc, metadata := range rows {
+			result[relFileLoc] = metadata
+		}
+		err = dbConn.Close()
+		tracelog.WarningLogger.PrintOnError(err)
+	}
+	return result, nil
+}

--- a/internal/databases/postgres/greenplum_tar_ball_composer.go
+++ b/internal/databases/postgres/greenplum_tar_ball_composer.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"sync"
+	"sync/atomic"
 
 	"github.com/wal-g/wal-g/internal/walparser"
 
@@ -248,6 +249,8 @@ func (c *GpTarBallComposer) addAOFile(cfi *ComposeFileInfo, aoMeta AoRelFileMeta
 		return err
 	}
 
+	// looks ugly, but currently it is the only way to keep track of the AO files size
+	atomic.AddInt64(c.tarBallQueue.AllTarballsSize, cfi.fileInfo.Size())
 	c.addAoFileMetadata(cfi, storageKey, aoMeta, false)
 
 	// add reference for the current backup to the storage

--- a/internal/databases/postgres/greenplum_tar_ball_composer.go
+++ b/internal/databases/postgres/greenplum_tar_ball_composer.go
@@ -239,7 +239,7 @@ func (c *GpTarBallComposer) addAOFile(cfi *ComposeFileInfo, aoMeta AoRelFileMeta
 
 	// do not compress AO/AOCS segment files since they are already compressed in most cases
 	// TODO: lookup the compression details for each relation and compress it when compression is turned off
-	var compressor compression.Compressor = nil
+	var compressor compression.Compressor
 
 	uploadContents := internal.CompressAndEncrypt(fileReadCloser, compressor, c.crypter)
 	uploadPath := path.Join(AoStoragePath, storageKey)

--- a/internal/databases/postgres/greenplum_tar_ball_composer.go
+++ b/internal/databases/postgres/greenplum_tar_ball_composer.go
@@ -1,0 +1,262 @@
+package postgres
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/wal-g/wal-g/internal/walparser"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/compression"
+
+	"github.com/wal-g/wal-g/internal/crypto"
+	"golang.org/x/sync/errgroup"
+)
+
+type GpTarBallComposerMaker struct {
+	relStorageMap AoRelFileStorageMap
+	bundleFiles   BundleFiles
+	TarFileSets   TarFileSets
+	aoFiles       *AOFilesMetadataDTO
+	uploader      *internal.Uploader
+	baseFiles     map[string]struct{}
+	backupName    string
+}
+
+func NewGpTarBallComposerMaker(relStorageMap AoRelFileStorageMap, uploader *internal.Uploader, backupName string,
+) (*GpTarBallComposerMaker, error) {
+	baseFiles, err := LoadStorageAoFiles(uploader.UploadingFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GpTarBallComposerMaker{
+		relStorageMap: relStorageMap,
+		bundleFiles:   &RegularBundleFiles{},
+		TarFileSets:   NewRegularTarFileSets(),
+		aoFiles:       NewAOFilesMetadataDTO(),
+		uploader:      uploader,
+		baseFiles:     baseFiles,
+		backupName:    backupName,
+	}, nil
+}
+
+func (maker *GpTarBallComposerMaker) Make(bundle *Bundle) (TarBallComposer, error) {
+	// checksums verification is not supported in Greenplum (yet)
+	// TODO: Add support for checksum verification
+	filePackerOptions := TarBallFilePackerOptions{
+		verifyPageChecksums:   false,
+		storeAllCorruptBlocks: false,
+	}
+	filePacker := newTarBallFilePacker(bundle.DeltaMap, bundle.IncrementFromLsn, maker.bundleFiles, filePackerOptions)
+	return NewGpTarBallComposer(
+		bundle.TarBallQueue,
+		bundle.Crypter,
+		maker.relStorageMap,
+		maker.bundleFiles,
+		filePacker,
+		maker.aoFiles,
+		maker.baseFiles,
+		maker.TarFileSets,
+		maker.uploader,
+		maker.backupName,
+	)
+}
+
+type GpTarBallComposer struct {
+	backupName    string
+	tarBallQueue  *internal.TarBallQueue
+	tarFilePacker *TarBallFilePacker
+	crypter       crypto.Crypter
+
+	addFileQueue     chan *ComposeFileInfo
+	addFileWaitGroup sync.WaitGroup
+
+	relStorageMap AoRelFileStorageMap
+	aoFiles       *AOFilesMetadataDTO
+	aoFilesMutex  sync.Mutex
+	baseAoFiles   map[string]struct{}
+
+	uploader *internal.Uploader
+
+	files            BundleFiles
+	tarFileSets      TarFileSets
+	tarFileSetsMutex sync.Mutex
+
+	errorGroup *errgroup.Group
+	ctx        context.Context
+}
+
+func NewGpTarBallComposer(
+	tarBallQueue *internal.TarBallQueue,
+	crypter crypto.Crypter, relStorageMap AoRelFileStorageMap, bundleFiles BundleFiles, packer *TarBallFilePacker,
+	aoFiles *AOFilesMetadataDTO, baseAoFiles map[string]struct{}, tarFileSets TarFileSets, uploader *internal.Uploader,
+	backupName string,
+) (*GpTarBallComposer, error) {
+	errorGroup, ctx := errgroup.WithContext(context.Background())
+
+	composer := &GpTarBallComposer{
+		backupName:    backupName,
+		tarBallQueue:  tarBallQueue,
+		tarFilePacker: packer,
+		crypter:       crypter,
+		relStorageMap: relStorageMap,
+		files:         bundleFiles,
+		aoFiles:       aoFiles,
+		baseAoFiles:   baseAoFiles,
+		uploader:      uploader.Clone(),
+		tarFileSets:   tarFileSets,
+		errorGroup:    errorGroup,
+		ctx:           ctx,
+	}
+
+	maxUploadDiskConcurrency, err := internal.GetMaxUploadDiskConcurrency()
+	if err != nil {
+		return nil, err
+	}
+	composer.addFileQueue = make(chan *ComposeFileInfo, maxUploadDiskConcurrency)
+	for i := 0; i < maxUploadDiskConcurrency; i++ {
+		composer.addFileWaitGroup.Add(1)
+		composer.errorGroup.Go(func() error {
+			return composer.addFileWorker(composer.addFileQueue)
+		})
+	}
+	return composer, nil
+}
+
+func (c *GpTarBallComposer) AddFile(info *ComposeFileInfo) {
+	select {
+	case c.addFileQueue <- info:
+		return
+	case <-c.ctx.Done():
+		tracelog.ErrorLogger.Printf("AddFile: not doing anything, err: %v", c.ctx.Err())
+		return
+	}
+}
+
+func (c *GpTarBallComposer) AddHeader(fileInfoHeader *tar.Header, info os.FileInfo) error {
+	tarBall, err := c.tarBallQueue.DequeCtx(c.ctx)
+	if err != nil {
+		return c.errorGroup.Wait()
+	}
+	tarBall.SetUp(c.crypter)
+	defer c.tarBallQueue.EnqueueBack(tarBall)
+	c.tarFileSets.AddFile(tarBall.Name(), fileInfoHeader.Name)
+	c.files.AddFile(fileInfoHeader, info, false)
+	return tarBall.TarWriter().WriteHeader(fileInfoHeader)
+}
+
+func (c *GpTarBallComposer) SkipFile(tarHeader *tar.Header, fileInfo os.FileInfo) {
+	c.files.AddSkippedFile(tarHeader, fileInfo)
+}
+
+func (c *GpTarBallComposer) FinishComposing() (TarFileSets, error) {
+	close(c.addFileQueue)
+
+	err := c.errorGroup.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	c.addFileWaitGroup.Wait()
+
+	err = internal.UploadDto(c.uploader.UploadingFolder, c.aoFiles, getAOFilesMetadataPath(c.backupName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload AO files metadata: %v", err)
+	}
+	return c.tarFileSets, nil
+}
+
+func (c *GpTarBallComposer) GetFiles() BundleFiles {
+	return c.files
+}
+
+func (c *GpTarBallComposer) addFileWorker(tasks <-chan *ComposeFileInfo) error {
+	for task := range tasks {
+		err := c.addFile(task)
+		if err != nil {
+			tracelog.ErrorLogger.Printf(
+				"Received an error while adding the file %s: %v", task.path, err)
+			return err
+		}
+	}
+	c.addFileWaitGroup.Done()
+	return nil
+}
+
+func (c *GpTarBallComposer) addFile(cfi *ComposeFileInfo) error {
+	// WAL-G uploads AO/AOCS relfiles to different location
+	if isAo, meta, location := c.relStorageMap.getAOStorageMetadata(cfi.path); isAo {
+		return c.addAOFile(cfi, meta, location)
+	}
+
+	tarBall, err := c.tarBallQueue.DequeCtx(c.ctx)
+	if err != nil {
+		return err
+	}
+	tarBall.SetUp(c.crypter)
+	c.tarFileSetsMutex.Lock()
+	c.tarFileSets.AddFile(tarBall.Name(), cfi.header.Name)
+	c.tarFileSetsMutex.Unlock()
+	c.errorGroup.Go(func() error {
+		err := c.tarFilePacker.PackFileIntoTar(cfi, tarBall)
+		if err != nil {
+			return err
+		}
+		return c.tarBallQueue.CheckSizeAndEnqueueBack(tarBall)
+	})
+	return nil
+}
+
+func (c *GpTarBallComposer) addAOFile(cfi *ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error {
+	storageKey := makeAoFileStorageKey(aoMeta.relNameMd5, aoMeta.modCount, location)
+	if _, exists := c.baseAoFiles[storageKey]; exists {
+		c.addAoFileMetadata(cfi, storageKey, aoMeta, true)
+		tracelog.DebugLogger.Printf("Skipping %s AO relfile (already exists in storage as %s)", cfi.path, storageKey)
+
+		// add reference for the current backup to the storage
+		return storeBackupReference(c.uploader.UploadingFolder, storageKey, c.backupName)
+	}
+
+	tracelog.DebugLogger.Printf("Uploading %s AO relfile to %s (does not exist in storage)", cfi.path, storageKey)
+	fileReadCloser, err := startReadingFile(cfi.header, cfi.fileInfo, cfi.path)
+	if err != nil {
+		switch err.(type) {
+		case FileNotExistError:
+			// File was deleted before opening. We should ignore file here as if it did not exist.
+			tracelog.WarningLogger.Println(err)
+			return nil
+		default:
+			return err
+		}
+	}
+	defer fileReadCloser.Close()
+
+	// do not compress AO/AOCS segment files since they are already compressed in most cases
+	// TODO: lookup the compression details for each relation and compress it when compression is turned off
+	var compressor compression.Compressor = nil
+
+	uploadContents := internal.CompressAndEncrypt(fileReadCloser, compressor, c.crypter)
+	uploadPath := path.Join(AoStoragePath, storageKey)
+	err = c.uploader.Upload(uploadPath, uploadContents)
+	if err != nil {
+		return err
+	}
+
+	c.addAoFileMetadata(cfi, storageKey, aoMeta, false)
+
+	// add reference for the current backup to the storage
+	return storeBackupReference(c.uploader.UploadingFolder, storageKey, c.backupName)
+}
+
+func (c *GpTarBallComposer) addAoFileMetadata(cfi *ComposeFileInfo, storageKey string, aoMeta AoRelFileMetadata, isSkipped bool) {
+	c.aoFilesMutex.Lock()
+	c.aoFiles.addFile(cfi.header.Name, storageKey, cfi.fileInfo.ModTime(), aoMeta, cfi.header.Mode, isSkipped)
+	c.aoFilesMutex.Unlock()
+	c.files.AddFile(cfi.header, cfi.fileInfo, false)
+}

--- a/internal/databases/postgres/regular_tar_ball_composer.go
+++ b/internal/databases/postgres/regular_tar_ball_composer.go
@@ -96,7 +96,7 @@ func (c *RegularTarBallComposer) SkipFile(tarHeader *tar.Header, fileInfo os.Fil
 	c.files.AddSkippedFile(tarHeader, fileInfo)
 }
 
-func (c *RegularTarBallComposer) PackTarballs() (TarFileSets, error) {
+func (c *RegularTarBallComposer) FinishComposing() (TarFileSets, error) {
 	err := c.errorGroup.Wait()
 	if err != nil {
 		return nil, err

--- a/internal/databases/postgres/walk_test.go
+++ b/internal/databases/postgres/walk_test.go
@@ -373,7 +373,7 @@ func testWalk(t *testing.T, composer postgres.TarBallComposerType, withoutFilesM
 	if err != nil {
 		t.Log(err)
 	}
-	tarFileSets, err := bundle.PackTarballs()
+	tarFileSets, err := bundle.FinishTarComposer()
 	if err != nil {
 		t.Log(err)
 	}

--- a/internal/extract_test.go
+++ b/internal/extract_test.go
@@ -286,9 +286,10 @@ type BufferReaderMaker struct {
 }
 
 func (b *BufferReaderMaker) Reader() (io.ReadCloser, error) { return io.NopCloser(b.Buf), nil }
-func (b *BufferReaderMaker) Path() string                   { return b.Key }
+func (b *BufferReaderMaker) StoragePath() string            { return b.Key }
+func (b *BufferReaderMaker) LocalPath() string              { return b.Key }
 func (b *BufferReaderMaker) FileType() internal.FileType    { return internal.TarFileType }
-func (b *BufferReaderMaker) Mode() int                      { return 0 }
+func (b *BufferReaderMaker) Mode() int64                    { return 0 }
 
 type NOPSleeper struct{}
 

--- a/internal/pgbackrest/backup_fetch_handler.go
+++ b/internal/pgbackrest/backup_fetch_handler.go
@@ -6,10 +6,11 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/wal-g/wal-g/utility"
+
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
-	"github.com/wal-g/wal-g/utility"
 )
 
 func HandlePgbackrestBackupFetch(folder storage.Folder, stanza string, destinationDirectory string,
@@ -53,7 +54,7 @@ func fullBackupFetch(folder storage.Folder, stanza string, backupName string,
 func getFilesToUnwrap(files []internal.ReaderMaker) map[string]bool {
 	filesToUnwrap := make(map[string]bool)
 	for _, file := range files {
-		filesToUnwrap[utility.TrimFileExtension(file.Path())] = true
+		filesToUnwrap[file.LocalPath()] = true
 	}
 	return filesToUnwrap
 }
@@ -84,7 +85,7 @@ func getFilesRecursively(folder storage.Folder, backupFilesFolder storage.Folder
 			return nil, err
 		}
 		filePath := path.Join(relativePath, object.GetName())
-		file := internal.NewRegularFileStorageReaderMarker(backupFilesFolder, filePath, fileMode)
+		file := internal.NewRegularFileStorageReaderMarker(backupFilesFolder, filePath, utility.TrimFileExtension(filePath), int64(fileMode))
 		files = append(files, file)
 	}
 

--- a/internal/reader_maker.go
+++ b/internal/reader_maker.go
@@ -13,15 +13,16 @@ const (
 // allows for ease of handling different file formats.
 type ReaderMaker interface {
 	Reader() (io.ReadCloser, error)
-	Path() string
+	StoragePath() string
+	LocalPath() string
 	FileType() FileType
-	Mode() int
+	Mode() int64
 }
 
 func readerMakersToFilePaths(readerMakers []ReaderMaker) []string {
 	paths := make([]string, 0)
 	for _, readerMaker := range readerMakers {
-		paths = append(paths, readerMaker.Path())
+		paths = append(paths, readerMaker.StoragePath())
 	}
 	return paths
 }

--- a/internal/storage_reader_maker.go
+++ b/internal/storage_reader_maker.go
@@ -9,25 +9,28 @@ import (
 // StorageReaderMaker creates readers for downloading from storage
 type StorageReaderMaker struct {
 	Folder          storage.Folder
-	RelativePath    string
+	storagePath     string
+	localPath       string
 	StorageFileType FileType
-	FileMode        int
+	FileMode        int64
 }
 
 func NewStorageReaderMaker(folder storage.Folder, relativePath string) *StorageReaderMaker {
-	return &StorageReaderMaker{folder, relativePath, TarFileType, 0}
+	return &StorageReaderMaker{folder, relativePath, relativePath, TarFileType, 0}
 }
 
-func NewRegularFileStorageReaderMarker(folder storage.Folder, relativePath string, fileMode int) *StorageReaderMaker {
-	return &StorageReaderMaker{folder, relativePath, RegularFileType, fileMode}
+func NewRegularFileStorageReaderMarker(folder storage.Folder, storagePath, localPath string, fileMode int64) *StorageReaderMaker {
+	return &StorageReaderMaker{folder, storagePath, localPath, RegularFileType, fileMode}
 }
 
-func (readerMaker *StorageReaderMaker) Path() string { return readerMaker.RelativePath }
+func (readerMaker *StorageReaderMaker) StoragePath() string { return readerMaker.storagePath }
+
+func (readerMaker *StorageReaderMaker) LocalPath() string { return readerMaker.localPath }
 
 func (readerMaker *StorageReaderMaker) Reader() (io.ReadCloser, error) {
-	return readerMaker.Folder.ReadObject(readerMaker.RelativePath)
+	return readerMaker.Folder.ReadObject(readerMaker.storagePath)
 }
 
 func (readerMaker *StorageReaderMaker) FileType() FileType { return readerMaker.StorageFileType }
 
-func (readerMaker *StorageReaderMaker) Mode() int { return readerMaker.FileMode }
+func (readerMaker *StorageReaderMaker) Mode() int64 { return readerMaker.FileMode }

--- a/testtools/reader_maker.go
+++ b/testtools/reader_maker.go
@@ -13,7 +13,9 @@ type FileReaderMaker struct {
 	Key string
 }
 
-func (f *FileReaderMaker) Path() string { return f.Key }
+func (f *FileReaderMaker) StoragePath() string { return f.Key }
+
+func (f *FileReaderMaker) LocalPath() string { return f.Key }
 
 // Reader creates a new reader from the passed in file.
 func (f *FileReaderMaker) Reader() (io.ReadCloser, error) {
@@ -29,6 +31,6 @@ func (f *FileReaderMaker) FileType() internal.FileType {
 	return internal.TarFileType
 }
 
-func (f *FileReaderMaker) Mode() int {
+func (f *FileReaderMaker) Mode() int64 {
 	return 0
 }


### PR DESCRIPTION
I propose to store the AO/AOCS segments in a separate storage folder so the single AO segment can be referenced from the multiple backups without copying.

Here is the sample storage layout:
```
basebackups_005/backup_20220413T183414Z_backup_stop_sentinel.json
segments_005/seg-1/basebackups_005/base_000000010000000000000009_backup_stop_sentinel.json
segments_005/seg-1/wal_005/000000010000000000000009.00000028.backup.br
segments_005/seg-1/wal_005/000000010000000000000009.br
segments_005/seg0/basebackups_005/base_000000010000000000000008_backup_stop_sentinel.json
segments_005/seg0/wal_005/000000010000000000000008.00000028.backup.br
segments_005/seg0/wal_005/000000010000000000000008.br
segments_005/seg1/basebackups_005/base_000000010000000000000008_backup_stop_sentinel.json
segments_005/seg1/wal_005/000000010000000000000008.00000028.backup.br
segments_005/seg1/wal_005/000000010000000000000008.br
segments_005/seg2/basebackups_005/base_000000010000000000000008_backup_stop_sentinel.json
segments_005/seg2/wal_005/000000010000000000000008.00000028.backup.br
segments_005/seg2/wal_005/000000010000000000000008.br
segments_005/seg-1/basebackups_005/base_000000010000000000000009/ao_files_metadata.json
segments_005/seg-1/basebackups_005/base_000000010000000000000009/files_metadata.json
segments_005/seg-1/basebackups_005/base_000000010000000000000009/metadata.json
segments_005/seg0/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_129_2_aoseg
segments_005/seg0/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_129_2_aoseg_base_000000010000000000000008_ref
segments_005/seg0/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_1_2_aoseg
segments_005/seg0/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_1_2_aoseg_base_000000010000000000000008_ref
segments_005/seg0/basebackups_005/aosegments/1663_24578_adac5e63f80f8629e9573527b25891d3_16385_1_2_aoseg
segments_005/seg0/basebackups_005/aosegments/1663_24578_adac5e63f80f8629e9573527b25891d3_16385_1_2_aoseg_base_000000010000000000000008_ref
segments_005/seg0/basebackups_005/base_000000010000000000000008/ao_files_metadata.json
segments_005/seg0/basebackups_005/base_000000010000000000000008/files_metadata.json
segments_005/seg0/basebackups_005/base_000000010000000000000008/metadata.json
segments_005/seg1/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_129_2_aoseg
segments_005/seg1/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_129_2_aoseg_base_000000010000000000000008_ref
segments_005/seg1/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_1_2_aoseg
segments_005/seg1/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_1_2_aoseg_base_000000010000000000000008_ref
segments_005/seg1/basebackups_005/aosegments/1663_24578_adac5e63f80f8629e9573527b25891d3_16385_1_2_aoseg
segments_005/seg1/basebackups_005/aosegments/1663_24578_adac5e63f80f8629e9573527b25891d3_16385_1_2_aoseg_base_000000010000000000000008_ref
segments_005/seg1/basebackups_005/base_000000010000000000000008/ao_files_metadata.json
segments_005/seg1/basebackups_005/base_000000010000000000000008/files_metadata.json
segments_005/seg1/basebackups_005/base_000000010000000000000008/metadata.json
segments_005/seg2/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_129_2_aoseg
segments_005/seg2/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_129_2_aoseg_base_000000010000000000000008_ref
segments_005/seg2/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_1_2_aoseg
segments_005/seg2/basebackups_005/aosegments/1663_24578_ab6c040066603ef2519d512b21dce9ab_16389_1_2_aoseg_base_000000010000000000000008_ref
segments_005/seg2/basebackups_005/aosegments/1663_24578_adac5e63f80f8629e9573527b25891d3_16385_1_2_aoseg
segments_005/seg2/basebackups_005/aosegments/1663_24578_adac5e63f80f8629e9573527b25891d3_16385_1_2_aoseg_base_000000010000000000000008_ref
segments_005/seg2/basebackups_005/base_000000010000000000000008/ao_files_metadata.json
segments_005/seg2/basebackups_005/base_000000010000000000000008/files_metadata.json
segments_005/seg2/basebackups_005/base_000000010000000000000008/metadata.json
segments_005/seg-1/basebackups_005/base_000000010000000000000009/tar_partitions/part_001.tar.br
segments_005/seg-1/basebackups_005/base_000000010000000000000009/tar_partitions/pg_control.tar.br
segments_005/seg0/basebackups_005/base_000000010000000000000008/tar_partitions/part_001.tar.br
segments_005/seg0/basebackups_005/base_000000010000000000000008/tar_partitions/pg_control.tar.br
segments_005/seg1/basebackups_005/base_000000010000000000000008/tar_partitions/part_001.tar.br
segments_005/seg1/basebackups_005/base_000000010000000000000008/tar_partitions/pg_control.tar.br
segments_005/seg2/basebackups_005/base_000000010000000000000008/tar_partitions/part_001.tar.br
segments_005/seg2/basebackups_005/base_000000010000000000000008/tar_partitions/pg_control.tar.br
```

For example, `1663_24578_adac5e63f80f8629e9573527b25891d3_16385_1_2_aoseg` contains the actual data and is referenced by backup `base_000000010000000000000008` because there is a reference named `1663_24578_adac5e63f80f8629e9573527b25891d3_16385_1_2_aoseg_base_000000010000000000000008_ref`.

AO segment filename consists of the following parts:
`SpcNode_DBNode_md5(relation_name)_RelNode_BlockNo_modCount_aoseg`
