### PR TITLE
enable using aws iam roles

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -10,9 +10,18 @@ To connect to Amazon S3, WAL-G requires that this variable be set:
 * `WALG_S3_PREFIX`
 (e.g. `s3://bucket/path/to/folder`) (alternative form `WALE_S3_PREFIX`)
 
-WAL-G determines AWS credentials [like other AWS tools](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence). You can set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (optionally with `AWS_SESSION_TOKEN`), or `~/.aws/credentials` (optionally with `AWS_PROFILE`), or you can set nothing to fetch credentials from the EC2 metadata service automatically.
+WAL-G determines AWS credentials [like other AWS tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html). You can set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (optionally with `AWS_SESSION_TOKEN`), or `~/.aws/credentials` (optionally with `AWS_PROFILE`), or you can set nothing to fetch credentials from the EC2 metadata service automatically.
 
 **Optional variables**
+
+* `AWS_ROLE_ARN`
+(e.g. `arn:aws:iam::123123123123:role/s3_access`)
+
+Set this variable along with `AWS_ROLE_SESSION_NAME` if you are using [AWS IAM](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-configure-role-oidc) roles to access S3 buckets.
+
+* `AWS_ROLE_SESSION_NAME`
+
+Specifies the name to attach to the role session. Useful only when `AWS_ROLE_ARN` is set.
 
 * `AWS_REGION`
 (e.g. `us-west-2`)

--- a/internal/config.go
+++ b/internal/config.go
@@ -301,6 +301,7 @@ var (
 		"AWS_DEFAULT_REGION":          true,
 		"AWS_DEFAULT_OUTPUT":          true,
 		"AWS_PROFILE":                 true,
+		"AWS_ROLE_ARN":                true,
 		"AWS_ROLE_SESSION_NAME":       true,
 		"AWS_CA_BUNDLE":               true,
 		"AWS_SHARED_CREDENTIALS_FILE": true,

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -27,6 +27,8 @@ const (
 	SecretAccessKeySetting   = "AWS_SECRET_ACCESS_KEY"
 	SecretKeySetting         = "AWS_SECRET_KEY"
 	SessionTokenSetting      = "AWS_SESSION_TOKEN"
+	SessionName              = "AWS_ROLE_SESSION_NAME"
+	RoleARN                  = "AWS_ROLE_ARN"
 	S3UseYcSessionToken      = "S3_USE_YC_SESSION_TOKEN"
 	SseSetting               = "S3_SSE"
 	SseCSetting              = "S3_SSE_C"
@@ -65,6 +67,8 @@ var (
 		SecretAccessKeySetting,
 		SecretKeySetting,
 		SessionTokenSetting,
+		SessionName,
+		RoleARN,
 		S3UseYcSessionToken,
 		SseSetting,
 		SseCSetting,


### PR DESCRIPTION
### Database name
All of them

## Pull request description
This PR allows using AWS IAM roles for S3 access. 
To do this, you need to set AWS_ROLE_ARN and AWS_ROLE_SESSION_NAME variables along with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.

### Describe what this PR fix
Currently, wal-g does not work with AWS IAM roles - you have to generate session token and pass it to wal-g env.
This PR adds ability to wal-g to get this token independently
