### PR TITLE
sqlserver: fixes for backup-import / backup-restore

### DIFF
--- a/internal/databases/sqlserver/backup_import_handler.go
+++ b/internal/databases/sqlserver/backup_import_handler.go
@@ -122,7 +122,11 @@ func importSingleDatabaseBackup(ctx context.Context, backupName string, dbname s
 
 func getProxyHTTPClient() *http.Client {
 	config := &tls.Config{InsecureSkipVerify: true}
-	tr := &http.Transport{TLSClientConfig: config}
+	tr := &http.Transport{
+		TLSClientConfig:   config,
+		ForceAttemptHTTP2: false,
+		TLSNextProto:      make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+	}
 	client := &http.Client{Transport: tr}
 	return client
 }

--- a/internal/databases/sqlserver/backup_restore_handler.go
+++ b/internal/databases/sqlserver/backup_restore_handler.go
@@ -76,7 +76,11 @@ func restoreSingleDatabase(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	move, err := buildPhysicalFileMove(files, dbname)
+	datadir, logdir, err := GetDefaultDataLogDirs(db)
+	if err != nil {
+		return err
+	}
+	move, err := buildPhysicalFileMove(files, dbname, datadir, logdir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* do not use http2 because of go_away error
* move database files to default datadir during restore
