### PR TITLE
Change link_libsodium.sh shebang to bash

### DIFF
--- a/link_libsodium.sh
+++ b/link_libsodium.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
The if conditional was using the bash syntax with a sh shebang.