### PR TITLE
MariaDB. Fix backup-push

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -125,6 +125,7 @@ jobs:
                    'make MYSQL_TEST=mysql_base_tests mysql_integration_test',
                    'make MYSQL_TEST=mysql_delete_tests mysql_integration_test',
                    'make MYSQL_TEST=mysql_copy_tests mysql_integration_test',
+                   'make mariadb_test',
                    'make gp_test',
                    'make st_test',
                    'make TEST="pg_pgbackrest_backup_fetch_test" pg_integration_test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,8 +65,11 @@ services:
       &&  mkdir -p /export/mysqlpitrmysqldumpbucket
       &&  mkdir -p /export/mysqllivereplay
       &&  mkdir -p /export/mysqlpermanentbackupbucket
-      &&  mkdir -p /export/mariadbfullmysqldumpbucket
-      &&  mkdir -p /export/mariadbfullmariabackupbucket
+      &&  mkdir -p /export/mariadb_binlog_push_fetch
+      &&  mkdir -p /export/mariadb_binlog_push_with_gtids_check
+      &&  mkdir -p /export/mariadb_full_mysqldump
+      &&  mkdir -p /export/mariadb_full_maria_backup
+      &&  mkdir -p /export/mariadb_pitr_xtrabackup
       &&  mkdir -p /export/mongostreampushbucket
       &&  mkdir -p /export/mongooplogpushbucket
       &&  mkdir -p /export/mongodeletebeforebucket

--- a/docker/mariadb/export_common.sh
+++ b/docker/mariadb/export_common.sh
@@ -9,9 +9,17 @@ export WALG_MYSQL_BACKUP_PREPARE_COMMAND="mariabackup --prepare --target-dir=${M
 
 # test tools
 mariadb_kill_and_clean_data() {
-    service mysql stop || true
+    # MariaDB service is weired - it returns error on service stop. Repeat it until success
+    while ! service mysql stop
+    do
+      echo "Stopping MariaDB... Try again"
+      sleep 1
+    done
+
     kill -9 `pidof mysqld` || true
+
     rm -rf "${MYSQLDATA}"/*
+    rm -rf "${MYSQLDATA}"/.tmp
     rm -rf /root/.walg_mysql_binlogs_cache
 }
 

--- a/docker/mariadb_tests/scripts/run_integration_tests.sh
+++ b/docker/mariadb_tests/scripts/run_integration_tests.sh
@@ -7,7 +7,7 @@ for i in /tmp/tests/*; do
   echo
   echo "===== RUNNING $i ====="
   set -x
-  "$i"
+  timeout 3m "$i"
   set +x
   echo "===== SUCCESS $i ====="
   echo

--- a/docker/mariadb_tests/scripts/tests/binlog_push_with_gtids_check.sh
+++ b/docker/mariadb_tests/scripts/tests/binlog_push_with_gtids_check.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mariadb_binlog_push_with_gtids_check
+export WALG_MYSQL_BINLOG_DST=/tmp/binlogs
+export WALG_MYSQL_CHECK_GTIDS=True
+
+mysql_install_db > /dev/null
+service mysql start
+
+sysbench --table-size=10 prepare
+sysbench --time=3 run
+mysql -e "FLUSH LOGS"
+
+export WALG_MYSQL_CHECK_GTIDS=True
+if wal-g binlog-push; then
+  echo "WALG_MYSQL_CHECK_GTIDS is broken for MariaDB. It shouldn't allow users to misconfigure wal-g"
+  exit 1
+fi

--- a/docker/mariadb_tests/scripts/tests/full_mariabackup_test.sh
+++ b/docker/mariadb_tests/scripts/tests/full_mariabackup_test.sh
@@ -3,7 +3,7 @@ set -e -x
 
 . /usr/local/export_common.sh
 
-export WALE_S3_PREFIX=s3://mariadbfullmariabackupbucket
+export WALE_S3_PREFIX=s3://mariadb_full_maria_backup
 
 
 mysql_install_db > /dev/null

--- a/docker/mariadb_tests/scripts/tests/full_mysqldump_test.sh
+++ b/docker/mariadb_tests/scripts/tests/full_mysqldump_test.sh
@@ -3,7 +3,7 @@ set -e -x
 
 . /usr/local/export_common.sh
 
-export WALE_S3_PREFIX=s3://mariadbfullmysqldumpbucket
+export WALE_S3_PREFIX=s3://mariadb_full_mysqldump
 export WALG_STREAM_CREATE_COMMAND="mysqldump --all-databases --single-transaction"
 export WALG_STREAM_RESTORE_COMMAND="mysql"
 export WALG_MYSQL_BACKUP_PREPARE_COMMAND=
@@ -13,7 +13,6 @@ mysql_install_db > /dev/null
 service mysql start
 
 sysbench --table-size=10 prepare
-
 sysbench --time=5 run
 
 mysql -e 'FLUSH LOGS'
@@ -22,8 +21,6 @@ mysqldump sbtest > /tmp/dump_before_backup
 
 wal-g backup-push
 
-
-ps aux | grep mysqld_safe
 
 mariadb_kill_and_clean_data
 

--- a/docker/mariadb_tests/scripts/tests/pitr_xtrabackup_test.sh
+++ b/docker/mariadb_tests/scripts/tests/pitr_xtrabackup_test.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mariadb_pitr_xtrabackup
+export WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
+export WALG_MYSQL_BINLOG_DST=/tmp
+
+mysql_install_db > /dev/null
+service mysql start
+
+# add some data to database, so
+sysbench --table-size=10 prepare
+sysbench --time=5 run
+
+# first full backup
+wal-g backup-push
+FIRST_BACKUP=$(wal-g backup-list | awk 'NR==2{print $1}')
+sleep 1
+
+mysql -e "CREATE TABLE sbtest.pitr(id VARCHAR(32), ts DATETIME)"
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr01', NOW())"
+mysql -e "FLUSH LOGS"
+wal-g binlog-push
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr02', NOW())"
+sleep 1
+
+# second full backup
+wal-g backup-push
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr03', NOW())"
+sleep 1
+
+DT1=$(date3339)
+
+sleep 1
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr04', NOW())"
+mysql -e "FLUSH LOGS"
+wal-g binlog-push
+
+
+# PiTR restore after LATEST backup
+mariadb_kill_and_clean_data
+wal-g backup-fetch LATEST
+
+cat /var/lib/mysql/xtrabackup_binlog_info
+
+chown -R mysql:mysql $MYSQLDATA
+service mysql start || (cat /var/log/mysql/error.log && false)
+# For backups made from replicas we should update GTIDs. Test our reset logic here.
+# https://mariadb.com/kb/en/gtid/#setting-up-a-new-replica-from-a-backup
+mysql_set_gtid_from_backup
+
+
+# WARNING:
+# PiTR with GTIDs supported by MariaDB 10.8+ versions:
+# https://fromdual.com/sites/default/files/fosdem_2022_pitr.pdf
+# https://mariadb.com/kb/en/mariadb-1080-release-notes/#mysqlbinlog-gtid-support
+#
+# Before 10.8 they recommend one of the options:
+# * replay with binlog and position
+# * replicate from alive MariaDB server
+#
+# It seems that MariaDB won't skip transactions it already seen: gtid_strict_mode will not prevent from applying wrong transactions
+
+#wal-g binlog-replay --since LATEST --until "$DT1"
+#mysqldump sbtest > /tmp/dump_after_pitr
+#grep -w 'testpitr01' /tmp/dump_after_pitr
+#grep -w 'testpitr02' /tmp/dump_after_pitr
+#grep -w 'testpitr03' /tmp/dump_after_pitr
+#! grep -w 'testpitr04' /tmp/dump_after_pitr
+#
+#
+## PiTR restore from first full backup
+#mariadb_kill_and_clean_data
+#wal-g backup-fetch $FIRST_BACKUP
+#chown -R mysql:mysql $MYSQLDATA
+#service mysql start || (cat /var/log/mysql/error.log && false)
+#mysql_set_gtid_from_backup
+#wal-g binlog-replay --since $FIRST_BACKUP --until "$DT1"
+#mysqldump sbtest > /tmp/dump_after_pitr
+#grep -w 'testpitr01' /tmp/dump_after_pitr
+#grep -w 'testpitr02' /tmp/dump_after_pitr
+#grep -w 'testpitr03' /tmp/dump_after_pitr
+#! grep -w 'testpitr04' /tmp/dump_after_pitr

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -1,9 +1,10 @@
 package mysql
 
 import (
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"os"
 	"os/exec"
+
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 
@@ -24,7 +25,8 @@ func HandleBackupPush(folder storage.Folder, uploader internal.UploaderProvider,
 
 	var binlogStart string
 	if flavor == gomysql.MySQLFlavor {
-		gtidStart, err := getMySQLGTIDExecuted(db, flavor)
+		var gtidStart string
+		gtidStart, err = getMySQLGTIDExecuted(db, flavor)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		binlogStart, err = getLastUploadedBinlogBeforeGTID(folder, gtidStart, flavor)

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"os"
 	"os/exec"
 
@@ -21,10 +22,15 @@ func HandleBackupPush(folder storage.Folder, uploader internal.UploaderProvider,
 	flavor, err := getMySQLFlavor(db)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	gtidStart, err := getMySQLGTIDExecuted(db, flavor)
-	tracelog.ErrorLogger.FatalOnError(err)
+	var binlogStart string
+	if flavor == gomysql.MySQLFlavor {
+		gtidStart, err := getMySQLGTIDExecuted(db, flavor)
+		tracelog.ErrorLogger.FatalOnError(err)
 
-	binlogStart, err := getLastUploadedBinlogBeforeGTID(folder, gtidStart, flavor)
+		binlogStart, err = getLastUploadedBinlogBeforeGTID(folder, gtidStart, flavor)
+	} else {
+		binlogStart, err = getLastUploadedBinlog(folder)
+	}
 	tracelog.ErrorLogger.FatalfOnError("failed to get last uploaded binlog: %v", err)
 	timeStart := utility.TimeNowCrossPlatformLocal()
 

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"os/exec"
 
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
-
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 
 	"github.com/wal-g/tracelog"
@@ -23,16 +21,10 @@ func HandleBackupPush(folder storage.Folder, uploader internal.UploaderProvider,
 	flavor, err := getMySQLFlavor(db)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	var binlogStart string
-	if flavor == gomysql.MySQLFlavor {
-		var gtidStart string
-		gtidStart, err = getMySQLGTIDExecuted(db, flavor)
-		tracelog.ErrorLogger.FatalOnError(err)
+	gtidStart, err := getMySQLGTIDExecuted(db, flavor)
+	tracelog.ErrorLogger.FatalOnError(err)
 
-		binlogStart, err = getLastUploadedBinlogBeforeGTID(folder, gtidStart, flavor)
-	} else {
-		binlogStart, err = getLastUploadedBinlog(folder)
-	}
+	binlogStart, err := getLastUploadedBinlogBeforeGTID(folder, gtidStart, flavor)
 	tracelog.ErrorLogger.FatalfOnError("failed to get last uploaded binlog: %v", err)
 	timeStart := utility.TimeNowCrossPlatformLocal()
 

--- a/internal/databases/mysql/binlog_find_handler.go
+++ b/internal/databases/mysql/binlog_find_handler.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 
@@ -13,11 +14,15 @@ func HandleBinlogFind(folder storage.Folder, gtid string) {
 	defer utility.LoggedClose(db, "")
 	flavor, err := getMySQLFlavor(db)
 	tracelog.ErrorLogger.FatalOnError(err)
+	var gtidSet gomysql.GTIDSet
 	if gtid == "" {
-		gtid, err = getMySQLGTIDExecuted(db, flavor)
+		gtidSet, err = getMySQLGTIDExecuted(db, flavor)
+		tracelog.ErrorLogger.FatalOnError(err)
+	} else {
+		gtidSet, err = gomysql.ParseGTIDSet(flavor, gtid)
 		tracelog.ErrorLogger.FatalOnError(err)
 	}
-	name, err := getLastUploadedBinlogBeforeGTID(folder, gtid, flavor)
+	name, err := getLastUploadedBinlogBeforeGTID(folder, gtidSet, flavor)
 	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.InfoLogger.Println(name)
 }

--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -90,7 +90,8 @@ func GetBinlogPreviousGTIDs(filename string, flavor string) (mysql.GTIDSet, erro
 			if err != nil {
 				return err
 			}
-			var _result = &mysql.MariadbGTIDSet{}
+			var _result = new(mysql.MariadbGTIDSet)
+			_result.Sets = make(map[uint32]*mysql.MariadbGTID) // there is no good constructor for MariadbGTIDSet
 			for _, gtid := range listEvent.GTIDs {
 				err = _result.AddSet(&gtid)
 				if err != nil {


### PR DESCRIPTION
### MaridDB
This patch fixes a regression in `backup-push` handler - now it works with MariaDB as well.

In addition fix MariaDB tests and adds MariaDB tests to the default github actions workflow, so we will not break it in future.


### Please provide steps to reproduce (if it's a bug)
Steps to reproduce:
* Setup MariaDB
* run `wal-g backup-push`
Following error raised:
```
ERROR: 2022/07/16 15:42:27.699160 failed to get last uploaded binlog: failed to parse server gtid: 0-1-4112: invalid GTID format, must UUID:interval[:interval]
```