### PR TITLE
Respect WALG_NETWORK_RATE_LIMIT globally

### DIFF
--- a/internal/configure.go
+++ b/internal/configure.go
@@ -131,6 +131,10 @@ func ConfigureFolder() (storage.Folder, error) {
 		return nil, err
 	}
 
+	if limiters.NetworkLimiter != nil {
+		folder = NewLimitedFolder(folder, limiters.NetworkLimiter)
+	}
+
 	return ConfigureStoragePrefix(folder), nil
 }
 

--- a/internal/limited_folder.go
+++ b/internal/limited_folder.go
@@ -1,0 +1,40 @@
+package internal
+
+import (
+	"io"
+
+	"github.com/wal-g/wal-g/internal/ioextensions"
+	"github.com/wal-g/wal-g/internal/limiters"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"golang.org/x/time/rate"
+)
+
+type LimitedFolder struct {
+	storage.Folder
+	limiter *rate.Limiter
+}
+
+func NewLimitedFolder(folder storage.Folder, limiter *rate.Limiter) *LimitedFolder {
+	return &LimitedFolder{Folder: folder, limiter: limiter}
+}
+
+func (lf *LimitedFolder) GetSubFolder(subFolderRelativePath string) storage.Folder {
+	folder := lf.Folder.GetSubFolder(subFolderRelativePath)
+	return NewLimitedFolder(folder, lf.limiter)
+}
+
+func (lf *LimitedFolder) ReadObject(objectRelativePath string) (io.ReadCloser, error) {
+	readCloser, err := lf.Folder.ReadObject(objectRelativePath)
+	if err != nil {
+		return nil, err
+	}
+	return ioextensions.ReadCascadeCloser{
+		Reader: limiters.NewReader(readCloser, lf.limiter),
+		Closer: readCloser,
+	}, nil
+}
+
+func (lf *LimitedFolder) PutObject(name string, content io.Reader) error {
+	limitedReader := limiters.NewReader(content, lf.limiter)
+	return lf.Folder.PutObject(name, limitedReader)
+}

--- a/internal/storage_tar_ball.go
+++ b/internal/storage_tar_ball.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/crypto"
-	"github.com/wal-g/wal-g/internal/limiters"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -87,7 +86,7 @@ func (tarBall *StorageTarBall) startUpload(name string, crypter crypto.Crypter) 
 	go func() {
 		defer uploader.waitGroup.Done()
 
-		err := uploader.Upload(path, limiters.NewNetworkLimitReader(pipeReader))
+		err := uploader.Upload(path, pipeReader)
 		if compressingError, ok := err.(CompressAndEncryptError); ok {
 			tracelog.ErrorLogger.Printf("could not upload '%s' due to compression error\n%+v\n", path, compressingError)
 		}


### PR DESCRIPTION
Currently, the `WALG_NETWORK_RATE_LIMIT` setting is ignored in all places except the PostgreSQL backup-push process. I propose to respect it globally.
