### PR TITLE
Statically compile wal-g using docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ clean_mongo_features:
 	cd tests_func/ && MONGO_MAJOR=$(MONGO_MAJOR) MONGO_VERSION=$(MONGO_VERSION) go test -v -count=1  -timeout 5m -tf.test=false -tf.debug=false -tf.clean=true -tf.stop=true -tf.database=mongodb
 
 fdb_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_FDB_PATH) && go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -ldflags "-s -w -linkmode external -extldflags \"-static\"")
+	$(BUILD_CMD) go build -mod vendor -tags "$(BUILD_TAGS)" -o $(MAIN_FDB_PATH)/wal-g -ldflags "-s -w $(BUILD_LDFLAGS)")
+	$(BUILD_CMD) upx $(MAIN_FDB_PATH)/wal-g
 
 fdb_install: fdb_build
 	mv $(MAIN_FDB_PATH)/wal-g $(GOBIN)/wal-g

--- a/docker/fdb_tests/Dockerfile
+++ b/docker/fdb_tests/Dockerfile
@@ -2,8 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests
+RUN apk update && apk upgrade
 
 COPY go.mod go.mod
 COPY vendor/ vendor/

--- a/docker/golang/Dockerfile
+++ b/docker/golang/Dockerfile
@@ -1,12 +1,11 @@
-FROM golang:buster
+FROM golang:alpine
 
-ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm-256color
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests \
-    cmake && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add musl-dev bash git gcc make cmake curl upx 
+RUN git config --global --add safe.directory /app
+WORKDIR /app
 
 COPY submodules/ tmp/
 

--- a/docker/gp_tests/Dockerfile
+++ b/docker/gp_tests/Dockerfile
@@ -2,8 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests
+RUN apk update && apk upgrade
 
 COPY go.mod go.mod
 COPY vendor/ vendor/

--- a/docker/mariadb_tests/Dockerfile
+++ b/docker/mariadb_tests/Dockerfile
@@ -2,8 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests
+RUN apk update && apk upgrade
 
 COPY go.mod go.mod
 COPY vendor/ vendor/

--- a/docker/mysql_tests/Dockerfile
+++ b/docker/mysql_tests/Dockerfile
@@ -2,8 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests
+RUN apk update && apk upgrade
 
 COPY go.mod go.mod
 COPY vendor/ vendor/

--- a/docker/mysql_tests/Dockerfile_base
+++ b/docker/mysql_tests/Dockerfile_base
@@ -2,8 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests
+RUN apk update && apk upgrade
 
 COPY go.mod go.mod
 COPY vendor/ vendor/
@@ -16,7 +15,7 @@ COPY utility/ utility/
 RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
         vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
     cd main/mysql && \
-    go build -mod vendor -tags brotli -race -o wal-g -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+    go build -mod vendor -tags brotli -race -o wal-g -ldflags "-s -w -linkmode external -extldflags \"-static\" -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
 
 FROM wal-g/mysql:latest
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin

--- a/docker/mysql_tests/Dockerfile_copy
+++ b/docker/mysql_tests/Dockerfile_copy
@@ -2,8 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests
+RUN apk update && apk upgrade
 
 COPY go.mod go.mod
 COPY vendor/ vendor/

--- a/docker/mysql_tests/Dockerfile_delete
+++ b/docker/mysql_tests/Dockerfile_delete
@@ -2,8 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests
+RUN apk update && apk upgrade
 
 COPY go.mod go.mod
 COPY vendor/ vendor/

--- a/docker/pg_tests/Dockerfile_prefix
+++ b/docker/pg_tests/Dockerfile_prefix
@@ -2,9 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests \
-    liblzo2-dev
+RUN apk update && apk upgrade && apk add lzo-dev
 
 COPY go.mod go.mod
 COPY vendor/ vendor/

--- a/docker/redis_tests/Dockerfile
+++ b/docker/redis_tests/Dockerfile
@@ -2,8 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests
+RUN apk update && apk upgrade
 
 COPY go.mod go.mod
 COPY vendor/ vendor/

--- a/docker/st_tests/Dockerfile
+++ b/docker/st_tests/Dockerfile
@@ -2,9 +2,7 @@ FROM wal-g/golang:latest as build
 
 WORKDIR /go/src/github.com/wal-g/wal-g
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends --no-install-suggests \
-    liblzo2-dev
+RUN apk update && apk update && apk add lzo-dev
 
 RUN ls
 


### PR DESCRIPTION
### Database name

All databases! 🙂 

# Pull request description

This PR allows compiling a statically-linked wal-g binary, compresses the binary using `upx`, and changes the `wal-g/golang` Dockerfile to Alpine Linux. All binaries are now smaller (10-12MB instead of >40MB). The static binary has the important advantage over the normal binary in that it can be used on any Linux system without recompilation.

The static build is not the new default (you can still compile dynamically-linked binaries as before). To compile a statically linked wal-g, set `export USE_STATIC_BUILD=1` before compiling:

```bash
# compile a statically linked binary for MySQL
export USE_LIBSODIUM=1
export USE_STATIC_BUILD=1
docker build -t wal-g/golang -f docker/golang/Dockerfile .
make deps
make mysql_build
```

### Describe what this PR fix

Currently wal-g binaries are not portable between different Linux distributions or versions because it relies on linking against libsodium and brotli. By statically linking instead, the resulting binary can be used on any Linux system. Fixes https://github.com/wal-g/wal-g/issues/300.

### Known issues

WAL-G linked against musl's libc will fail to read users managed by services like FreeIPA/sssd/GCP OSLogin. This is because musl doesn't properly support NSS. Running wal-g with a user created by sssd/OSLogin/etc. will result in the error below:

```
$ wal-g backup-list
ERROR: 2022/07/14 17:16:17.325247 user: unknown userid 1092191234
```

However I ultimately feel this error is a non-issue: you're usually going to be using sudo to execute wal-g as a local UNIX user anyways (and these work just fine). 

Credit for this PR mostly goes to @halsbox who came up with the idea to do this here: https://github.com/wal-g/wal-g/issues/300#issuecomment-1166289794

I've only really tested this for the MySQL build.