### PR TITLE
Add recovery_target_timeline setting to Greenplum restore config

### DIFF
--- a/internal/databases/greenplum/recovery_cfg_maker.go
+++ b/internal/databases/greenplum/recovery_cfg_maker.go
@@ -23,7 +23,8 @@ func (m RecoveryConfigMaker) Make(contentID int) string {
 	restoreCmd := fmt.Sprintf(
 		"restore_command = '%s seg wal-fetch \"%%f\" \"%%p\" --content-id=%d --config %s'",
 		m.walgBinaryPath, contentID, m.cfgPath)
-	recoveryTarget := fmt.Sprintf("recovery_target_name = '%s'", m.recoveryTargetName)
+	recoveryTargetName := fmt.Sprintf("recovery_target_name = '%s'", m.recoveryTargetName)
+	recoveryTargetTli := "recovery_target_timeline = latest"
 
-	return strings.Join([]string{restoreCmd, recoveryTarget}, "\n")
+	return strings.Join([]string{restoreCmd, recoveryTargetName, recoveryTargetTli}, "\n")
 }

--- a/internal/databases/greenplum/recovery_cfg_maker_test.go
+++ b/internal/databases/greenplum/recovery_cfg_maker_test.go
@@ -15,7 +15,8 @@ func TestGenerateRecoveryConf(t *testing.T) {
 	contentID := -1
 
 	expectedCfg := `restore_command = '/usr/bin/wal-g seg wal-fetch "%f" "%p" --content-id=-1 --config /etc/wal-g/wal-g.yaml'
-recovery_target_name = 'some_backup'`
+recovery_target_name = 'some_backup'
+recovery_target_timeline = latest`
 	actualCfg := recCfgMaker.Make(contentID)
 	assert.Equal(t, expectedCfg, actualCfg, "Actual recovery.conf does not match the expected one")
 }


### PR DESCRIPTION
Since GPDB 6X is based on Postgresql 9.4, default behaviour is to stay on the backup timeline. However, in most cases it results in incorrect backup restorations in cases of timeline switches. I propose to add the `recovery_target_timeline=latest` setting to mimic the default recovery option setting of the new PostgreSQL versions.