### PR TITLE
Greenplum: populate pg_hba.conf on master host during restore

### DIFF
--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -164,7 +164,7 @@ func (fh *FetchHandler) createPgHbaOnSegments() error {
 	}
 
 	remoteOutput := fh.cluster.GenerateAndExecuteCommand("Updating pg_hba on segments",
-		cluster.ON_SEGMENTS|cluster.EXCLUDE_MIRRORS,
+		cluster.ON_SEGMENTS|cluster.EXCLUDE_MIRRORS|cluster.INCLUDE_MASTER,
 		func(contentID int) string {
 			if !fh.contentIDsToFetch[contentID] {
 				return newSkippedSegmentMsg(contentID)


### PR DESCRIPTION
Currently, WAL-G does not alter the master `pg_hba.conf` file during restore. This PR corrects this behaviour so Greenplum can start with the correct `pg_hba.conf` version.