### PR TITLE
feat: removing binlogs after using them

### DIFF
--- a/internal/databases/mysql/binlog_server_handler.go
+++ b/internal/databases/mysql/binlog_server_handler.go
@@ -133,7 +133,9 @@ func sendEventsFromBinlogFiles(logFilesProvider *storage.ObjectProvider, pos mys
 		tracelog.InfoLogger.Printf("Synced binlog file %s", binlogName)
 		binlogPath := path.Join(dstDir, binlogName)
 		err = p.ParseFile(binlogPath, int64(pos.Pos), f)
+		handleEventError(err, s)
 
+		err = os.Remove(binlogPath)
 		handleEventError(err, s)
 		pos.Pos = 4
 	}
@@ -153,7 +155,7 @@ func syncBinlogFiles(pos mysql.Position, s *replication.BinlogStreamer) error {
 	if err != nil {
 		return err
 	}
-	logFilesProvider := storage.NewObjectProvider()
+	logFilesProvider := storage.NewLowMemoryObjectProvider()
 
 	// start sync
 	go sendEventsFromBinlogFiles(logFilesProvider, pos, s)

--- a/internal/databases/mysql/mysql.go
+++ b/internal/databases/mysql/mysql.go
@@ -254,22 +254,12 @@ outer:
 	return nil
 }
 
-func handleObjectProviderError(err error, p *storage.ObjectProvider) {
-	if err == nil {
-		return
-	}
-	ok := p.AddErrorToProvider(err)
-	for !ok {
-		ok = p.AddErrorToProvider(err)
-	}
-}
-
 func provideLogs(folder storage.Folder, dstDir string, startTS, endTS time.Time, p *storage.ObjectProvider) {
 	defer p.Close()
 	_, err := os.Stat(dstDir)
 	if os.IsNotExist(err) {
 		err = os.MkdirAll(dstDir, 0777)
-		handleObjectProviderError(err, p)
+		p.HandleError(err)
 		if err != nil {
 			return
 		}
@@ -277,7 +267,7 @@ func provideLogs(folder storage.Folder, dstDir string, startTS, endTS time.Time,
 
 	logFolder := folder.GetSubFolder(BinlogPath)
 	logsToFetch, err := getLogsCoveringInterval(logFolder, startTS, true, utility.MaxTime)
-	handleObjectProviderError(err, p)
+	p.HandleError(err)
 	if err != nil {
 		return
 	}
@@ -292,20 +282,20 @@ func provideLogs(folder storage.Folder, dstDir string, startTS, endTS time.Time,
 				tracelog.WarningLogger.Printf("file %s exist skipping", binlogName)
 			} else {
 				tracelog.ErrorLogger.Printf("failed to download %s: %v", binlogName, err)
-				handleObjectProviderError(err, p)
+				p.HandleError(err)
 				return
 			}
 		}
 
 		// add file to provider
-		err = p.AddObjectToProvider(logFile)
-		handleObjectProviderError(err, p)
+		err = p.AddObject(logFile)
+		p.HandleError(err)
 		if err != nil {
 			return
 		}
 
 		timestamp, err := GetBinlogStartTimestamp(binlogPath, gomysql.MySQLFlavor)
-		handleObjectProviderError(err, p)
+		p.HandleError(err)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
### Database name
MySQL

# Pull request description
Improving the binlog server

### Describe what this PR fix
The binlog server does not delete binlogs after using them, and also downloads them too many at a time, which takes up extra space