### PR TITLE
Produce warning instead of failure on db connection failure

### DIFF
--- a/internal/databases/postgres/greenplum_relfile_storage_map.go
+++ b/internal/databases/postgres/greenplum_relfile_storage_map.go
@@ -76,7 +76,8 @@ func newAoRelFileStorageMap(queryRunner *PgQueryRunner) (AoRelFileStorageMap, er
 		}
 		rows, err := queryRunner.fetchAOStorageMetadata(db)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to fetch storage types")
+			tracelog.WarningLogger.Printf("failed to fetch storage types: %s\n'%v'\n", db.name, err)
+			continue
 		}
 		for relFileLoc, metadata := range rows {
 			result[relFileLoc] = metadata


### PR DESCRIPTION
Produce a warning instead of failing during the `AoRelFileStorageMap` init process.