### PR TITLE
Fix Greenplum deleted AO segment file error handling

### DIFF
--- a/internal/databases/greenplum/ao_storage_uploader.go
+++ b/internal/databases/greenplum/ao_storage_uploader.go
@@ -1,7 +1,6 @@
 package greenplum
 
 import (
-	"errors"
 	"io"
 	"path"
 	"sync"
@@ -44,8 +43,10 @@ func NewAoStorageUploader(uploader *internal.Uploader, baseAoFiles BackupAOFiles
 
 func (u *AoStorageUploader) AddFile(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error {
 	err := u.addFile(cfi, aoMeta, location)
-	if errors.Is(err, internal.FileNotExistError{}) {
-		// File was deleted before opening. We should ignore file here as if it did not exist.
+	switch err.(type) {
+	case internal.FileNotExistError:
+		// File was deleted before opening.
+		// We should ignore file here as if it did not exist.
 		tracelog.WarningLogger.Println(err)
 		return nil
 	}


### PR DESCRIPTION
Fix error handling: current `errors.Is` logic does not work for custom errors. That causes entire backup to abort if the AO/AOCS file was deleted while making a backup.