### PR TITLE
[Greenplum] do not count the uploaded AO segment size in total backup size

### DIFF
--- a/internal/databases/postgres/greenplum_tar_ball_composer.go
+++ b/internal/databases/postgres/greenplum_tar_ball_composer.go
@@ -4,12 +4,10 @@ import (
 	"archive/tar"
 	"context"
 	"fmt"
+	"github.com/wal-g/wal-g/internal/walparser"
 	"os"
 	"path"
 	"sync"
-	"sync/atomic"
-
-	"github.com/wal-g/wal-g/internal/walparser"
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -249,8 +247,6 @@ func (c *GpTarBallComposer) addAOFile(cfi *ComposeFileInfo, aoMeta AoRelFileMeta
 		return err
 	}
 
-	// looks ugly, but currently it is the only way to keep track of the AO files size
-	atomic.AddInt64(c.tarBallQueue.AllTarballsSize, cfi.fileInfo.Size())
 	c.addAoFileMetadata(cfi, storageKey, aoMeta, false)
 
 	// add reference for the current backup to the storage


### PR DESCRIPTION
I propose not to include the AO segment files size in the total backup size because a single AO file can be referenced by many backups.