### PR TITLE
MDB-21194: [MongoDB] fix retryable error from code to name

### DIFF
--- a/internal/databases/mongo/binary/backup.go
+++ b/internal/databases/mongo/binary/backup.go
@@ -40,7 +40,7 @@ func (backupService *BackupService) DoBackup(backupName string, permanent bool) 
 
 	backupCursor, err := CreateBackupCursor(backupService.MongodService)
 	if err != nil {
-		return errors.Wrap(err, "unable to open backup cursor")
+		return err
 	}
 	defer backupCursor.Close()
 

--- a/internal/databases/mongo/binary/backup_cursor.go
+++ b/internal/databases/mongo/binary/backup_cursor.go
@@ -26,7 +26,7 @@ type BackupCursor struct {
 func CreateBackupCursor(mongodService *MongodService) (*BackupCursor, error) {
 	mongoBackupCursor, err := mongodService.GetBackupCursor()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to open backup cursor")
 	}
 
 	backupCursor := &BackupCursor{
@@ -37,7 +37,7 @@ func CreateBackupCursor(mongodService *MongodService) (*BackupCursor, error) {
 
 	err = backupCursor.loadMetadata()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to load metadata")
 	}
 
 	return backupCursor, nil

--- a/internal/databases/mongo/binary/mongod.go
+++ b/internal/databases/mongo/binary/mongod.go
@@ -136,7 +136,7 @@ func (mongodService *MongodService) GetBackupCursor() (cursor *mongo.Cursor, err
 }
 
 func backupCursorErrorIsRetried(err error) bool {
-	return strings.Contains(err.Error(), "(Location50915)") // mongodb take checkpoint
+	return strings.Contains(err.Error(), "(BackupCursorOpenConflictWithCheckpoint)") // mongodb take checkpoint
 }
 
 func (mongodService *MongodService) GetBackupCursorExtended(backupCursorMeta *BackupCursorMeta) (*mongo.Cursor, error) {


### PR DESCRIPTION
ERROR: (BackupCursorOpenConflictWithCheckpoint) A checkpoint took place while opening a backup cursor.
unable to open backup cursor