### PR TITLE
Add parallel segment delete for Greenplum

### DIFF
--- a/docs/Greenplum.md
+++ b/docs/Greenplum.md
@@ -125,3 +125,6 @@ WAL-G can also do in-place backup restoration without the restore config. It mig
 ```bash
 wal-g backup-fetch LATEST --in-place --config=/path/to/config.yaml
 ```
+
+#### Delete concurrency
+During the delete execution, WAL-G can process segments in parallel mode. To control, how many segments will be processed simultaneously, use the `WALG_GP_DELETE_CONCURRENCY` setting. The default value is `1`. 

--- a/internal/config.go
+++ b/internal/config.go
@@ -120,6 +120,7 @@ const (
 	GPSegmentsPollRetries  = "WALG_GP_SEG_POLL_RETRIES"
 	GPSegmentsUpdInterval  = "WALG_GP_SEG_UPD_INTERVAL"
 	GPSegmentStatesDir     = "WALG_GP_SEG_STATES_DIR"
+	GPDeleteConcurrency    = "WALG_GP_DELETE_CONCURRENCY"
 
 	GoMaxProcs = "GOMAXPROCS"
 
@@ -207,6 +208,7 @@ var (
 		GPSegmentsUpdInterval:  "10s",
 		GPSegmentsPollRetries:  "5",
 		GPSegmentStatesDir:     "/tmp",
+		GPDeleteConcurrency:    "1",
 	}
 
 	AllowedSettings map[string]bool
@@ -407,6 +409,7 @@ var (
 		GPSegmentsPollInterval: true,
 		GPSegmentsUpdInterval:  true,
 		GPSegmentStatesDir:     true,
+		GPDeleteConcurrency:    true,
 	}
 
 	RequiredSettings       = make(map[string]bool)

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -3,11 +3,12 @@ package greenplum
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -126,7 +127,8 @@ func (h *DeleteHandler) DeleteBeforeTarget(target internal.BackupObject, confirm
 	deleteSem := make(chan struct{}, deleteConcurrency)
 
 	// clean the segments
-	for _, meta := range sentinel.Segments {
+	for i := range sentinel.Segments {
+		meta := sentinel.Segments[i]
 		errorGroup.Go(func() error {
 			deleteSem <- struct{}{}
 			deleteErr := h.runDeleteOnSegment(backup, meta, confirmed)


### PR DESCRIPTION
Add the `WALG_GP_DELETE_CONCURRENCY` setting to control the concurrency for segment backups deletion.