### PR TITLE
add unit test for greenplum/backup_fetch_handler

### DIFF
--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -94,7 +94,6 @@ func NewFetchHandler(
 	}
 }
 
-// TODO: Unit tests
 // prepareContentIDsToFetch returns a set containing the IDs of segments to be fetched
 func prepareContentIDsToFetch(fetchContentIds []int, segmentConfigs []cluster.SegConfig) map[int]bool {
 	contentIDsToFetch := make(map[int]bool)

--- a/internal/databases/greenplum/backup_fetch_handler_test.go
+++ b/internal/databases/greenplum/backup_fetch_handler_test.go
@@ -1,0 +1,52 @@
+package greenplum
+
+import (
+	"testing"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepareContentIDsToFetch(t *testing.T) {
+	testcases := []struct {
+		fetchContentId []int
+		segmentConfig []cluster.SegConfig
+		contentIDsToFetch map[int]bool
+	} {
+		{
+			fetchContentId: []int{},
+			segmentConfig: []cluster.SegConfig{},
+			contentIDsToFetch: map[int]bool{},
+		},
+		{
+			fetchContentId: []int{},
+			segmentConfig: []cluster.SegConfig{{ContentID: 21}, {ContentID: 42}},
+			contentIDsToFetch: map[int]bool{21: true, 42: true},
+		},
+		{
+			fetchContentId: []int{1},
+			segmentConfig: []cluster.SegConfig{{ContentID: 1231}, {ContentID: 6743}, {ContentID: 7643}},
+			contentIDsToFetch: map[int]bool{1: true},
+		},
+		{
+			fetchContentId: []int{65, 42, 12, 76, 22},
+			segmentConfig: []cluster.SegConfig{},
+			contentIDsToFetch: map[int]bool{65: true, 42: true, 12: true, 76: true, 22: true},
+		},
+		{
+			fetchContentId: []int{5, 4, 3, 2, 1},
+			segmentConfig: []cluster.SegConfig{{ContentID: 4}, {ContentID: 5}, {ContentID: 6}},
+			contentIDsToFetch: map[int]bool{1: true, 2: true, 3: true, 4: true, 5: true},
+		},
+		{
+			fetchContentId: []int{6, 7, 8, 9, 10},
+			segmentConfig: []cluster.SegConfig{{ContentID: 1}, {ContentID: 5}, {ContentID: 7}},
+			contentIDsToFetch: map[int]bool{6: true, 7: true, 8: true, 9: true, 10: true},
+		},
+	}
+
+	for _, tc := range testcases {
+		contentIDsToFetch := prepareContentIDsToFetch(tc.fetchContentId, tc.segmentConfig)
+		assert.Equal(t, tc.contentIDsToFetch, contentIDsToFetch)
+	}
+}


### PR DESCRIPTION
### Database name
Greenplum

# Pull request description
Add unit test for utility function `prepareContentIDsToFetch` ([source code link](https://github.com/wal-g/wal-g/blob/69a3f47825465286d8ea375b53c951e167aabe2d/internal/databases/greenplum/backup_fetch_handler.go#L99))

