### PR TITLE
  Only dump relevant env variables with LOG_LEVEL=DEVEL

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/user"
@@ -522,12 +523,25 @@ func Configure() {
 		tracelog.ErrorLogger.FatalError(err)
 	}
 
-	// Show all ENV vars in DEVEL Logging Mode
-	tracelog.DebugLogger.Println("--- COMPILED ENVIRONMENT VARS ---")
-	env := os.Environ()
-	sort.Strings(env)
-	for _, pair := range env {
-		tracelog.DebugLogger.Println(pair)
+	// Show all relevant ENV vars in DEVEL Logging Mode
+	{
+		var buff bytes.Buffer
+		buff.WriteString("--- COMPILED ENVIRONMENT VARS ---\n")
+
+		var keys []string
+		for k := range viper.AllSettings() {
+			keys = append(keys, strings.ToUpper(k))
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			val, ok := os.LookupEnv(k)
+			if ok {
+				fmt.Fprintf(&buff, "\t%s=%s\n", k, val)
+			}
+		}
+
+		tracelog.DebugLogger.Print(buff.String())
 	}
 
 	configureLimiters()

--- a/internal/config.go
+++ b/internal/config.go
@@ -729,6 +729,7 @@ func bindConfigToEnv(globalViper *viper.Viper) {
 		if !ok {
 			// note: all viper settings are currently strings, this warning will not be triggered at the moment
 			tracelog.WarningLogger.Printf("config value for %s is not a string: %T %v\n", k, v, v)
+			continue
 		}
 		k = strings.ToUpper(k)
 


### PR DESCRIPTION
### Database name
code for all commands

# Pull request description

When dumping the environment (with `WALG_LOG_LEVEL=DEVEL`), only dump environment variables that have a set value, and that are relevant to wal-g.

Additionally: reformat the way these variables are printed to the log.

### Describe what this PR fix
fixes #1366 

<details>
<summary>
Before (with my current env: 203 lines)
</summary>

```bash
$ WALG_LOG_LEVEL=DEVEL ./wal-g help
DEBUG: 2022/11/02 07:56:24.819270 --- COMPILED ENVIRONMENT VARS ---
DEBUG: 2022/11/02 07:56:24.819338 AWS_ACCESS_KEY=
DEBUG: 2022/11/02 07:56:24.819342 AWS_ACCESS_KEY_ID=
DEBUG: 2022/11/02 07:56:24.819344 AWS_CA_BUNDLE=
DEBUG: 2022/11/02 07:56:24.819346 AWS_CONFIG_FILE=
DEBUG: 2022/11/02 07:56:24.819347 AWS_DEFAULT_OUTPUT=
DEBUG: 2022/11/02 07:56:24.819350 AWS_DEFAULT_REGION=
DEBUG: 2022/11/02 07:56:24.819351 AWS_ENDPOINT=
DEBUG: 2022/11/02 07:56:24.819353 AWS_PROFILE=
DEBUG: 2022/11/02 07:56:24.819354 AWS_REGION=
DEBUG: 2022/11/02 07:56:24.819357 AWS_ROLE_SESSION_NAME=
DEBUG: 2022/11/02 07:56:24.819360 AWS_S3_FORCE_PATH_STYLE=
DEBUG: 2022/11/02 07:56:24.819363 AWS_SECRET_ACCESS_KEY=
DEBUG: 2022/11/02 07:56:24.819365 AWS_SECRET_KEY=
DEBUG: 2022/11/02 07:56:24.819368 AWS_SESSION_TOKEN=
DEBUG: 2022/11/02 07:56:24.819370 AWS_SHARED_CREDENTIALS_FILE=
DEBUG: 2022/11/02 07:56:24.819373 AZURE_BUFFER_SIZE=
DEBUG: 2022/11/02 07:56:24.819375 AZURE_ENDPOINT_SUFFIX=
DEBUG: 2022/11/02 07:56:24.819380 AZURE_ENVIRONMENT_NAME=
DEBUG: 2022/11/02 07:56:24.819382 AZURE_MAX_BUFFERS=
DEBUG: 2022/11/02 07:56:24.819385 AZURE_STORAGE_ACCESS_KEY=
DEBUG: 2022/11/02 07:56:24.819389 AZURE_STORAGE_ACCOUNT=
DEBUG: 2022/11/02 07:56:24.819392 AZURE_STORAGE_SAS_TOKEN=
DEBUG: 2022/11/02 07:56:24.819395 COLORTERM=truecolor
DEBUG: 2022/11/02 07:56:24.819398 DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
DEBUG: 2022/11/02 07:56:24.819402 DESKTOP_SESSION=ubuntu
DEBUG: 2022/11/02 07:56:24.819405 DISPLAY=:0
DEBUG: 2022/11/02 07:56:24.819410 DOTNET_BUNDLE_EXTRACT_BASE_DIR=/home/username/.cache/dotnet_bundle_extract
DEBUG: 2022/11/02 07:56:24.819414 DOTNET_CLI_TELEMETRY_OPTOUT=1
DEBUG: 2022/11/02 07:56:24.819417 DOTNET_ROOT=/usr/lib/dotnet/dotnet6-6.0.110
DEBUG: 2022/11/02 07:56:24.819420 GCS_CONTEXT_TIMEOUT=
DEBUG: 2022/11/02 07:56:24.819423 GCS_ENCRYPTION_KEY=
DEBUG: 2022/11/02 07:56:24.819427 GCS_MAX_CHUNK_SIZE=
DEBUG: 2022/11/02 07:56:24.819431 GCS_MAX_RETRIES=
DEBUG: 2022/11/02 07:56:24.819435 GCS_NORMALIZE_PREFIX=
DEBUG: 2022/11/02 07:56:24.819439 GDMSESSION=ubuntu
DEBUG: 2022/11/02 07:56:24.819442 GIO_LAUNCHED_DESKTOP_FILE_PID=3947
DEBUG: 2022/11/02 07:56:24.819445 GNOME_DESKTOP_SESSION_ID=this-is-deprecated
DEBUG: 2022/11/02 07:56:24.819448 GNOME_SETUP_DISPLAY=:1
DEBUG: 2022/11/02 07:56:24.819452 GNOME_SHELL_SESSION_MODE=ubuntu
DEBUG: 2022/11/02 07:56:24.819456 GOMAXPROCS=
DEBUG: 2022/11/02 07:56:24.819458 GOOGLE_APPLICATION_CREDENTIALS=
DEBUG: 2022/11/02 07:56:24.819460 GOPATH=/home/username
DEBUG: 2022/11/02 07:56:24.819463 GTK_MODULES=gail:atk-bridge
DEBUG: 2022/11/02 07:56:24.819467 HOME=/home/username
DEBUG: 2022/11/02 07:56:24.819470 HTTP_EXPOSE_EXPVAR=
DEBUG: 2022/11/02 07:56:24.819472 HTTP_EXPOSE_PPROF=
DEBUG: 2022/11/02 07:56:24.819475 HTTP_LISTEN=
DEBUG: 2022/11/02 07:56:24.819478 IM_CONFIG_PHASE=1
DEBUG: 2022/11/02 07:56:24.819480 INVOCATION_ID=eacf3201ffd20085a7d511cdc345e53b
DEBUG: 2022/11/02 07:56:24.819483 JOURNAL_STREAM=8:50003
DEBUG: 2022/11/02 07:56:24.819485 LANG=en_US.UTF-8
DEBUG: 2022/11/02 07:56:24.819488 LANGUAGE=en_US:en
DEBUG: 2022/11/02 07:56:24.819490 LC_ADDRESS=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819493 LC_IDENTIFICATION=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819497 LC_MEASUREMENT=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819501 LC_MONETARY=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819505 LC_NAME=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819508 LC_NUMERIC=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819512 LC_PAPER=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819517 LC_TELEPHONE=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819520 LC_TIME=fr_FR.UTF-8
DEBUG: 2022/11/02 07:56:24.819523 LESSCLOSE=/usr/bin/lesspipe %s %s
DEBUG: 2022/11/02 07:56:24.819527 LESSOPEN=| /usr/bin/lesspipe %s
DEBUG: 2022/11/02 07:56:24.819530 LIBVIRT_DEFAULT_URI=qemu:///system
DEBUG: 2022/11/02 07:56:24.819534 LOGNAME=username
DEBUG: 2022/11/02 07:56:24.819540 LS_COLORS=rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.webp=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:
DEBUG: 2022/11/02 07:56:24.819554 MANAGERPID=3031
DEBUG: 2022/11/02 07:56:24.819558 MOZ_DBUS_REMOTE=1
DEBUG: 2022/11/02 07:56:24.819561 OLDPWD=/home/username
DEBUG: 2022/11/02 07:56:24.819565 OS_AUTH_URL=
DEBUG: 2022/11/02 07:56:24.819568 OS_PASSWORD=
DEBUG: 2022/11/02 07:56:24.819572 OS_REGION_NAME=
DEBUG: 2022/11/02 07:56:24.819575 OS_TENANT_NAME=
DEBUG: 2022/11/02 07:56:24.819579 OS_USERNAME=
DEBUG: 2022/11/02 07:56:24.819582 PAPERSIZE=a4
DEBUG: 2022/11/02 07:56:24.819585 PATH=/home/username/go/bin:/home/username/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/home/username/.dotnet/tools
DEBUG: 2022/11/02 07:56:24.819589 PGBACKREST_STANZA=main
DEBUG: 2022/11/02 07:56:24.819593 PGDATA=
DEBUG: 2022/11/02 07:56:24.819596 PGDATABASE=
DEBUG: 2022/11/02 07:56:24.819599 PGHOST=
DEBUG: 2022/11/02 07:56:24.819602 PGPASSFILE=
DEBUG: 2022/11/02 07:56:24.819606 PGPASSWORD=
DEBUG: 2022/11/02 07:56:24.819609 PGPORT=
DEBUG: 2022/11/02 07:56:24.819612 PGSSLMODE=
DEBUG: 2022/11/02 07:56:24.819615 PGUSER=
DEBUG: 2022/11/02 07:56:24.819618 PG_READY_RENAME=
DEBUG: 2022/11/02 07:56:24.819622 PNPM_HOME=/home/username/.local/share/pnpm
DEBUG: 2022/11/02 07:56:24.819625 PROFILE_MODE=
DEBUG: 2022/11/02 07:56:24.819628 PROFILE_PATH=
DEBUG: 2022/11/02 07:56:24.819631 PROFILE_SAMPLING_RATIO=
DEBUG: 2022/11/02 07:56:24.819634 PWD=/home/username/code/github.com/wal-g/wal-g
DEBUG: 2022/11/02 07:56:24.819638 QT_ACCESSIBILITY=1
DEBUG: 2022/11/02 07:56:24.819641 QT_IM_MODULE=ibus
DEBUG: 2022/11/02 07:56:24.819644 QT_QPA_PLATFORM=xcb
DEBUG: 2022/11/02 07:56:24.819647 S3_CA_CERT_FILE=
DEBUG: 2022/11/02 07:56:24.819650 S3_ENDPOINT_PORT=
DEBUG: 2022/11/02 07:56:24.819653 S3_ENDPOINT_SOURCE=
DEBUG: 2022/11/02 07:56:24.819657 S3_LOG_LEVEL=
DEBUG: 2022/11/02 07:56:24.819660 S3_MAX_PART_SIZE=
DEBUG: 2022/11/02 07:56:24.819663 S3_MAX_RETRIES=
DEBUG: 2022/11/02 07:56:24.819666 S3_RANGE_BATCH_ENABLED=
DEBUG: 2022/11/02 07:56:24.819669 S3_RANGE_MAX_RETRIES=
DEBUG: 2022/11/02 07:56:24.819672 S3_SSE=
DEBUG: 2022/11/02 07:56:24.819675 S3_SSE_C=
DEBUG: 2022/11/02 07:56:24.819678 S3_SSE_KMS_ID=
DEBUG: 2022/11/02 07:56:24.819681 S3_STORAGE_CLASS=
DEBUG: 2022/11/02 07:56:24.819685 S3_USE_LIST_OBJECTS_V1=
DEBUG: 2022/11/02 07:56:24.819688 S3_USE_YC_SESSION_TOKEN=
DEBUG: 2022/11/02 07:56:24.819691 SESSION_MANAGER=local/mypc:@/tmp/.ICE-unix/3143,unix/mypc:/tmp/.ICE-unix/3143
DEBUG: 2022/11/02 07:56:24.819695 SHELL=/bin/bash
DEBUG: 2022/11/02 07:56:24.819698 SHLVL=1
DEBUG: 2022/11/02 07:56:24.819701 SSH_AGENT_LAUNCHER=gnome-keyring
DEBUG: 2022/11/02 07:56:24.819704 SSH_AUTH_SOCK=/run/user/1000/keyring/ssh
DEBUG: 2022/11/02 07:56:24.819707 SSH_PASSWORD=
DEBUG: 2022/11/02 07:56:24.819710 SSH_PORT=
DEBUG: 2022/11/02 07:56:24.819713 SSH_PRIVATE_KEY_PATH=
DEBUG: 2022/11/02 07:56:24.819717 SSH_USERNAME=
DEBUG: 2022/11/02 07:56:24.819724 SYSTEMD_EXEC_PID=3310
DEBUG: 2022/11/02 07:56:24.819728 TERM=xterm-256color
DEBUG: 2022/11/02 07:56:24.819731 TILIX_ID=e33fa3f0-8f75-4012-8953-800ac267482e
DEBUG: 2022/11/02 07:56:24.819735 TLM_ROOT=/home/username/dev
DEBUG: 2022/11/02 07:56:24.819738 TOTAL_BG_UPLOADED_LIMIT=32
DEBUG: 2022/11/02 07:56:24.819741 UPLOAD_CONCURRENCY=
DEBUG: 2022/11/02 07:56:24.819744 USER=username
DEBUG: 2022/11/02 07:56:24.819747 USERNAME=username
DEBUG: 2022/11/02 07:56:24.819750 VTE_VERSION=6800
DEBUG: 2022/11/02 07:56:24.819753 WALE_GPG_KEY_ID=
DEBUG: 2022/11/02 07:56:24.819757 WALE_S3_PREFIX=
DEBUG: 2022/11/02 07:56:24.819760 WALG_ALIVE_CHECK_INTERVAL=
DEBUG: 2022/11/02 07:56:24.819763 WALG_AZURE_BUFFER_SIZE=
DEBUG: 2022/11/02 07:56:24.819766 WALG_AZURE_MAX_BUFFERS=
DEBUG: 2022/11/02 07:56:24.819769 WALG_AZ_PREFIX=
DEBUG: 2022/11/02 07:56:24.819772 WALG_COMPRESSION_METHOD=lz4
DEBUG: 2022/11/02 07:56:24.819776 WALG_CSE_KMS_ID=
DEBUG: 2022/11/02 07:56:24.819779 WALG_CSE_KMS_REGION=
DEBUG: 2022/11/02 07:56:24.819782 WALG_DELTA_FROM_NAME=
DEBUG: 2022/11/02 07:56:24.819785 WALG_DELTA_FROM_USER_DATA=
DEBUG: 2022/11/02 07:56:24.819788 WALG_DELTA_MAX_STEPS=0
DEBUG: 2022/11/02 07:56:24.819791 WALG_DELTA_ORIGIN=
DEBUG: 2022/11/02 07:56:24.819794 WALG_DISK_RATE_LIMIT=
DEBUG: 2022/11/02 07:56:24.819798 WALG_DOWNLOAD_CONCURRENCY=10
DEBUG: 2022/11/02 07:56:24.819801 WALG_FETCH_TARGET_USER_DATA=
DEBUG: 2022/11/02 07:56:24.819804 WALG_FILE_PREFIX=
DEBUG: 2022/11/02 07:56:24.819808 WALG_GPG_KEY_ID=
DEBUG: 2022/11/02 07:56:24.819811 WALG_GS_PREFIX=
DEBUG: 2022/11/02 07:56:24.819814 WALG_INTEGRITY_MAX_DELAYED_WALS=0
DEBUG: 2022/11/02 07:56:24.819817 WALG_LIBSODIUM_KEY=
DEBUG: 2022/11/02 07:56:24.819820 WALG_LIBSODIUM_KEY_PATH=
DEBUG: 2022/11/02 07:56:24.819823 WALG_LIBSODIUM_KEY_TRANSFORM=none
DEBUG: 2022/11/02 07:56:24.819827 WALG_LOG_LEVEL=DEVEL
DEBUG: 2022/11/02 07:56:24.819830 WALG_NETWORK_RATE_LIMIT=
DEBUG: 2022/11/02 07:56:24.819833 WALG_PGP_KEY=
DEBUG: 2022/11/02 07:56:24.819836 WALG_PGP_KEY_PASSPHRASE=
DEBUG: 2022/11/02 07:56:24.819839 WALG_PGP_KEY_PATH=
DEBUG: 2022/11/02 07:56:24.819842 WALG_PG_WAL_SIZE=16
DEBUG: 2022/11/02 07:56:24.819845 WALG_PREFETCH_DIR=
DEBUG: 2022/11/02 07:56:24.819849 WALG_PREVENT_WAL_OVERWRITE=false
DEBUG: 2022/11/02 07:56:24.819852 WALG_S3_CA_CERT_FILE=
DEBUG: 2022/11/02 07:56:24.819855 WALG_S3_MAX_PART_SIZE=
DEBUG: 2022/11/02 07:56:24.819858 WALG_S3_PREFIX=
DEBUG: 2022/11/02 07:56:24.819861 WALG_S3_SSE=
DEBUG: 2022/11/02 07:56:24.819865 WALG_S3_SSE_C=
DEBUG: 2022/11/02 07:56:24.819868 WALG_S3_SSE_KMS_ID=
DEBUG: 2022/11/02 07:56:24.819871 WALG_S3_STORAGE_CLASS=
DEBUG: 2022/11/02 07:56:24.819874 WALG_SENTINEL_USER_DATA=
DEBUG: 2022/11/02 07:56:24.819877 WALG_SERIALIZER_TYPE=json_default
DEBUG: 2022/11/02 07:56:24.819880 WALG_SKIP_REDUNDANT_TARS=false
DEBUG: 2022/11/02 07:56:24.819884 WALG_SLOTNAME=
DEBUG: 2022/11/02 07:56:24.819887 WALG_SSH_PREFIX=
DEBUG: 2022/11/02 07:56:24.819890 WALG_STATSD_ADDRESS=
DEBUG: 2022/11/02 07:56:24.819893 WALG_STOP_BACKUP_TIMEOUT=
DEBUG: 2022/11/02 07:56:24.819896 WALG_STORAGE_PREFIX=
DEBUG: 2022/11/02 07:56:24.819899 WALG_STORE_ALL_CORRUPT_BLOCKS=false
DEBUG: 2022/11/02 07:56:24.819902 WALG_STREAM_CREATE_COMMAND=
DEBUG: 2022/11/02 07:56:24.819906 WALG_STREAM_RESTORE_COMMAND=
DEBUG: 2022/11/02 07:56:24.819909 WALG_SWIFT_PREFIX=
DEBUG: 2022/11/02 07:56:24.819912 WALG_TAR_DISABLE_FSYNC=false
DEBUG: 2022/11/02 07:56:24.819915 WALG_TAR_SIZE_THRESHOLD=1073741823
DEBUG: 2022/11/02 07:56:24.819918 WALG_UPLOAD_CONCURRENCY=16
DEBUG: 2022/11/02 07:56:24.819921 WALG_UPLOAD_DISK_CONCURRENCY=1
DEBUG: 2022/11/02 07:56:24.819925 WALG_UPLOAD_QUEUE=2
DEBUG: 2022/11/02 07:56:24.819928 WALG_UPLOAD_WAL_METADATA=NOMETADATA
DEBUG: 2022/11/02 07:56:24.819931 WALG_USE_COPY_COMPOSER=false
DEBUG: 2022/11/02 07:56:24.819934 WALG_USE_RATING_COMPOSER=false
DEBUG: 2022/11/02 07:56:24.819938 WALG_USE_REVERSE_UNPACK=false
DEBUG: 2022/11/02 07:56:24.819941 WALG_USE_WAL_DELTA=false
DEBUG: 2022/11/02 07:56:24.819944 WALG_VERIFY_PAGE_CHECKSUMS=false
DEBUG: 2022/11/02 07:56:24.819947 WALG_WITHOUT_FILES_METADATA=false
DEBUG: 2022/11/02 07:56:24.819951 WAYLAND_DISPLAY=wayland-0
DEBUG: 2022/11/02 07:56:24.819954 XAUTHORITY=/run/user/1000/.mutter-Xwaylandauth.9EAYU1
DEBUG: 2022/11/02 07:56:24.819957 XDG_CONFIG_DIRS=/etc/xdg/xdg-ubuntu:/etc/xdg
DEBUG: 2022/11/02 07:56:24.819961 XDG_CURRENT_DESKTOP=ubuntu:GNOME
DEBUG: 2022/11/02 07:56:24.819964 XDG_DATA_DIRS=/usr/share/ubuntu:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop
DEBUG: 2022/11/02 07:56:24.819967 XDG_MENU_PREFIX=gnome-
DEBUG: 2022/11/02 07:56:24.819970 XDG_RUNTIME_DIR=/run/user/1000
DEBUG: 2022/11/02 07:56:24.819974 XDG_SESSION_CLASS=user
DEBUG: 2022/11/02 07:56:24.819977 XDG_SESSION_DESKTOP=ubuntu
DEBUG: 2022/11/02 07:56:24.819980 XDG_SESSION_TYPE=wayland
DEBUG: 2022/11/02 07:56:24.819983 XMODIFIERS=@im=ibus
DEBUG: 2022/11/02 07:56:24.819987 YC_CSE_KMS_KEY_ID=
DEBUG: 2022/11/02 07:56:24.819990 YC_SERVICE_ACCOUNT_KEY_FILE=
DEBUG: 2022/11/02 07:56:24.819993 _=./wal-g
PostgreSQL backup tool

Usage:
wal-g [command]
...
```
</details>

<details>
<summary>
After (with my current env: 26 lines)
</summary>

```
$ WALG_LOG_LEVEL=DEVEL ./wal-g help
DEBUG: 2022/11/02 08:07:54.181313 --- COMPILED ENVIRONMENT VARS ---
	PGBACKREST_STANZA=main
	TOTAL_BG_UPLOADED_LIMIT=32
	WALG_COMPRESSION_METHOD=lz4
	WALG_DELTA_MAX_STEPS=0
	WALG_DOWNLOAD_CONCURRENCY=10
	WALG_INTEGRITY_MAX_DELAYED_WALS=0
	WALG_LIBSODIUM_KEY_TRANSFORM=none
	WALG_LOG_LEVEL=DEVEL
	WALG_PG_WAL_SIZE=16
	WALG_PREVENT_WAL_OVERWRITE=false
	WALG_SERIALIZER_TYPE=json_default
	WALG_SKIP_REDUNDANT_TARS=false
	WALG_STORE_ALL_CORRUPT_BLOCKS=false
	WALG_TAR_DISABLE_FSYNC=false
	WALG_TAR_SIZE_THRESHOLD=1073741823
	WALG_UPLOAD_CONCURRENCY=16
	WALG_UPLOAD_DISK_CONCURRENCY=1
	WALG_UPLOAD_QUEUE=2
	WALG_UPLOAD_WAL_METADATA=NOMETADATA
	WALG_USE_COPY_COMPOSER=false
	WALG_USE_RATING_COMPOSER=false
	WALG_USE_REVERSE_UNPACK=false
	WALG_USE_WAL_DELTA=false
	WALG_VERIFY_PAGE_CHECKSUMS=false
	WALG_WITHOUT_FILES_METADATA=false
PostgreSQL backup tool

Usage:
wal-g [command]
...
```
