### PR TITLE
Greenplum: cancel backup on Postgres process failure

### DIFF
--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -136,6 +136,16 @@ Examples:
 - `10m` - check every 10 minutes
 
 
+* `WALG_STOP_BACKUP_TIMEOUT`
+
+Timeout for the pg_stop_backup() call. By default, there is no timeout.
+
+Examples:
+- `0` - disable the timeout (default value)
+- `10s` - 10 seconds timeout
+- `10m` - 10 minutes timeout
+
+
 Usage
 -----
 

--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -126,6 +126,16 @@ Sample metadata file (000000020000000300000071.json)
 ```
 If the parameter value is NOMETADATA or not specified, it will fallback to default setting (no wal metadata generation)
 
+* `WALG_ALIVE_CHECK_INTERVAL`
+
+To control how frequently WAL-G will check if Postgres is alive during the backup-push. If the check fails, backup-push terminates.
+
+Examples:
+- `0` - disable the alive checks (default value)
+- `10s` - check every 10 seconds
+- `10m` - check every 10 minutes
+
+
 Usage
 -----
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -83,6 +83,7 @@ const (
 	StreamSplitterBlockSize      = "WALG_STREAM_SPLITTER_BLOCK_SIZE"
 	StatsdAddressSetting         = "WALG_STATSD_ADDRESS"
 	PgAliveCheckInterval         = "WALG_ALIVE_CHECK_INTERVAL"
+	PgStopBackupTimeout          = "WALG_STOP_BACKUP_TIMEOUT"
 
 	ProfileSamplingRatio = "PROFILE_SAMPLING_RATIO"
 	ProfileMode          = "PROFILE_MODE"
@@ -350,6 +351,7 @@ var (
 		PgReadyRename:        true,
 		PgBackRestStanza:     true,
 		PgAliveCheckInterval: true,
+		PgStopBackupTimeout:  true,
 	}
 
 	MongoAllowedSettings = map[string]bool{

--- a/internal/config.go
+++ b/internal/config.go
@@ -82,6 +82,7 @@ const (
 	StreamSplitterPartitions     = "WALG_STREAM_SPLITTER_PARTITIONS"
 	StreamSplitterBlockSize      = "WALG_STREAM_SPLITTER_BLOCK_SIZE"
 	StatsdAddressSetting         = "WALG_STATSD_ADDRESS"
+	PgAliveCheckInterval         = "WALG_ALIVE_CHECK_INTERVAL"
 
 	ProfileSamplingRatio = "PROFILE_SAMPLING_RATIO"
 	ProfileMode          = "PROFILE_MODE"
@@ -335,19 +336,20 @@ var (
 
 	PGAllowedSettings = map[string]bool{
 		// Postgres
-		PgPortSetting:     true,
-		PgUserSetting:     true,
-		PgHostSetting:     true,
-		PgDataSetting:     true,
-		PgPasswordSetting: true,
-		PgDatabaseSetting: true,
-		PgSslModeSetting:  true,
-		PgSlotName:        true,
-		PgWalSize:         true,
-		"PGPASSFILE":      true,
-		PrefetchDir:       true,
-		PgReadyRename:     true,
-		PgBackRestStanza:  true,
+		PgPortSetting:        true,
+		PgUserSetting:        true,
+		PgHostSetting:        true,
+		PgDataSetting:        true,
+		PgPasswordSetting:    true,
+		PgDatabaseSetting:    true,
+		PgSslModeSetting:     true,
+		PgSlotName:           true,
+		PgWalSize:            true,
+		"PGPASSFILE":         true,
+		PrefetchDir:          true,
+		PgReadyRename:        true,
+		PgBackRestStanza:     true,
+		PgAliveCheckInterval: true,
 	}
 
 	MongoAllowedSettings = map[string]bool{

--- a/internal/databases/greenplum/generic_meta_interactor_test.go
+++ b/internal/databases/greenplum/generic_meta_interactor_test.go
@@ -1,12 +1,13 @@
 package greenplum_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/testtools"
-	"testing"
-	"time"
 )
 
 func init() {
@@ -68,7 +69,7 @@ func TestFetch(t *testing.T) {
 	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
 	assert.True(t, isEqualTimeFinish)
 
-	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time  
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
 	expectedResult.StartTime = actualResult.StartTime
 	expectedResult.FinishTime = actualResult.FinishTime
 

--- a/internal/databases/greenplum/segment_backup_runner.go
+++ b/internal/databases/greenplum/segment_backup_runner.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/wal-g/tracelog"
@@ -62,15 +64,17 @@ func (r *SegBackupRunner) Run() {
 		done <- cmd.Wait()
 	}()
 
-	err = r.waitBackup(done)
+	err = r.waitBackup(cmd, done)
 	tracelog.ErrorLogger.FatalOnError(err)
 }
 
-func (r *SegBackupRunner) waitBackup(doneCh chan error) error {
+func (r *SegBackupRunner) waitBackup(cmd *exec.Cmd, doneCh chan error) error {
 	ticker := time.NewTicker(r.stateUpdateInterval)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	for {
-		status, err := checkBackupStatus(ticker, doneCh)
+		status, err := checkBackupStatus(ticker, doneCh, sigCh)
 		saveErr := writeBackupState(SegBackupState{Status: status, TS: time.Now()}, r.contentID, r.backupName)
 		if saveErr != nil {
 			tracelog.WarningLogger.Printf("Failed to update the backup status file: %v", saveErr)
@@ -86,12 +90,18 @@ func (r *SegBackupRunner) waitBackup(doneCh chan error) error {
 			return nil
 		case FailedBackupStatus:
 			return fmt.Errorf("backup-push failed: %v", err)
+		case InterruptedBackupStatus:
+			// on receiving a SIGTERM, also broadcast it to the backup process
+			if termErr := cmd.Process.Signal(syscall.SIGTERM); termErr != nil {
+				tracelog.ErrorLogger.Printf("failed to send SIGTERM to the backup process: %v", termErr)
+			}
+			return fmt.Errorf("backup-push terminated")
 		}
 	}
 }
 
 // TODO: unit tests
-func checkBackupStatus(ticker *time.Ticker, doneCh chan error) (SegBackupStatus, error) {
+func checkBackupStatus(ticker *time.Ticker, doneCh chan error, sigCh chan os.Signal) (SegBackupStatus, error) {
 	select {
 	case <-ticker.C:
 		tracelog.DebugLogger.Printf("Tick")
@@ -103,6 +113,10 @@ func checkBackupStatus(ticker *time.Ticker, doneCh chan error) (SegBackupStatus,
 		}
 
 		return SuccessBackupStatus, nil
+
+	case sig := <-sigCh:
+		tracelog.ErrorLogger.Printf("Received signal: %s, terminating the running backup...", sig)
+		return InterruptedBackupStatus, nil
 	}
 }
 

--- a/internal/databases/greenplum/segment_backup_state.go
+++ b/internal/databases/greenplum/segment_backup_state.go
@@ -29,9 +29,10 @@ func FormatSegmentStateFolderPath(contentID int) string {
 type SegBackupStatus string
 
 const (
-	RunningBackupStatus SegBackupStatus = "running"
-	FailedBackupStatus  SegBackupStatus = "failed"
-	SuccessBackupStatus SegBackupStatus = "success"
+	RunningBackupStatus     SegBackupStatus = "running"
+	FailedBackupStatus      SegBackupStatus = "failed"
+	SuccessBackupStatus     SegBackupStatus = "success"
+	InterruptedBackupStatus SegBackupStatus = "interrupted"
 )
 
 type SegBackupState struct {

--- a/internal/databases/postgres/backup_terminator.go
+++ b/internal/databases/postgres/backup_terminator.go
@@ -1,0 +1,83 @@
+package postgres
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/jackc/pgx"
+	"github.com/wal-g/tracelog"
+)
+
+const backupLabelFileName = "backup_label"
+const backupLabelDstFileName = "backup_label.old"
+const stopBackupTimeout = 1 * time.Minute
+
+type BackupTerminator struct {
+	conn              *pgx.Conn
+	removeBackupLabel bool
+	pgDataDir         string
+}
+
+func NewBackupTerminator(conn *pgx.Conn, pgVersion int, pgDataDir string) *BackupTerminator {
+	// for PostgreSQL version earlier than v9.6, WAL-G uses an exclusive backup,
+	// so it is useful to remove the backup label on backup termination
+	removeBackupLabel := pgVersion < 90600
+	return &BackupTerminator{conn: conn, removeBackupLabel: removeBackupLabel, pgDataDir: pgDataDir}
+}
+
+func (t *BackupTerminator) TerminateBackup() {
+	stopBackupErrCh := make(chan error, 1)
+
+	go func() {
+		err := t.tryStopPgBackup()
+		stopBackupErrCh <- err
+	}()
+
+	var err error
+	select {
+	case stopErr := <-stopBackupErrCh:
+		if stopErr == nil {
+			tracelog.InfoLogger.Printf("Successfully stopped the running backup")
+			return
+		}
+
+		err = stopErr
+
+	case <-time.After(stopBackupTimeout):
+		err = fmt.Errorf("run out of time (%s)", stopBackupTimeout.String())
+	}
+
+	tracelog.WarningLogger.Printf("Failed to stop backup: %v", err)
+	// failed to stop backup, try to rename the backup_label file (if required)
+	t.renameBackupLabel()
+}
+
+func (t *BackupTerminator) tryStopPgBackup() error {
+	queryRunner, err := NewPgQueryRunner(t.conn)
+	if err != nil {
+		return fmt.Errorf("failed to build query runner: %w", err)
+	}
+
+	_, _, _, err = queryRunner.stopBackup()
+	if err != nil {
+		return fmt.Errorf("failed to stop backup: %w", err)
+	}
+	return nil
+}
+
+func (t *BackupTerminator) renameBackupLabel() {
+	if !t.removeBackupLabel {
+		return
+	}
+
+	backupLabelPath := path.Join(t.pgDataDir, backupLabelFileName)
+	backupLabelDstPath := path.Join(t.pgDataDir, backupLabelDstFileName)
+	err := os.Rename(backupLabelPath, backupLabelDstPath)
+	if err != nil {
+		tracelog.WarningLogger.Printf("Failed to rename the backup label file (%s -> %s): %v", backupLabelPath, backupLabelDstPath, err)
+		return
+	}
+	tracelog.InfoLogger.Printf("Successfully renamed the backup label file (%s -> %s)", backupLabelPath, backupLabelDstPath)
+}

--- a/internal/databases/postgres/configure.go
+++ b/internal/databases/postgres/configure.go
@@ -1,6 +1,8 @@
 package postgres
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
@@ -64,4 +66,17 @@ func configureWalDeltaUsage() (useWalDelta bool, deltaDataFolder fsutil.DataFold
 		err = nil
 	}
 	return
+}
+
+func getStopBackupTimeoutSetting() (time.Duration, error) {
+	if !viper.IsSet(internal.PgStopBackupTimeout) {
+		return 0, nil
+	}
+
+	timeout, err := internal.GetDurationSetting(internal.PgStopBackupTimeout)
+	if err != nil {
+		return 0, err
+	}
+
+	return timeout, nil
 }

--- a/internal/databases/postgres/pg_alive_watcher.go
+++ b/internal/databases/postgres/pg_alive_watcher.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/wal-g/tracelog"
+)
+
+func NewPgWatcher(aliveCheckInterval time.Duration) *PgAliveWatcher {
+	ticker := time.NewTicker(aliveCheckInterval)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- watchPgStatus(ticker)
+		close(errCh)
+	}()
+
+	return &PgAliveWatcher{Err: errCh}
+}
+
+type PgAliveWatcher struct {
+	Err <-chan error
+}
+
+func watchPgStatus(ticker *time.Ticker) error {
+	for {
+		<-ticker.C
+		tracelog.DebugLogger.Printf("Checking if Postgres is still alive...")
+		conn, err := Connect()
+		if err != nil {
+			return fmt.Errorf("failed to connect to Postgres: %v", err)
+		}
+
+		err = conn.Close()
+		if err != nil {
+			tracelog.WarningLogger.Printf("watchPgStatus: failed to disconnect: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
I propose to introduce the functionality to automatically cancel the backup if one of the following events occurs:
- WAL-G segment process failure
- Postgresql segment process failure

Also, I propose to introduce the following setting to control how frequently WAL-G will try to check if the Postgresql segment process is alive:
* `WALG_ALIVE_CHECK_INTERVAL`

To control how frequently WAL-G will check if Postgres is alive during the backup-push. If the check fails, backup-push terminates.

Examples:
- `0` - disable the alive checks (default value)
- `10s` - check every 10 seconds
- `10m` - check every 10 minutes
