### PR TITLE
Add ListFolderRecursivelyWithFilter to storages & optimize delete handler in Greenplum

### DIFF
--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -191,7 +191,8 @@ func cleanupAOSegments(segFolder storage.Folder, confirmed bool) error {
 	}
 
 	tracelog.InfoLogger.Printf("Cleaning up the AO segment objects")
-	return storage.DeleteObjectsWhere(aoSegFolder, confirmed, func(object storage.Object) bool {
+
+	objFilter := func(object storage.Object) bool {
 		if !strings.HasSuffix(object.GetName(), postgres.AoSegSuffix) {
 			return false
 		}
@@ -199,7 +200,10 @@ func cleanupAOSegments(segFolder storage.Folder, confirmed bool) error {
 		segName := path.Base(object.GetName())
 		_, shouldDelete := aoSegmentsToDelete[segName]
 		return shouldDelete
-	})
+	}
+
+	folderFilter := func(path string) bool { return true }
+	return storage.DeleteObjectsWhere(aoSegFolder, confirmed, objFilter, folderFilter)
 }
 
 func findAoSegmentsToDelete(aoSegFolder storage.Folder) (map[string]struct{}, error) {

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 
@@ -187,51 +186,49 @@ func (h *DeleteHandler) runDeleteOnSegment(backup Backup, meta SegmentMetadata, 
 
 func cleanupAOSegments(segFolder storage.Folder, confirmed bool) error {
 	aoSegFolder := segFolder.GetSubFolder(utility.BaseBackupPath).GetSubFolder(postgres.AoStoragePath)
+	tracelog.InfoLogger.Printf("Cleaning up the AO segment objects")
 	aoSegmentsToDelete, err := findAoSegmentsToDelete(aoSegFolder)
 	if err != nil {
 		return err
 	}
 
-	tracelog.InfoLogger.Printf("Cleaning up the AO segment objects")
-
-	objFilter := func(object storage.Object) bool {
-		if !strings.HasSuffix(object.GetName(), postgres.AoSegSuffix) {
-			return false
-		}
-
-		segName := path.Base(object.GetName())
-		_, shouldDelete := aoSegmentsToDelete[segName]
-		return shouldDelete
-	}
-
-	folderFilter := func(path string) bool { return true }
-	return storage.DeleteObjectsWhere(aoSegFolder, confirmed, objFilter, folderFilter)
+	return aoSegFolder.DeleteObjects(aoSegmentsToDelete)
 }
 
-func findAoSegmentsToDelete(aoSegFolder storage.Folder) (map[string]struct{}, error) {
+func findAoSegmentsToDelete(aoSegFolder storage.Folder) ([]string, error) {
 	aoObjects, _, err := aoSegFolder.ListFolder()
 	if err != nil {
 		return nil, err
 	}
 
-	aoSegmentsToDelete := make(map[string]struct{})
-	// by default, we want to delete all segments
-	for _, obj := range aoObjects {
-		if strings.HasSuffix(obj.GetName(), postgres.AoSegSuffix) {
-			aoSegName := path.Base(obj.GetName())
-			aoSegmentsToDelete[aoSegName] = struct{}{}
-		}
-	}
-
-	// now exclude the still referenced ones
+	// we want to retain AO segments that are still referenced by some backups
+	aoSegmentsToRetain := make(map[string]struct{})
 	for _, obj := range aoObjects {
 		if strings.HasSuffix(obj.GetName(), postgres.BackupRefSuffix) {
 			// this should never fail, since slice len is always > 0
 			referencedSegName := strings.SplitAfter(obj.GetName(), postgres.AoSegSuffix)[0]
-			tracelog.InfoLogger.Printf(
-				"AO segment %s is still referenced by some backups, will not delete it\n", referencedSegName)
-			delete(aoSegmentsToDelete, referencedSegName)
+			aoSegmentsToRetain[referencedSegName] = struct{}{}
 		}
 	}
+
+	aoSegmentsToDelete := make([]string, 0)
+	for _, obj := range aoObjects {
+		if !strings.HasSuffix(obj.GetName(), postgres.AoSegSuffix) {
+			// this is not an AO segment file, skip it
+			tracelog.InfoLogger.Println("\tis not an AO segment file, will not delete: " + obj.GetName())
+			continue
+		}
+
+		if _, ok := aoSegmentsToRetain[obj.GetName()]; ok {
+			// this AO segment file is still referenced by some backup, skip it
+			tracelog.InfoLogger.Println("\tis still referenced by some backups, will not delete: " + obj.GetName())
+			continue
+		}
+
+		tracelog.InfoLogger.Println("\twill be deleted: " + obj.GetName())
+
+		aoSegmentsToDelete = append(aoSegmentsToDelete, obj.GetName())
+	}
+
 	return aoSegmentsToDelete, nil
 }

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -144,7 +144,9 @@ func (h *DeleteHandler) DeleteBeforeTarget(target internal.BackupObject, confirm
 
 	tracelog.InfoLogger.Printf("Finished deleting the segments backups")
 
-	return h.DeleteHandler.DeleteBeforeTarget(target, confirmed)
+	objFilter := func(object storage.Object) bool { return true }
+	folderFilter := func(name string) bool { return strings.HasPrefix(name, utility.BaseBackupPath) }
+	return h.DeleteHandler.DeleteBeforeTargetWhere(target, confirmed, objFilter, folderFilter)
 }
 
 func (h *DeleteHandler) runDeleteOnSegment(backup Backup, meta SegmentMetadata, confirmed bool) error {
@@ -174,8 +176,8 @@ func (h *DeleteHandler) runDeleteOnSegment(backup Backup, meta SegmentMetadata, 
 	filterFunc := func(object storage.Object) bool {
 		return !strings.HasSuffix(object.GetName(), postgres.AoSegSuffix)
 	}
-
-	err = segDeleteHandler.DeleteBeforeTargetWhere(segTarget, confirmed, filterFunc)
+	folderFilter := func(string) bool { return true }
+	err = segDeleteHandler.DeleteBeforeTargetWhere(segTarget, confirmed, filterFunc, folderFilter)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/postgres/delete.go
+++ b/internal/databases/postgres/delete.go
@@ -222,7 +222,8 @@ func (dh *DeleteHandler) HandleDeleteGarbage(args []string, folder storage.Folde
 		return err
 	}
 
-	return dh.DeleteBeforeTargetWhere(target, confirm, predicate)
+	folderFilter := func(string) bool { return true }
+	return dh.DeleteBeforeTargetWhere(target, confirm, predicate, folderFilter)
 }
 
 // ExtractDeleteGarbagePredicate extracts delete modifier the "delete garbage" command

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -38,7 +38,7 @@ const (
 	DeleteTargetExamples = `  target base_0000000100000000000000C4	delete base backup by name
   target --target-user-data "{ \"x\": [3], \"y\": 4 }"	delete backup specified by user data
   target base_0000000100000000000000C9_D_0000000100000000000000C4	delete delta backup and all dependant delta backups 
-  target FIND_FULL base_0000000100000000000000C9_D_0000000100000000000000C4	delete delta backup and all delta backups with the same base backup` //nolint:lll
+  target FIND_FULL base_0000000100000000000000C9_D_0000000100000000000000C4	delete delta backup and all delta backups with the same base backup`  //nolint:lll
 
 	DeleteEverythingUsageExample = "everything [FORCE]"
 	DeleteRetainUsageExample     = "retain [FULL|FIND_FULL] backup_count"

--- a/pkg/storages/storage/folder.go
+++ b/pkg/storages/storage/folder.go
@@ -31,15 +31,15 @@ type Folder interface {
 	CopyObject(srcPath string, dstPath string) error
 }
 
-func DeleteObjectsWhere(folder Folder, confirm bool, filter func(object1 Object) bool) error {
-	relativePathObjects, err := ListFolderRecursively(folder)
+func DeleteObjectsWhere(folder Folder, confirm bool, objFilter func(object1 Object) bool, folderFilter func(name string) bool) error {
+	relativePathObjects, err := ListFolderRecursivelyWithFilter(folder, folderFilter)
 	if err != nil {
 		return err
 	}
 	filteredRelativePaths := make([]string, 0)
 	tracelog.InfoLogger.Println("Objects in folder:")
 	for _, object := range relativePathObjects {
-		if filter(object) {
+		if objFilter(object) {
 			tracelog.InfoLogger.Println("\twill be deleted: " + object.GetName())
 			filteredRelativePaths = append(filteredRelativePaths, object.GetName())
 		} else {


### PR DESCRIPTION
Add the `ListFolderRecursivelyWithFilter` function that accepts folder filters so we can avoid the excessive storage listing calls (for example, ListObjects in S3). This allows for optimizing some functionality, such as delete handlers.