### PR TITLE
Support ARM64 builds on MacOS 

### DIFF
--- a/docs/FoundationDB.md
+++ b/docs/FoundationDB.md
@@ -4,31 +4,6 @@
 
 You can use wal-g as a tool for encrypting, compressing FoundationDB backups and push/fetch them to/from storage.
 
-Development
------------
-### Installing
-To compile and build the binary for FoundationDB:
-
-Optional:
-
-- To build with libsodium, just set `USE_LIBSODIUM` environment variable.
-- To build with lzo decompressor, just set `USE_LZO` environment variable.
-```plaintext
-go get github.com/wal-g/wal-g
-cd $GOPATH/src/github.com/wal-g/wal-g
-make install
-make deps
-make fdb_build
-```
-Users can also install WAL-G by using `make install`. Specifying the GOBIN environment variable before installing allows the user to specify the installation location. On default, `make install` puts the compiled binary in `go/bin`.
-```plaintext
-export GOBIN=/usr/local/bin
-cd $GOPATH/src/github.com/wal-g/wal-g
-make install
-make deps
-make fdb_install
-```
-
 Usage
 -----
 

--- a/docs/Greenplum.md
+++ b/docs/Greenplum.md
@@ -2,12 +2,6 @@
 
 You can use WAL-G as a tool for making encrypted, compressed physical Greenplum backups and push/fetch them to/from the remote storage without saving it on your filesystem.
 
-Development
------------
-### Installing
-
-Installing process is the same as for [WAL-G for Postgres](PostgreSQL.md#installing). To build or install binary for Greenplum, use the `make gp_build` and `make gp_install` commands respectively.
-
 Configuration
 -------------
 WAL-G for Greenplum understands the basic configuration options that are [supported by the WAL-G for Postgres](PostgreSQL.md#Configuration), except the advanced features such as delta backups, remote backups, catchup backup, etc.

--- a/docs/MongoDB.md
+++ b/docs/MongoDB.md
@@ -4,31 +4,6 @@
 
 You can use wal-g as a tool for making encrypted, compressed MongoDB backups and push/fetch them to/from storage without saving it on your filesystem.
 
-Development
------------
-### Installing
-To compile and build the binary:
-
-Optional:
-
-- To build with libsodium, just set `USE_LIBSODIUM` environment variable.
-- To build with lzo decompressor, just set `USE_LZO` environment variable.
-```plaintext
-go get github.com/wal-g/wal-g
-cd $GOPATH/src/github.com/wal-g/wal-g
-make install
-make deps
-make mongo_build
-```
-Users can also install WAL-G by using `make mongo_install`. Specifying the GOBIN environment variable before installing allows the user to specify the installation location. On default, `make mongo_install` puts the compiled binary in `go/bin`.
-```plaintext
-export GOBIN=/usr/local/bin
-cd $GOPATH/src/github.com/wal-g/wal-g
-make install
-make deps
-make mongo_install
-```
-
 Configuration
 -------------
 

--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -4,31 +4,6 @@
 
 You can use wal-g as a tool for encrypting, compressing MySQL backups and push/fetch them to/from storage without saving it on your filesystem.
 
-Development
------------
-### Installing
-To compile and build the binary for MySQL:
-
-Optional:
-
-- To build with libsodium, just set `USE_LIBSODIUM` environment variable.
-- To build with lzo decompressor, just set `USE_LZO` environment variable.
-```plaintext
-go get github.com/wal-g/wal-g
-cd $GOPATH/src/github.com/wal-g/wal-g
-make install
-make deps
-make mysql_build
-```
-Users can also install WAL-G by using `make install`. Specifying the GOBIN environment variable before installing allows the user to specify the installation location. On default, `make install` puts the compiled binary in `go/bin`.
-```plaintext
-export GOBIN=/usr/local/bin
-cd $GOPATH/src/github.com/wal-g/wal-g
-make install
-make deps
-make mysql_install
-```
-
 Configuration
 -------------
 

--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -4,55 +4,6 @@ You can use wal-g as a tool for making encrypted, compressed PostgreSQL backups(
 
 If you prefer use Docker Image, you can directly test wal-g with this [playground](https://github.com/stephane-klein/playground-postgresql-walg).
 
-Development
------------
-
-Optional:
-
-- To build with libsodium, set the `USE_LIBSODIUM` environment variable.
-- To build with lzo decompressor, set the `USE_LZO` environment variable.
-
-### Ubuntu
-
-```sh
-# Install latest Go compiler
-sudo add-apt-repository ppa:longsleep/golang-backports 
-sudo apt update
-sudo apt install golang-go
-
-# Install lib dependencies
-sudo apt install libbrotli-dev liblzo2-dev libsodium-dev cmake
-
-# Fetch project and build
-go get github.com/wal-g/wal-g
-cd ~/go/src/github.com/wal-g/wal-g
-make deps
-make pg_build
-main/pg/wal-g --version
-```
-
-Users can also install WAL-G by using `make pg_install`. Specifying the `GOBIN` environment variable before installing allows the user to specify the installation location. By default, `make pg_install` puts the compiled binary in the root directory (`/`).
-
-```sh
-export USE_LIBSODIUM=1
-export USE_LZO=1
-make pg_clean
-make deps
-GOBIN=/usr/local/bin make pg_install
-```
-
-### macOS
-
-```sh
-# brew command is Homebrew for Mac OS
-brew install cmake
-export USE_LIBSODIUM="true" # since we're linking libsodium later
-./link_brotli.sh
-./link_libsodium.sh
-make install_and_build_pg
-```
-
-The compiled binary to run is `main/pg/wal-g`
 
 Configuration
 -------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -224,8 +224,60 @@ Databases
 
 Development
 -----------
-### Installing
-It is specified for your type of [database](#databases).
+
+The following steps describe how to build WAL-G for PostgreSQL, but the process is the same for other databases. For example, to build WAL-G for MySQL, use the `make mysql_build` instead of `make pg_build`.
+
+Optional:
+
+- To build with libsodium, set the `USE_LIBSODIUM` environment variable.
+- To build with lzo decompressor, set the `USE_LZO` environment variable.
+
+### Ubuntu
+
+```sh
+# Install latest Go compiler
+sudo add-apt-repository ppa:longsleep/golang-backports 
+sudo apt update
+sudo apt install golang-go
+
+# Install lib dependencies
+sudo apt install libbrotli-dev liblzo2-dev libsodium-dev curl cmake
+
+# Fetch project and build
+go get github.com/wal-g/wal-g
+cd ~/go/src/github.com/wal-g/wal-g
+make deps
+make pg_build
+main/pg/wal-g --version
+```
+
+Users can also install WAL-G by using `make pg_install`. Specifying the `GOBIN` environment variable before installing allows the user to specify the installation location. By default, `make pg_install` puts the compiled binary in the root directory (`/`).
+
+```sh
+export USE_LIBSODIUM=1
+export USE_LZO=1
+make pg_clean
+make deps
+GOBIN=/usr/local/bin make pg_install
+```
+
+### macOS
+
+```sh
+# brew command is Homebrew for Mac OS
+brew install cmake
+export USE_LIBSODIUM="true" # since we're linking libsodium later
+./link_brotli.sh
+./link_libsodium.sh
+make install_and_build_pg
+```
+
+To build on ARM64, set the corresponding `GOOS`/`GOARCH` environment variables:
+```
+env GOOS=darwin GOARCH=arm64 make pg_build
+```
+
+The compiled binary to run is `main/pg/wal-g`
 
 ### Testing
 

--- a/docs/Redis.md
+++ b/docs/Redis.md
@@ -4,31 +4,6 @@
 
 You can use wal-g as a tool for making encrypted, compressed Redis backups and push/fetch them to/from storage without saving it on your filesystem.
 
-Development
------------
-### Installing
-To compile and build the binary:
-
-Optional:
-
-- To build with libsodium, just set `USE_LIBSODIUM` environment variable.
-- To build with lzo decompressor, just set `USE_LZO` environment variable.
-```plaintext
-go get github.com/wal-g/wal-g
-cd $GOPATH/src/github.com/wal-g/wal-g
-make install
-make deps
-make redis_build
-```
-Users can also install WAL-G by using `make redis_install`. Specifying the GOBIN environment variable before installing allows the user to specify the installation location. On default, `make redis_install` puts the compiled binary in `go/bin`.
-```plaintext
-export GOBIN=/usr/local/bin
-cd $GOPATH/src/github.com/wal-g/wal-g
-make install
-make deps
-make redis_install
-```
-
 Configuration
 -------------
 

--- a/internal/compression/brotli_enabled.go
+++ b/internal/compression/brotli_enabled.go
@@ -1,5 +1,7 @@
-//go:build brotli && !windows
-// +build brotli,!windows
+//go:build brotli && !windows && !(darwin && arm64)
+// +build brotli
+// +build !windows
+// +build !darwin !arm64
 
 package compression
 

--- a/internal/compression/compression_default.go
+++ b/internal/compression/compression_default.go
@@ -7,20 +7,17 @@ import (
 	"github.com/wal-g/wal-g/internal/compression/gzip"
 	"github.com/wal-g/wal-g/internal/compression/lz4"
 	"github.com/wal-g/wal-g/internal/compression/lzma"
-	"github.com/wal-g/wal-g/internal/compression/zstd"
 )
 
-var CompressingAlgorithms = []string{lz4.AlgorithmName, lzma.AlgorithmName, zstd.AlgorithmName}
+var CompressingAlgorithms = []string{lz4.AlgorithmName, lzma.AlgorithmName}
 
 var Compressors = map[string]Compressor{
 	lz4.AlgorithmName:  lz4.Compressor{},
 	lzma.AlgorithmName: lzma.Compressor{},
-	zstd.AlgorithmName: zstd.Compressor{},
 }
 
 var Decompressors = []Decompressor{
 	lz4.Decompressor{},
 	lzma.Decompressor{},
-	zstd.Decompressor{},
 	gzip.Decompressor{},
 }

--- a/internal/compression/zstd/compressor.go
+++ b/internal/compression/zstd/compressor.go
@@ -1,3 +1,6 @@
+//go:build !(arm64 && darwin)
+// +build !arm64 !darwin
+
 package zstd
 
 import (

--- a/internal/compression/zstd/decompressor.go
+++ b/internal/compression/zstd/decompressor.go
@@ -1,3 +1,6 @@
+//go:build !(arm64 && darwin)
+// +build !arm64 !darwin
+
 package zstd
 
 import (

--- a/internal/compression/zstd_enabled.go
+++ b/internal/compression/zstd_enabled.go
@@ -1,0 +1,15 @@
+//go:build !windows && !(arm64 && darwin)
+// +build !windows
+// +build !arm64 !darwin
+
+package compression
+
+import (
+	"github.com/wal-g/wal-g/internal/compression/zstd"
+)
+
+func init() {
+	Decompressors = append(Decompressors, zstd.Decompressor{})
+	Compressors[zstd.AlgorithmName] = zstd.Compressor{}
+	CompressingAlgorithms = append(CompressingAlgorithms, zstd.AlgorithmName)
+}


### PR DESCRIPTION
I propose to adjust the build flags to exclude `brotli` and `zstd` from macos arm64 builds since they do not support this platform (yet?) and update the documentation.