### PR TITLE
Remove redundant check for --without-files-metadata flag

### DIFF
--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -72,10 +72,10 @@ var (
 						"%s option cannot be used with non-regular tar ball composer",
 						withoutFilesMetadataFlag)
 				}
-				if deltaFromName != "" || deltaFromUserData != "" || userDataRaw != "" {
+				if deltaFromName != "" || deltaFromUserData != "" {
 					tracelog.ErrorLogger.Fatalf(
-						"%s option cannot be used with %s, %s, %s options",
-						withoutFilesMetadataFlag, deltaFromNameFlag, deltaFromUserDataFlag, addUserDataFlag)
+						"%s option cannot be used with %s, %s options",
+						withoutFilesMetadataFlag, deltaFromNameFlag, deltaFromUserDataFlag)
 				}
 				tracelog.InfoLogger.Print("Files metadata tracking is disabled")
 				fullBackup = true


### PR DESCRIPTION
Removes unnecessary check for user data. It can be safely included in the backup, because it is stored in the backup sentinel, not the files metadata.
