### PR TITLE
Refactor AO/AOCS storage metadata queries for Greenplum

### DIFF
--- a/internal/databases/postgres/greenplum_ao_metadata.go
+++ b/internal/databases/postgres/greenplum_ao_metadata.go
@@ -16,7 +16,7 @@ type BackupAOFileDesc struct {
 	IsSkipped   bool           `json:"IsSkipped"`
 	MTime       time.Time      `json:"MTime"`
 	StorageType RelStorageType `json:"StorageType"`
-	EOF         uint32         `json:"EOF"`
+	EOF         int64          `json:"EOF"`
 	Compressor  string         `json:"Compressor,omitempty"`
 	FileMode    int64          `json:"FileMode"`
 }

--- a/internal/databases/postgres/greenplum_ao_storage.go
+++ b/internal/databases/postgres/greenplum_ao_storage.go
@@ -16,7 +16,7 @@ const (
 	AoSegSuffix     = "_aoseg"
 )
 
-func makeAoFileStorageKey(relNameMd5 string, modCount uint32, location *walparser.BlockLocation) string {
+func makeAoFileStorageKey(relNameMd5 string, modCount int64, location *walparser.BlockLocation) string {
 	return fmt.Sprintf("%d_%d_%s_%d_%d_%d%s",
 		location.RelationFileNode.SpcNode, location.RelationFileNode.DBNode,
 		relNameMd5,

--- a/internal/databases/postgres/greenplum_relfile_storage_map.go
+++ b/internal/databases/postgres/greenplum_relfile_storage_map.go
@@ -17,8 +17,8 @@ const (
 type AoRelFileMetadata struct {
 	relNameMd5  string
 	storageType RelStorageType
-	eof         uint32
-	modCount    uint32
+	eof         int64
+	modCount    int64
 }
 
 // AoRelFileStorageMap indicates the storage type for the relfile
@@ -79,6 +79,7 @@ func newAoRelFileStorageMap(queryRunner *PgQueryRunner) (AoRelFileStorageMap, er
 			tracelog.WarningLogger.Printf("failed to fetch storage types: %s\n'%v'\n", db.name, err)
 			continue
 		}
+		tracelog.InfoLogger.Printf("Successfully loaded AO/AOCS metadata about %d relations in database %s\n", len(rows), db.name)
 		for relFileLoc, metadata := range rows {
 			result[relFileLoc] = metadata
 		}

--- a/internal/databases/postgres/greenplum_tar_ball_composer.go
+++ b/internal/databases/postgres/greenplum_tar_ball_composer.go
@@ -152,7 +152,9 @@ func (c *GpTarBallComposer) AddHeader(fileInfoHeader *tar.Header, info os.FileIn
 	}
 	tarBall.SetUp(c.crypter)
 	defer c.tarBallQueue.EnqueueBack(tarBall)
+	c.tarFileSetsMutex.Lock()
 	c.tarFileSets.AddFile(tarBall.Name(), fileInfoHeader.Name)
+	c.tarFileSetsMutex.Unlock()
 	c.files.AddFile(fileInfoHeader, info, false)
 	return tarBall.TarWriter().WriteHeader(fileInfoHeader)
 }

--- a/internal/databases/postgres/queryRunner.go
+++ b/internal/databases/postgres/queryRunner.go
@@ -67,6 +67,15 @@ type PgQueryRunner struct {
 	mu                sync.Mutex
 }
 
+type aoRelPgClassInfo struct {
+	oid           uint32
+	relNameMd5    string
+	relFileNodeID uint32
+	relNAtts      int16
+	spcNode       uint32
+	storage       RelStorageType
+}
+
 // BuildGetVersion formats a query to retrieve PostgreSQL numeric version
 func (queryRunner *PgQueryRunner) buildGetVersion() string {
 	return "select (current_setting('server_version_num'))::int"
@@ -441,73 +450,122 @@ func (queryRunner *PgQueryRunner) IsTablespaceMapExists() bool {
 	return queryRunner.Version >= 90600
 }
 
-// BuildRelStorageQuery formats a query that fetch list of relfilenodes along with the storage type
-func (queryRunner *PgQueryRunner) BuildAORelStorageQuery() (string, error) {
-	switch {
-	case queryRunner.Version >= 90000:
-		// combine AO and AOCS metadata
-		return "SELECT md5(c.relname), c.relfilenode, c.reltablespace, c.relstorage, aocs.physical_segno as segno, aocs.modcount, aocs.eof " +
-			"FROM pg_class c, gp_toolkit.__gp_aocsseg(c.oid) aocs " +
-			"WHERE relstorage='c' " +
-			"UNION " +
-			"SELECT md5(c.relname), c.relfilenode, c.reltablespace, c.relstorage, ao.segno, ao.modcount, ao.eof " +
-			"FROM pg_class c, gp_toolkit.__gp_aoseg(c.oid) ao " +
-			"WHERE relstorage='a';", nil
-	case queryRunner.Version == 0:
-		return "", newNoPostgresVersionError()
-	default:
-		return "", newUnsupportedPostgresVersionError(queryRunner.Version)
-	}
-}
-
 // fetchAOStorageMetadata queries the storage metadata for AO & AOCS tables (GreenplumDB)
 func (queryRunner *PgQueryRunner) fetchAOStorageMetadata(dbInfo PgDatabaseInfo) (AoRelFileStorageMap, error) {
 	queryRunner.mu.Lock()
 	defer queryRunner.mu.Unlock()
 
-	tracelog.InfoLogger.Printf("fetchAOStorageMetadata: Querying pg_class for %s", dbInfo.name)
-	getStatQuery, err := queryRunner.BuildAORelStorageQuery()
+	tracelog.InfoLogger.Printf("Querying pg_class for %s", dbInfo.name)
+	getStatQuery, err := queryRunner.buildAORelPgClassQuery()
 	conn := queryRunner.Connection
 	if err != nil {
-		return nil, errors.Wrap(err, "QueryRunner fetchRelStorages: failed to build the pg_class query")
+		return nil, errors.Wrap(err, "failed to build the pg_class query")
 	}
 
 	rows, err := conn.Query(getStatQuery)
 	if err != nil {
-		return nil, errors.Wrap(err, "QueryRunner fetchRelStorages: pg_class query failed")
+		return nil, errors.Wrap(err, "pg_class query failed")
 	}
 
 	defer rows.Close()
-	relStorageMap := make(AoRelFileStorageMap)
+	relPgClassInfo := make(map[string]aoRelPgClassInfo)
 	for rows.Next() {
+		var oid uint32
 		var relNameMd5 string
+		var aoSegTableFqn string
 		var relFileNodeID uint32
 		var spcNode uint32
 		var storage RelStorageType
-		var segNo uint32
-		var modCount uint32
-		var eof uint32
-		if err := rows.Scan(&relNameMd5, &relFileNodeID, &spcNode, &storage, &segNo, &modCount, &eof); err != nil {
-			tracelog.WarningLogger.Printf("fetchAOStorageMetadata: failed to parse query result: %v\n", err.Error())
+		var relNAtts int16
+		if err := rows.Scan(&oid, &relNameMd5, &aoSegTableFqn, &relFileNodeID, &spcNode, &storage, &relNAtts); err != nil {
+			return nil, errors.Wrapf(err, "failed to parse query result")
 		}
-		relFileLoc := walparser.NewBlockLocation(walparser.Oid(spcNode), dbInfo.oid, walparser.Oid(relFileNodeID), segNo)
+		row := aoRelPgClassInfo{
+			oid:           oid,
+			relNameMd5:    relNameMd5,
+			relFileNodeID: relFileNodeID,
+			relNAtts:      relNAtts,
+			spcNode:       spcNode,
+			storage:       storage,
+		}
+		relPgClassInfo[aoSegTableFqn] = row
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	relStorageMap := make(AoRelFileStorageMap)
+
+	for aoSegTableFqn, row := range relPgClassInfo {
+		var queryFunc func() (*pgx.Rows, error)
+		switch row.storage {
+		case AppendOptimized:
+			queryFunc = func() (*pgx.Rows, error) {
+				query, err := queryRunner.buildAOMetadataQuery(aoSegTableFqn)
+				if err != nil {
+					return nil, err
+				}
+
+				return conn.Query(query)
+			}
+		case ColumnOriented:
+			queryFunc = func() (*pgx.Rows, error) {
+				query, err := queryRunner.buildAOCSMetadataQuery()
+				if err != nil {
+					return nil, err
+				}
+
+				return conn.Query(query, row.oid)
+			}
+		default:
+			tracelog.WarningLogger.Printf("Unexpected relation storage type %c for relfilenode %d in database %s",
+				row.storage, row.relFileNodeID, dbInfo.name)
+			continue
+		}
+
+		err = loadStorageMetadata(relStorageMap, dbInfo, queryFunc, aoSegTableFqn, relPgClassInfo)
+		if err != nil {
+			tracelog.WarningLogger.Printf("failed to fetch the AOCS storage metadata: %v\n", err)
+		}
+	}
+
+	return relStorageMap, nil
+}
+
+func loadStorageMetadata(relStorageMap AoRelFileStorageMap, dbInfo PgDatabaseInfo,
+	queryFn func() (*pgx.Rows, error), aoSegTableFqn string, relPgClassInfo map[string]aoRelPgClassInfo) error {
+	rows, err := queryFn()
+	if err != nil {
+		return errors.Wrap(err, "storage metadata query failed")
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		var segNo int
+		var modCount int64
+		var eof int64
+
+		if err := rows.Scan(&segNo, &modCount, &eof); err != nil {
+			tracelog.WarningLogger.Printf("failed to parse query result: %v\n", err.Error())
+		}
+
+		cInfo := relPgClassInfo[aoSegTableFqn]
+		relFileLoc := walparser.NewBlockLocation(walparser.Oid(cInfo.spcNode), dbInfo.oid, walparser.Oid(cInfo.relFileNodeID), uint32(segNo))
 		// if tablespace id is zero, use the default database tablespace id
 		if relFileLoc.RelationFileNode.SpcNode == walparser.Oid(0) {
 			relFileLoc.RelationFileNode.SpcNode = dbInfo.tblSpcOid
 		}
 		relStorageMap[*relFileLoc] = AoRelFileMetadata{
-			relNameMd5:  relNameMd5,
-			storageType: storage,
+			relNameMd5:  cInfo.relNameMd5,
+			storageType: cInfo.storage,
 			eof:         eof,
 			modCount:    modCount,
 		}
 	}
-
 	if rows.Err() != nil {
-		return nil, rows.Err()
+		return rows.Err()
 	}
-
-	return relStorageMap, nil
+	return nil
 }
 
 func (queryRunner *PgQueryRunner) readTimeline() (timeline uint32, err error) {
@@ -531,4 +589,55 @@ func (queryRunner *PgQueryRunner) Ping() error {
 
 	ctx := context.Background()
 	return queryRunner.Connection.Ping(ctx)
+}
+
+func (queryRunner *PgQueryRunner) buildAORelPgClassQuery() (string, error) {
+	switch {
+	case queryRunner.Version >= 90000:
+		return `
+SELECT seg.aooid, md5(seg.aotablefqn), 'pg_aoseg.' || quote_ident(aoseg_c.relname) AS aosegtablefqn,
+	seg.relfilenode, seg.reltablespace, seg.relstorage, seg.relnatts 
+FROM pg_class aoseg_c
+JOIN (
+	SELECT pg_ao.relid AS aooid, pg_ao.segrelid, 
+			aotables.aotablefqn, aotables.relstorage, 
+			aotables.relnatts, aotables.relfilenode, aotables.reltablespace
+	FROM pg_appendonly pg_ao
+	JOIN (
+		SELECT c.oid, quote_ident(n.nspname)|| '.' || quote_ident(c.relname) AS aotablefqn, 
+				c.relstorage, c.relnatts, c.relfilenode, c.reltablespace 
+		FROM pg_class c
+		JOIN pg_namespace n ON c.relnamespace = n.oid
+		WHERE relstorage IN ( 'ao', 'co' ) AND relpersistence='p'
+		) aotables ON pg_ao.relid = aotables.oid
+	) seg ON aoseg_c.oid = seg.segrelid;
+`, nil
+	case queryRunner.Version == 0:
+		return "", newNoPostgresVersionError()
+	default:
+		return "", newUnsupportedPostgresVersionError(queryRunner.Version)
+	}
+}
+
+func (queryRunner *PgQueryRunner) buildAOCSMetadataQuery() (string, error) {
+	switch {
+	case queryRunner.Version >= 90000:
+		return `SELECT aocs.physical_segno as segno, aocs.modcount, aocs.eof " +
+			"FROM gp_toolkit.__gp_aocsseg($1::oid) aocs;`, nil
+	case queryRunner.Version == 0:
+		return "", newNoPostgresVersionError()
+	default:
+		return "", newUnsupportedPostgresVersionError(queryRunner.Version)
+	}
+}
+
+func (queryRunner *PgQueryRunner) buildAOMetadataQuery(aoSegTableFqn string) (string, error) {
+	switch {
+	case queryRunner.Version >= 90000:
+		return fmt.Sprintf(`SELECT segno, modcount, eof FROM %s;`, aoSegTableFqn), nil
+	case queryRunner.Version == 0:
+		return "", newNoPostgresVersionError()
+	default:
+		return "", newUnsupportedPostgresVersionError(queryRunner.Version)
+	}
 }


### PR DESCRIPTION
Currently, AO/AOCS the entire storage metadata query might fail if there is a concurrent delete of some relation. This PR should help to avoid such cases by selecting the metadata one-by-one for each relation. This PR also fixes a possible concurrent write in Greenplum tar ball composer.