### PR TITLE
Adaptive timeout for mongodb restore

### DIFF
--- a/internal/databases/mongo/binary/mongod.go
+++ b/internal/databases/mongo/binary/mongod.go
@@ -26,7 +26,7 @@ type MongodService struct {
 	MongoClient *mongo.Client
 }
 
-func CreateMongodService(ctx context.Context, appName, mongodbURI string) (*MongodService, error) {
+func CreateMongodService(ctx context.Context, appName, mongodbURI string, timeout time.Duration) (*MongodService, error) {
 	var repeatOptions backoff.BackOff
 	repeatOptions = backoff.NewExponentialBackOff()
 	repeatOptions = backoff.WithMaxRetries(repeatOptions, mongoConnectRetries)
@@ -38,8 +38,8 @@ func CreateMongodService(ctx context.Context, appName, mongodbURI string) (*Mong
 		func() error {
 			mongoClient, err = mongo.Connect(ctx,
 				options.Client().ApplyURI(mongodbURI).
-					SetServerSelectionTimeout(10*time.Minute).
-					SetConnectTimeout(10*time.Minute).
+					SetServerSelectionTimeout(timeout).
+					SetConnectTimeout(timeout).
 					SetSocketTimeout(time.Minute).
 					SetAppName(appName).
 					SetDirect(true).

--- a/internal/databases/mongo/binary/utilities.go
+++ b/internal/databases/mongo/binary/utilities.go
@@ -1,7 +1,9 @@
 package binary
 
 import (
+	"math"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
@@ -65,4 +67,11 @@ func EnsureCompatibilityToRestoreMongodVersions(backupMongodVersion, restoreMong
 			backupMongodVersion, restoreMongodVersion)
 	}
 	return nil
+}
+
+// ComputeMongoStartTimeout compute timeout with formula max(10min, UncompressedSizeTb * 40min)
+func ComputeMongoStartTimeout(backupUncompressedSize int64) time.Duration {
+	var tb float64 = 1 << (10 * 4)
+	coef := float64(backupUncompressedSize) / tb
+	return time.Duration(math.Max(10, coef*40) * float64(time.Minute))
 }

--- a/internal/databases/mongo/binary/utilities_test.go
+++ b/internal/databases/mongo/binary/utilities_test.go
@@ -2,6 +2,7 @@ package binary
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,4 +16,17 @@ func TestEnsureCompatibilityToRestoreMongodVersions(t *testing.T) {
 
 	assert.Error(t, EnsureCompatibilityToRestoreMongodVersions("5.0", "4.4"))
 	assert.Error(t, EnsureCompatibilityToRestoreMongodVersions("4.4", "4.2"))
+}
+
+func TestComputeMongoStartTimeout(t *testing.T) {
+	var tb int64 = 1 << (10 * 4)
+	var gb int64 = 1 << (10 * 3)
+
+	assert.Equal(t, 200*time.Minute, ComputeMongoStartTimeout(5*tb))
+	assert.Equal(t, 40*time.Minute, ComputeMongoStartTimeout(tb))
+	assert.Equal(t, 20*time.Minute, ComputeMongoStartTimeout(tb/2))
+	assert.Equal(t, 10*time.Minute, ComputeMongoStartTimeout(256*gb))
+	assert.Equal(t, 10*time.Minute, ComputeMongoStartTimeout(20*gb))
+	assert.Equal(t, 10*time.Minute, ComputeMongoStartTimeout(gb))
+
 }

--- a/internal/databases/mongo/binary_backup_push_handler.go
+++ b/internal/databases/mongo/binary_backup_push_handler.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"time"
 
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/mongo/binary"
@@ -15,7 +16,7 @@ func HandleBinaryBackupPush(ctx context.Context, permanent bool, appName string)
 	if err != nil {
 		return err
 	}
-	mongodService, err := binary.CreateMongodService(ctx, appName, mongodbURI)
+	mongodService, err := binary.CreateMongodService(ctx, appName, mongodbURI, 10*time.Minute)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Starting mongod while restoring backups can take a long time, so for these backups will be compute timeout depends on backup size

Unable to connect due 'server selection error: server selection timeout, current topology: { Type: Single, Servers: [{ Addr: localhost:34027, Type: Unknown, Last error: connection() error occurred during connection handshake: dial tcp [::1]:34027:connect: connection refused }, ] } ping to mongod is failed
github.com/wal-g/wal-g/internal/databases/mongo/binary.CreateMongodService.func1
        /root/wal-g/internal/databases/mongo/binary/mongod.go:52
github.com/cenkalti/backoff.RetryNotify
        /root/wal-g/vendor/github.com/cenkalti/backoff/retry.go:37
github.com/wal-g/wal-g/internal/databases/mongo/binary.CreateMongodService
        /root/wal-g/internal/databases/mongo/binary/mongod.go:37
github.com/wal-g/wal-g/internal/databases/mongo/binary.(*RestoreService).recoverFromOplogAsStandalone
        /root/wal-g/internal/databases/mongo/binary/restore.go:106
github.com/wal-g/wal-g/internal/databases/mongo/binary.(*RestoreService).DoRestore
        /root/wal-g/internal/databases/mongo/binary/restore.go:60
github.com/wal-g/wal-g/internal/databases/mongo.HandleBinaryFetchPush
        /root/wal-g/internal/databases/mongo/binary_backup_fetch_handler.go:44
github.com/wal-g/wal-g/cmd/mongo.glob..func7
        /root/wal-g/cmd/mongo/binary_backup_fetch.go:46
github.com/spf13/cobra.(*Command).execute
        /root/wal-g/vendor/github.com/spf13/cobra/command.go:860
github.com/spf13/cobra.(*Command).ExecuteC
        /root/wal-g/vendor/github.com/spf13/cobra/command.go:974
github.com/spf13/cobra.(*Command).Execute
        /root/wal-g/vendor/github.com/spf13/cobra/command.go:902
github.com/wal-g/wal-g/cmd/mongo.Execute
        /root/wal-g/cmd/mongo/mongo.go:37
main.main
        /root/wal-g/main/mongo/main.go:8
runtime.main
        /usr/local/go/src/runtime/proc.go:250
runtime.goexit