### PR TITLE
Postgres: make queryRunner thread-safe

### DIFF
--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -133,9 +133,9 @@ func (bundle *Bundle) getIncrementBaseFiles() internal.BackupFileList {
 
 // TODO : unit tests
 // checkTimelineChanged compares timelines of pg_backup_start() and pg_backup_stop()
-func (bundle *Bundle) checkTimelineChanged(conn *pgx.Conn) bool {
+func (bundle *Bundle) checkTimelineChanged(queryRunner *PgQueryRunner) bool {
 	if bundle.Replica {
-		timeline, err := readTimeline(conn)
+		timeline, err := queryRunner.readTimeline()
 		if err != nil {
 			tracelog.ErrorLogger.Printf("Unable to check timeline change. Sentinel for the backup will not be uploaded.")
 			return true
@@ -157,13 +157,9 @@ func (bundle *Bundle) checkTimelineChanged(conn *pgx.Conn) bool {
 // `backup_label` and `tablespace_map` contents are not immediately written to
 // a file but returned instead. Returns empty string and an error if backup
 // fails.
-func (bundle *Bundle) StartBackup(conn *pgx.Conn,
+func (bundle *Bundle) StartBackup(queryRunner *PgQueryRunner,
 	backup string) (backupName string, lsn uint64, err error) {
 	var name, lsnStr string
-	queryRunner, err := NewPgQueryRunner(conn)
-	if err != nil {
-		return "", 0, errors.Wrap(err, "StartBackup: Failed to build query runner.")
-	}
 	name, lsnStr, bundle.Replica, err = queryRunner.startBackup(backup)
 
 	if err != nil {
@@ -175,12 +171,12 @@ func (bundle *Bundle) StartBackup(conn *pgx.Conn,
 	}
 
 	if bundle.Replica {
-		name, bundle.Timeline, err = getWalFilename(lsn, conn)
+		name, bundle.Timeline, err = getWalFilename(lsn, queryRunner)
 		if err != nil {
 			return "", 0, err
 		}
 	} else {
-		bundle.Timeline, err = readTimeline(conn)
+		bundle.Timeline, err = queryRunner.readTimeline()
 		if err != nil {
 			tracelog.WarningLogger.Printf("Couldn't get current timeline because of error: '%v'\n", err)
 		}
@@ -358,11 +354,7 @@ func (bundle *Bundle) UploadPgControl(compressorFileExtension string) error {
 // TODO : unit tests
 // UploadLabelFiles creates the `backup_label` and `tablespace_map` files by stopping the backup
 // and uploads them to S3.
-func (bundle *Bundle) uploadLabelFiles(conn *pgx.Conn) (string, []string, uint64, error) {
-	queryRunner, err := NewPgQueryRunner(conn)
-	if err != nil {
-		return "", nil, 0, errors.Wrap(err, "UploadLabelFiles: Failed to build query runner.")
-	}
+func (bundle *Bundle) uploadLabelFiles(queryRunner *PgQueryRunner) (string, []string, uint64, error) {
 	label, offsetMap, lsnStr, err := queryRunner.stopBackup()
 	if err != nil {
 		return "", nil, 0, errors.Wrap(err, "UploadLabelFiles: failed to stop backup")

--- a/internal/databases/postgres/bundle_files.go
+++ b/internal/databases/postgres/bundle_files.go
@@ -134,8 +134,8 @@ func (relStat *RelFileStatistics) getFileUpdateCount(filePath string) uint64 {
 	return fileStat.deletedTuplesCount + fileStat.updatedTuplesCount + fileStat.insertedTuplesCount
 }
 
-func newRelFileStatistics(conn *pgx.Conn) (RelFileStatistics, error) {
-	databases, err := getDatabaseInfos(conn)
+func newRelFileStatistics(queryRunner *PgQueryRunner) (RelFileStatistics, error) {
+	databases, err := queryRunner.getDatabaseInfos()
 	if err != nil {
 		return nil, errors.Wrap(err, "CollectStatistics: Failed to get db names.")
 	}
@@ -169,12 +169,4 @@ func newRelFileStatistics(conn *pgx.Conn) (RelFileStatistics, error) {
 		tracelog.WarningLogger.PrintOnError(err)
 	}
 	return result, nil
-}
-
-func getDatabaseInfos(conn *pgx.Conn) ([]PgDatabaseInfo, error) {
-	queryRunner, err := NewPgQueryRunner(conn)
-	if err != nil {
-		return nil, errors.Wrap(err, "getDatabaseInfos: Failed to build query runner.")
-	}
-	return queryRunner.getDatabaseInfos()
 }

--- a/internal/databases/postgres/greenplum_relfile_storage_map.go
+++ b/internal/databases/postgres/greenplum_relfile_storage_map.go
@@ -49,8 +49,8 @@ func (storageMap *AoRelFileStorageMap) getAOStorageMetadata(filePath string) (bo
 	return true, storageInfo, location
 }
 
-func newAoRelFileStorageMap(conn *pgx.Conn) (AoRelFileStorageMap, error) {
-	databases, err := getDatabaseInfos(conn)
+func newAoRelFileStorageMap(queryRunner *PgQueryRunner) (AoRelFileStorageMap, error) {
+	databases, err := queryRunner.getDatabaseInfos()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get database names")
 	}

--- a/internal/databases/postgres/pg_alive_watcher.go
+++ b/internal/databases/postgres/pg_alive_watcher.go
@@ -1,20 +1,17 @@
 package postgres
 
 import (
-	"context"
 	"fmt"
 	"time"
-
-	"github.com/jackc/pgx"
 
 	"github.com/wal-g/tracelog"
 )
 
-func NewPgWatcher(conn *pgx.Conn, aliveCheckInterval time.Duration) *PgAliveWatcher {
+func NewPgWatcher(queryRunner *PgQueryRunner, aliveCheckInterval time.Duration) *PgAliveWatcher {
 	ticker := time.NewTicker(aliveCheckInterval)
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- watchPgStatus(conn, ticker)
+		errCh <- watchPgStatus(queryRunner, ticker)
 		close(errCh)
 	}()
 
@@ -25,13 +22,12 @@ type PgAliveWatcher struct {
 	Err <-chan error
 }
 
-func watchPgStatus(conn *pgx.Conn, ticker *time.Ticker) error {
+func watchPgStatus(queryRunner *PgQueryRunner, ticker *time.Ticker) error {
 	for {
 		<-ticker.C
 		tracelog.DebugLogger.Printf("Checking if Postgres is still alive...")
 
-		ctx := context.Background()
-		err := conn.Ping(ctx)
+		err := queryRunner.Ping()
 		if err != nil {
 			return fmt.Errorf("failed to check if the Postgres connection is alive: %v", err)
 		}

--- a/internal/databases/postgres/queryRunner.go
+++ b/internal/databases/postgres/queryRunner.go
@@ -1,8 +1,10 @@
 package postgres
 
 import (
+	"context"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx"
@@ -62,6 +64,7 @@ type PgQueryRunner struct {
 	Version           int
 	SystemIdentifier  *uint64
 	stopBackupTimeout time.Duration
+	mu                sync.Mutex
 }
 
 // BuildGetVersion formats a query to retrieve PostgreSQL numeric version
@@ -166,6 +169,9 @@ func (queryRunner *PgQueryRunner) buildGetPhysicalSlotInfo() string {
 
 // Retrieve PostgreSQL numeric version
 func (queryRunner *PgQueryRunner) getVersion() (err error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	conn := queryRunner.Connection
 	err = conn.QueryRow(queryRunner.buildGetVersion()).Scan(&queryRunner.Version)
 	return errors.Wrap(err, "GetVersion: getting Postgres version failed")
@@ -173,6 +179,9 @@ func (queryRunner *PgQueryRunner) getVersion() (err error) {
 
 // Get current LSN of cluster
 func (queryRunner *PgQueryRunner) getCurrentLsn() (lsn string, err error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	conn := queryRunner.Connection
 	err = conn.QueryRow(queryRunner.buildGetCurrentLsn()).Scan(&lsn)
 	if err != nil {
@@ -182,6 +191,9 @@ func (queryRunner *PgQueryRunner) getCurrentLsn() (lsn string, err error) {
 }
 
 func (queryRunner *PgQueryRunner) getSystemIdentifier() (err error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	if queryRunner.Version < 90600 {
 		tracelog.WarningLogger.Println("GetSystemIdentifier: Unable to get system identifier")
 		return nil
@@ -194,6 +206,9 @@ func (queryRunner *PgQueryRunner) getSystemIdentifier() (err error) {
 // StartBackup informs the database that we are starting copy of cluster contents
 func (queryRunner *PgQueryRunner) startBackup(backup string) (backupName string,
 	lsnString string, inRecovery bool, err error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	tracelog.InfoLogger.Println("Calling pg_start_backup()")
 	startBackupQuery, err := queryRunner.BuildStartBackup()
 	conn := queryRunner.Connection
@@ -210,6 +225,9 @@ func (queryRunner *PgQueryRunner) startBackup(backup string) (backupName string,
 
 // StopBackup informs the database that copy is over
 func (queryRunner *PgQueryRunner) stopBackup() (label string, offsetMap string, lsnStr string, err error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	tracelog.InfoLogger.Println("Calling pg_stop_backup()")
 	conn := queryRunner.Connection
 
@@ -265,6 +283,9 @@ func (queryRunner *PgQueryRunner) BuildStatisticsQuery() (string, error) {
 // getStatistics queries the relations statistics from database
 func (queryRunner *PgQueryRunner) getStatistics(
 	dbInfo PgDatabaseInfo) (map[walparser.RelFileNode]PgRelationStat, error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	tracelog.InfoLogger.Println("Querying pg_stat_all_tables")
 	getStatQuery, err := queryRunner.BuildStatisticsQuery()
 	conn := queryRunner.Connection
@@ -317,6 +338,9 @@ func (queryRunner *PgQueryRunner) BuildGetDatabasesQuery() (string, error) {
 
 // getDatabaseInfos fetches a list of all databases in cluster which are allowed to connect
 func (queryRunner *PgQueryRunner) getDatabaseInfos() ([]PgDatabaseInfo, error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	tracelog.InfoLogger.Println("Querying pg_database")
 	getDBInfoQuery, err := queryRunner.BuildGetDatabasesQuery()
 	conn := queryRunner.Connection
@@ -353,6 +377,9 @@ func (queryRunner *PgQueryRunner) getDatabaseInfos() ([]PgDatabaseInfo, error) {
 // GetParameter reads a Postgres setting
 // TODO: Unittest
 func (queryRunner *PgQueryRunner) GetParameter(parameterName string) (string, error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	var value string
 	conn := queryRunner.Connection
 	err := conn.QueryRow(queryRunner.buildGetParameter(), parameterName).Scan(&value)
@@ -380,6 +407,9 @@ func (queryRunner *PgQueryRunner) GetWalSegmentBytes() (segBlocks uint64, err er
 // GetDataDir reads the wals segment size (in bytes) and converts it to uint64
 // TODO: Unittest
 func (queryRunner *PgQueryRunner) GetDataDir() (dataDir string, err error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	conn := queryRunner.Connection
 	err = conn.QueryRow("show data_directory").Scan(&dataDir)
 	return dataDir, err
@@ -388,6 +418,9 @@ func (queryRunner *PgQueryRunner) GetDataDir() (dataDir string, err error) {
 // GetPhysicalSlotInfo reads information on a physical replication slot
 // TODO: Unittest
 func (queryRunner *PgQueryRunner) GetPhysicalSlotInfo(slotName string) (PhysicalSlot, error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	var active bool
 	var restartLSN string
 
@@ -429,6 +462,9 @@ func (queryRunner *PgQueryRunner) BuildAORelStorageQuery() (string, error) {
 
 // fetchAOStorageMetadata queries the storage metadata for AO & AOCS tables (GreenplumDB)
 func (queryRunner *PgQueryRunner) fetchAOStorageMetadata(dbInfo PgDatabaseInfo) (AoRelFileStorageMap, error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
 	tracelog.InfoLogger.Printf("fetchAOStorageMetadata: Querying pg_class for %s", dbInfo.name)
 	getStatQuery, err := queryRunner.BuildAORelStorageQuery()
 	conn := queryRunner.Connection
@@ -472,4 +508,27 @@ func (queryRunner *PgQueryRunner) fetchAOStorageMetadata(dbInfo PgDatabaseInfo) 
 	}
 
 	return relStorageMap, nil
+}
+
+func (queryRunner *PgQueryRunner) readTimeline() (timeline uint32, err error) {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
+	conn := queryRunner.Connection
+	var bytesPerWalSegment uint32
+
+	err = conn.QueryRow("select timeline_id, bytes_per_wal_segment "+
+		"from pg_control_checkpoint(), pg_control_init()").Scan(&timeline, &bytesPerWalSegment)
+	if err == nil && uint64(bytesPerWalSegment) != WalSegmentSize {
+		return 0, newBytesPerWalSegmentError()
+	}
+	return
+}
+
+func (queryRunner *PgQueryRunner) Ping() error {
+	queryRunner.mu.Lock()
+	defer queryRunner.mu.Unlock()
+
+	ctx := context.Background()
+	return queryRunner.Connection.Ping(ctx)
 }

--- a/internal/databases/postgres/tar_ball_composer.go
+++ b/internal/databases/postgres/tar_ball_composer.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/wal-g/tracelog"
 
-	"github.com/jackc/pgx"
 	"github.com/wal-g/wal-g/internal"
 )
 
@@ -49,7 +48,7 @@ type TarBallComposerMaker interface {
 	Make(bundle *Bundle) (TarBallComposer, error)
 }
 
-func NewTarBallComposerMaker(composerType TarBallComposerType, conn *pgx.Conn, uploader *internal.Uploader,
+func NewTarBallComposerMaker(composerType TarBallComposerType, queryRunner *PgQueryRunner, uploader *internal.Uploader,
 	newBackupName string, filePackOptions TarBallFilePackerOptions,
 	withoutFilesMetadata bool) (TarBallComposerMaker, error) {
 	folder := uploader.UploadingFolder
@@ -60,7 +59,7 @@ func NewTarBallComposerMaker(composerType TarBallComposerType, conn *pgx.Conn, u
 		}
 		return NewRegularTarBallComposerMaker(filePackOptions, &RegularBundleFiles{}, NewRegularTarFileSets()), nil
 	case RatingComposer:
-		relFileStats, err := newRelFileStatistics(conn)
+		relFileStats, err := newRelFileStatistics(queryRunner)
 		if err != nil {
 			return nil, err
 		}
@@ -88,7 +87,7 @@ func NewTarBallComposerMaker(composerType TarBallComposerType, conn *pgx.Conn, u
 		}
 		return NewCopyTarBallComposerMaker(previousBackup, newBackupName, filePackOptions), nil
 	case GreenplumComposer:
-		relStorageMap, err := newAoRelFileStorageMap(conn)
+		relStorageMap, err := newAoRelFileStorageMap(queryRunner)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/databases/postgres/wal_verify_handler.go
+++ b/internal/databases/postgres/wal_verify_handler.go
@@ -94,7 +94,7 @@ func QueryCurrentWalSegment() WalSegmentDescription {
 	currentSegmentNo, err := getCurrentWalSegmentNo(queryRunner)
 	tracelog.ErrorLogger.FatalfOnError("Failed to get current WAL segment number %v", err)
 
-	currentTimeline, err := getCurrentTimeline(conn)
+	currentTimeline, err := queryRunner.readTimeline()
 	tracelog.ErrorLogger.FatalfOnError("Failed to get current timeline %v", err)
 
 	tracelog.InfoLogger.Printf("Current WAL segment: %s\n", currentSegmentNo.getFilename(currentTimeline))
@@ -172,13 +172,4 @@ func getCurrentWalSegmentNo(queryRunner *PgQueryRunner) (WalSegmentNo, error) {
 		return 0, err
 	}
 	return newWalSegmentNo(lsn - 1), nil
-}
-
-// get the current timeline of the cluster
-func getCurrentTimeline(conn *pgx.Conn) (uint32, error) {
-	timeline, err := readTimeline(conn)
-	if err != nil {
-		return 0, err
-	}
-	return timeline, nil
 }


### PR DESCRIPTION
Since WAL-G doesn't use the `pgxpool`, we must ensure that we don't use the same connection concurrently in the different goroutines. I suggest adding mutex inside the `queryRunner` and getting rid of using the `conn` directly to avoid such errors.