### PR TITLE
MDB-21194: [MongoDB] fix bug with purge garbage and change logic for retains

### DIFF
--- a/cmd/mongo/delete.go
+++ b/cmd/mongo/delete.go
@@ -46,9 +46,6 @@ func runPurge(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Flags().Changed(retainCountFlag) {
-		if retainCount == 0 { // TODO: provide folder cleanup
-			tracelog.ErrorLogger.Fatalln("Retain count can not be 0")
-		}
 		opts = append(opts, mongo.PurgeRetainCount(int(retainCount)))
 	}
 
@@ -66,7 +63,9 @@ func runPurge(cmd *cobra.Command, args []string) {
 
 func init() {
 	cmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().BoolVar(&confirmed, internal.ConfirmFlag, false, "Confirms backup deletion")
+	deleteCmd.Flags().BoolVar(&confirmed, internal.ConfirmFlag, false, "Confirms backup, garbage and oplog deletion."+
+		" If `retainAfterFlag` and `retainCountFlag` are not specified then all backups will be retained.")
+
 	deleteCmd.Flags().BoolVar(&purgeOplog, purgeOplogFlag, false, "Purge oplog archives")
 	deleteCmd.Flags().BoolVar(&purgeGarbage, purgeGarbageFlag, false, "Purge garbage in backup folder")
 	deleteCmd.Flags().StringVar(&retainAfter, retainAfterFlag, "", "Keep backups newer")

--- a/cmd/redis/backup_delete.go
+++ b/cmd/redis/backup_delete.go
@@ -56,7 +56,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 
 func init() {
 	cmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().BoolVar(&confirmed, internal.ConfirmFlag, false, "Confirms backup deletion")
+	deleteCmd.Flags().BoolVar(&confirmed, internal.ConfirmFlag, false, "Confirms backup and garbage deletion")
 	deleteCmd.Flags().BoolVar(&purgeGarbage, purgeGarbageFlag, false, "Delete garbage in backup folder")
 	deleteCmd.Flags().StringVar(&retainAfter, retainAfterFlag, "", "Keep backups newer")
 	deleteCmd.Flags().UintVar(&retainCount, retainCountFlag, 0, "Keep minimum count, except permanent backups")

--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -168,18 +168,24 @@ func FolderSize(folder storage.Folder, path string) (int64, error) {
 	return size, nil
 }
 
-// SplitPurgingBackups partitions backups to delete and retain
+// SplitPurgingBackups partitions backups to delete and retain, if no retains policy than retain all backups
 func SplitPurgingBackups(backups []TimedBackup,
 	retainCount *int,
 	retainAfter *time.Time) (purge, retain map[string]bool, err error) {
 	retain = make(map[string]bool)
 	purge = make(map[string]bool)
-
+	retainAll := retainCount == nil && retainAfter == nil
 	retainedCount := 0
 	for i := range backups {
 		backup := backups[i]
 		if backup.IsPermanent() {
 			tracelog.DebugLogger.Printf("Preserving backup due to keep permanent policy: %s", backup.Name())
+			retain[backup.Name()] = true
+			continue
+		}
+
+		if retainAll {
+			tracelog.DebugLogger.Printf("Preserving backup due to an unspecified policy: %s", backup.Name())
 			retain[backup.Name()] = true
 			continue
 		}
@@ -206,7 +212,7 @@ func SplitPurgingBackups(backups []TimedBackup,
 func DeleteGarbage(folder storage.Folder, garbage []string) error {
 	var keys []string
 	for _, prefix := range garbage {
-		garbageObjects, _, err := folder.GetSubFolder(prefix).ListFolder()
+		garbageObjects, err := storage.ListFolderRecursively(folder.GetSubFolder(prefix))
 		if err != nil {
 			return err
 		}
@@ -226,7 +232,7 @@ func DeleteBackups(folder storage.Folder, backups []string) error {
 		backupName := backups[i]
 		keys = append(keys, SentinelNameFromBackup(backupName))
 
-		dataObjects, _, err := folder.GetSubFolder(backupName).ListFolder()
+		dataObjects, err := storage.ListFolderRecursively(folder.GetSubFolder(backupName))
 		if err != nil {
 			return err
 		}

--- a/internal/backup_util_test.go
+++ b/internal/backup_util_test.go
@@ -106,3 +106,65 @@ func TestGetGarbageFromPrefix_emptyFolders(t *testing.T) {
 	garbage := internal.GetGarbageFromPrefix(folders, nonGarbage)
 	assert.Equal(t, garbage, make([]string, 0))
 }
+
+func TestDeleteGarbage_emptyFolder(t *testing.T) {
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+
+	objects, folders, _ := folder.ListFolder()
+	assert.Equal(t, 0, len(objects))
+	assert.Equal(t, 0, len(folders))
+
+	err := internal.DeleteGarbage(folder, []string{"backup1", "backup2", "backup3"})
+	assert.Equal(t, nil, err)
+
+	objects, folders, _ = folder.ListFolder()
+	assert.Equal(t, 0, len(objects))
+	assert.Equal(t, 0, len(folders))
+}
+
+func TestDeleteGarbage_nonRecursive(t *testing.T) {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	_ = folder.PutObject("backup1/file.json", &bytes.Buffer{})
+	_ = folder.PutObject("backup2/file.json", &bytes.Buffer{})
+
+	objects, folders, _ := folder.ListFolder()
+	assert.Equal(t, 0, len(objects))
+	assert.Equal(t, 2, len(folders))
+
+	err := internal.DeleteGarbage(folder, []string{"backup1"})
+	assert.Equal(t, nil, err)
+
+	objects, folders, _ = folder.ListFolder()
+	assert.Equal(t, 0, len(objects))
+	assert.Equal(t, 1, len(folders))
+	assert.Equal(t, folders[0].GetPath(), "in_memory/backup2/")
+}
+
+func TestDeleteGarbage_recursive(t *testing.T) {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	_ = folder.PutObject("backup1/folder1/obj1.tar", &bytes.Buffer{})
+	_ = folder.PutObject("backup1/folder2/obj2.zip", &bytes.Buffer{})
+	_ = folder.PutObject("backup1/meta.json", &bytes.Buffer{})
+	_ = folder.PutObject("backup2/meta_b2.json", &bytes.Buffer{})
+	_ = folder.PutObject("backup2/folder1/obj1.tar", &bytes.Buffer{})
+
+	objects, folders, _ := folder.ListFolder()
+	assert.Equal(t, 0, len(objects))
+	assert.Equal(t, 2, len(folders))
+
+	err := internal.DeleteGarbage(folder, []string{"backup1"})
+	assert.Equal(t, nil, err)
+
+	objects, folders, _ = folder.ListFolder()
+	assert.Equal(t, 0, len(objects))
+	assert.Equal(t, 1, len(folders))
+	backup2 := folders[0]
+	assert.Equal(t, backup2.GetPath(), "in_memory/backup2/")
+	objects, folders, _ = backup2.ListFolder()
+	assert.Equal(t, 1, len(objects))
+	assert.Equal(t, 1, len(folders))
+	assert.Equal(t, objects[0].GetName(), "meta_b2.json")
+	assert.Equal(t, folders[0].GetPath(), "in_memory/backup2/folder1/")
+
+}

--- a/internal/databases/mongo/archive/layout_test.go
+++ b/internal/databases/mongo/archive/layout_test.go
@@ -440,10 +440,10 @@ func TestSplitPurgingBackups(t *testing.T) {
 		err        error
 	}{
 		{
-			name: "Purge_all,count=nil,after=nil",
+			name: "Purge_all,count=0,after=nil",
 			args: args{
 				backups:     SplitBackups,
-				retainCount: nil,
+				retainCount: IntPtr(0),
 				retainAfter: nil,
 			},
 			wantPurge:  SplitBackups,


### PR DESCRIPTION


### Database name
MongoDB
# Pull request description

### Describe what this PR fix
1) Fix bug when don't remove recursive garbage nodes. 
2) Fix bug when don't remove recursive backups data nodes. 
3) Change logic for retains,
Now: If `retainAfterFlag` and `retainCountFlag` are not specified then all backups will be retained. Previous: If `retainAfterFlag` and `retainCountFlag` are not specified then remove all backups. 
4) Add tests for DeleteGarbage.

### Please provide steps to reproduce (if it's a bug)
1) Create backup 
2) Try to remove backup
3) Try to purge garbage
4) Check s3 storage

