### PR TITLE
Fix non-string config settings handling

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -781,12 +781,7 @@ func FolderFromConfig(configFile string) (storage.Folder, error) {
 // Applicable for Swift/Postgres/etc libs that waiting config paramenters only from ENV.
 func bindConfigToEnv(globalViper *viper.Viper) {
 	for k, v := range globalViper.AllSettings() {
-		val, ok := v.(string)
-		if !ok {
-			// note: all viper settings are currently strings, this warning will not be triggered at the moment
-			tracelog.WarningLogger.Printf("config value for %s is not a string: %T %v\n", k, v, v)
-			continue
-		}
+		val := fmt.Sprint(v)
 		k = strings.ToUpper(k)
 
 		// avoid filling environment with empty values :


### PR DESCRIPTION
After the https://github.com/wal-g/wal-g/pull/1367, WAL-G complains about any non-string values found in its config:
```
~ # wal-g backup-list
WARNING: 2022/11/29 13:54:15.088991 config value for walg_disk_rate_limit is not a string: int 44739242
WARNING: 2022/11/29 13:54:15.089056 config value for gomaxprocs is not a string: int 10
```
This PR allows WAL-G to handle the non-string values correctly.
