### PR TITLE
postgresql: fix data path mismatch on local backups

### DIFF
--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -304,28 +304,35 @@ func (bh *BackupHandler) uploadBackup() internal.TarFileSets {
 // HandleBackupPush handles the backup being read from Postgres or filesystem and being pushed to the repository
 // TODO : unit tests
 func (bh *BackupHandler) HandleBackupPush() {
-	folder := bh.Workers.Uploader.UploadingFolder
-	baseBackupFolder := folder.GetSubFolder(bh.Arguments.backupsFolder)
-	tracelog.DebugLogger.Printf("Base backup folder: %s", baseBackupFolder)
-
 	bh.CurBackupInfo.StartTime = utility.TimeNowCrossPlatformUTC()
 
 	if bh.Arguments.pgDataDirectory == "" {
-		if bh.Arguments.forceIncremental {
-			tracelog.ErrorLogger.Println("Delta backup not available for remote backup.")
-			tracelog.ErrorLogger.Fatal("To run delta backup, supply [db_directory].")
-		}
-		// If no arg is parsed, try to run remote backup using pglogrepl's BASE_BACKUP functionality
-		tracelog.InfoLogger.Println("Running remote backup through Postgres connection.")
-		tracelog.InfoLogger.Println("Features like delta backup are disabled, there might be a performance impact.")
-		tracelog.InfoLogger.Println("To run with local backup functionalities, supply [db_directory].")
-		if bh.PgInfo.pgVersion < 110000 && !bh.Arguments.verifyPageChecksums {
-			tracelog.InfoLogger.Println("VerifyPageChecksums=false is only supported for streaming backup since PG11")
-			bh.Arguments.verifyPageChecksums = true
-		}
-		bh.createAndPushRemoteBackup()
-		return
+		bh.handleBackupPushRemote()
+	} else {
+		bh.handleBackupPushLocal()
 	}
+}
+
+func (bh *BackupHandler) handleBackupPushRemote() {
+	if bh.Arguments.forceIncremental {
+		tracelog.ErrorLogger.Println("Delta backup not available for remote backup.")
+		tracelog.ErrorLogger.Fatal("To run delta backup, supply [db_directory].")
+	}
+	// If no arg is parsed, try to run remote backup using pglogrepl's BASE_BACKUP functionality
+	tracelog.InfoLogger.Println("Running remote backup through Postgres connection.")
+	tracelog.InfoLogger.Println("Features like delta backup are disabled, there might be a performance impact.")
+	tracelog.InfoLogger.Println("To run with local backup functionalities, supply [db_directory].")
+	if bh.PgInfo.pgVersion < 110000 && !bh.Arguments.verifyPageChecksums {
+		tracelog.InfoLogger.Println("VerifyPageChecksums=false is only supported for streaming backup since PG11")
+		bh.Arguments.verifyPageChecksums = true
+	}
+	bh.createAndPushRemoteBackup()
+}
+
+func (bh *BackupHandler) handleBackupPushLocal() {
+	folder := bh.Workers.Uploader.UploadingFolder
+	baseBackupFolder := folder.GetSubFolder(bh.Arguments.backupsFolder)
+	tracelog.DebugLogger.Printf("Base backup folder: %s", baseBackupFolder)
 
 	if utility.ResolveSymlink(bh.Arguments.pgDataDirectory) != bh.PgInfo.PgDataDirectory {
 		tracelog.ErrorLogger.Panicf("Data directory read from Postgres (%s) is different than as parsed (%s).",
@@ -402,11 +409,12 @@ func NewBackupHandler(arguments BackupArguments) (bh *BackupHandler, err error) 
 
 	uploader, err := ConfigureWalUploader()
 	if err != nil {
-		return bh, err
+		return nil, err
 	}
 	pgInfo, err := getPgServerInfo()
 	if err != nil {
-		return bh, err
+		return nil, err
+	}
 	}
 
 	if arguments.pgDataDirectory != "" && arguments.pgDataDirectory != pgInfo.PgDataDirectory {
@@ -423,7 +431,7 @@ func NewBackupHandler(arguments BackupArguments) (bh *BackupHandler, err error) 
 		PgInfo: pgInfo,
 	}
 
-	return bh, err
+	return bh, nil
 }
 
 func (bh *BackupHandler) runRemoteBackup() *StreamingBaseBackup {

--- a/utility/utility.go
+++ b/utility/utility.go
@@ -137,6 +137,19 @@ func ResolveSymlink(path string) string {
 	return resolve
 }
 
+// AbsResolveSymlink first tries to turn 'path' to an absolute path, then calls ResolveSymlink.
+// If 'path' can't be turned to an absolute path, keep the relative path.
+func AbsResolveSymlink(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		// keep a trace of the errors, but keep going with 'path'
+		tracelog.DebugLogger.Printf("could not convert path to absolute path: %s", err)
+		abs = path
+	}
+
+	return ResolveSymlink(abs)
+}
+
 func GetFileExtension(filePath string) string {
 	ext := path.Ext(filePath)
 	if ext != "" {


### PR DESCRIPTION
### Database name

postgresql

# Pull request description

### Describe what this PR fix

fixes #1382 

expand data path from command line to an absolute path before resolving symlinks and comparing it to value returned from pgsql.