### PR TITLE
add timeout for s3 upload operations

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -302,6 +302,7 @@ var (
 		"S3_RANGE_BATCH_ENABLED":      true,
 		"S3_RANGE_MAX_RETRIES":        true,
 		"S3_MAX_RETRIES":              true,
+		"S3_UPLOAD_WITH_TIMEOUT":      true,
 
 		// Azure
 		"WALG_AZ_PREFIX":           true,

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"context"
 	"io"
 	"path"
 	"strconv"
@@ -41,6 +42,8 @@ const (
 	UseListObjectsV1         = "S3_USE_LIST_OBJECTS_V1"
 	RangeBatchEnabled        = "S3_RANGE_BATCH_ENABLED"
 	RangeQueriesMaxRetries   = "S3_RANGE_MAX_RETRIES"
+	UploadWithTimeout        = "S3_UPLOAD_WITH_TIMEOUT"
+	UploadTimeout            = "S3_UPLOAD_TIMEOUT"
 	// MaxRetriesSetting limits retries during interaction with S3
 	MaxRetriesSetting = "S3_MAX_RETRIES"
 
@@ -78,6 +81,8 @@ var (
 		RangeBatchEnabled,
 		RangeQueriesMaxRetries,
 		MaxRetriesSetting,
+		UploadWithTimeout,
+		UploadTimeout,
 	}
 )
 
@@ -278,10 +283,20 @@ func (folder *Folder) listObjectsPagesV1(prefix *string, delimiter *string,
 		Prefix:    prefix,
 		Delimiter: delimiter,
 	}
-	return folder.S3API.ListObjectsPages(s3Objects, func(files *s3.ListObjectsOutput, lastPage bool) bool {
-		listFunc(files.CommonPrefixes, files.Contents)
-		return true
-	})
+	uploadTimeout := folder.getUploadTimeout()
+	if uploadTimeout != 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(uploadTimeout * int(time.Second)))
+		defer cancel()
+		return folder.S3API.ListObjectsPagesWithContext(ctx, s3Objects, func(files *s3.ListObjectsOutput, lastPage bool) bool {
+			listFunc(files.CommonPrefixes, files.Contents)
+			return true
+		})
+	} else {
+		return folder.S3API.ListObjectsPages(s3Objects, func(files *s3.ListObjectsOutput, lastPage bool) bool {
+			listFunc(files.CommonPrefixes, files.Contents)
+			return true
+		})
+	}
 }
 
 func (folder *Folder) listObjectsPagesV2(prefix *string, delimiter *string,
@@ -291,10 +306,20 @@ func (folder *Folder) listObjectsPagesV2(prefix *string, delimiter *string,
 		Prefix:    prefix,
 		Delimiter: delimiter,
 	}
-	return folder.S3API.ListObjectsV2Pages(s3Objects, func(files *s3.ListObjectsV2Output, lastPage bool) bool {
-		listFunc(files.CommonPrefixes, files.Contents)
-		return true
-	})
+	uploadTimeout := folder.getUploadTimeout()
+	if uploadTimeout != 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(uploadTimeout * int(time.Second)))
+		defer cancel()
+		return folder.S3API.ListObjectsV2PagesWithContext(ctx, s3Objects, func(files *s3.ListObjectsV2Output, lastPage bool) bool {
+			listFunc(files.CommonPrefixes, files.Contents)
+			return true
+		})
+	} else {
+		return folder.S3API.ListObjectsV2Pages(s3Objects, func(files *s3.ListObjectsV2Output, lastPage bool) bool {
+			listFunc(files.CommonPrefixes, files.Contents)
+			return true
+		})
+	}
 }
 
 func (folder *Folder) DeleteObjects(objectRelativePaths []string) error {
@@ -317,6 +342,28 @@ func (folder *Folder) partitionToObjects(keys []string) []*s3.ObjectIdentifier {
 		objects[id] = &s3.ObjectIdentifier{Key: aws.String(folder.Path + key)}
 	}
 	return objects
+}
+
+func (folder *Folder) getUploadTimeout() int {
+	var err error
+	uploadWithTimeout := false
+	if strUploadWithTimeout, ok := folder.settings[UploadWithTimeout]; ok {
+		uploadWithTimeout, err = strconv.ParseBool(strUploadWithTimeout)
+		if err != nil {
+			return 0
+		}
+	}
+
+	uploadTimeout := 0
+	if uploadWithTimeout {
+		if strUploadTimeout, ok := folder.settings[UploadTimeout]; ok {
+			uploadTimeout, err = strconv.Atoi(strUploadTimeout)
+			if err != nil {
+				return 0
+			}
+		}
+	}
+	return uploadTimeout
 }
 
 func isAwsNotExist(err error) bool {

--- a/pkg/storages/s3/uploader.go
+++ b/pkg/storages/s3/uploader.go
@@ -1,11 +1,13 @@
 package s3
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -38,10 +40,11 @@ type Uploader struct {
 	SSECustomerKey       string
 	SSEKMSKeyId          string
 	StorageClass         string
+	uploadTimeout        int
 }
 
-func NewUploader(uploaderAPI s3manageriface.UploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyId, storageClass string) *Uploader {
-	return &Uploader{uploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyId, storageClass}
+func NewUploader(uploaderAPI s3manageriface.UploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyId, storageClass string, uploadTimeout int) *Uploader {
+	return &Uploader{uploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyId, storageClass, uploadTimeout}
 }
 
 // TODO : unit tests
@@ -74,8 +77,16 @@ func (uploader *Uploader) createUploadInput(bucket, path string, content io.Read
 }
 
 func (uploader *Uploader) upload(bucket, path string, content io.Reader) error {
+	var err error
+	uploadTimeout := uploader.uploadTimeout
 	input := uploader.createUploadInput(bucket, path, content)
-	_, err := uploader.uploaderAPI.Upload(input)
+	if uploadTimeout != 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(uploadTimeout * int(time.Second)))
+		defer cancel()
+		_, err = uploader.uploaderAPI.UploadWithContext(ctx, input)
+	} else {
+		_, err = uploader.uploaderAPI.Upload(input)
+	}
 	return errors.Wrapf(err, "failed to upload '%s' to bucket '%s'", path, bucket)
 }
 
@@ -139,6 +150,24 @@ func configureUploader(s3Client *s3.S3, settings map[string]string) (*Uploader, 
 		maxPartSize = DefaultMaxPartSize
 	}
 
+	uploadWithTimeout := false
+	if strUploadWithTimeout, ok := settings[UploadWithTimeout]; ok {
+		uploadWithTimeout, err = strconv.ParseBool(strUploadWithTimeout)
+		if err != nil {
+			return nil, NewFolderError(err, "Invalid s3 upload with timeout setting")
+		}
+	}
+
+	uploadTimeout := 0
+	if uploadWithTimeout {
+		if strUploadTimeout, ok := settings[UploadTimeout]; ok {
+			uploadTimeout, err = strconv.Atoi(strUploadTimeout)
+			if err != nil {
+				return nil, NewFolderError(err, "Invalid s3 upload timeout setting")
+			}
+		}
+	}
+
 	uploaderApi := CreateUploaderAPI(s3Client, maxPartSize, concurrency)
 
 	serverSideEncryption, sseCustomerKey, sseKmsKeyId, err := configureServerSideEncryption(settings)
@@ -151,5 +180,5 @@ func configureUploader(s3Client *s3.S3, settings map[string]string) (*Uploader, 
 	if storageClass, ok = settings[StorageClassSetting]; !ok {
 		storageClass = "STANDARD"
 	}
-	return NewUploader(uploaderApi, serverSideEncryption, sseCustomerKey, sseKmsKeyId, storageClass), nil
+	return NewUploader(uploaderApi, serverSideEncryption, sseCustomerKey, sseKmsKeyId, storageClass, uploadTimeout), nil
 }


### PR DESCRIPTION
# Pull request description

Fix will allow to set timeout for s3-upload operations to prevent wal-g hanging for indefinite time in case of some unavailability of s3 server

### Please provide steps to reproduce (if it's a bug)

It's not really a bug, I was able to repeate this wal-g behaviour by editing iptables rules (and allowing/denying requests to s3). The issue is that if s3 server is for some reason unavailable, wal-g wouldn't just drop some error, but will hang for some indefinite time. This may cause databases locks unreleased for some time. 

After fix if wal-g has in it's config S3_UPLOAD_WITH_TIMEOUT = true and non-zero value of S3_UPLOAD_TIMEOUT, wal-g will drop request after timeout passed with error of "context deadline exceeded"
