### PR TITLE
Add warning output on backup-fetch retries

### DIFF
--- a/internal/extract.go
+++ b/internal/extract.go
@@ -164,6 +164,8 @@ func ExtractAllWithSleeper(tarInterpreter TarInterpreter, files []ReaderMaker, s
 		}
 		currentRun = failed
 		if len(failed) > 0 {
+			tracelog.WarningLogger.Printf("%d files failed to download: %s. Going to sleep and retry downloading them.\n",
+						   len(failed), readerMakersToFilePaths(failed)) 
 			sleeper.Sleep()
 		}
 	}

--- a/internal/extract.go
+++ b/internal/extract.go
@@ -165,7 +165,7 @@ func ExtractAllWithSleeper(tarInterpreter TarInterpreter, files []ReaderMaker, s
 		currentRun = failed
 		if len(failed) > 0 {
 			tracelog.WarningLogger.Printf("%d files failed to download: %s. Going to sleep and retry downloading them.\n",
-						   len(failed), readerMakersToFilePaths(failed)) 
+				len(failed), readerMakersToFilePaths(failed))
 			sleeper.Sleep()
 		}
 	}


### PR DESCRIPTION
This should help to debug issues like https://github.com/wal-g/wal-g/issues/1071 and https://github.com/wal-g/wal-g/issues/1323.