### PR TITLE
Postgres requires data dir to be 0700 or 0750.

### DIFF
--- a/internal/databases/postgres/tar_interpreter.go
+++ b/internal/databases/postgres/tar_interpreter.go
@@ -90,7 +90,7 @@ func (tarInterpreter *FileTarInterpreter) Interpret(fileReader io.Reader, fileIn
 		}
 		return tarInterpreter.unwrapRegularFileOld(fileReader, fileInfo, targetPath, fsync)
 	case tar.TypeDir:
-		err := os.MkdirAll(targetPath, 0755)
+		err := os.MkdirAll(targetPath, 0750)
 		if err != nil {
 			return errors.Wrapf(err, "Interpret: failed to create all directories in %s", targetPath)
 		}
@@ -116,6 +116,6 @@ func PrepareDirs(fileName string, targetPath string) error {
 	}
 	base := filepath.Base(fileName)
 	dir := strings.TrimSuffix(targetPath, base)
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0750)
 	return err
 }


### PR DESCRIPTION
### Database name
Postgresql

# Pull request description

### Describe what this PR fix
Postgresql requires the data dir to have 0700 or 0750 permissions. Currently, wal-g creates the directory in 0755. I'm not sure how this has not been caught before now, as the permission check has existed since 2018: https://github.com/postgres/postgres/blob/7e8a80d1fefd1e96992652ed5a628c437971c82e/src/backend/utils/init/miscinit.c#L390

### Please provide steps to reproduce (if it's a bug)
We run postgresql 14 in kubernetes via spilo, with patroni configured to use wal-g for database re-initialization. A simple way to see the permissions is to run `wal-g backup-fetch $DATA_DIR $BACKUP_VERSION`, then check the permissions of the data directory. If you use spilo with patroni configured to use wal-g, reinitialize a follower with `patronictl reinitialize $CLUSTER $FOLLOWER`, confirm that you wish to re-initialize, then check the logs of the follower. You will find 

```
FATAL:  data directory "$DATA_DIR" has invalid permissions
DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
```

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
