### PR TITLE
Restrict rate limiting only to backup-push/backup-fetch commands

### DIFF
--- a/cmd/fdb/backup_fetch.go
+++ b/cmd/fdb/backup_fetch.go
@@ -20,6 +20,8 @@ var backupFetchCmd = &cobra.Command{
 	Short: backupFetchShortDescription,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 		defer func() { _ = signalHandler.Close() }()

--- a/cmd/fdb/backup_push.go
+++ b/cmd/fdb/backup_push.go
@@ -19,6 +19,8 @@ var backupPushCmd = &cobra.Command{
 	Use:   "backup-push",
 	Short: backupPushShortDescription,
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 		defer func() { _ = signalHandler.Close() }()

--- a/cmd/gp/backup_fetch.go
+++ b/cmd/gp/backup_fetch.go
@@ -34,6 +34,8 @@ var backupFetchCmd = &cobra.Command{
 	Short: backupFetchShortDescription, // TODO : improve description
 	Args:  cobra.RangeArgs(0, 1),
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		if !inPlaceRestore && restoreConfigPath == "" {
 			tracelog.ErrorLogger.Fatalf(
 				"No restore config was specified. Either specify one via the --restore-config flag or add the --in-place flag to restore in-place.")

--- a/cmd/gp/backup_push.go
+++ b/cmd/gp/backup_push.go
@@ -35,6 +35,8 @@ var (
 		Short: backupPushShortDescription, // TODO : improve description
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			internal.ConfigureLimiters()
+
 			if userDataRaw == "" {
 				userDataRaw = viper.GetString(internal.SentinelUserDataSetting)
 			}

--- a/cmd/mongo/backup_fetch.go
+++ b/cmd/mongo/backup_fetch.go
@@ -19,6 +19,8 @@ var backupFetchCmd = &cobra.Command{
 	Short: backupFetchShortDescription,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 		defer func() { _ = signalHandler.Close() }()

--- a/cmd/mongo/backup_push.go
+++ b/cmd/mongo/backup_push.go
@@ -30,6 +30,8 @@ var backupPushCmd = &cobra.Command{
 	Short: backupPushShortDescription,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 		defer func() { _ = signalHandler.Close() }()

--- a/cmd/mysql/backup_fetch.go
+++ b/cmd/mysql/backup_fetch.go
@@ -25,6 +25,7 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			internal.ConfigureLimiters()
 			folder, err := internal.ConfigureFolder()
 			tracelog.ErrorLogger.FatalOnError(err)
 			restoreCmd, err := internal.GetCommandSetting(internal.NameStreamRestoreCmd)

--- a/cmd/mysql/backup_push.go
+++ b/cmd/mysql/backup_push.go
@@ -28,6 +28,8 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			internal.ConfigureLimiters()
+
 			uploader, err := internal.ConfigureSplitUploader()
 			tracelog.ErrorLogger.FatalOnError(err)
 			folder := uploader.Folder()

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -34,6 +34,8 @@ var backupFetchCmd = &cobra.Command{
 	Short: backupFetchShortDescription, // TODO : improve description
 	Args:  cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		if fetchTargetUserData == "" {
 			fetchTargetUserData = viper.GetString(internal.FetchTargetUserDataSetting)
 		}

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -44,6 +44,8 @@ var (
 		Short: backupPushShortDescription, // TODO : improve description
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			internal.ConfigureLimiters()
+
 			var dataDirectory string
 
 			if len(args) > 0 {

--- a/cmd/pg/catchup_fetch.go
+++ b/cmd/pg/catchup_fetch.go
@@ -20,6 +20,8 @@ var catchupFetchCmd = &cobra.Command{
 	Short: CatchupFetchShortDescription, // TODO : improve description
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
 		postgres.HandleCatchupFetch(folder, args[0], args[1], useNewUnwrap)

--- a/cmd/pg/catchup_push.go
+++ b/cmd/pg/catchup_push.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
@@ -16,6 +17,8 @@ var (
 		Short: catchupPushShortDescription,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			internal.ConfigureLimiters()
+
 			postgres.HandleCatchupPush(args[0], postgres.LSN(fromLSN))
 		},
 	}

--- a/cmd/pg/pgbackrest_backup_fetch.go
+++ b/cmd/pg/pgbackrest_backup_fetch.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres/pgbackrest"
 )
 
@@ -11,6 +12,8 @@ var pgbackrestBackupFetchCmd = &cobra.Command{
 	Short: backupFetchShortDescription,
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		destinationDirectory := args[0]
 		backupName := args[1]
 		folder, stanza := configurePgbackrestSettings()

--- a/cmd/redis/backup_fetch.go
+++ b/cmd/redis/backup_fetch.go
@@ -20,6 +20,8 @@ var backupFetchCmd = &cobra.Command{
 	Short: backupFetchShortDescription,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 		defer func() { _ = signalHandler.Close() }()

--- a/cmd/redis/backup_push.go
+++ b/cmd/redis/backup_push.go
@@ -30,6 +30,8 @@ var backupPushCmd = &cobra.Command{
 	Short: backupPushShortDescription,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 		defer func() { _ = signalHandler.Close() }()

--- a/cmd/sqlserver/backup_push.go
+++ b/cmd/sqlserver/backup_push.go
@@ -2,6 +2,7 @@ package sqlserver
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/sqlserver"
 )
 
@@ -14,6 +15,7 @@ var backupPushCmd = &cobra.Command{
 	Use:   "backup-push",
 	Short: backupPushShortDescription,
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
 		sqlserver.HandleBackupPush(backupPushDatabases, backupUpdateLatest)
 	},
 }

--- a/cmd/sqlserver/backup_restore.go
+++ b/cmd/sqlserver/backup_restore.go
@@ -2,6 +2,7 @@ package sqlserver
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/sqlserver"
 )
 
@@ -16,6 +17,7 @@ var backupRestoreCmd = &cobra.Command{
 	Short: backupRestoreShortDescription,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		internal.ConfigureLimiters()
 		sqlserver.HandleBackupRestore(args[0], restoreDatabases, restoreFrom, restoreNoRecovery)
 	},
 }

--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -64,10 +64,6 @@ WAL-G uses [the usual PostgreSQL environment variables](https://www.postgresql.o
 
 To configure disk read rate limit during ```backup-push``` in bytes per second.
 
-* `WALG_NETWORK_RATE_LIMIT`
-To configure the network upload rate limit during ```backup-push``` in bytes per second.
-
-
 Concurrency values can be configured using:
 
 * `WALG_DOWNLOAD_CONCURRENCY`

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,12 @@ The type of pprof profiler to use. Can be one of `cpu`, `mem`, `mutex`, `block`,
 
 The directory to store profiles in. Defaults to `$TMPDIR`.
 
+### Rate limiting
+* `WALG_NETWORK_RATE_LIMIT`
+
+Network traffic rate limit during the ```backup-push```/```backup-fetch``` operations in bytes per second.
+
+
 ### Database-specific options
 **More options are available for the chosen database. See it in [Databases](#databases)**
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -532,8 +532,6 @@ func Configure() {
 	for _, pair := range env {
 		tracelog.DebugLogger.Println(pair)
 	}
-
-	configureLimiters()
 }
 
 // ConfigureAndRunDefaultWebServer configures and runs web server

--- a/internal/configure.go
+++ b/internal/configure.go
@@ -107,7 +107,7 @@ func (err UnmarshallingError) Error() string {
 }
 
 // TODO : unit tests
-func configureLimiters() {
+func ConfigureLimiters() {
 	if Turbo {
 		return
 	}


### PR DESCRIPTION
After the https://github.com/wal-g/wal-g/pull/1330, WAL-G limits the network traffic on all subcommands. However, we don't want to limit the performance of the `wal-push/wal-fetch`, `binlog-push/binlog-fetch`, and other commands that are not related to the backup-push/backup-fetch. So I propose to restrict the rate-limiting only to backup-push/backup-fetch subcommands.