### PR TITLE
Greenplum: use AO files metadata instead of backup references

### DIFF
--- a/internal/databases/postgres/backup.go
+++ b/internal/databases/postgres/backup.go
@@ -348,9 +348,9 @@ func (backup *Backup) getTarsToExtract(filesMeta FilesMetadataDto, filesToUnwrap
 		tarsToExtract = append(tarsToExtract, tarToExtract)
 	}
 
-	aoMeta, err := backup.loadAoFilesMetadata()
+	aoMeta, err := backup.LoadAoFilesMetadata()
 	if err != nil {
-		tracelog.InfoLogger.Printf("AO files metadata was not found. Skipping the AO segments unpacking.")
+		tracelog.DebugLogger.Printf("AO files metadata was not found. Skipping the AO segments unpacking.")
 	} else {
 		tracelog.InfoLogger.Printf("AO files metadata found. Will perform the AO segments unpacking.")
 		for extractPath, meta := range aoMeta.Files {
@@ -387,7 +387,7 @@ func (backup *Backup) GetFilesToUnwrap(fileMask string) (map[string]bool, error)
 	return utility.SelectMatchingFiles(fileMask, filesToUnwrap)
 }
 
-func (backup *Backup) loadAoFilesMetadata() (*AOFilesMetadataDTO, error) {
+func (backup *Backup) LoadAoFilesMetadata() (*AOFilesMetadataDTO, error) {
 	if backup.AoFilesMetadataDto != nil {
 		return backup.AoFilesMetadataDto, nil
 	}

--- a/internal/databases/postgres/delete_util.go
+++ b/internal/databases/postgres/delete_util.go
@@ -54,12 +54,6 @@ func IsPermanent(objectName string, permanentBackups, permanentWals map[string]b
 		return permanentWals[wal]
 	}
 	if strings.HasPrefix(objectName, utility.BaseBackupPath) {
-		// Handle Greenplum AO segment backup reference
-		if strings.HasSuffix(objectName, BackupRefSuffix) {
-			backupRef := strings.SplitAfter(objectName, AoSegSuffix+"_")[1]
-			return permanentBackups[strings.TrimSuffix(backupRef, BackupRefSuffix)]
-		}
-
 		backup := utility.StripLeftmostBackupName(objectName[len(utility.BaseBackupPath):])
 		return permanentBackups[backup]
 	}

--- a/internal/databases/postgres/greenplum_ao_storage.go
+++ b/internal/databases/postgres/greenplum_ao_storage.go
@@ -1,9 +1,7 @@
 package postgres
 
 import (
-	"bytes"
 	"fmt"
-	"path"
 
 	"github.com/wal-g/wal-g/internal/walparser"
 
@@ -11,9 +9,8 @@ import (
 )
 
 const (
-	AoStoragePath   = "aosegments"
-	BackupRefSuffix = "_ref"
-	AoSegSuffix     = "_aoseg"
+	AoStoragePath = "aosegments"
+	AoSegSuffix   = "_aoseg"
 )
 
 func makeAoFileStorageKey(relNameMd5 string, modCount int64, location *walparser.BlockLocation) string {
@@ -22,11 +19,6 @@ func makeAoFileStorageKey(relNameMd5 string, modCount int64, location *walparser
 		relNameMd5,
 		location.RelationFileNode.RelNode, location.BlockNo,
 		modCount, AoSegSuffix)
-}
-
-func storeBackupReference(baseBackupsFolder storage.Folder, aoFilename string, backupName string) error {
-	refName := aoFilename + "_" + backupName + BackupRefSuffix
-	return baseBackupsFolder.PutObject(path.Join(AoStoragePath, refName), &bytes.Buffer{})
 }
 
 func LoadStorageAoFiles(baseBackupsFolder storage.Folder) (map[string]struct{}, error) {

--- a/internal/databases/postgres/greenplum_tar_ball_composer.go
+++ b/internal/databases/postgres/greenplum_tar_ball_composer.go
@@ -226,9 +226,7 @@ func (c *GpTarBallComposer) addAOFile(cfi *internal.ComposeFileInfo, aoMeta AoRe
 	if _, exists := c.baseAoFiles[storageKey]; exists {
 		c.addAoFileMetadata(cfi, storageKey, aoMeta, true)
 		tracelog.DebugLogger.Printf("Skipping %s AO relfile (already exists in storage as %s)", cfi.Path, storageKey)
-
-		// add reference for the current backup to the storage
-		return storeBackupReference(c.uploader.UploadingFolder, storageKey, c.backupName)
+		return nil
 	}
 
 	tracelog.DebugLogger.Printf("Uploading %s AO relfile to %s (does not exist in storage)", cfi.Path, storageKey)
@@ -257,9 +255,7 @@ func (c *GpTarBallComposer) addAOFile(cfi *internal.ComposeFileInfo, aoMeta AoRe
 	}
 
 	c.addAoFileMetadata(cfi, storageKey, aoMeta, false)
-
-	// add reference for the current backup to the storage
-	return storeBackupReference(c.uploader.UploadingFolder, storageKey, c.backupName)
+	return nil
 }
 
 func (c *GpTarBallComposer) addAoFileMetadata(cfi *internal.ComposeFileInfo, storageKey string, aoMeta AoRelFileMetadata, isSkipped bool) {


### PR DESCRIPTION
Currently, WAL-G needs to upload a separate backup reference object for each AO segment file during the backup push. So, If there are 6 backups in storage, it is required to store `7 x total_ao_segment_files` objects in storage. This PR switches WAL-G delete handler to use AO files metadata instead of backup references to determine which objects to retain.