### PR TITLE
Add data catalog size for PostgreSQL/Greenplum backups

### DIFF
--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -87,7 +87,7 @@ type CurrBackupInfo struct {
 	startTime            time.Time
 	systemIdentifier     *uint64
 	gpVersion            semver.Version
-	segmentsMetadata     map[string]PgSegmentMetaDto
+	segmentsMetadata     map[string]PgSegmentSentinelDto
 	backupPidByContentID map[int]int
 	incrementCount       int
 }
@@ -482,8 +482,8 @@ func NewBackupArguments(isPermanent, isFull bool, userData interface{}, fwdArgs 
 	}
 }
 
-func (bh *BackupHandler) fetchSegmentBackupsMetadata() (map[string]PgSegmentMetaDto, error) {
-	metadata := make(map[string]PgSegmentMetaDto)
+func (bh *BackupHandler) fetchSegmentBackupsMetadata() (map[string]PgSegmentSentinelDto, error) {
+	metadata := make(map[string]PgSegmentSentinelDto)
 
 	backupIDs := make([]string, 0)
 	for backupID := range bh.currBackupInfo.segmentBackups {
@@ -519,7 +519,7 @@ func (bh *BackupHandler) fetchSegmentBackupsMetadata() (map[string]PgSegmentMeta
 	return metadata, nil
 }
 
-func (bh *BackupHandler) fetchSingleMetadata(backupID string, segCfg *cluster.SegConfig) (*PgSegmentMetaDto, error) {
+func (bh *BackupHandler) fetchSingleMetadata(backupID string, segCfg *cluster.SegConfig) (*PgSegmentSentinelDto, error) {
 	// Actually, this is not a real completed backup. It is only used to fetch the segment metadata
 	currentBackup := NewBackup(bh.workers.Uploader.UploadingFolder, bh.currBackupInfo.backupName)
 
@@ -528,11 +528,11 @@ func (bh *BackupHandler) fetchSingleMetadata(backupID string, segCfg *cluster.Se
 		return nil, err
 	}
 
-	meta := PgSegmentMetaDto{
+	meta := PgSegmentSentinelDto{
 		BackupName: pgBackup.Name,
 	}
 
-	meta.ExtendedMetadataDto, err = pgBackup.FetchMeta()
+	meta.BackupSentinelDto, err = pgBackup.GetSentinel()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/greenplum/backup_sentinel_dto.go
+++ b/internal/databases/greenplum/backup_sentinel_dto.go
@@ -60,9 +60,9 @@ func NewSegmentMetadata(backupID string, segCfg cluster.SegConfig, restoreLSN, b
 	}
 }
 
-// PgSegmentMetaDto is used during the initial fetching of the segment backup metadata
-type PgSegmentMetaDto struct {
-	postgres.ExtendedMetadataDto
+// PgSegmentSentinelDto is used during the initial fetching of the segment backup metadata
+type PgSegmentSentinelDto struct {
+	postgres.BackupSentinelDto
 	BackupName string
 }
 
@@ -82,6 +82,7 @@ type BackupSentinelDto struct {
 
 	UncompressedSize int64 `json:"uncompressed_size"`
 	CompressedSize   int64 `json:"compressed_size"`
+	DataCatalogSize  int64 `json:"data_catalog_size"`
 
 	IncrementFrom     *string `json:"increment_from,omitempty"`
 	IncrementFullName *string `json:"increment_full_name,omitempty"`
@@ -130,6 +131,7 @@ func NewBackupSentinelDto(currBackupInfo CurrBackupInfo, prevBackupInfo PrevBack
 	for backupID := range currBackupInfo.segmentsMetadata {
 		sentinel.CompressedSize += currBackupInfo.segmentsMetadata[backupID].CompressedSize
 		sentinel.UncompressedSize += currBackupInfo.segmentsMetadata[backupID].UncompressedSize
+		sentinel.DataCatalogSize += currBackupInfo.segmentsMetadata[backupID].DataCatalogSize
 	}
 
 	for backupID, cfg := range currBackupInfo.segmentBackups {

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -69,6 +69,7 @@ type CurBackupInfo struct {
 	endLSN           LSN
 	uncompressedSize int64
 	compressedSize   int64
+	dataCatalogSize  int64
 	incrementCount   int
 }
 
@@ -278,6 +279,7 @@ func (bh *BackupHandler) uploadBackup() internal.TarFileSets {
 	bh.CurBackupInfo.endLSN = finishLsn
 	bh.CurBackupInfo.uncompressedSize = atomic.LoadInt64(bundle.TarBallQueue.AllTarballsSize)
 	bh.CurBackupInfo.compressedSize, err = bh.Workers.Uploader.UploadedDataSize()
+	bh.CurBackupInfo.dataCatalogSize = atomic.LoadInt64(bundle.DataCatalogSize)
 	tracelog.ErrorLogger.FatalOnError(err)
 	tarFileSets.AddFiles(labelFilesTarBallName, labelFilesList)
 	timelineChanged := bundle.checkTimelineChanged(bh.Workers.QueryRunner)

--- a/internal/databases/postgres/backup_sentinel_dto.go
+++ b/internal/databases/postgres/backup_sentinel_dto.go
@@ -27,6 +27,7 @@ type BackupSentinelDto struct {
 
 	UncompressedSize int64           `json:"UncompressedSize"`
 	CompressedSize   int64           `json:"CompressedSize"`
+	DataCatalogSize  int64           `json:"DataCatalogSize,omitempty"`
 	TablespaceSpec   *TablespaceSpec `json:"Spec"`
 
 	UserData interface{} `json:"UserData,omitempty"`
@@ -56,6 +57,7 @@ func NewBackupSentinelDto(bh *BackupHandler, tbsSpec *TablespaceSpec) BackupSent
 	sentinel.SystemIdentifier = bh.PgInfo.systemIdentifier
 	sentinel.UncompressedSize = bh.CurBackupInfo.uncompressedSize
 	sentinel.CompressedSize = bh.CurBackupInfo.compressedSize
+	sentinel.DataCatalogSize = bh.CurBackupInfo.dataCatalogSize
 	sentinel.FilesMetadataDisabled = bh.Arguments.withoutFilesMetadata
 	return sentinel
 }


### PR DESCRIPTION
In this PR, I propose to add the data catalog size for PostgreSQL and Greenplum backups.

Currently, WAL-G doesn't store the database catalog size at the time of the backup. However, this might be useful for:
- PostgreSQL delta backups
- Greenplum backups (both base and delta)

These backups do not contain the actual database catalog size: PostgreSQL delta backups measure only the size of the delta, and Greenplum backups do not measure the common AO storage size.