### PR TITLE
Allow point-in-time-restores of MySQL servers with encrypted binlogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ tmp/
 *.xml
 *.iml
 *.so
+*.pprof
+*.pdf
 .session_conf.sav
 __pycache__/
 venv/

--- a/cmd/mysql/binlog_push.go
+++ b/cmd/mysql/binlog_push.go
@@ -20,7 +20,9 @@ var binlogPushCmd = &cobra.Command{
 		uploader, err := internal.ConfigureUploader()
 		tracelog.ErrorLogger.FatalOnError(err)
 		checkGTIDs, _ := internal.GetBoolSettingDefault(internal.MysqlCheckGTIDs, false)
-		mysql.HandleBinlogPush(uploader, untilBinlog, checkGTIDs)
+		readFromRemoteServer, _ := internal.GetBoolSettingDefault(
+			internal.MysqlBinlogReadFromRemoteServer, false)
+		mysql.HandleBinlogPush(uploader, untilBinlog, checkGTIDs, readFromRemoteServer)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
 		internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -48,6 +48,11 @@ Configuration
   (created by `WALG_STREAM_CREATE_COMMAND`) to STDIN and unpack it to MySQL datadir.
 Required.
 
+* `WALG_STREAM_SPLITTER_PARTITIONS` and `WALG_STREAM_SPLITTER_BLOCK_SIZE` - Splits the
+  backup stream into `WALG_STREAM_SPLITTER_PARTITIONS` different output streams in blocks
+  of `WALG_STREAM_SPLITTER_BLOCK_SIZE` bytes. Each stream is uploaded separately. Using
+  multiple backup streams significantly improve restore performance. Optional. 
+
 * `WALG_MYSQL_BACKUP_PREPARE_COMMAND` - Command to prepare MySQL backup after restoring.
   Needed for xtrabackup. Optional.
 
@@ -70,11 +75,6 @@ Required.
 are taken from the same host, this variable should be left False (default).
 
 > **Operations with binlogs**: If you'd like to do binlog operations with wal-g don't forget to [activate the binary log](https://mariadb.com/kb/en/activating-the-binary-log/) by starting mysql/mariadb with [--log-bin](https://mariadb.com/kb/en/replication-and-binary-log-server-system-variables/#log_bin) and [--log-basename](https://mariadb.com/kb/en/mysqld-options/#-log-basename)=\[name\].
-
-* `WALG_STREAM_SPLITTER_PARTITIONS` and `WALG_STREAM_SPLITTER_BLOCK_SIZE` - Splits the
-  backup stream into `WALG_STREAM_SPLITTER_PARTITIONS` different output streams in blocks
-  of `WALG_STREAM_SPLITTER_BLOCK_SIZE` bytes. Each stream is uploaded separately. Using
-  multiple backup streams significantly improve restore performance. Optional. 
 
 Usage
 -----

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -1,18 +1,18 @@
 # WAL-G for MySQL
 
-**Interface of MySQL and MariaDB now is unstable**
-
 You can use wal-g as a tool for encrypting, compressing MySQL backups and push/fetch them to/from storage without saving it on your filesystem.
 
 Development
 -----------
 ### Installing
+
 To compile and build the binary for MySQL:
 
 Optional:
 
-- To build with libsodium, just set `USE_LIBSODIUM` environment variable.
-- To build with lzo decompressor, just set `USE_LZO` environment variable.
+* To build with libsodium, just set `USE_LIBSODIUM` environment variable.
+* To build with lzo decompressor, just set `USE_LZO` environment variable.
+
 ```plaintext
 go get github.com/wal-g/wal-g
 cd $GOPATH/src/github.com/wal-g/wal-g
@@ -20,7 +20,9 @@ make install
 make deps
 make mysql_build
 ```
+
 Users can also install WAL-G by using `make install`. Specifying the GOBIN environment variable before installing allows the user to specify the installation location. On default, `make install` puts the compiled binary in `go/bin`.
+
 ```plaintext
 export GOBIN=/usr/local/bin
 cd $GOPATH/src/github.com/wal-g/wal-g
@@ -32,42 +34,47 @@ make mysql_install
 Configuration
 -------------
 
-* `WALG_MYSQL_DATASOURCE_NAME`
+* `WALG_MYSQL_DATASOURCE_NAME` - Configure the connection string for MySQL. Required.
+  Format `user:password@host/dbname` (use
+  `user:password@unix(/path/to/socket.sock)/dbname` to connect via UNIX socket).
 
-To configure the connection string for MySQL. Required. Format ```user:password@host/dbname```
+* `WALG_MYSQL_SSL_CA` - If connecting to MySQL using SSL, this variable should be set to a
+  path to file with CA certificates.
 
-* `WALG_MYSQL_SSL_CA`
+* `WALG_STREAM_CREATE_COMMAND` - Command to create MySQL backup, should return backup as
+  single stream to STDOUT. Requried.
 
-To use SSL, a path to file with certificates should be set to this variable.
+* `WALG_STREAM_RESTORE_COMMAND` - Command to unpack MySQL backup, should take backup
+  (created by `WALG_STREAM_CREATE_COMMAND`) to STDIN and unpack it to MySQL datadir.
+Required.
 
-*  `WALG_STREAM_CREATE_COMMAND`
+* `WALG_MYSQL_BACKUP_PREPARE_COMMAND` - Command to prepare MySQL backup after restoring.
+  Needed for xtrabackup. Optional.
 
-Command to create MySQL backup, should return backup as single stream to STDOUT. Requried.
+* `WALG_MYSQL_BINLOG_REPLAY_COMMAND` - Command to replay binlog on runing MySQL. Required
+  for binlog-fetch command.
 
-*  `WALG_STREAM_RESTORE_COMMAND`
+* `WALG_MYSQL_BINLOG_DST` - Which directory should be used to store binlogs during
+  binlog-fetch or binlog-replay.
 
-Command to unpack MySQL backup, should take backup (created by `WALG_STREAM_CREATE_COMMAND`) 
-to STDIN and unpack it to MySQL datadir. Required.
+* `WALG_MYSQL_BINLOG_READ_FROM_REMOTE_SERVER` - When this is enabled, wal-g will connect
+  to the server at `WALG_MYSQL_DATASOURCE_NAME` and read binary logs directly from MySQL
+  as if wal-g was a replica server. This option is equivalent to backing up binary logs
+  using `mysqlbinlog --raw --read-from-remote-server`.  Set this to true if you have are
+  using binary log encryption-at-rest (and also make sure you have configured [WAL-G's
+  encryption](https://github.com/wal-g/wal-g#encryption)), otherwise leave false (default).
+  Optional.
 
-* `WALG_MYSQL_BACKUP_PREPARE_COMMAND`
-
-Command to prepare MySQL backup after restoring. Optional. Needed for xtrabackup case.
-
-* `WALG_MYSQL_BINLOG_REPLAY_COMMAND`
-
-Command to replay binlog on runing MySQL. Required for binlog-fetch command.
-
-* `WALG_MYSQL_BINLOG_DST`
-
-To place binlogs in the specified directory during binlog-fetch or binlog-replay
-
-* `WALG_MYSQL_TAKE_BINLOGS_FROM_MASTER`
-
-Set this variable to True if you are planning to take base backup from replica and binlog backup from master.
-If base and binlogs backups are taken from the same host, this variable should be left False (default).
+* `WALG_MYSQL_TAKE_BINLOGS_FROM_MASTER` - Set this variable to True if you are planning to
+  take base backup from replica and binlog backup from master. If base and binlogs backups
+are taken from the same host, this variable should be left False (default).
 
 > **Operations with binlogs**: If you'd like to do binlog operations with wal-g don't forget to [activate the binary log](https://mariadb.com/kb/en/activating-the-binary-log/) by starting mysql/mariadb with [--log-bin](https://mariadb.com/kb/en/replication-and-binary-log-server-system-variables/#log_bin) and [--log-basename](https://mariadb.com/kb/en/mysqld-options/#-log-basename)=\[name\].
 
+* `WALG_STREAM_SPLITTER_PARTITIONS` and `WALG_STREAM_SPLITTER_BLOCK_SIZE` - Splits the
+  backup stream into `WALG_STREAM_SPLITTER_PARTITIONS` different output streams in blocks
+  of `WALG_STREAM_SPLITTER_BLOCK_SIZE` bytes. Each stream is uploaded separately. Using
+  multiple backup streams significantly improve restore performance. Optional. 
 
 Usage
 -----
@@ -103,7 +110,7 @@ wal-g backup-fetch example_backup
 WAL-G can also fetch the latest backup using:
 
 ```bash
-wal-g backup-fetch  LATEST
+wal-g backup-fetch LATEST
 ```
 
 ### ``binlog-push``
@@ -114,12 +121,12 @@ Sends (not yet archived) binlogs to storage. Typically run in CRON.
 wal-g binlog-push
 ```
 
-
-When `WALG_MYSQL_CHECK_GTIDS` is set wal-g will try to be upload only binlogs which GTID sets contains events that
-wasn't seen before. This is done by parsing binlogs and peeking first PREVIOUS_GTIDS_EVENT that holds GTID set of
-all executed transactions at the moment this particular binlog file created.
-This feature may be useful when you are uploading binlogs from different hosts (e.g. after master switchower)
-Note: Don't use `WALG_MYSQL_CHECK_GTIDS` when GTIDs are not used - it will slow down binlog upload.
+When `WALG_MYSQL_CHECK_GTIDS` is set wal-g will try to be upload only binlogs which GTID
+sets contains events that wasn't seen before. This is done by parsing binlogs and peeking
+first PREVIOUS_GTIDS_EVENT that holds GTID set of all executed transactions at the moment
+this particular binlog file created. This feature may be useful when you are uploading
+binlogs from different hosts (e.g. after master switchower). Note: Don't use
+`WALG_MYSQL_CHECK_GTIDS` when GTIDs are not used - it will slow down binlog upload.
 
 ### ``binlog-fetch``
 
@@ -183,20 +190,21 @@ Typical configurations
 
 It's recommended to use wal-g with xtrabackup tool in case of MySQL for creating lock-less backups.
 Here's typical wal-g configuration for that case:
+
 ```bash
- WALG_MYSQL_DATASOURCE_NAME=user:pass@tcp(localhost:3306)/mysql                                                                                                                                      
- WALG_STREAM_CREATE_COMMAND="xtrabackup --backup --stream=xbstream --datadir=/var/lib/mysql"                                                                                                                               
- WALG_STREAM_RESTORE_COMMAND="xbstream -x -C /var/lib/mysql"                                                                                                                       
- WALG_MYSQL_BACKUP_PREPARE_COMMAND="xtrabackup --prepare --target-dir=/var/lib/mysql"                                                                                              
- WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
+WALG_MYSQL_DATASOURCE_NAME=user:pass@tcp(localhost:3306)/mysql
+WALG_STREAM_CREATE_COMMAND="xtrabackup --backup --stream=xbstream --datadir=/var/lib/mysql"
+WALG_STREAM_RESTORE_COMMAND="xbstream -x -C /var/lib/mysql"
+WALG_MYSQL_BACKUP_PREPARE_COMMAND="xtrabackup --prepare --target-dir=/var/lib/mysql"
+WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
 ```
 
 Restore procedure is a bit tricky:
 * stop mysql
-* clean a datadir (typically `/var/lib/mysql`)
+* remove all files in the MySQL datadir (typically `/var/lib/mysql`)
 * fetch and prepare desired backup using `wal-g backup-fetch "backup_name"`
 * start mysql
-* in case of you have replication and GTID enabled: set mysql GTID_PURGED variable to value from `/var/lib/mysql/xtrabackup_binlog_info`, using
+* in case you have replication and GTID enabled: set mysql GTID_PURGED variable to value from `/var/lib/mysql/xtrabackup_binlog_info`, using
 ```bash
 gtids=$(tr -d '\n' < /var/lib/mysql/xtrabackup_binlog_info | awk '{print $3}')
 mysql -e "RESET MASTER; SET @@GLOBAL.GTID_PURGED='$gtids';"
@@ -206,35 +214,91 @@ mysql -e "RESET MASTER; SET @@GLOBAL.GTID_PURGED='$gtids';"
 wal-g binlog-replay --since "backup_name" --until "2006-01-02T15:04:05Z07:00"
 ```
 
-### MySQL - using with `mysqldump`
+### MySQL - using `xtrabackup` with InnoDB encryption-at-rest and binary log encryption
 
+Percona Server 5.7+ and MySQL 8.0 support encryption-at-rest of both MySQL tablespaces as
+well as binary logs. WAL-G is capable of backing up and restoring this encrypted data using
+transition keys.
 
-It's possible to use wal-g with standard mysqldump/mysql tools.
-In that case MySQL mysql backup is a plain SQL script.
-Here's typical wal-g configuration for that case:
+To understand how restores work, it is important to understand how MySQL encrypts tables:
+
+* Each tablespace (typically corresponding to one table) is stored as a single file on disk.
+* Each tablespace file has a header containing the encryption key for the rest of the
+  data.
+* This header is encrypted using a master encryption key stored in a keyring.
+
+When we backup an encrypted table using a transition key, `xtrabackup` re-encrypts the
+tablespace headers with the transition key (instead of the master encryption key),
+making the backup no longer depend on the presence of the keyring for a successful
+restore. When restoring an encrypted backup, `xtrabackup` generates a new encryption key
+during the `--move-back`/`--copy-back` step. This allows MySQL to perform backups and
+restores without spending hours re-encrypting all of the data (only the master
+encryption key is changed, the actual encryption keys used to encrypt your MySQL data are
+not rotated).
+
+If you are using MySQL binary log encryption, these are encrypted in a similar manner:
+each binary log file has its own encryption key encrypted by the server's master key.
+Unfortunately, `mysqlbinlog` is incapable of using MySQL's keyring plugins and cannot
+decrypt binlogs making point-in-time-restores using encrypted binlogs impossible. As a
+workaround, you can set `WALG_MYSQL_BINLOG_READ_FROM_REMOTE_SERVER=true` to have wal-g
+archive unencrypted binary logs instead (the "unencrypted" binary logs are still encrypted
+by WAL-G before remote storage using the same encryption settings as normal WAL-G backups).
+When `WALG_MYSQL_BINLOG_READ_FROM_REMOTE_SERVER` is set, WAL-G connects to MySQL as if it
+was a replica server and encrypts+streams the binary log directly to cloud storage without
+the unencrypted binary log being stored to disk.
+
+Taken together, this procedure allows you to perform point-in-time-recovery of encrypted
+MySQL databases even if the master keyring has been lost or corrupted (keep your
+transition key safe, however!). For more reading, see 
+https://docs.percona.com/percona-xtrabackup/2.4/advanced/encrypted_innodb_tablespace_backups.html#restoring-backup-when-keyring-is-not-available
+
+This is an example config for backups and restores of encrypted tables and binary logs,
+using the `keyring_file` plugin as an example (please don't use `hunter2` as your
+transition key): 
 
 ```bash
- WALG_MYSQL_DATASOURCE_NAME=user:pass@localhost/mysql                                                                                                               
- WALG_STREAM_CREATE_COMMAND="mysqldump --all-databases --single-transaction --set-gtid-purged=ON"                                                                                                                               
- WALG_STREAM_RESTORE_COMMAND="mysql"
- WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
+# make sure you are encrypting backups using libsodium/pgp/etc.
+WALG_LIBSODIUM_KEY_PATH=/path/to/your/libsodium/key
+# make sure you connect over tls in the datasource config if using a tcp connection
+WALG_MYSQL_DATASOURCE_NAME=user:pass@unix(/path/to/socket.sock)/mysql
+WALG_STREAM_CREATE_COMMAND="xtrabackup --backup --stream=xbstream --datadir=/var/lib/mysql --transition-key=hunter2"
+WALG_STREAM_RESTORE_COMMAND="xbstream -x -C /var/lib/mysql-restore"
+WALG_MYSQL_BACKUP_PREPARE_COMMAND="xtrabackup --prepare --target-dir=/var/lib/mysql-restore --transition-key=hunter2 && xtrabackup --move-back --target-dir=/var/lib/mysql-restore --datadir=/var/lib/mysql --transition-key=hunter2 --generate-new-master-key --keyring-file-data=/path/to/mysql/keyring"
+WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
+WALG_MYSQL_BINLOG_READ_FROM_REMOTE_SERVER=true
+```
+
+With this configuration, backup and restores are otherwise identical to the normal
+`xtrabackup` instructions above (the `/var/lib/mysql-restore/` directory must exist
+beforehand however).
+
+### MySQL - using `mysqldump`
+
+It's possible to use wal-g with standard mysqldump/mysql tools. In that case the MySQL
+mysql backup is a plain SQL script. Here's a typical wal-g configuration for that use case:
+
+```bash
+WALG_MYSQL_DATASOURCE_NAME=user:pass@localhost/mysql
+WALG_STREAM_CREATE_COMMAND="mysqldump --all-databases --single-transaction --set-gtid-purged=ON"
+WALG_STREAM_RESTORE_COMMAND="mysql"
+WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
 ```
 
 Restore procedure is straightforward:
 * start mysql (it's recommended to create new mysql instance)
 * fetch and apply desired backup using `wal-g backup-fetch "backup_name"`
 
-
-### MariaDB - using with `mariabackup`
+### MariaDB - using `mariabackup`
 
 It's recommended to use wal-g with `mariabackup` tool in case of MariaDB for creating lock-less backups.
-Here's typical wal-g configuration for that case:
+Here's a typical wal-g configuration for that use case:
+
 ```bash
- WALG_MYSQL_DATASOURCE_NAME=user:pass@tcp(localhost:3305)/mysql                                                                                                                                      
- WALG_STREAM_CREATE_COMMAND="mariabackup --backup --stream=xbstream --datadir=/var/lib/mysql"                                                                                                                               
- WALG_STREAM_RESTORE_COMMAND="mbstream -x -C /var/lib/mysql"                                                                                                                       
- WALG_MYSQL_BACKUP_PREPARE_COMMAND="mariabackup --prepare --target-dir=/var/lib/mysql"                                                                                              
- WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
+WALG_MYSQL_DATASOURCE_NAME=user:pass@tcp(localhost:3305)/mysql
+WALG_STREAM_CREATE_COMMAND="mariabackup --backup --stream=xbstream --datadir=/var/lib/mysql"
+WALG_STREAM_RESTORE_COMMAND="mbstream -x -C /var/lib/mysql"
+WALG_MYSQL_BACKUP_PREPARE_COMMAND="mariabackup --prepare --target-dir=/var/lib/mysql"
+WALG_MYSQL_BINLOG_REPLAY_COMMAND='mysqlbinlog --stop-datetime="$WALG_MYSQL_BINLOG_END_TS" "$WALG_MYSQL_CURRENT_BINLOG" | mysql'
 ```
 
 For the restore procedure you have to do similar things to [what the offical docs says about full backup and restore](https://mariadb.com/kb/en/full-backup-and-restore-with-mariabackup/):
@@ -252,3 +316,4 @@ wal-g binlog-replay --since "backup_name" --until "2006-01-02T15:04:05Z07:00"
 ### MariaDB - using with `mysqldump`
 
 The procedure is same as in case of [MySQL. You can follow the instructions from the previous section.](#mysql---using-with-mysqldump)
+

--- a/internal/config.go
+++ b/internal/config.go
@@ -104,13 +104,14 @@ const (
 	OplogReplayOplogApplicationMode = "OPLOG_REPLAY_OPLOG_APPLICATION_MODE"
 	OplogReplayIgnoreErrorCodes     = "OPLOG_REPLAY_IGNORE_ERROR_CODES"
 
-	MysqlDatasourceNameSetting = "WALG_MYSQL_DATASOURCE_NAME"
-	MysqlSslCaSetting          = "WALG_MYSQL_SSL_CA"
-	MysqlBinlogReplayCmd       = "WALG_MYSQL_BINLOG_REPLAY_COMMAND"
-	MysqlBinlogDstSetting      = "WALG_MYSQL_BINLOG_DST"
-	MysqlBackupPrepareCmd      = "WALG_MYSQL_BACKUP_PREPARE_COMMAND"
-	MysqlTakeBinlogsFromMaster = "WALG_MYSQL_TAKE_BINLOGS_FROM_MASTER"
-	MysqlCheckGTIDs            = "WALG_MYSQL_CHECK_GTIDS"
+	MysqlDatasourceNameSetting      = "WALG_MYSQL_DATASOURCE_NAME"
+	MysqlSslCaSetting               = "WALG_MYSQL_SSL_CA"
+	MysqlBinlogReadFromRemoteServer = "WALG_MYSQL_BINLOG_READ_FROM_REMOTE_SERVER"
+	MysqlBinlogReplayCmd            = "WALG_MYSQL_BINLOG_REPLAY_COMMAND"
+	MysqlBinlogDstSetting           = "WALG_MYSQL_BINLOG_DST"
+	MysqlBackupPrepareCmd           = "WALG_MYSQL_BACKUP_PREPARE_COMMAND"
+	MysqlTakeBinlogsFromMaster      = "WALG_MYSQL_TAKE_BINLOGS_FROM_MASTER"
+	MysqlCheckGTIDs                 = "WALG_MYSQL_CHECK_GTIDS"
 
 	RedisPassword = "WALG_REDIS_PASSWORD"
 
@@ -386,15 +387,16 @@ var (
 
 	MysqlAllowedSettings = map[string]bool{
 		// MySQL
-		MysqlDatasourceNameSetting: true,
-		MysqlSslCaSetting:          true,
-		MysqlBinlogReplayCmd:       true,
-		MysqlBinlogDstSetting:      true,
-		MysqlBackupPrepareCmd:      true,
-		MysqlTakeBinlogsFromMaster: true,
-		MysqlCheckGTIDs:            true,
-		StreamSplitterPartitions:   true,
-		StreamSplitterBlockSize:    true,
+		MysqlDatasourceNameSetting:      true,
+		MysqlSslCaSetting:               true,
+		MysqlBinlogReadFromRemoteServer: true,
+		MysqlBinlogReplayCmd:            true,
+		MysqlBinlogDstSetting:           true,
+		MysqlBackupPrepareCmd:           true,
+		MysqlTakeBinlogsFromMaster:      true,
+		MysqlCheckGTIDs:                 true,
+		StreamSplitterPartitions:        true,
+		StreamSplitterBlockSize:         true,
 	}
 
 	RedisAllowedSettings = map[string]bool{

--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -2,6 +2,10 @@ package mysql
 
 import (
 	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,7 +16,9 @@ import (
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
+	mysqlDriver "github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
+	"github.com/siddontang/go-log/log"
 	"github.com/wal-g/tracelog"
 
 	"github.com/wal-g/wal-g/internal"
@@ -159,4 +165,152 @@ func BinlogPrefix(filename string) string {
 		tracelog.ErrorLogger.Panicf("unexpected binlog name: %v", filename)
 	}
 	return filename[:p]
+}
+
+// BinlogStream is a replication.BinlogSyncer masquerading as an io.Reader.
+// We use it to extract a raw binary log from the server.
+type BinlogStream struct {
+	replication.BinlogSyncer
+	replication.BinlogStreamer
+
+	hasStarted    bool
+	lastData      []byte
+	lastOffset    uint32
+	lastEventSize uint32
+}
+
+// GetBinlogSyncerConfig parses apart walg_mysql_datasource_name into the format
+// that replication.BinlogSyncer wants
+func GetBinlogSyncerConfig(datasource string, flavor string) (*replication.BinlogSyncerConfig, error) {
+	driverConfig, err := mysqlDriver.ParseDSN(datasource)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &replication.BinlogSyncerConfig{
+		Host:           driverConfig.Addr,
+		User:           driverConfig.User,
+		Password:       driverConfig.Passwd,
+		ServerID:       99991, // we pretend to be a replication server with this ID
+		Flavor:         flavor,
+		RawModeEnabled: true,
+	}
+
+	// if you specify a CA cert in the wal-g settings, it should act like we
+	// specified "&tls=custom"
+	caFile, ok := internal.GetSetting(internal.MysqlSslCaSetting)
+	if ok {
+		driverConfig.TLSConfig = "custom"
+	}
+
+	switch driverConfig.TLSConfig {
+	case "true":
+		cfg.TLSConfig = &tls.Config{}
+	case "skip-verify":
+		cfg.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	case "custom":
+		rootCertPool := x509.NewCertPool()
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, err
+		}
+		if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+			return nil, fmt.Errorf("failed to load certificate from %s", caFile)
+		}
+		cfg.TLSConfig = &tls.Config{RootCAs: rootCertPool}
+	}
+
+	return cfg, err
+}
+
+// NewBinlogStream begins retrieval of a raw binary log from the MySQL server
+func NewBinlogStream(db *sql.DB, binlog string) (*BinlogStream, error) {
+	flavor, err := getMySQLFlavor(db)
+	if err != nil {
+		return nil, err
+	}
+
+	datasourceName, err := internal.GetRequiredSetting(internal.MysqlDatasourceNameSetting)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := GetBinlogSyncerConfig(datasourceName, flavor)
+	if err != nil {
+		return nil, err
+	}
+
+	// the go-mysql integrated logging library is super noisy
+	log.SetLevel(log.LevelError)
+	stream := BinlogStream{BinlogSyncer: *replication.NewBinlogSyncer(*cfg)}
+
+	// even if server is using GTIDs we want a specific file at offset 0
+	// (we're trying to sync this specific binlog file)
+	streamer, err := stream.StartSync(mysql.Position{Name: binlog, Pos: 0})
+	if err != nil {
+		return nil, err
+	}
+	stream.BinlogStreamer = *streamer
+	return &stream, nil
+}
+
+// Read converts the per-event output from BinlogStreamer.GetEvent() to the []byte
+// output expected by the io.Reader interface.
+func (b *BinlogStream) Read(p []byte) (int, error) {
+	if b.lastData == nil {
+		// no existing data left from a prior binlog event, read next event
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		event, err := b.GetEvent(ctx)
+		cancel()
+		if err != nil {
+			return 0, err
+		}
+
+		// handle special event types
+		switch event.Header.EventType {
+		case replication.ROTATE_EVENT:
+			if event.Header.Timestamp == 0 || event.Header.LogPos == 0 {
+				// fake rotate event, ignore
+				return 0, nil
+			}
+		case replication.HEARTBEAT_EVENT:
+			// heartbeat events aren't "real data" according to
+			// https://dev.mysql.com/doc/internals/en/heartbeat-event.html
+			// and break mysqlbinlog, ignore
+			return 0, nil
+		case replication.FORMAT_DESCRIPTION_EVENT:
+			// beginning of binlog
+			if b.hasStarted {
+				// we are now reading binlog #2, stop.
+				return 0, io.EOF
+			}
+			// start the stream by writing the binlog header
+			b.hasStarted = true
+			b.lastData = event.RawData
+			return copy(p, replication.BinLogFileHeader), nil
+		}
+
+		n := copy(p, event.RawData)
+		if event.Header.EventSize > uint32(n) {
+			// the event is larger than the buffer allocated by read,
+			// so we need to save the leftovers for next Read()
+			b.lastData = event.RawData
+			b.lastOffset = uint32(n - 1)
+			b.lastEventSize = event.Header.EventSize
+		}
+		return n, nil
+	}
+
+	// prior event has leftover data that we need to finish
+	n := copy(p, b.lastData[b.lastOffset:])
+	if b.lastOffset+uint32(n) >= b.lastEventSize {
+		// we have now finished writing prior data
+		b.lastOffset = 0
+		b.lastData = nil
+	} else {
+		// still not done with last event,
+		// increment the offset up by however many bytes we just read
+		b.lastOffset += uint32(n)
+	}
+	return n, nil
 }


### PR DESCRIPTION
### Database name

MySQL

# Pull request description

### Describe what this PR fixes

`mysqlbinlog` cannot use MySQL keyring plugins, which makes it impossible for it to read encrypted MySQL binary logs (using either `encrypt_binlog=ON` in Percona Server 5.7 or `binlog_encryption=ON` in MySQL 8.0). Though there's a python script out there that can decrypt binary logs created by MySQL 8.0, no tools are available to decrypt binlogs created by Percona Server 5.7 (or early versions of Percona Server 8.0). Since mysqlbinlog cannot decrypt encrypted binlogs on its own, there's currently no way to use WAL-G perform a point-in-time-restore if the MySQL server is using encrypted binlogs.

However, there is a workaround: MySQL servers using binlog encryption send the decrypted binlog  to their replicas as part of MySQL replication. Likewise `mysqlbinlog --raw --read-from-remote-server` also fetches the decrypted binlog from an active server (the catch is that it saves the decrypted binlog to the working directory). This PR adds the ability to have WAL-G directly read unencrypted MySQL binlogs from a remote server the same way `mysqlbinlog --raw --read-from-remote-server` does without saving it to disk (the binary log still gets encrypted by WAL-G before sending it to cloud storage). The new option to read decrypted binary logs from the server is `WALG_MYSQL_BINLOG_READ_FROM_REMOTE_SERVER`. This lets us perform PITR restores for MySQL servers with encrypted binlogs as normal.

I also did a general documentation update for MySQL and documented how to perform backup and restores of encrypted tables as well as use the new `WALG_STREAM_SPLITTER_PARTITIONS` feature.

### Please provide steps to test this PR

Try encrypting some tables with your favorite MySQL keyring plugin (`keyring_file` is the easiest to setup) and use the documentation in this PR to perform a backup and restore of those encrypted tables. You can try deleting the keyring file after taking a backup to prove that the instructions still work even if the original keyring has been lost.

I have personally tested this on MySQL 8.0 and Percona Server 5.7.
