### PR TITLE
mysql: binlog cache fixes

### DIFF
--- a/internal/databases/mysql/mysql_binlog_test.go
+++ b/internal/databases/mysql/mysql_binlog_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/stretchr/testify/assert"
 )
 
 const testFilenameSmall = "testdata/binlog_small_test"
@@ -30,4 +31,15 @@ func TestGetBinlogStartTimestamp(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBinlogNum(t *testing.T) {
+	assert.Equal(t, 1, BinlogNum("foo.bar.000001"))
+	assert.Equal(t, 1, BinlogNum("foo.bar.01"))
+	assert.Equal(t, 1, BinlogNum("foo.bar.1"))
+	assert.Equal(t, 1, BinlogNum("foo.000001"))
+	assert.Equal(t, 1, BinlogNum("foo.01"))
+	assert.Equal(t, 1, BinlogNum("foo.1"))
+	assert.Equal(t, 123456, BinlogNum("foo.123456"))
+	assert.Equal(t, 123456789, BinlogNum("foo.123456789"))
 }


### PR DESCRIPTION
* use numeric binlog comparison
* clear binlogs cache after reset master or host resetup