### PR TITLE
adding push metrics as a defer in the upload method to make sure metrics are pushed even on failure

### DIFF
--- a/internal/uploader.go
+++ b/internal/uploader.go
@@ -166,6 +166,8 @@ func (uploader *Uploader) Compression() compression.Compressor {
 
 // TODO : unit tests
 func (uploader *Uploader) Upload(path string, content io.Reader) error {
+	defer PushMetrics()
+
 	WalgMetrics.uploadedFilesTotal.Inc()
 	if uploader.tarSize != nil {
 		content = NewWithSizeReader(content, uploader.tarSize)


### PR DESCRIPTION
### Database name
All of them

# Pull request description
The metrics feature works fine to record uploads when they are successful but metrics are never pushed when an upload fails because Fatal logging exits directly and prevents the `PostRun` cobra hook from running.

To solve that I propose to call `PushMetrics` directly from the `uploader.Upload` method.


### Describe what this PR fix
It fixes https://github.com/wal-g/wal-g/issues/1422
