### PR TITLE
Fix distro name for ubuntu-20.04 in arm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{ matrix.arch }}
-          distro: ${{ matrix.distro }}
+          distro: ubuntu20.04
           env: |
             USE_LIBSODIUM: ${{ env.USE_LIBSODIUM }}
             USE_LZO: ${{ env.USE_LZO }}


### PR DESCRIPTION
### Database name
postgresql

# Pull request description
I was trying to use checksum in my ansible pipeline but fall down in checksum problem
```
- name: Download wal-g.tar.gz with checksum testing
  get_url:
    url: "https://github.com/wal-g/wal-g/releases/download/v2.0.1/wal-g-pg-ubuntu-20.04-aarch64.tar.gz"
    dest: "{{ ansible_env.HOME }}"
    checksum: "sha256:https://github.com/wal-g/wal-g/releases/download/v2.0.1/wal-g-pg-ubuntu-20.04-aarch64.tar.gz.sha256"
  register: walg_download
```
so I find out that the checksum file is invalid due to invalid filename.

### Describe what this PR fix
Add dash in release filename for ubuntu 20.04.

### Please provide steps to reproduce (if it's a bug)
```
➜  ~ wget -o -s https://github.com/wal-g/wal-g/releases/download/v2.0.1/wal-g-pg-ubuntu-20.04-aarch64.tar.gz
➜  ~ wget -o -s https://github.com/wal-g/wal-g/releases/download/v2.0.1/wal-g-pg-ubuntu-20.04-aarch64.tar.gz.sha256
➜  ~ sha256sum wal-g-pg-ubuntu-20.04-aarch64.tar.gz
9782bd6f4f08ec26d0f2f5f8fd8f9531e4fe39f14ef5f764cbec08e93da2bbcc  wal-g-pg-ubuntu-20.04-aarch64.tar.gz
➜  ~ cat wal-g-pg-ubuntu-20.04-aarch64.tar.gz.sha256
9782bd6f4f08ec26d0f2f5f8fd8f9531e4fe39f14ef5f764cbec08e93da2bbcc  wal-g-pg-ubuntu20.04-aarch64.tar.gz

➜  ~ sha256sum wal-g-pg-ubuntu-20.04-aarch64.tar.gz| diff wal-g-pg-ubuntu-20.04-aarch64.tar.gz.sha256 -
< 9782bd6f4f08ec26d0f2f5f8fd8f9531e4fe39f14ef5f764cbec08e93da2bbcc  wal-g-pg-ubuntu20.04-aarch64.tar.gz
---
> 9782bd6f4f08ec26d0f2f5f8fd8f9531e4fe39f14ef5f764cbec08e93da2bbcc  wal-g-pg-ubuntu-20.04-aarch64.tar.gz

```