### PR TITLE
Bump golangci-lint version in CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,4 +27,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.46.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,9 @@ linters-settings:
     locale: US
   lll:
     line-length: 140
+  staticcheck:
+    # SA1019 is disabled until WAL-G has migrated from the deprecated package golang.org/x/crypto/openpgp
+    checks: [ "all", "-SA1019" ]
   revive:
     rules:
       - name: blank-imports

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -284,9 +284,6 @@ func (h *DeleteHandler) FindTargetRetainAfterName(
 		}
 		return meetName && object.IsFullBackup()
 	}
-	if choiceFuncAfterName == nil {
-		return nil, utility.NewForbiddenActionError("Not allowed modifier for 'delete before'")
-	}
 
 	target1, err := findTarget(h.backups, h.greater, choiceFuncRetain)
 	if err != nil && err != errNotFound {


### PR DESCRIPTION
After migration to Go 1.18, some linters are now skipped in CI:
```
  Running [/home/runner/golangci-lint-1.45.2-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  level=warning msg="[linters context] bodyclose is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
  level=warning msg="[linters context] gosimple is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
  level=warning msg="[linters context] staticcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
  level=warning msg="[linters context] stylecheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
  level=warning msg="[linters context] unparam is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
  level=warning msg="[linters context] unused is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649."
  level=warning msg="[runner/nolint] Found unknown linters in //nolint directives: hugeparam"
  ```
  
  This PR should re-enable them.