### PR TITLE
Issue/1108

### DIFF
--- a/cmd/fdb/backup_list.go
+++ b/cmd/fdb/backup_list.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/fdb"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -17,7 +18,7 @@ var backupListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
-		internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), false, false)
+		internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), fdb.NewGenericMetaInteractor(), false, false)
 	},
 }
 

--- a/cmd/gp/backup_list.go
+++ b/cmd/gp/backup_list.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -22,7 +23,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			folder, err := internal.ConfigureFolder()
 			tracelog.ErrorLogger.FatalOnError(err)
-			internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), pretty, jsonOutput)
+			internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), greenplum.NewGenericMetaInteractor(), pretty, jsonOutput)
 		},
 	}
 	pretty     = false

--- a/cmd/mongo/backup_list.go
+++ b/cmd/mongo/backup_list.go
@@ -36,7 +36,7 @@ var backupListCmd = &cobra.Command{
 			err := mongo.HandleDetailedBackupList(backupFolder, os.Stdout, prettyPrint, jsonFormat)
 			tracelog.ErrorLogger.FatalOnError(err)
 		} else {
-			internal.DefaultHandleBackupList(backupFolder, prettyPrint, jsonFormat)
+			internal.DefaultHandleBackupList(backupFolder, mongo.NewGenericMetaInteractor(), prettyPrint, jsonFormat)
 		}
 	},
 }

--- a/cmd/mysql/backup_list.go
+++ b/cmd/mysql/backup_list.go
@@ -27,7 +27,7 @@ var (
 			if detail {
 				mysql.HandleDetailedBackupList(folder.GetSubFolder(utility.BaseBackupPath), pretty, json)
 			} else {
-				internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), pretty, json)
+				internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), mysql.NewGenericMetaInteractor(), pretty, json)
 			}
 		},
 	}

--- a/cmd/pg/backup_list.go
+++ b/cmd/pg/backup_list.go
@@ -27,7 +27,7 @@ var (
 			if detail {
 				postgres.HandleDetailedBackupList(folder.GetSubFolder(utility.BaseBackupPath), pretty, json)
 			} else {
-				internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), pretty, json)
+				internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), postgres.NewGenericMetaInteractor(), pretty, json)
 			}
 		},
 	}

--- a/cmd/pg/catchup_list.go
+++ b/cmd/pg/catchup_list.go
@@ -24,7 +24,7 @@ var (
 			if detail {
 				postgres.HandleDetailedBackupList(folder.GetSubFolder(utility.CatchupPath), pretty, json)
 			} else {
-				internal.DefaultHandleBackupList(folder.GetSubFolder(utility.CatchupPath), pretty, json)
+				internal.DefaultHandleBackupList(folder.GetSubFolder(utility.CatchupPath), postgres.NewGenericMetaInteractor(), pretty, json)
 			}
 		},
 	}

--- a/cmd/redis/backup_list.go
+++ b/cmd/redis/backup_list.go
@@ -27,7 +27,7 @@ var (
 			if detail {
 				redis.HandleDetailedBackupList(folder.GetSubFolder(utility.BaseBackupPath), pretty, json)
 			} else {
-				internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), pretty, json)
+				internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), redis.NewGenericMetaInteractor(), pretty, json)
 			}
 		},
 	}

--- a/cmd/sqlserver/backup_list.go
+++ b/cmd/sqlserver/backup_list.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/sqlserver"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -18,7 +19,7 @@ var backupListCmd = &cobra.Command{
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
 		// todo: implement pretty and json logic
-		internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), false, false)
+		internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), sqlserver.NewGenericMetaInteractor(), false, false)
 	},
 }
 

--- a/internal/BackupTimeWithMetadata.go
+++ b/internal/BackupTimeWithMetadata.go
@@ -1,11 +1,8 @@
 package internal
 
-import "time"
-
 // BackupTimeWithMetadata is used to sort backups by
 // latest modified time or creation time.
 type BackupTimeWithMetadata struct {
 	BackupTime
-
-	StartTime time.Time
+	GenericMetadata
 }

--- a/internal/BackupTimeWithMetadata.go
+++ b/internal/BackupTimeWithMetadata.go
@@ -1,0 +1,11 @@
+package internal
+
+import "time"
+
+// BackupTimeWithMetadata is used to sort backups by
+// latest modified time or creation time.
+type BackupTimeWithMetadata struct {
+	BackupTime
+
+	StartTime time.Time
+}

--- a/internal/backup_list_handler_test.go
+++ b/internal/backup_list_handler_test.go
@@ -56,25 +56,31 @@ var emptyColonsBackups = []internal.BackupTime{
 }
 
 func TestHandleBackupListWriteBackups(t *testing.T) {
-	backups := []internal.BackupTime{
+	backups := []internal.BackupTimeWithMetadata{
 		{
-			BackupName:  "backup000",
-			Time:        time.Time{},
-			WalFileName: "wallName0",
+			BackupTime: internal.BackupTime{
+				BackupName:  "backup000",
+				Time:        time.Time{},
+				WalFileName: "wallName0",
+			},
+			StartTime: time.Time{},
 		},
 		{
-			BackupName:  "backup001",
-			Time:        time.Time{},
-			WalFileName: "wallName1",
+			BackupTime: internal.BackupTime{
+				BackupName:  "backup001",
+				Time:        time.Time{},
+				WalFileName: "wallName1",
+			},
+			StartTime: time.Time{},
 		},
 	}
 
-	getBackupsFunc := func() ([]internal.BackupTime, error) {
+	getBackupsFunc := func() ([]internal.BackupTimeWithMetadata, error) {
 		return backups, nil
 	}
 	writeBackupListCallsCount := 0
-	var writeBackupListCallArgs []internal.BackupTime
-	writeBackupListFunc := func(backups []internal.BackupTime) {
+	var writeBackupListCallArgs []internal.BackupTimeWithMetadata
+	writeBackupListFunc := func(backups []internal.BackupTimeWithMetadata) {
 		writeBackupListCallsCount++
 		writeBackupListCallArgs = backups
 	}
@@ -91,23 +97,29 @@ func TestHandleBackupListWriteBackups(t *testing.T) {
 }
 
 func TestHandleBackupListLogError(t *testing.T) {
-	backups := []internal.BackupTime{
+	backups := []internal.BackupTimeWithMetadata{
 		{
-			BackupName:  "backup000",
-			Time:        time.Time{},
-			WalFileName: "wallName0",
+			BackupTime: internal.BackupTime{
+				BackupName:  "backup000",
+				Time:        time.Time{},
+				WalFileName: "wallName0",
+			},
+			StartTime: time.Time{},
 		},
 		{
-			BackupName:  "backup001",
-			Time:        time.Time{},
-			WalFileName: "wallName1",
+			BackupTime: internal.BackupTime{
+				BackupName:  "backup001",
+				Time:        time.Time{},
+				WalFileName: "wallName1",
+			},
+			StartTime: time.Time{},
 		},
 	}
 	someErrorInstance := someError{errors.New("some error")}
-	getBackupsFunc := func() ([]internal.BackupTime, error) {
+	getBackupsFunc := func() ([]internal.BackupTimeWithMetadata, error) {
 		return backups, someErrorInstance
 	}
-	writeBackupListFunc := func(backups []internal.BackupTime) {}
+	writeBackupListFunc := func(backups []internal.BackupTimeWithMetadata) {}
 	infoLogger, errorLogger := testtools.MockLoggers()
 
 	internal.HandleBackupList(
@@ -121,10 +133,10 @@ func TestHandleBackupListLogError(t *testing.T) {
 }
 
 func TestHandleBackupListLogNoBackups(t *testing.T) {
-	getBackupsFunc := func() ([]internal.BackupTime, error) {
-		return []internal.BackupTime{}, nil
+	getBackupsFunc := func() ([]internal.BackupTimeWithMetadata, error) {
+		return []internal.BackupTimeWithMetadata{}, nil
 	}
-	writeBackupListFunc := func(backups []internal.BackupTime) {}
+	writeBackupListFunc := func(backups []internal.BackupTimeWithMetadata) {}
 	infoLogger, errorLogger := testtools.MockLoggers()
 
 	internal.HandleBackupList(

--- a/internal/backup_list_handler_test.go
+++ b/internal/backup_list_handler_test.go
@@ -56,31 +56,25 @@ var emptyColonsBackups = []internal.BackupTime{
 }
 
 func TestHandleBackupListWriteBackups(t *testing.T) {
-	backups := []internal.BackupTimeWithMetadata{
+	backups := []internal.BackupTime{
 		{
-			BackupTime: internal.BackupTime{
-				BackupName:  "backup000",
-				Time:        time.Time{},
-				WalFileName: "wallName0",
-			},
-			StartTime: time.Time{},
+			BackupName:  "backup000",
+			Time:        time.Time{},
+			WalFileName: "wallName0",
 		},
 		{
-			BackupTime: internal.BackupTime{
-				BackupName:  "backup001",
-				Time:        time.Time{},
-				WalFileName: "wallName1",
-			},
-			StartTime: time.Time{},
+			BackupName:  "backup001",
+			Time:        time.Time{},
+			WalFileName: "wallName1",
 		},
 	}
 
-	getBackupsFunc := func() ([]internal.BackupTimeWithMetadata, error) {
+	getBackupsFunc := func() ([]internal.BackupTime, error) {
 		return backups, nil
 	}
 	writeBackupListCallsCount := 0
-	var writeBackupListCallArgs []internal.BackupTimeWithMetadata
-	writeBackupListFunc := func(backups []internal.BackupTimeWithMetadata) {
+	var writeBackupListCallArgs []internal.BackupTime
+	writeBackupListFunc := func(backups []internal.BackupTime) {
 		writeBackupListCallsCount++
 		writeBackupListCallArgs = backups
 	}
@@ -97,29 +91,23 @@ func TestHandleBackupListWriteBackups(t *testing.T) {
 }
 
 func TestHandleBackupListLogError(t *testing.T) {
-	backups := []internal.BackupTimeWithMetadata{
+	backups := []internal.BackupTime{
 		{
-			BackupTime: internal.BackupTime{
-				BackupName:  "backup000",
-				Time:        time.Time{},
-				WalFileName: "wallName0",
-			},
-			StartTime: time.Time{},
+			BackupName:  "backup000",
+			Time:        time.Time{},
+			WalFileName: "wallName0",
 		},
 		{
-			BackupTime: internal.BackupTime{
-				BackupName:  "backup001",
-				Time:        time.Time{},
-				WalFileName: "wallName1",
-			},
-			StartTime: time.Time{},
+			BackupName:  "backup001",
+			Time:        time.Time{},
+			WalFileName: "wallName1",
 		},
 	}
 	someErrorInstance := someError{errors.New("some error")}
-	getBackupsFunc := func() ([]internal.BackupTimeWithMetadata, error) {
+	getBackupsFunc := func() ([]internal.BackupTime, error) {
 		return backups, someErrorInstance
 	}
-	writeBackupListFunc := func(backups []internal.BackupTimeWithMetadata) {}
+	writeBackupListFunc := func(backups []internal.BackupTime) {}
 	infoLogger, errorLogger := testtools.MockLoggers()
 
 	internal.HandleBackupList(
@@ -133,10 +121,10 @@ func TestHandleBackupListLogError(t *testing.T) {
 }
 
 func TestHandleBackupListLogNoBackups(t *testing.T) {
-	getBackupsFunc := func() ([]internal.BackupTimeWithMetadata, error) {
-		return []internal.BackupTimeWithMetadata{}, nil
+	getBackupsFunc := func() ([]internal.BackupTime, error) {
+		return []internal.BackupTime{}, nil
 	}
-	writeBackupListFunc := func(backups []internal.BackupTimeWithMetadata) {}
+	writeBackupListFunc := func(backups []internal.BackupTime) {}
 	infoLogger, errorLogger := testtools.MockLoggers()
 
 	internal.HandleBackupList(

--- a/internal/backup_list_test.go
+++ b/internal/backup_list_test.go
@@ -3,6 +3,7 @@ package internal_test
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"testing"
 	"time"
 
@@ -13,9 +14,23 @@ import (
 	"github.com/wal-g/wal-g/testtools"
 )
 
+type MockGenericMetaInteractor struct{}
+
+func (m *MockGenericMetaInteractor) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	return internal.GenericMetadata{}, nil
+}
+
+func (m *MockGenericMetaInteractor) SetUserData(backupName string, backupFolder storage.Folder, userData interface{}) error {
+	return nil
+}
+
+func (m *MockGenericMetaInteractor) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	return nil
+}
+
 func TestBackupListFindsBackups(t *testing.T) {
 	folder := testtools.CreateMockStorageFolder()
-	internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), false, false)
+	internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), &MockGenericMetaInteractor{}, false, false)
 }
 
 var backups = []internal.BackupTime{
@@ -94,4 +109,62 @@ func TestBackupListCorrectPrettyJsonOutput(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, unmarshaledBackups, backups)
 	assert.Equal(t, buf.String(), expectedString)
+}
+
+var backupsWithMeta = []internal.BackupTimeWithMetadata{
+	{
+		BackupTime: internal.BackupTime{
+			BackupName:  "base_123",
+			Time:        time.Date(2019, 4, 25, 14, 48, 0, 0, time.UTC),
+			WalFileName: "ZZZZZZZZZZZZZZZZZZZZZZZZ",
+		},
+		StartTime: time.Date(2017, 4, 17, 16, 49, 0, 0, time.UTC),
+	},
+	{
+		BackupTime: internal.BackupTime{
+			BackupName:  "base_456",
+			Time:        time.Date(2020, 7, 5, 1, 1, 50, 0, time.UTC),
+			WalFileName: "ZZZZZZZZZZZZZZZZZZZZZZZZ",
+		},
+		StartTime: time.Date(2016, 4, 17, 16, 49, 0, 0, time.UTC),
+	},
+}
+
+func TestBackupWithMetaListCorrectOutput(t *testing.T) {
+	const expected = "" +
+		"name     modified             wal_segment_backup_start\n" +
+		"base_456 2020-07-05T01:01:50Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n" +
+		"base_123 2019-04-25T14:48:00Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n"
+
+	buf := new(bytes.Buffer)
+	internal.SortBackupTimeWithMetadataSlices(backupsWithMeta)
+
+	sortedBackups := make([]internal.BackupTime, len(backupsWithMeta))
+	for i, backupWithMeta := range backupsWithMeta {
+		sortedBackups[i] = backupWithMeta.BackupTime
+	}
+
+	internal.WriteBackupList(sortedBackups, buf)
+	assert.Equal(t, buf.String(), expected)
+}
+
+func TestBackupWithMetaListCorrectPrettyOutput(t *testing.T) {
+	const expected = "" +
+		"+---+----------+----------------------------------+--------------------------+\n" +
+		"| # | NAME     | MODIFIED                         | WAL SEGMENT BACKUP START |\n" +
+		"+---+----------+----------------------------------+--------------------------+\n" +
+		"| 0 | base_456 | Sunday, 05-Jul-20 01:01:50 UTC   | ZZZZZZZZZZZZZZZZZZZZZZZZ |\n" +
+		"| 1 | base_123 | Thursday, 25-Apr-19 14:48:00 UTC | ZZZZZZZZZZZZZZZZZZZZZZZZ |\n" +
+		"+---+----------+----------------------------------+--------------------------+\n"
+
+	buf := new(bytes.Buffer)
+	internal.SortBackupTimeWithMetadataSlices(backupsWithMeta)
+
+	sortedBackups := make([]internal.BackupTime, len(backupsWithMeta))
+	for i, backupWithMeta := range backupsWithMeta {
+		sortedBackups[i] = backupWithMeta.BackupTime
+	}
+
+	internal.WritePrettyBackupList(sortedBackups, buf)
+	assert.Equal(t, buf.String(), expected)
 }

--- a/internal/backup_list_test.go
+++ b/internal/backup_list_test.go
@@ -3,7 +3,6 @@ package internal_test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"testing"
 	"time"
 
@@ -14,23 +13,9 @@ import (
 	"github.com/wal-g/wal-g/testtools"
 )
 
-type MockGenericMetaInteractor struct{}
-
-func (m *MockGenericMetaInteractor) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
-	return internal.GenericMetadata{}, nil
-}
-
-func (m *MockGenericMetaInteractor) SetUserData(backupName string, backupFolder storage.Folder, userData interface{}) error {
-	return nil
-}
-
-func (m *MockGenericMetaInteractor) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
-	return nil
-}
-
 func TestBackupListFindsBackups(t *testing.T) {
 	folder := testtools.CreateMockStorageFolder()
-	internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), &MockGenericMetaInteractor{}, false, false)
+	internal.DefaultHandleBackupList(folder.GetSubFolder(utility.BaseBackupPath), &testtools.MockGenericMetaFetcher{}, false, false)
 }
 
 var backups = []internal.BackupTime{
@@ -109,62 +94,4 @@ func TestBackupListCorrectPrettyJsonOutput(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, unmarshalledBackups, backups)
 	assert.Equal(t, buf.String(), expectedString)
-}
-
-var backupsWithMeta = []internal.BackupTimeWithMetadata{
-	{
-		BackupTime: internal.BackupTime{
-			BackupName:  "base_123",
-			Time:        time.Date(2019, 4, 25, 14, 48, 0, 0, time.UTC),
-			WalFileName: "ZZZZZZZZZZZZZZZZZZZZZZZZ",
-		},
-		StartTime: time.Date(2017, 4, 17, 16, 49, 0, 0, time.UTC),
-	},
-	{
-		BackupTime: internal.BackupTime{
-			BackupName:  "base_456",
-			Time:        time.Date(2020, 7, 5, 1, 1, 50, 0, time.UTC),
-			WalFileName: "ZZZZZZZZZZZZZZZZZZZZZZZZ",
-		},
-		StartTime: time.Date(2016, 4, 17, 16, 49, 0, 0, time.UTC),
-	},
-}
-
-func TestBackupWithMetaListCorrectOutput(t *testing.T) {
-	const expected = "" +
-		"name     modified             wal_segment_backup_start\n" +
-		"base_456 2020-07-05T01:01:50Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n" +
-		"base_123 2019-04-25T14:48:00Z ZZZZZZZZZZZZZZZZZZZZZZZZ\n"
-
-	buf := new(bytes.Buffer)
-	internal.SortBackupTimeWithMetadataSlices(backupsWithMeta)
-
-	sortedBackups := make([]internal.BackupTime, len(backupsWithMeta))
-	for i, backupWithMeta := range backupsWithMeta {
-		sortedBackups[i] = backupWithMeta.BackupTime
-	}
-
-	internal.WriteBackupList(sortedBackups, buf)
-	assert.Equal(t, buf.String(), expected)
-}
-
-func TestBackupWithMetaListCorrectPrettyOutput(t *testing.T) {
-	const expected = "" +
-		"+---+----------+----------------------------------+--------------------------+\n" +
-		"| # | NAME     | MODIFIED                         | WAL SEGMENT BACKUP START |\n" +
-		"+---+----------+----------------------------------+--------------------------+\n" +
-		"| 0 | base_456 | Sunday, 05-Jul-20 01:01:50 UTC   | ZZZZZZZZZZZZZZZZZZZZZZZZ |\n" +
-		"| 1 | base_123 | Thursday, 25-Apr-19 14:48:00 UTC | ZZZZZZZZZZZZZZZZZZZZZZZZ |\n" +
-		"+---+----------+----------------------------------+--------------------------+\n"
-
-	buf := new(bytes.Buffer)
-	internal.SortBackupTimeWithMetadataSlices(backupsWithMeta)
-
-	sortedBackups := make([]internal.BackupTime, len(backupsWithMeta))
-	for i, backupWithMeta := range backupsWithMeta {
-		sortedBackups[i] = backupWithMeta.BackupTime
-	}
-
-	internal.WritePrettyBackupList(sortedBackups, buf)
-	assert.Equal(t, buf.String(), expected)
 }

--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -87,6 +87,26 @@ func GetBackups(folder storage.Folder) (backups []BackupTime, err error) {
 	return
 }
 
+// GetBackupsWithMetadata receives backup descriptions with meta information
+func GetBackupsWithMetadata(folder storage.Folder, metaFetcher GenericMetaFetcher) (backupsWithMeta []BackupTimeWithMetadata, err error) {
+	backups, err := GetBackups(folder)
+
+	if err != nil {
+		return nil, err
+	}
+
+	backupsWithMeta = make([]BackupTimeWithMetadata, len(backups))
+	for i, backup := range backups {
+		meta, err := metaFetcher.Fetch(backup.BackupName, folder)
+		if err != nil {
+			return nil, err
+		}
+
+		backupsWithMeta[i] = BackupTimeWithMetadata{backup, meta}
+	}
+	return
+}
+
 // TODO : unit tests
 func GetBackupsAndGarbage(folder storage.Folder) (backups []BackupTime, garbage []string, err error) {
 	backupObjects, subFolders, err := folder.ListFolder()

--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -13,6 +13,13 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
+type BackupTimeSlicesOrder int
+
+const (
+	ByCreationTime BackupTimeSlicesOrder = iota
+	ByModificationTime
+)
+
 type NoBackupsFoundError struct {
 	error
 }
@@ -111,6 +118,27 @@ func SortBackupTimeSlices(backupTimes []BackupTime) {
 	sort.Slice(backupTimes, func(i, j int) bool {
 		return backupTimes[i].Time.Before(backupTimes[j].Time)
 	})
+}
+
+func SortBackupTimeWithMetadataSlices(backupTimes []BackupTimeWithMetadata) {
+	order := ByCreationTime
+
+	for _, backupTime := range backupTimes {
+		if (backupTime.StartTime == time.Time{}) {
+			order = ByModificationTime
+			break
+		}
+	}
+
+	if order == ByCreationTime {
+		sort.Slice(backupTimes, func(i, j int) bool {
+			return backupTimes[i].StartTime.Before(backupTimes[j].StartTime)
+		})
+	} else {
+		sort.Slice(backupTimes, func(i, j int) bool {
+			return backupTimes[i].Time.Before(backupTimes[j].Time)
+		})
+	}
 }
 
 func GetGarbageFromPrefix(folders []storage.Folder, nonGarbage []BackupTime) []string {

--- a/internal/backup_util_test.go
+++ b/internal/backup_util_test.go
@@ -106,3 +106,136 @@ func TestGetGarbageFromPrefix_emptyFolders(t *testing.T) {
 	garbage := internal.GetGarbageFromPrefix(folders, nonGarbage)
 	assert.Equal(t, garbage, make([]string, 0))
 }
+
+func TestSortBackupTimeWithMetadataSlices_ByCreationTimeWhenCreationTimeIsNotDefault(t *testing.T) {
+	backups := []internal.BackupTimeWithMetadata{
+		{
+			BackupTime: internal.BackupTime{
+				BackupName:  "fBackup",
+				Time:        time.Date(2021, 3, 21, 0, 0, 0, 0, time.UTC),
+				WalFileName: "fWalFileName",
+			},
+			GenericMetadata: internal.GenericMetadata{
+				StartTime: time.Date(2020, 3, 21, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			BackupTime: internal.BackupTime{
+				BackupName:  "sBackup",
+				Time:        time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC),
+				WalFileName: "sWalFileName",
+			},
+			GenericMetadata: internal.GenericMetadata{
+				StartTime: time.Date(2016, 3, 21, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	expectedBackups := []internal.BackupTimeWithMetadata{
+		{
+			BackupTime: internal.BackupTime{
+				BackupName:  "sBackup",
+				Time:        time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC),
+				WalFileName: "sWalFileName",
+			},
+			GenericMetadata: internal.GenericMetadata{
+				StartTime: time.Date(2016, 3, 21, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			BackupTime: internal.BackupTime{
+				BackupName:  "fBackup",
+				Time:        time.Date(2021, 3, 21, 0, 0, 0, 0, time.UTC),
+				WalFileName: "fWalFileName",
+			},
+			GenericMetadata: internal.GenericMetadata{
+				StartTime: time.Date(2020, 3, 21, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	internal.SortBackupTimeWithMetadataSlices(backups)
+	assert.Equal(t, expectedBackups, backups)
+}
+
+func TestSortBackupTimeWithMetadataSlices_ByModificationTimeWhenCreationTimeIsDefault(t *testing.T) {
+	backups := []internal.BackupTimeWithMetadata{
+		{
+			BackupTime: internal.BackupTime{
+				BackupName:  "fBackup",
+				Time:        time.Date(2021, 3, 21, 0, 0, 0, 0, time.UTC),
+				WalFileName: "fWalFileName",
+			},
+			GenericMetadata: internal.GenericMetadata{},
+		},
+		{
+			BackupTime: internal.BackupTime{
+				BackupName:  "sBackup",
+				Time:        time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC),
+				WalFileName: "sWalFileName",
+			},
+			GenericMetadata: internal.GenericMetadata{},
+		},
+	}
+
+	expectedBackups := []internal.BackupTimeWithMetadata{
+		{
+			BackupTime: internal.BackupTime{
+				BackupName:  "fBackup",
+				Time:        time.Date(2021, 3, 21, 0, 0, 0, 0, time.UTC),
+				WalFileName: "fWalFileName",
+			},
+			GenericMetadata: internal.GenericMetadata{},
+		},
+		{
+			BackupTime: internal.BackupTime{
+				BackupName:  "sBackup",
+				Time:        time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC),
+				WalFileName: "sWalFileName",
+			},
+			GenericMetadata: internal.GenericMetadata{},
+		},
+	}
+
+	internal.SortBackupTimeWithMetadataSlices(backups)
+	assert.Equal(t, expectedBackups, backups)
+}
+
+func TestGetBackupsWithMetadata(t *testing.T) {
+	fBackup := internal.BackupTime{
+		BackupName:  "fSentinelBackup",
+		WalFileName: "ZZZZZZZZZZZZZZZZZZZZZZZZ",
+	}
+	sBackup := internal.BackupTime{
+		BackupName:  "sSentinelBackup",
+		WalFileName: "ZZZZZZZZZZZZZZZZZZZZZZZZ",
+	}
+
+	metadata := map[string]internal.GenericMetadata{
+		fBackup.BackupName: {StartTime: time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)},
+		sBackup.BackupName: {StartTime: time.Date(2016, 3, 21, 0, 0, 0, 0, time.UTC)},
+	}
+
+	expected := []internal.BackupTimeWithMetadata{
+		{fBackup, metadata[fBackup.BackupName]},
+		{sBackup, metadata[sBackup.BackupName]},
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+
+	marshaller, _ := internal.NewDtoSerializer()
+	fFile, _ := marshaller.Marshal(fBackup)
+	sFile, _ := marshaller.Marshal(sBackup)
+
+	_ = folder.PutObject(internal.SentinelNameFromBackup(fBackup.BackupName), fFile)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(sBackup.BackupName), sFile)
+
+	actual, _ := internal.GetBackupsWithMetadata(folder, &testtools.MockGenericMetaFetcher{MockMeta: metadata})
+
+	// ignore time difference
+	for i, _ := range expected {
+		expected[i].Time = actual[i].Time
+	}
+
+	assert.Equal(t, expected, actual)
+}

--- a/internal/databases/fdb/backup_push_handler.go
+++ b/internal/databases/fdb/backup_push_handler.go
@@ -10,8 +10,10 @@ import (
 )
 
 // TODO: add more metadata
-type streamSentinelDto struct {
+type StreamSentinelDto struct {
 	StartLocalTime time.Time
+	IsPermanent    bool
+	UserData       interface{}
 }
 
 func HandleBackupPush(uploader internal.UploaderProvider, backupCmd *exec.Cmd) {
@@ -29,7 +31,7 @@ func HandleBackupPush(uploader internal.UploaderProvider, backupCmd *exec.Cmd) {
 		tracelog.ErrorLogger.Fatalf("backup create command failed: %v", err)
 	}
 
-	sentinel := streamSentinelDto{StartLocalTime: timeStart}
+	sentinel := StreamSentinelDto{StartLocalTime: timeStart}
 
 	err = internal.UploadSentinel(uploader, &sentinel, fileName)
 	tracelog.ErrorLogger.FatalOnError(err)

--- a/internal/databases/fdb/generic_meta_interactor.go
+++ b/internal/databases/fdb/generic_meta_interactor.go
@@ -1,0 +1,79 @@
+package fdb
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaInteractor struct {
+	GenericMetaFetcher
+	GenericMetaSetter
+}
+
+func NewGenericMetaInteractor() GenericMetaInteractor {
+	return GenericMetaInteractor{
+		GenericMetaFetcher: NewGenericMetaFetcher(),
+		GenericMetaSetter:  NewGenericMetaSetter(),
+	}
+}
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	var backup = internal.NewBackup(backupFolder, backupName)
+	var sentinel StreamSentinelDto
+	err := backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:       backupName,
+		StartTime:        sentinel.StartLocalTime,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         sentinel.UserData,
+		IsPermanent:      sentinel.IsPermanent,
+	}, nil
+}
+
+type GenericMetaSetter struct{}
+
+func NewGenericMetaSetter() GenericMetaSetter {
+	return GenericMetaSetter{}
+}
+
+func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData interface{}) error {
+	modifier := func(dto StreamSentinelDto) StreamSentinelDto {
+		dto.UserData = userData
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	modifier := func(dto StreamSentinelDto) StreamSentinelDto {
+		dto.IsPermanent = isPermanent
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func modifyBackupSentinel(backupName string, backupFolder storage.Folder, modifier func(StreamSentinelDto) StreamSentinelDto) error {
+	backup := internal.NewBackup(backupFolder, backupName)
+	var sentinel StreamSentinelDto
+	err := backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch the existing backup metadata for modifying")
+	}
+	sentinel = modifier(sentinel)
+	err = backup.UploadSentinel(sentinel)
+	if err != nil {
+		return errors.Wrap(err, "failed to upload the modified metadata to the storage")
+	}
+	return nil
+}

--- a/internal/databases/fdb/generic_meta_interactor_test.go
+++ b/internal/databases/fdb/generic_meta_interactor_test.go
@@ -1,0 +1,102 @@
+package fdb_test
+
+import (
+	"github.com/wal-g/wal-g/internal/databases/fdb"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	internal.InitConfig()
+	internal.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	data := "Data"
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := fdb.StreamSentinelDto{
+		UserData:       data,
+		StartLocalTime: date,
+		IsPermanent:    isPermanent,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		StartTime:        date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	actualResult, err := fdb.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := fdb.StreamSentinelDto{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = fdb.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	backup, err := fdb.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := fdb.StreamSentinelDto{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = fdb.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+
+	backup, err := fdb.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/mongo/generic_meta_interactor.go
+++ b/internal/databases/mongo/generic_meta_interactor.go
@@ -1,0 +1,85 @@
+package mongo
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"github.com/wal-g/wal-g/internal/databases/redis/archive"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaInteractor struct {
+	GenericMetaFetcher
+	GenericMetaSetter
+}
+
+func NewGenericMetaInteractor() GenericMetaInteractor {
+	return GenericMetaInteractor{
+		GenericMetaFetcher: NewGenericMetaFetcher(),
+		GenericMetaSetter:  NewGenericMetaSetter(),
+	}
+}
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	var backup = internal.NewBackup(backupFolder, backupName)
+	var sentinel models.Backup
+	err := backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: sentinel.UncompressedSize,
+		CompressedSize:   sentinel.CompressedSize,
+		Hostname:         sentinel.Hostname,
+		StartTime:        sentinel.StartLocalTime,
+		FinishTime:       sentinel.FinishLocalTime,
+		IsPermanent:      sentinel.Permanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         sentinel.UserData,
+	}, nil
+}
+
+type GenericMetaSetter struct{}
+
+func NewGenericMetaSetter() GenericMetaSetter {
+	return GenericMetaSetter{}
+}
+
+func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData interface{}) error {
+	modifier := func(dto archive.Backup) archive.Backup {
+		dto.UserData = userData
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	modifier := func(dto archive.Backup) archive.Backup {
+		dto.Permanent = isPermanent
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func modifyBackupSentinel(backupName string, backupFolder storage.Folder, modifier func(archive.Backup) archive.Backup) error {
+	backup := internal.NewBackup(backupFolder, backupName)
+	var sentinel archive.Backup
+	err := backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch the existing backup metadata for modifying")
+	}
+	sentinel = modifier(sentinel)
+	err = backup.UploadSentinel(sentinel)
+	if err != nil {
+		return errors.Wrap(err, "failed to upload the modified metadata to the storage")
+	}
+	return nil
+}

--- a/internal/databases/mongo/generic_meta_interactor_test.go
+++ b/internal/databases/mongo/generic_meta_interactor_test.go
@@ -1,0 +1,119 @@
+package mongo_test
+
+import (
+	"github.com/wal-g/wal-g/internal/databases/mongo"
+	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	internal.InitConfig()
+	internal.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	backupType := "type"
+	hostname := "hostname"
+	data := "Data"
+	uncompressedSize := rand.Int63()
+	compressedSize := rand.Int63()
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := models.Backup{
+		BackupName:       backupName,
+		BackupType:       backupType,
+		Hostname:         hostname,
+		StartLocalTime:   date,
+		FinishLocalTime:  date,
+		UserData:         data,
+		MongoMeta:        models.MongoMeta{},
+		Permanent:        isPermanent,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   compressedSize,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   compressedSize,
+		Hostname:         hostname,
+		StartTime:        date,
+		FinishTime:       date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	actualResult, err := mongo.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := models.Backup{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		Permanent:      false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = mongo.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	backup, err := mongo.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := models.Backup{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		Permanent:      false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = mongo.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+
+	backup, err := mongo.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/mysql/generic_meta_interactor.go
+++ b/internal/databases/mysql/generic_meta_interactor.go
@@ -24,7 +24,6 @@ func NewGenericMetaFetcher() GenericMetaFetcher {
 	return GenericMetaFetcher{}
 }
 
-//TODO: Unit tests
 func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
 	var backup = internal.NewBackup(backupFolder, backupName)
 	var sentinel StreamSentinelDto
@@ -52,7 +51,6 @@ func NewGenericMetaSetter() GenericMetaSetter {
 	return GenericMetaSetter{}
 }
 
-//TODO: Unit tests
 func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData interface{}) error {
 	modifier := func(dto StreamSentinelDto) StreamSentinelDto {
 		dto.UserData = userData
@@ -61,7 +59,6 @@ func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.
 	return modifyBackupSentinel(backupName, backupFolder, modifier)
 }
 
-//TODO: Unit tests
 func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
 	modifier := func(dto StreamSentinelDto) StreamSentinelDto {
 		dto.IsPermanent = isPermanent

--- a/internal/databases/mysql/generic_meta_interactor_test.go
+++ b/internal/databases/mysql/generic_meta_interactor_test.go
@@ -1,0 +1,114 @@
+package mysql_test
+
+import (
+	"github.com/wal-g/wal-g/internal/databases/mysql"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	internal.InitConfig()
+	internal.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	data := "Data"
+	hostname := "hostname"
+	uncompressedSize := rand.Int63()
+	compressedSize := rand.Int63()
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := mysql.StreamSentinelDto{
+		StartLocalTime:   date,
+		StopLocalTime:    date,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   compressedSize,
+		Hostname:         hostname,
+		IsPermanent:      isPermanent,
+		UserData:         data,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   compressedSize,
+		Hostname:         hostname,
+		StartTime:        date,
+		FinishTime:       date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	actualResult, err := mysql.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := mysql.StreamSentinelDto{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = mysql.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	backup, err := mysql.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := mysql.StreamSentinelDto{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = mysql.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+
+	backup, err := mysql.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/redis/generic_meta_interactor.go
+++ b/internal/databases/redis/generic_meta_interactor.go
@@ -1,0 +1,83 @@
+package redis
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/redis/archive"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaInteractor struct {
+	GenericMetaFetcher
+	GenericMetaSetter
+}
+
+func NewGenericMetaInteractor() GenericMetaInteractor {
+	return GenericMetaInteractor{
+		GenericMetaFetcher: NewGenericMetaFetcher(),
+		GenericMetaSetter:  NewGenericMetaSetter(),
+	}
+}
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	var backup = internal.NewBackup(backupFolder, backupName)
+	var sentinel archive.Backup
+	err := backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: sentinel.DataSize,
+		CompressedSize:   sentinel.BackupSize,
+		StartTime:        sentinel.StartLocalTime,
+		FinishTime:       sentinel.FinishLocalTime,
+		IsPermanent:      sentinel.Permanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         sentinel.UserData,
+	}, nil
+}
+
+type GenericMetaSetter struct{}
+
+func NewGenericMetaSetter() GenericMetaSetter {
+	return GenericMetaSetter{}
+}
+
+func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData interface{}) error {
+	modifier := func(dto archive.Backup) archive.Backup {
+		dto.UserData = userData
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	modifier := func(dto archive.Backup) archive.Backup {
+		dto.Permanent = isPermanent
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func modifyBackupSentinel(backupName string, backupFolder storage.Folder, modifier func(archive.Backup) archive.Backup) error {
+	backup := internal.NewBackup(backupFolder, backupName)
+	var sentinel archive.Backup
+	err := backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch the existing backup metadata for modifying")
+	}
+	sentinel = modifier(sentinel)
+	err = backup.UploadSentinel(sentinel)
+	if err != nil {
+		return errors.Wrap(err, "failed to upload the modified metadata to the storage")
+	}
+	return nil
+}

--- a/internal/databases/redis/generic_meta_interactor_test.go
+++ b/internal/databases/redis/generic_meta_interactor_test.go
@@ -1,0 +1,112 @@
+package redis_test
+
+import (
+	"github.com/wal-g/wal-g/internal/databases/redis"
+	"github.com/wal-g/wal-g/internal/databases/redis/archive"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	internal.InitConfig()
+	internal.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	data := "Data"
+	dataSize := rand.Int63()
+	backupSize := rand.Int63()
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := archive.Backup{
+		StartLocalTime:  date,
+		FinishLocalTime: date,
+		DataSize:        dataSize,
+		BackupSize:      backupSize,
+		BackupName:      backupName,
+		UserData:        data,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: dataSize,
+		CompressedSize:   backupSize,
+		StartTime:        date,
+		FinishTime:       date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	actualResult, err := redis.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := archive.Backup{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		Permanent:      false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = redis.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	backup, err := redis.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := archive.Backup{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		Permanent:      false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = redis.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+
+	backup, err := redis.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/sqlserver/generic_meta_interactor.go
+++ b/internal/databases/sqlserver/generic_meta_interactor.go
@@ -1,0 +1,80 @@
+package sqlserver
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaInteractor struct {
+	GenericMetaFetcher
+	GenericMetaSetter
+}
+
+func NewGenericMetaInteractor() GenericMetaInteractor {
+	return GenericMetaInteractor{
+		GenericMetaFetcher: NewGenericMetaFetcher(),
+		GenericMetaSetter:  NewGenericMetaSetter(),
+	}
+}
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	var backup = internal.NewBackup(backupFolder, backupName)
+	var sentinel SentinelDto
+	err := backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:       backupName,
+		StartTime:        sentinel.StartLocalTime,
+		FinishTime:       sentinel.StopLocalTime,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		IsPermanent:      sentinel.IsPermanent,
+		UserData:         sentinel.UserData,
+	}, nil
+}
+
+type GenericMetaSetter struct{}
+
+func NewGenericMetaSetter() GenericMetaSetter {
+	return GenericMetaSetter{}
+}
+
+func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData interface{}) error {
+	modifier := func(dto SentinelDto) SentinelDto {
+		dto.UserData = userData
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	modifier := func(dto SentinelDto) SentinelDto {
+		dto.IsPermanent = isPermanent
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func modifyBackupSentinel(backupName string, backupFolder storage.Folder, modifier func(SentinelDto) SentinelDto) error {
+	backup := internal.NewBackup(backupFolder, backupName)
+	var sentinel SentinelDto
+	err := backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch the existing backup metadata for modifying")
+	}
+	sentinel = modifier(sentinel)
+	err = backup.UploadSentinel(sentinel)
+	if err != nil {
+		return errors.Wrap(err, "failed to upload the modified metadata to the storage")
+	}
+	return nil
+}

--- a/internal/databases/sqlserver/generic_meta_interactor_test.go
+++ b/internal/databases/sqlserver/generic_meta_interactor_test.go
@@ -1,0 +1,103 @@
+package sqlserver_test
+
+import (
+	"github.com/wal-g/wal-g/internal/databases/sqlserver"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	internal.InitConfig()
+	internal.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	data := "Data"
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := sqlserver.SentinelDto{
+		StartLocalTime: date,
+		StopLocalTime:  date,
+		UserData:       data,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		StartTime:        date,
+		FinishTime:       date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	actualResult, err := sqlserver.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := sqlserver.SentinelDto{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = sqlserver.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	backup, err := sqlserver.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := sqlserver.SentinelDto{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	_ = sqlserver.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+
+	backup, err := sqlserver.NewGenericMetaFetcher().Fetch(backupName, folder)
+
+	assert.NoError(t, err)
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -50,8 +50,11 @@ var SystemDbnames = []string{
 type SentinelDto struct {
 	Server         string
 	Databases      []string
+	IsPermanent    bool
 	StartLocalTime time.Time `json:"StartLocalTime,omitempty"`
 	StopLocalTime  time.Time `json:"StopLocalTime,omitempty"`
+
+	UserData interface{}
 }
 
 func (s *SentinelDto) String() string {

--- a/testtools/mock_generic_metadata_interactor.go
+++ b/testtools/mock_generic_metadata_interactor.go
@@ -1,0 +1,14 @@
+package testtools
+
+import (
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type MockGenericMetaFetcher struct {
+	MockMeta map[string]internal.GenericMetadata
+}
+
+func (m *MockGenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	return m.MockMeta[backupName], nil
+}


### PR DESCRIPTION
# Pull request description
[Issue] (https://github.com/wal-g/wal-g/issues/1108)
Added GenericMetaInteractors for:
-  Mongo
- Redis
- Fdb 
- SqlServers

Interactors are used for fetching backup StartTime to sort backups by creation time. 
Added sorting by creation time in DefaultHandleBackupList when `--detailed` flag is not specified.