### PR TITLE
Correct the --without-files-metadata docs

### DIFF
--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -287,7 +287,7 @@ If `--without-files-metadata` or `WALG_WITHOUT_FILES_METADATA` is enabled, WAL-G
 Limitations
 
 * Cannot be used with `rating-composer`, `copy-composer`
-* Cannot be used with `delta-from-user-data`, `delta-from-name`, `add-user-data`
+* Cannot be used with `WALG_DELTA_MAX_STEPS` setting or `delta-from-user-data`, `delta-from-name` flags.
 
 To activate this feature, do one of the following:
 


### PR DESCRIPTION
I propose to make some clarification since the current docs might appear misleading.
