### PR TITLE
Add --after option support for PostgreSQL delete retain command

### DIFF
--- a/.github/workflows/dockertests-par.yml
+++ b/.github/workflows/dockertests-par.yml
@@ -42,6 +42,7 @@ jobs:
         "make TEST=\"pg_delete_retain_find_full_test\" pg_integration_test",
         "make TEST=\"pg_delete_retain_full_multist_test\" pg_integration_test",
         "make TEST=\"pg_delete_retain_full_test\" pg_integration_test",
+        "make TEST=\"pg_delete_retain_after_test\" pg_integration_test",
         "make TEST=\"pg_delete_target_delta_find_full_test\" pg_integration_test",
         "make TEST=\"pg_delete_target_delta_multist_test\" pg_integration_test",
         "make TEST=\"pg_delete_target_delta_test\" pg_integration_test",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       &&  mkdir -p /export/waldeltabucket
       &&  mkdir -p /export/ghostbucket
       &&  mkdir -p /export/compressionbucket
+      &&  mkdir -p /export/deleteretainafterbucket
       &&  mkdir -p /export/copyallbucket
       &&  mkdir -p /export/copybackupbucket
       &&  mkdir -p /export/compressionreversebucket
@@ -309,6 +310,11 @@ services:
     <<: *pg_test_common
     container_name: wal-g_pg_delete_retain_full_multist_test
     command: /tmp/tests/delete_retain_full_multist_test.sh
+
+  pg_delete_retain_after_test:
+    <<: *pg_test_common
+    container_name: wal-g_pg_delete_retain_after_test
+    command: /tmp/tests/delete_retain_after_test.sh
 
   pg_full_backup_test:
     <<: *pg_test_common

--- a/docker/pg_tests/scripts/configs/delete_retain_after_test_config.json
+++ b/docker/pg_tests/scripts/configs/delete_retain_after_test_config.json
@@ -1,0 +1,3 @@
+"WALG_DELTA_MAX_STEPS": "1",
+"WALE_S3_PREFIX": "s3://deleteretainafterbucket",
+"WALG_USE_WAL_DELTA": "true"

--- a/docker/pg_tests/scripts/tests/delete_retain_after_test.sh
+++ b/docker/pg_tests/scripts/tests/delete_retain_after_test.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -e -x
+CONFIG_FILE="/tmp/configs/delete_retain_after_test_config.json"
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/scripts/wrap_config_file.sh ${TMP_CONFIG}
+
+/usr/lib/postgresql/10/bin/initdb ${PGDATA}
+
+echo "archive_mode = on" >> /var/lib/postgresql/10/main/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 /usr/bin/wal-g --config=${TMP_CONFIG} wal-push %p'" >> /var/lib/postgresql/10/main/postgresql.conf
+echo "archive_timeout = 600" >> /var/lib/postgresql/10/main/postgresql.conf
+
+/usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA} -w start
+/tmp/scripts/wait_while_pg_not_ready.sh
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+for i in 1 2 3 4
+do
+    pgbench -i -s 1 postgres &
+    sleep 1
+    wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+    if [ $i = 2 ]
+    then
+      sleep 1
+      retain_time=`date -u +%Y-%m-%dT%H:%M:%SZ`
+    fi
+done
+
+wal-g --config=${TMP_CONFIG} backup-list
+lines_before_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
+wal-g --config=${TMP_CONFIG} backup-list > /tmp/list_before_delete
+
+wal-g --config=${TMP_CONFIG} delete retain 1 --after "${retain_time}" --confirm
+
+wal-g --config=${TMP_CONFIG} backup-list
+lines_after_delete=`wal-g --config=${TMP_CONFIG} backup-list | wc -l`
+wal-g --config=${TMP_CONFIG} backup-list > /tmp/list_after_delete
+
+# we deleted all backups crated after the first two
+expected_backups_deleted=$((4-2))
+
+if [ $(($lines_before_delete-$expected_backups_deleted)) -ne $lines_after_delete ];
+then
+    echo $(($lines_before_delete-$expected_backups_deleted)) > /tmp/before_delete
+    echo $lines_after_delete > /tmp/after_delete
+    echo "Wrong number of deleted lines"
+    diff /tmp/before_delete /tmp/after_delete
+fi
+
+# ensure all backups which we weren't going to delete still exist after performing deletion
+xargs -I {} grep {} /tmp/list_before_delete </tmp/list_after_delete
+
+/tmp/scripts/drop_pg.sh
+rm ${TMP_CONFIG}


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description

This PR fixes **--after** option support for **delete retain** command for PostgreSQL. The option allows to specify timestamp or backup name after which backups should be kept.

There is an example of using **--after** option in **delete retain** command description but trying to apply it results in error.

This problem is mentioned in #1117 and #637.

### Steps to reproduce

Run command `wal-g delete retain 5 --after 2019-12-12T12:12:12`

Error output: `Error: unknown flag: --after`