### PR TITLE
PostgreSQL 15 Support

### DIFF
--- a/internal/databases/postgres/queryRunner_test.go
+++ b/internal/databases/postgres/queryRunner_test.go
@@ -29,6 +29,10 @@ func TestBuildStartBackup(t *testing.T) {
 	queryBuilder.Version = 100000
 	queryString, err = queryBuilder.BuildStartBackup()
 	assert.Equal(t, "SELECT case when pg_is_in_recovery() then '' else (pg_walfile_name_offset(lsn)).file_name end, lsn::text, pg_is_in_recovery() FROM pg_start_backup($1, true, false) lsn", queryString)
+
+	queryBuilder.Version = 150000
+	queryString, err = queryBuilder.BuildStartBackup()
+	assert.Equal(t, "SELECT case when pg_is_in_recovery() then '' else (pg_walfile_name_offset(lsn)).file_name end, lsn::text, pg_is_in_recovery() FROM pg_backup_start($1, true) lsn", queryString)
 }
 
 // Tests building stop backup query
@@ -52,4 +56,8 @@ func TestBuildStopBackup(t *testing.T) {
 	queryBuilder.Version = 100000
 	queryString, err = queryBuilder.BuildStopBackup()
 	assert.Equal(t, "SELECT labelfile, spcmapfile, lsn FROM pg_stop_backup(false)", queryString)
+
+	queryBuilder.Version = 150000
+	queryString, err = queryBuilder.BuildStopBackup()
+	assert.Equal(t, "SELECT labelfile, spcmapfile, lsn FROM pg_backup_stop(false)", queryString)
 }


### PR DESCRIPTION
### Database name

PostgreSQL

# Pull request description

PostgreSQL 15 Support

### Describe what this PR fixes

Fixes #1273; the `pg_start_backup` and `pg_stop_backup` functions have been renamed to `pg_backup_start` and `pg_backup_stop`, respectively, in [PostgreSQL 15](https://www.postgresql.org/docs/15/release-15.html):

> Remove long-deprecated exclusive backup mode (David Steele, Nathan Bossart)
>
> If the database server stops abruptly while in this mode, the server could fail to start. The non-exclusive backup mode requires a continuous database connection during the backup. Functions `pg_start_backup()`/`pg_stop_backup()` have been renamed to `pg_backup_start()`/`pg_backup_stop()`, and the functions `pg_backup_start_time()` and `pg_is_in_backup()` have been removed.


### Please provide steps to reproduce

When using PostgreSQL 15, `wal-g` will produce an error when trying to use the `backup-push` command because there's no `pg_start_backup` function:

```
ERROR: 2022/07/26 17:18:46.520295 QueryRunner StartBackup: pg_start_backup() failed: ERROR: function pg_start_backup(unknown, boolean, boolean) does not exist (SQLSTATE 42883)
```

This was encountered in our `wal-g` RPM build pipeline for CentOS 9 using PostgreSQL 15 beta 2 (refs radiant-maxar/geoint-deps#59). More specifically, here's the relevant [build portion of our `wal-g.spec`](https://github.com/radiant-maxar/geoint-deps/blob/5e11051cfb1db7ac7b859a31f6e8b14848c0f642/SPECS/el9/wal-g.spec#L34-L44) and [the `Dockerfile`](https://github.com/radiant-maxar/geoint-deps/blob/5e11051cfb1db7ac7b859a31f6e8b14848c0f642/docker/el9/Dockerfile.rpmbuild-go) used to create it.