### PR TITLE
Refactor storage abstractions

### DIFF
--- a/cmd/pg/backup_mark.go
+++ b/cmd/pg/backup_mark.go
@@ -23,9 +23,9 @@ var (
 		Long:  BackupMarkLongDescription,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			uploader, err := postgres.ConfigureWalUploader()
+			uploader, err := internal.ConfigureUploader()
 			tracelog.ErrorLogger.FatalOnError(err)
-			internal.HandleBackupMark(uploader.Uploader, args[0], !toImpermanent, postgres.NewGenericMetaInteractor())
+			internal.HandleBackupMark(uploader, args[0], !toImpermanent, postgres.NewGenericMetaInteractor())
 		},
 	}
 	toImpermanent = false

--- a/cmd/pg/daemon.go
+++ b/cmd/pg/daemon.go
@@ -17,7 +17,10 @@ var daemonCmd = &cobra.Command{
 	Short: DaemonShortDescription, // TODO : improve description
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		uploader, err := postgres.ConfigureWalUploader()
+		baseUploader, err := internal.ConfigureUploader()
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		uploader, err := postgres.ConfigureWalUploader(baseUploader)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		archiveStatusManager, err := internal.ConfigureArchiveStatusManager()
@@ -35,7 +38,7 @@ var daemonCmd = &cobra.Command{
 			tracelog.ErrorLogger.PrintError(err)
 			uploader.PGArchiveStatusManager = asm.NewNopASM()
 		}
-		uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.WalPath)
+		uploader.ChangeDirectory(utility.WalPath)
 		postgres.HandleDaemon(uploader, args[0])
 	},
 }

--- a/cmd/pg/wal_fetch.go
+++ b/cmd/pg/wal_fetch.go
@@ -17,7 +17,7 @@ var walFetchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
-		postgres.HandleWALFetch(folder, args[0], args[1], true)
+		postgres.HandleWALFetch(internal.NewFolderReader(folder), args[0], args[1], true)
 	},
 }
 

--- a/cmd/pg/wal_prefetch.go
+++ b/cmd/pg/wal_prefetch.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
@@ -16,9 +17,9 @@ var WalPrefetchCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(2),
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		uploader, err := postgres.ConfigureWalUploaderWithoutCompressMethod()
+		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
-		postgres.HandleWALPrefetch(uploader, args[0], args[1])
+		postgres.HandleWALPrefetch(internal.NewFolderReader(folder), args[0], args[1])
 	},
 }
 

--- a/cmd/pg/wal_push.go
+++ b/cmd/pg/wal_push.go
@@ -17,7 +17,10 @@ var walPushCmd = &cobra.Command{
 	Short: WalPushShortDescription, // TODO : improve description
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		uploader, err := postgres.ConfigureWalUploader()
+		baseUploader, err := internal.ConfigureUploader()
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		uploader, err := postgres.ConfigureWalUploader(baseUploader)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		archiveStatusManager, err := internal.ConfigureArchiveStatusManager()
@@ -36,7 +39,7 @@ var walPushCmd = &cobra.Command{
 			uploader.PGArchiveStatusManager = asm.NewNopASM()
 		}
 
-		uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.WalPath)
+		uploader.ChangeDirectory(utility.WalPath)
 		err = postgres.HandleWALPush(uploader, args[0])
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/cmd/pg/wal_receive.go
+++ b/cmd/pg/wal_receive.go
@@ -16,7 +16,10 @@ var walReceiveCmd = &cobra.Command{
 	Short: walReceiveShortDescription,
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		uploader, err := postgres.ConfigureWalUploader()
+		baseUploader, err := internal.ConfigureUploader()
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		uploader, err := postgres.ConfigureWalUploader(baseUploader)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		archiveStatusManager, err := internal.ConfigureArchiveStatusManager()

--- a/cmd/redis/backup_push.go
+++ b/cmd/redis/backup_push.go
@@ -40,7 +40,7 @@ var backupPushCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		// Configure folder
-		uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.BaseBackupPath)
+		uploader.ChangeDirectory(utility.BaseBackupPath)
 
 		backupCmd, err := internal.GetCommandSettingContext(ctx, internal.NameStreamCreateCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
@@ -50,7 +50,7 @@ var backupPushCmd = &cobra.Command{
 			backupCmd.Env = append(backupCmd.Env, fmt.Sprintf("REDISCLI_AUTH=%s", redisPassword))
 		}
 		backupCmd.Stderr = os.Stderr
-		metaConstructor := archive.NewBackupRedisMetaConstructor(ctx, uploader.UploadingFolder, permanent)
+		metaConstructor := archive.NewBackupRedisMetaConstructor(ctx, uploader.Folder(), permanent)
 
 		err = redis.HandleBackupPush(uploader, backupCmd, metaConstructor)
 		tracelog.ErrorLogger.FatalfOnError("Redis backup creation failed: %v", err)

--- a/internal/backup.go
+++ b/internal/backup.go
@@ -152,7 +152,7 @@ func GetBackupByName(backupName, subfolder string, folder storage.Folder) (Backu
 }
 
 // TODO : unit tests
-func UploadSentinel(uploader UploaderProvider, sentinelDto interface{}, backupName string) error {
+func UploadSentinel(uploader Uploader, sentinelDto interface{}, backupName string) error {
 	sentinelName := SentinelNameFromBackup(backupName)
 	return UploadDto(uploader.Folder(), sentinelDto, sentinelName)
 }

--- a/internal/backup_mark_handler.go
+++ b/internal/backup_mark_handler.go
@@ -1,14 +1,6 @@
 package internal
 
-import (
-	"github.com/wal-g/wal-g/utility"
-)
-
-func HandleBackupMark(uploader *Uploader, backupName string, toPermanent bool, metaInteractor GenericMetaInteractor) {
-	folder := uploader.UploadingFolder
-	baseBackupFolder := uploader.UploadingFolder.GetSubFolder(utility.BaseBackupPath)
-	uploader.UploadingFolder = baseBackupFolder
-
-	markHandler := NewBackupMarkHandler(metaInteractor, folder)
+func HandleBackupMark(uploader Uploader, backupName string, toPermanent bool, metaInteractor GenericMetaInteractor) {
+	markHandler := NewBackupMarkHandler(metaInteractor, uploader.Folder())
 	markHandler.MarkBackup(backupName, toPermanent)
 }

--- a/internal/databases/fdb/backup_push_handler.go
+++ b/internal/databases/fdb/backup_push_handler.go
@@ -14,7 +14,7 @@ type streamSentinelDto struct {
 	StartLocalTime time.Time
 }
 
-func HandleBackupPush(uploader internal.UploaderProvider, backupCmd *exec.Cmd) {
+func HandleBackupPush(uploader internal.Uploader, backupCmd *exec.Cmd) {
 	timeStart := utility.TimeNowCrossPlatformLocal()
 
 	stdout, stderr, err := utility.StartCommandWithStdoutStderr(backupCmd)

--- a/internal/databases/greenplum/ao_storage_uploader.go
+++ b/internal/databases/greenplum/ao_storage_uploader.go
@@ -15,7 +15,7 @@ import (
 )
 
 type AoStorageUploader struct {
-	uploader      *internal.Uploader
+	uploader      internal.Uploader
 	baseAoFiles   BackupAOFiles
 	meta          *AOFilesMetadataDTO
 	metaMutex     sync.Mutex
@@ -24,7 +24,7 @@ type AoStorageUploader struct {
 	isIncremental bool
 }
 
-func NewAoStorageUploader(uploader *internal.Uploader, baseAoFiles BackupAOFiles,
+func NewAoStorageUploader(uploader internal.Uploader, baseAoFiles BackupAOFiles,
 	crypter crypto.Crypter, files internal.BundleFiles, isIncremental bool) *AoStorageUploader {
 	// Separate uploader for AO/AOCS relfiles with disabled file size tracking since
 	// WAL-G does not count them

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -84,7 +84,7 @@ type RestorePointCreator struct {
 	systemIdentifier *uint64
 	gpVersion        semver.Version
 
-	Uploader *internal.Uploader
+	Uploader internal.Uploader
 	Conn     *pgx.Conn
 
 	logsDir string
@@ -115,7 +115,7 @@ func NewRestorePointCreator(pointName string) (rpc *RestorePointCreator, err err
 		gpVersion:        version,
 		logsDir:          viper.GetString(internal.GPLogsDirectory),
 	}
-	rpc.Uploader.UploadingFolder = rpc.Uploader.UploadingFolder.GetSubFolder(utility.BaseBackupPath)
+	rpc.Uploader.ChangeDirectory(utility.BaseBackupPath)
 
 	return rpc, nil
 }
@@ -153,7 +153,7 @@ func createRestorePoint(conn *pgx.Conn, restorePointName string) (restoreLSNs ma
 }
 
 func (rpc *RestorePointCreator) checkExists() error {
-	exists, err := rpc.Uploader.UploadingFolder.Exists(RestorePointMetadataFileName(rpc.pointName))
+	exists, err := rpc.Uploader.Folder().Exists(RestorePointMetadataFileName(rpc.pointName))
 	if err != nil {
 		return fmt.Errorf("failed to check restore point existence: %v", err)
 	}
@@ -183,7 +183,7 @@ func (rpc *RestorePointCreator) uploadMetadata(restoreLSNs map[int]string) (err 
 	tracelog.InfoLogger.Printf("Uploading restore point metadata file %s", metaFileName)
 	tracelog.InfoLogger.Println(meta.String())
 
-	return internal.UploadDto(rpc.Uploader.UploadingFolder, meta, metaFileName)
+	return internal.UploadDto(rpc.Uploader.Folder(), meta, metaFileName)
 }
 
 type RestorePointTime struct {

--- a/internal/databases/greenplum/segment_backup_push_handler.go
+++ b/internal/databases/greenplum/segment_backup_push_handler.go
@@ -17,7 +17,7 @@ func NewSegBackupHandler(arguments postgres.BackupArguments) (*postgres.BackupHa
 			return err
 		}
 
-		maker, err := NewGpTarBallComposerMaker(relStorageMap, bh.Workers.Uploader.Uploader, handler.CurBackupInfo.Name)
+		maker, err := NewGpTarBallComposerMaker(relStorageMap, bh.Workers.Uploader, handler.CurBackupInfo.Name)
 		if err != nil {
 			return err
 		}

--- a/internal/databases/mongo/archive/loader.go
+++ b/internal/databases/mongo/archive/loader.go
@@ -107,7 +107,7 @@ func (sd *StorageDownloader) ListBackups() ([]internal.BackupTime, []string, err
 
 // DownloadOplogArchive downloads, decompresses and decrypts (if needed) oplog archive.
 func (sd *StorageDownloader) DownloadOplogArchive(arch models.Archive, writeCloser io.WriteCloser) error {
-	return internal.DownloadFile(sd.oplogsFolder, arch.Filename(), arch.Extension(), writeCloser)
+	return internal.DownloadFile(internal.NewFolderReader(sd.oplogsFolder), arch.Filename(), arch.Extension(), writeCloser)
 }
 
 // ListOplogArchives fetches all oplog archives existed in storage.
@@ -185,13 +185,13 @@ func (d *DiscardUploader) UploadBackup(stream io.Reader, cmd internal.ErrWaiter,
 // StorageUploader extends base uploader with mongodb specific.
 // is NOT thread-safe
 type StorageUploader struct {
-	internal.UploaderProvider
+	internal.Uploader
 	crypter crypto.Crypter // usages only in UploadOplogArchive
 	buf     *bytes.Buffer
 }
 
 // NewStorageUploader builds mongodb uploader.
-func NewStorageUploader(upl internal.UploaderProvider) *StorageUploader {
+func NewStorageUploader(upl internal.Uploader) *StorageUploader {
 	upl.DisableSizeTracking() // providing io.ReaderAt+io.ReadSeeker to s3 upload enables buffer pool usage
 	return &StorageUploader{upl, internal.ConfigureCrypter(), &bytes.Buffer{}}
 }
@@ -203,7 +203,7 @@ func (su *StorageUploader) UploadOplogArchive(stream io.Reader, firstTS, lastTS 
 		return fmt.Errorf("can not build archive: %w", err)
 	}
 
-	_, err = su.buf.ReadFrom(internal.CompressAndEncrypt(stream, su.UploaderProvider.Compression(), su.crypter))
+	_, err = su.buf.ReadFrom(internal.CompressAndEncrypt(stream, su.Uploader.Compression(), su.crypter))
 	// TODO: warn if read > 2 * models.MaxDocumentSize and shrink buf capacity if it's too high
 	defer su.buf.Reset()
 	if err != nil {
@@ -251,7 +251,7 @@ func (su *StorageUploader) UploadBackup(stream io.Reader, cmd internal.ErrWaiter
 	}
 
 	backupSentinel := metaConstructor.MetaInfo()
-	if err := internal.UploadSentinel(su.UploaderProvider, backupSentinel, backupName); err != nil {
+	if err := internal.UploadSentinel(su.Uploader, backupSentinel, backupName); err != nil {
 		return fmt.Errorf("can not upload sentinel: %+v", err)
 	}
 	return nil

--- a/internal/databases/mongo/binary/backup.go
+++ b/internal/databases/mongo/binary/backup.go
@@ -14,7 +14,7 @@ import (
 type BackupService struct {
 	Context       context.Context
 	MongodService *MongodService
-	Uploader      *internal.Uploader
+	Uploader      internal.Uploader
 
 	Sentinel models.Backup
 }
@@ -23,7 +23,7 @@ func GenerateNewBackupName() string {
 	return common.BinaryBackupType + "_" + utility.TimeNowCrossPlatformUTC().Format(utility.BackupTimeFormat)
 }
 
-func CreateBackupService(ctx context.Context, mongodService *MongodService, uploader *internal.Uploader,
+func CreateBackupService(ctx context.Context, mongodService *MongodService, uploader internal.Uploader,
 ) (*BackupService, error) {
 	return &BackupService{
 		Context:       ctx,

--- a/internal/databases/mongo/binary/concurrent_downloader.go
+++ b/internal/databases/mongo/binary/concurrent_downloader.go
@@ -14,7 +14,7 @@ type ConcurrentDownloader struct {
 	folder storage.Folder
 }
 
-func CreateConcurrentDownloader(uploader *internal.Uploader) *ConcurrentDownloader {
+func CreateConcurrentDownloader(uploader internal.Uploader) *ConcurrentDownloader {
 	return &ConcurrentDownloader{
 		folder: uploader.Folder(),
 	}

--- a/internal/databases/mongo/binary/concurrent_uploader.go
+++ b/internal/databases/mongo/binary/concurrent_uploader.go
@@ -8,14 +8,14 @@ import (
 )
 
 type ConcurrentUploader struct {
-	uploader *internal.Uploader
+	uploader internal.Uploader
 	bundle   *internal.Bundle
 
 	UncompressedSize int64
 	CompressedSize   int64
 }
 
-func CreateConcurrentUploader(uploader *internal.Uploader, backupName, directory string) (*ConcurrentUploader, error) {
+func CreateConcurrentUploader(uploader internal.Uploader, backupName, directory string) (*ConcurrentUploader, error) {
 	crypter := internal.ConfigureCrypter()
 	tarSizeThreshold := viper.GetInt64(internal.TarSizeThresholdSetting)
 	bundle := internal.NewBundle(directory, crypter, tarSizeThreshold, map[string]utility.Empty{})

--- a/internal/databases/mongo/binary/restore.go
+++ b/internal/databases/mongo/binary/restore.go
@@ -14,12 +14,12 @@ import (
 type RestoreService struct {
 	Context      context.Context
 	LocalStorage *LocalStorage
-	Uploader     *internal.Uploader
+	Uploader     internal.Uploader
 
 	minimalConfigPath string
 }
 
-func CreateRestoreService(ctx context.Context, localStorage *LocalStorage, uploader *internal.Uploader,
+func CreateRestoreService(ctx context.Context, localStorage *LocalStorage, uploader internal.Uploader,
 	minimalConfigPath string) (*RestoreService, error) {
 	return &RestoreService{
 		Context:           ctx,

--- a/internal/databases/mysql/backup_mark_handler.go
+++ b/internal/databases/mysql/backup_mark_handler.go
@@ -6,7 +6,7 @@ import (
 )
 
 // MarkBackup marks a backup as permanent or impermanent
-func MarkBackup(uploader *internal.Uploader, backupName string, toPermanent bool) {
+func MarkBackup(uploader internal.Uploader, backupName string, toPermanent bool) {
 	tracelog.InfoLogger.Printf("Retrieving previous related backups to be marked: toPermanent=%t", toPermanent)
 	internal.HandleBackupMark(uploader, backupName, toPermanent, NewGenericMetaInteractor())
 }

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-func HandleBackupPush(folder storage.Folder, uploader internal.UploaderProvider,
+func HandleBackupPush(folder storage.Folder, uploader internal.Uploader,
 	backupCmd *exec.Cmd, isPermanent bool, userDataRaw string) {
 	db, err := getMySQLConnection()
 	tracelog.ErrorLogger.FatalOnError(err)

--- a/internal/databases/mysql/binlog_push_handler.go
+++ b/internal/databases/mysql/binlog_push_handler.go
@@ -25,7 +25,7 @@ type LogsCache struct {
 
 //gocyclo:ignore
 //nolint:funlen
-func HandleBinlogPush(uploader internal.UploaderProvider, untilBinlog string, checkGTIDs bool) {
+func HandleBinlogPush(uploader internal.Uploader, untilBinlog string, checkGTIDs bool) {
 	rootFolder := uploader.Folder()
 	uploader.ChangeDirectory(BinlogPath)
 
@@ -170,7 +170,7 @@ func getMySQLBinlogsFolder(db *sql.DB) (string, error) {
 	return path.Dir(logBinBasename), nil
 }
 
-func archiveBinLog(uploader internal.UploaderProvider, dataDir string, binlog string) error {
+func archiveBinLog(uploader internal.Uploader, dataDir string, binlog string) error {
 	tracelog.InfoLogger.Printf("Archiving %v\n", binlog)
 
 	filename := path.Join(dataDir, binlog)

--- a/internal/databases/mysql/mysql.go
+++ b/internal/databases/mysql/mysql.go
@@ -231,7 +231,7 @@ outer:
 			binlogName := utility.TrimFileExtension(logFile.GetName())
 			binlogPath := path.Join(dstDir, binlogName)
 			tracelog.InfoLogger.Printf("downloading %s into %s", binlogName, binlogPath)
-			if err = internal.DownloadFileTo(logFolder, binlogName, binlogPath); err != nil {
+			if err = internal.DownloadFileTo(internal.NewFolderReader(logFolder), binlogName, binlogPath); err != nil {
 				tracelog.ErrorLogger.Printf("failed to download %s: %v", binlogName, err)
 				return err
 			}
@@ -287,7 +287,7 @@ func provideLogs(folder storage.Folder, dstDir string, startTS, endTS time.Time,
 		binlogName := utility.TrimFileExtension(logFile.GetName())
 		binlogPath := path.Join(dstDir, binlogName)
 		tracelog.InfoLogger.Printf("downloading %s into %s", binlogName, binlogPath)
-		if err = internal.DownloadFileTo(logFolder, binlogName, binlogPath); err != nil {
+		if err = internal.DownloadFileTo(internal.NewFolderReader(logFolder), binlogName, binlogPath); err != nil {
 			if os.IsExist(err) {
 				tracelog.WarningLogger.Printf("file %s exist skipping", binlogName)
 			} else {

--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -114,7 +114,7 @@ func GetBinlogPreviousGTIDs(filename string, flavor string) (mysql.GTIDSet, erro
 
 func GetBinlogPreviousGTIDsRemote(folder storage.Folder, filename string, flavor string) (mysql.GTIDSet, error) {
 	binlogName := utility.TrimFileExtension(filename)
-	fh, err := internal.DownloadAndDecompressStorageFile(folder, binlogName)
+	fh, err := internal.DownloadAndDecompressStorageFile(internal.NewFolderReader(folder), binlogName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read binlog %s: %w", binlogName, err)
 	}

--- a/internal/databases/postgres/backup_sentinel_dto_test.go
+++ b/internal/databases/postgres/backup_sentinel_dto_test.go
@@ -1,9 +1,10 @@
 package postgres
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBackupSentinelDto_IsIncremental(t *testing.T) {

--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/crypto"
-	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -402,7 +401,7 @@ func (bundle *Bundle) getDeltaBitmapFor(filePath string) (*roaring.Bitmap, error
 	return bundle.DeltaMap.GetDeltaBitmapFor(filePath)
 }
 
-func (bundle *Bundle) DownloadDeltaMap(folder storage.Folder, backupStartLSN LSN) error {
+func (bundle *Bundle) DownloadDeltaMap(folder internal.StorageFolderReader, backupStartLSN LSN) error {
 	deltaMap, err := getDeltaMap(folder, bundle.Timeline, *bundle.IncrementFromLsn, backupStartLSN)
 	if err != nil {
 		return err

--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -401,8 +401,8 @@ func (bundle *Bundle) getDeltaBitmapFor(filePath string) (*roaring.Bitmap, error
 	return bundle.DeltaMap.GetDeltaBitmapFor(filePath)
 }
 
-func (bundle *Bundle) DownloadDeltaMap(folder internal.StorageFolderReader, backupStartLSN LSN) error {
-	deltaMap, err := getDeltaMap(folder, bundle.Timeline, *bundle.IncrementFromLsn, backupStartLSN)
+func (bundle *Bundle) DownloadDeltaMap(reader internal.StorageFolderReader, backupStartLSN LSN) error {
+	deltaMap, err := getDeltaMap(reader, bundle.Timeline, *bundle.IncrementFromLsn, backupStartLSN)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/postgres/bundle_test.go
+++ b/internal/databases/postgres/bundle_test.go
@@ -209,7 +209,7 @@ func TestLoadDeltaMap_AllDeltas(t *testing.T) {
 	_, curLogSegNo, _ := postgres.ParseWALFilename(backupNextWalFilename)
 
 	backupStartLsn := postgres.LSN(curLogSegNo*postgres.WalSegmentSize + 1)
-	err = bundle.DownloadDeltaMap(folder, backupStartLsn)
+	err = bundle.DownloadDeltaMap(internal.NewFolderReader(folder), backupStartLsn)
 	deltaMap := bundle.DeltaMap
 	assert.NoError(t, err)
 	assert.NotNil(t, deltaMap)
@@ -226,7 +226,7 @@ func TestLoadDeltaMap_MissingDelta(t *testing.T) {
 	backupNextWalFilename := "0000000100000000000000B0"
 	_, curLogSegNo, _ := postgres.ParseWALFilename(backupNextWalFilename)
 
-	err = bundle.DownloadDeltaMap(folder, postgres.LSN(curLogSegNo*postgres.WalSegmentSize))
+	err = bundle.DownloadDeltaMap(internal.NewFolderReader(folder), postgres.LSN(curLogSegNo*postgres.WalSegmentSize))
 	assert.Error(t, err)
 	assert.Nil(t, bundle.DeltaMap)
 }
@@ -238,7 +238,7 @@ func TestLoadDeltaMap_WalTail(t *testing.T) {
 	backupNextWalFilename := "000000010000000000000091"
 	_, curLogSegNo, _ := postgres.ParseWALFilename(backupNextWalFilename)
 
-	err = bundle.DownloadDeltaMap(folder, postgres.LSN(curLogSegNo*postgres.WalSegmentSize))
+	err = bundle.DownloadDeltaMap(internal.NewFolderReader(folder), postgres.LSN(curLogSegNo*postgres.WalSegmentSize))
 	assert.NoError(t, err)
 	assert.NotNil(t, bundle.DeltaMap)
 	assert.Equal(t, []uint32{4, 9}, bundle.DeltaMap[BundleTestLocations[0].RelationFileNode].ToArray())

--- a/internal/databases/postgres/configure.go
+++ b/internal/databases/postgres/configure.go
@@ -13,30 +13,7 @@ import (
 // ConfigureWalUploader connects to storage and creates an uploader. It makes sure
 // that a valid session has started; if invalid, returns AWS error
 // and `<nil>` values.
-func ConfigureWalUploader() (uploader *WalUploader, err error) {
-	uploader, err = ConfigureWalUploaderWithoutCompressMethod()
-	if err != nil {
-		return nil, err
-	}
-
-	folder := uploader.UploadingFolder
-	deltaFileManager := uploader.DeltaFileManager
-
-	compressor, err := internal.ConfigureCompressor()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to configure compression")
-	}
-
-	uploader = NewWalUploader(compressor, folder, deltaFileManager)
-	return uploader, err
-}
-
-func ConfigureWalUploaderWithoutCompressMethod() (uploader *WalUploader, err error) {
-	folder, err := internal.ConfigureFolder()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to configure folder")
-	}
-
+func ConfigureWalUploader(baseUploader internal.Uploader) (uploader *WalUploader, err error) {
 	useWalDelta, deltaDataFolder, err := configureWalDeltaUsage()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to configure WAL Delta usage")
@@ -47,7 +24,7 @@ func ConfigureWalUploaderWithoutCompressMethod() (uploader *WalUploader, err err
 		deltaFileManager = NewDeltaFileManager(deltaDataFolder)
 	}
 
-	uploader = NewWalUploader(nil, folder, deltaFileManager)
+	uploader = NewWalUploader(baseUploader, deltaFileManager)
 	return uploader, err
 }
 

--- a/internal/databases/postgres/delta_file_manager.go
+++ b/internal/databases/postgres/delta_file_manager.go
@@ -148,7 +148,7 @@ func (manager *DeltaFileManager) FlushPartFiles() (completedPartFiles map[string
 	return
 }
 
-func (manager *DeltaFileManager) FlushDeltaFiles(uploader *internal.Uploader, completedPartFiles map[string]bool) {
+func (manager *DeltaFileManager) FlushDeltaFiles(uploader internal.Uploader, completedPartFiles map[string]bool) {
 	manager.DeltaFileWriters.Range(func(key string, deltaFileWriter *DeltaFileChanWriter) bool {
 		deltaFileWriter.close()
 		return true
@@ -184,7 +184,7 @@ func (manager *DeltaFileManager) FlushDeltaFiles(uploader *internal.Uploader, co
 	})
 }
 
-func (manager *DeltaFileManager) FlushFiles(uploader *internal.Uploader) {
+func (manager *DeltaFileManager) FlushFiles(uploader internal.Uploader) {
 	err := manager.dataFolder.CleanFolder()
 	if err != nil {
 		tracelog.WarningLogger.Printf("Failed to clean delta folder because of error: '%v'\n", err)

--- a/internal/databases/postgres/delta_map_downloader.go
+++ b/internal/databases/postgres/delta_map_downloader.go
@@ -6,7 +6,7 @@ import (
 	"github.com/wal-g/wal-g/internal"
 )
 
-func getDeltaMap(folder internal.StorageFolderReader,
+func getDeltaMap(reader internal.StorageFolderReader,
 	timeline uint32,
 	firstUsedLSN,
 	firstNotUsedLSN LSN) (PagedFileDeltaMap, error) {
@@ -19,13 +19,13 @@ func getDeltaMap(folder internal.StorageFolderReader,
 	deltaMap := NewPagedFileDeltaMap()
 	firstUsedDeltaNo, firstNotUsedDeltaNo := getDeltaRange(firstUsedLSN, firstNotUsedLSN)
 	// Get locations from [firstUsedDeltaNo, lastUsedDeltaNo). We use lastUsedDeltaNo in next step
-	err := deltaMap.getLocationsFromDeltas(folder, timeline, firstUsedDeltaNo, firstNotUsedDeltaNo.previous())
+	err := deltaMap.getLocationsFromDeltas(reader, timeline, firstUsedDeltaNo, firstNotUsedDeltaNo.previous())
 	if err != nil {
 		return deltaMap, errors.Wrapf(err, "Error during fetch locations from delta files.\n")
 	}
 
 	// Handle last delta file separately for fetch locations and walParser from it
-	lastDeltaFile, err := getDeltaFile(folder, firstNotUsedDeltaNo.previous().getFilename(timeline))
+	lastDeltaFile, err := getDeltaFile(reader, firstNotUsedDeltaNo.previous().getFilename(timeline))
 	if err != nil {
 		return deltaMap, errors.Wrapf(err, "Error during downloading last delta file.\n")
 	}
@@ -33,7 +33,7 @@ func getDeltaMap(folder internal.StorageFolderReader,
 
 	firstUsedWalSegmentNo, firstNotUsedWalSegmentNo := getWalSegmentRange(firstNotUsedDeltaNo, firstNotUsedLSN)
 	// we handle WAL files from [firstUsedWalSegmentNo, lastUsedWalSegmentNo]
-	err = deltaMap.getLocationsFromWals(folder, timeline, firstUsedWalSegmentNo,
+	err = deltaMap.getLocationsFromWals(reader, timeline, firstUsedWalSegmentNo,
 		firstNotUsedWalSegmentNo, lastDeltaFile.WalParser)
 	if err != nil {
 		return deltaMap, errors.Wrapf(err, "Error during fetch locations from wal segments.\n")

--- a/internal/databases/postgres/delta_map_downloader.go
+++ b/internal/databases/postgres/delta_map_downloader.go
@@ -3,10 +3,10 @@ package postgres
 import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/internal"
 )
 
-func getDeltaMap(folder storage.Folder,
+func getDeltaMap(folder internal.StorageFolderReader,
 	timeline uint32,
 	firstUsedLSN,
 	firstNotUsedLSN LSN) (PagedFileDeltaMap, error) {

--- a/internal/databases/postgres/paged_file_delta_map.go
+++ b/internal/databases/postgres/paged_file_delta_map.go
@@ -140,13 +140,13 @@ func GetRelFileNodeFrom(filePath string) (*walparser.RelFileNode, error) {
 	}
 }
 
-func (deltaMap *PagedFileDeltaMap) getLocationsFromDeltas(folder internal.StorageFolderReader,
+func (deltaMap *PagedFileDeltaMap) getLocationsFromDeltas(reader internal.StorageFolderReader,
 	timeline uint32,
 	first,
 	last DeltaNo) error {
 	for deltaNo := first; deltaNo < last; deltaNo = deltaNo.next() {
 		filename := deltaNo.getFilename(timeline)
-		deltaFile, err := getDeltaFile(folder, filename)
+		deltaFile, err := getDeltaFile(reader, filename)
 		if err != nil {
 			return err
 		}
@@ -156,14 +156,14 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromDeltas(folder internal.Storag
 	return nil
 }
 
-func (deltaMap *PagedFileDeltaMap) getLocationsFromWals(folder internal.StorageFolderReader,
+func (deltaMap *PagedFileDeltaMap) getLocationsFromWals(reader internal.StorageFolderReader,
 	timeline uint32,
 	first,
 	last WalSegmentNo,
 	walParser *walparser.WalParser) error {
 	for walSegmentNo := first; walSegmentNo < last; walSegmentNo = walSegmentNo.next() {
 		filename := walSegmentNo.getFilename(timeline)
-		err := deltaMap.getLocationsFromWal(folder, filename, walParser)
+		err := deltaMap.getLocationsFromWal(reader, filename, walParser)
 		if err != nil {
 			return err
 		}
@@ -173,8 +173,8 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromWals(folder internal.StorageF
 }
 
 func (deltaMap *PagedFileDeltaMap) getLocationsFromWal(
-	folder internal.StorageFolderReader, filename string, walParser *walparser.WalParser) error {
-	reader, err := internal.DownloadAndDecompressStorageFile(folder, filename)
+	folderReader internal.StorageFolderReader, filename string, walParser *walparser.WalParser) error {
+	reader, err := internal.DownloadAndDecompressStorageFile(folderReader, filename)
 	if err != nil {
 		return errors.Wrapf(err, "Error during wal segment'%s' downloading.", filename)
 	}
@@ -190,8 +190,8 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromWal(
 	return nil
 }
 
-func getDeltaFile(folder internal.StorageFolderReader, filename string) (*DeltaFile, error) {
-	reader, err := internal.DownloadAndDecompressStorageFile(folder, filename)
+func getDeltaFile(folderReader internal.StorageFolderReader, filename string) (*DeltaFile, error) {
+	reader, err := internal.DownloadAndDecompressStorageFile(folderReader, filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error during delta file '%s' downloading.", filename)
 	}

--- a/internal/databases/postgres/paged_file_delta_map.go
+++ b/internal/databases/postgres/paged_file_delta_map.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/walparser"
-	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
 const (
@@ -141,7 +140,7 @@ func GetRelFileNodeFrom(filePath string) (*walparser.RelFileNode, error) {
 	}
 }
 
-func (deltaMap *PagedFileDeltaMap) getLocationsFromDeltas(folder storage.Folder,
+func (deltaMap *PagedFileDeltaMap) getLocationsFromDeltas(folder internal.StorageFolderReader,
 	timeline uint32,
 	first,
 	last DeltaNo) error {
@@ -157,7 +156,7 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromDeltas(folder storage.Folder,
 	return nil
 }
 
-func (deltaMap *PagedFileDeltaMap) getLocationsFromWals(folder storage.Folder,
+func (deltaMap *PagedFileDeltaMap) getLocationsFromWals(folder internal.StorageFolderReader,
 	timeline uint32,
 	first,
 	last WalSegmentNo,
@@ -173,7 +172,8 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromWals(folder storage.Folder,
 	return nil
 }
 
-func (deltaMap *PagedFileDeltaMap) getLocationsFromWal(folder storage.Folder, filename string, walParser *walparser.WalParser) error {
+func (deltaMap *PagedFileDeltaMap) getLocationsFromWal(
+	folder internal.StorageFolderReader, filename string, walParser *walparser.WalParser) error {
 	reader, err := internal.DownloadAndDecompressStorageFile(folder, filename)
 	if err != nil {
 		return errors.Wrapf(err, "Error during wal segment'%s' downloading.", filename)
@@ -190,7 +190,7 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromWal(folder storage.Folder, fi
 	return nil
 }
 
-func getDeltaFile(folder storage.Folder, filename string) (*DeltaFile, error) {
+func getDeltaFile(folder internal.StorageFolderReader, filename string) (*DeltaFile, error) {
 	reader, err := internal.DownloadAndDecompressStorageFile(folder, filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error during delta file '%s' downloading.", filename)

--- a/internal/databases/postgres/pgbackrest/wal_fetch_handler.go
+++ b/internal/databases/postgres/pgbackrest/wal_fetch_handler.go
@@ -17,13 +17,13 @@ func HandleWalFetch(folder storage.Folder, stanza string, walFileName string, lo
 
 	archiveFolder := folder.GetSubFolder(WalArchivePath).GetSubFolder(stanza).GetSubFolder(*archiveName)
 	if strings.HasSuffix(walFileName, ".history") {
-		return internal.DownloadFileTo(archiveFolder, walFileName, location)
+		return internal.DownloadFileTo(internal.NewFolderReader(archiveFolder), walFileName, location)
 	}
 
 	subdirectoryName := walFileName[0:16]
 	walFolder := archiveFolder.GetSubFolder(subdirectoryName)
 	if strings.HasSuffix(walFileName, ".backup") {
-		return internal.DownloadFileTo(walFolder, walFileName, location)
+		return internal.DownloadFileTo(internal.NewFolderReader(walFolder), walFileName, location)
 	}
 	fileList, _, err := walFolder.ListFolder()
 	if err != nil {
@@ -33,7 +33,7 @@ func HandleWalFetch(folder storage.Folder, stanza string, walFileName string, lo
 	for _, file := range fileList {
 		fileName := file.GetName()
 		if strings.HasPrefix(fileName, walFileName) {
-			return internal.DownloadFileTo(walFolder, strings.TrimSuffix(fileName, filepath.Ext(fileName)), location)
+			return internal.DownloadFileTo(internal.NewFolderReader(walFolder), strings.TrimSuffix(fileName, filepath.Ext(fileName)), location)
 		}
 	}
 

--- a/internal/databases/postgres/tar_ball_composer.go
+++ b/internal/databases/postgres/tar_ball_composer.go
@@ -22,10 +22,10 @@ type TarBallComposerMaker interface {
 	Make(bundle *Bundle) (internal.TarBallComposer, error)
 }
 
-func NewTarBallComposerMaker(composerType TarBallComposerType, queryRunner *PgQueryRunner, uploader *internal.Uploader,
+func NewTarBallComposerMaker(composerType TarBallComposerType, queryRunner *PgQueryRunner, uploader internal.Uploader,
 	newBackupName string, filePackOptions TarBallFilePackerOptions,
 	withoutFilesMetadata bool) (TarBallComposerMaker, error) {
-	folder := uploader.UploadingFolder
+	folder := uploader.Folder()
 
 	if withoutFilesMetadata {
 		if composerType != RegularComposer {

--- a/internal/databases/postgres/timeline_history_record.go
+++ b/internal/databases/postgres/timeline_history_record.go
@@ -124,7 +124,7 @@ func parseHistoryFile(historyReader io.Reader) ([]*TimelineHistoryRecord, error)
 
 func getHistoryFileFromStorage(timeline uint32, walFolder storage.Folder) (io.ReadCloser, error) {
 	historyFileName := fmt.Sprintf(walHistoryFileFormat, timeline)
-	reader, err := internal.DownloadAndDecompressStorageFile(walFolder, historyFileName)
+	reader, err := internal.DownloadAndDecompressStorageFile(internal.NewFolderReader(walFolder), historyFileName)
 	if _, ok := err.(internal.ArchiveNonExistenceError); ok {
 		return nil, newHistoryFileNotFoundError(historyFileName)
 	}

--- a/internal/databases/postgres/wal_fetch_handler.go
+++ b/internal/databases/postgres/wal_fetch_handler.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -34,9 +33,9 @@ func (err InvalidWalFileMagicError) Error() string {
 
 // TODO : unit tests
 // HandleWALFetch is invoked to performa wal-g wal-fetch
-func HandleWALFetch(folder storage.Folder, walFileName string, location string, triggerPrefetch bool) {
+func HandleWALFetch(folder internal.StorageFolderReader, walFileName string, location string, triggerPrefetch bool) {
 	tracelog.DebugLogger.Printf("HandleWALFetch(folder, %s, %s, %v)\n", walFileName, location, triggerPrefetch)
-	folder = folder.GetSubFolder(utility.WalPath)
+	folder = folder.SubFolder(utility.WalPath)
 	location = utility.ResolveSymlink(location)
 	if triggerPrefetch {
 		prefetchLocation := location

--- a/internal/databases/postgres/wal_fetch_handler.go
+++ b/internal/databases/postgres/wal_fetch_handler.go
@@ -33,9 +33,9 @@ func (err InvalidWalFileMagicError) Error() string {
 
 // TODO : unit tests
 // HandleWALFetch is invoked to performa wal-g wal-fetch
-func HandleWALFetch(folder internal.StorageFolderReader, walFileName string, location string, triggerPrefetch bool) {
+func HandleWALFetch(reader internal.StorageFolderReader, walFileName string, location string, triggerPrefetch bool) {
 	tracelog.DebugLogger.Printf("HandleWALFetch(folder, %s, %s, %v)\n", walFileName, location, triggerPrefetch)
-	folder = folder.SubFolder(utility.WalPath)
+	reader = reader.SubFolder(utility.WalPath)
 	location = utility.ResolveSymlink(location)
 	if triggerPrefetch {
 		prefetchLocation := location
@@ -97,7 +97,7 @@ func HandleWALFetch(folder internal.StorageFolderReader, walFileName string, loc
 		time.Sleep(2 * time.Millisecond)
 	}
 
-	err := internal.DownloadFileTo(folder, walFileName, location)
+	err := internal.DownloadFileTo(reader, walFileName, location)
 	if _, isArchNonExistErr := err.(internal.ArchiveNonExistenceError); isArchNonExistErr {
 		tracelog.ErrorLogger.Print(err.Error())
 		os.Exit(exIoError)

--- a/internal/databases/postgres/wal_fetch_handler_test.go
+++ b/internal/databases/postgres/wal_fetch_handler_test.go
@@ -40,7 +40,7 @@ func TestWallFetchCachesLastDecompressor(t *testing.T) {
 
 		assert.NoError(t, folder.PutObject(walFilename+"."+decompressor.FileExtension(), &data))
 
-		_, err = internal.DownloadAndDecompressStorageFile(folder, walFilename)
+		_, err = internal.DownloadAndDecompressStorageFile(internal.NewFolderReader(folder), walFilename)
 		assert.NoError(t, err)
 
 		last, err := internal.GetLastDecompressor()
@@ -64,7 +64,7 @@ func TestTryDownloadWALFile_Exist(t *testing.T) {
 	expectedData := []byte("mock")
 	folder := testtools.MakeDefaultInMemoryStorageFolder().GetSubFolder(utility.WalPath)
 	folder.PutObject(WalFilename, bytes.NewBuffer(expectedData))
-	archiveReader, exist, err := internal.TryDownloadFile(folder, WalFilename)
+	archiveReader, exist, err := internal.TryDownloadFile(internal.NewFolderReader(folder), WalFilename)
 	assert.NoError(t, err)
 	assert.True(t, exist)
 	actualData, err := io.ReadAll(archiveReader)
@@ -74,7 +74,7 @@ func TestTryDownloadWALFile_Exist(t *testing.T) {
 
 func TestTryDownloadWALFile_NotExist(t *testing.T) {
 	folder := testtools.MakeDefaultInMemoryStorageFolder()
-	reader, exist, err := internal.TryDownloadFile(folder, WalFilename)
+	reader, exist, err := internal.TryDownloadFile(internal.NewFolderReader(folder), WalFilename)
 	assert.Nil(t, reader)
 	assert.False(t, exist)
 	assert.NoError(t, err)

--- a/internal/databases/postgres/wal_metadata_uploader.go
+++ b/internal/databases/postgres/wal_metadata_uploader.go
@@ -49,7 +49,7 @@ func NewWalMetadataUploader(walMetadataSetting string) (*WalMetadataUploader, er
 	return walMetadataUploader, nil
 }
 
-func (u *WalMetadataUploader) UploadWalMetadata(walFileName string, createdTime time.Time, uploader *internal.Uploader) error {
+func (u *WalMetadataUploader) UploadWalMetadata(walFileName string, createdTime time.Time, uploader internal.Uploader) error {
 	var walMetadata WalMetadataDescription
 	walMetadataMap := make(map[string]WalMetadataDescription)
 	walMetadataName := walFileName + ".json"
@@ -73,7 +73,7 @@ func (u *WalMetadataUploader) UploadWalMetadata(walFileName string, createdTime 
 	return errors.Wrapf(err, "upload: could not Upload metadata'%s'\n", walFileName)
 }
 
-func (u *WalMetadataUploader) uploadBulkMetadataFile(walFileName string, uploader *internal.Uploader) error {
+func (u *WalMetadataUploader) uploadBulkMetadataFile(walFileName string, uploader internal.Uploader) error {
 	// Creating consolidated wal metadata only for bulk option
 	// Checking if the walfile name ends with "F" (last file in the series) and consolidating all
 	// the metadata together.
@@ -137,7 +137,7 @@ func checkWalMetadataLevel(walMetadataLevel string) error {
 	return nil
 }
 
-func uploadLocalWalMetadata(walFilePath string, uploader *internal.Uploader) error {
+func uploadLocalWalMetadata(walFilePath string, uploader internal.Uploader) error {
 	walMetadataSetting := viper.GetString(internal.UploadWalMetadata)
 	if walMetadataSetting == WalNoMetadataLevel {
 		return nil
@@ -158,7 +158,7 @@ func uploadLocalWalMetadata(walFilePath string, uploader *internal.Uploader) err
 	return walMetadataUploader.UploadWalMetadata(walFileName, createdTime, uploader)
 }
 
-func uploadRemoteWalMetadata(walFileName string, uploader *internal.Uploader) error {
+func uploadRemoteWalMetadata(walFileName string, uploader internal.Uploader) error {
 	walMetadataSetting := viper.GetString(internal.UploadWalMetadata)
 	if walMetadataSetting == WalNoMetadataLevel {
 		return nil

--- a/internal/databases/postgres/wal_push_handler.go
+++ b/internal/databases/postgres/wal_push_handler.go
@@ -38,7 +38,7 @@ func HandleWALPush(uploader *WalUploader, walFilePath string) error {
 		if err != nil {
 			tracelog.ErrorLogger.Printf("unmark wal-g status for %s file failed due following error %+v", walFilePath, err)
 		}
-		return uploadLocalWalMetadata(walFilePath, uploader.Uploader)
+		return uploadLocalWalMetadata(walFilePath, uploader)
 	}
 
 	concurrency, err := internal.GetMaxUploadConcurrency()
@@ -96,7 +96,7 @@ func uploadWALFile(uploader *WalUploader, walFilePath string, preventWalOverwrit
 
 // TODO : unit tests
 func checkWALOverwrite(uploader *WalUploader, walFilePath string) (overwriteAttempt bool, err error) {
-	walFileReader, err := internal.DownloadAndDecompressStorageFile(uploader.UploadingFolder, filepath.Base(walFilePath))
+	walFileReader, err := internal.DownloadAndDecompressStorageFile(internal.NewFolderReader(uploader.Folder()), filepath.Base(walFilePath))
 	if err != nil {
 		if _, ok := err.(internal.ArchiveNonExistenceError); ok {
 			err = nil

--- a/internal/databases/postgres/wal_push_handler_test.go
+++ b/internal/databases/postgres/wal_push_handler_test.go
@@ -37,7 +37,7 @@ func TestWalPush_HandleWALPush(t *testing.T) {
 	uploader, _, dir, testFileName := generateAndUploadWalFile(t, "1")
 	defer testtools.Cleanup(t, dir)
 	// ".mock" suffix is the MockCompressor file extension
-	_, err := uploader.UploadingFolder.ReadObject(testFileName + ".mock")
+	_, err := uploader.Folder().ReadObject(testFileName + ".mock")
 	assert.NoError(t, err)
 }
 
@@ -45,7 +45,7 @@ func TestWalPush_IndividualMetadataUploader(t *testing.T) {
 	viper.Set(internal.UploadWalMetadata, postgres.WalIndividualMetadataLevel)
 	uploader, _, dir, testFileName := generateAndUploadWalFile(t, "1")
 	defer testtools.Cleanup(t, dir)
-	_, err := uploader.UploadingFolder.ReadObject(testFileName + ".json")
+	_, err := uploader.Folder().ReadObject(testFileName + ".json")
 	assert.NoError(t, err)
 }
 
@@ -53,7 +53,7 @@ func TestWalPush_BulkMetadataUploader(t *testing.T) {
 	viper.Set(internal.UploadWalMetadata, postgres.WalBulkMetadataLevel)
 	uploader, _, dir, testFileName := generateAndUploadWalFile(t, "F")
 	defer testtools.Cleanup(t, dir)
-	_, err := uploader.UploadingFolder.ReadObject(testFileName[0:len(testFileName)-1] + ".json")
+	_, err := uploader.Folder().ReadObject(testFileName[0:len(testFileName)-1] + ".json")
 	assert.NoError(t, err)
 }
 
@@ -61,7 +61,7 @@ func TestWalPush_NoMetataNoUploader(t *testing.T) {
 	viper.Set(internal.UploadWalMetadata, postgres.WalNoMetadataLevel)
 	uploader, _, dir, testFileName := generateAndUploadWalFile(t, "1")
 	defer testtools.Cleanup(t, dir)
-	_, err := uploader.UploadingFolder.ReadObject(testFileName + ".json")
+	_, err := uploader.Folder().ReadObject(testFileName + ".json")
 	assert.Error(t, err)
 }
 
@@ -70,6 +70,6 @@ func TestWalPush_BulkMetadataUploaderWithUploadConcurrency(t *testing.T) {
 	viper.Set(internal.UploadConcurrencySetting, 4)
 	uploader, _, dir, testFileName := generateAndUploadWalFile(t, "F")
 	defer testtools.Cleanup(t, dir)
-	_, err := uploader.UploadingFolder.ReadObject(testFileName[0:len(testFileName)-1] + ".json")
+	_, err := uploader.Folder().ReadObject(testFileName[0:len(testFileName)-1] + ".json")
 	assert.NoError(t, err)
 }

--- a/internal/databases/postgres/wal_receive_handler.go
+++ b/internal/databases/postgres/wal_receive_handler.go
@@ -54,7 +54,7 @@ func HandleWALReceive(uploader *WalUploader) {
 	var XLogPos pglogrepl.LSN
 	var segment *WalSegment
 
-	uploader.UploadingFolder = uploader.UploadingFolder.GetSubFolder(utility.WalPath)
+	uploader.ChangeDirectory(utility.WalPath)
 
 	slot, walSegmentBytes, err := getCurrentWalInfo()
 	tracelog.ErrorLogger.FatalOnError(err)

--- a/internal/databases/postgres/wal_restore_handler.go
+++ b/internal/databases/postgres/wal_restore_handler.go
@@ -78,7 +78,7 @@ func HandleWALRestore(targetPath, sourcePath string, cloudFolder storage.Folder)
 	tracelog.InfoLogger.Printf("WAL files to restore: %v", filenamesToRestore)
 	for _, walFilename := range filenamesToRestore {
 		location := utility.ResolveSymlink(path.Join(sourceWalDir, walFilename))
-		if err = internal.DownloadFileTo(cloudFolder, walFilename, location); err != nil {
+		if err = internal.DownloadFileTo(internal.NewFolderReader(cloudFolder), walFilename, location); err != nil {
 			tracelog.ErrorLogger.Printf("Failed to download WAL file %v: %v\n", walFilename, err)
 		} else {
 			tracelog.InfoLogger.Printf("Successfully download WAL file %v\n", walFilename)

--- a/internal/databases/redis/archive/backup.go
+++ b/internal/databases/redis/archive/backup.go
@@ -109,11 +109,11 @@ func NewBackupRedisMetaConstructor(ctx context.Context, folder storage.Folder, p
 }
 
 type StorageUploader struct {
-	internal.UploaderProvider
+	internal.Uploader
 }
 
 // NewRedisStorageUploader builds redis uploader, that also push metadata
-func NewRedisStorageUploader(upl *internal.Uploader) *StorageUploader {
+func NewRedisStorageUploader(upl internal.Uploader) *StorageUploader {
 	return &StorageUploader{upl}
 }
 

--- a/internal/databases/redis/backup_list_handler_test.go
+++ b/internal/databases/redis/backup_list_handler_test.go
@@ -2,9 +2,10 @@ package redis
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal/databases/redis/archive"
-	"testing"
 )
 
 var emptyColumnsBackups = []archive.Backup{

--- a/internal/databases/redis/backup_push_handler.go
+++ b/internal/databases/redis/backup_push_handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-func HandleBackupPush(uploader *internal.Uploader, backupCmd *exec.Cmd, metaConstructor internal.MetaConstructor) error {
+func HandleBackupPush(uploader internal.Uploader, backupCmd *exec.Cmd, metaConstructor internal.MetaConstructor) error {
 	stdout, err := utility.StartCommandWithStdoutPipe(backupCmd)
 	tracelog.ErrorLogger.FatalfOnError("failed to start backup create command: %v", err)
 

--- a/internal/directory_uploader.go
+++ b/internal/directory_uploader.go
@@ -22,14 +22,14 @@ type CommonDirectoryUploader struct {
 
 	excludedFiles map[string]utility.Empty
 	backupName    string
-	uploader      *Uploader
+	uploader      Uploader
 }
 
 func NewCommonDirectoryUploader(
 	crypter crypto.Crypter, packer TarBallFilePacker,
 	tarBallComposerMaker TarBallComposerMaker, tarSizeThreshold int64,
 	excludedFiles map[string]utility.Empty, backupName string,
-	uploader *Uploader) *CommonDirectoryUploader {
+	uploader Uploader) *CommonDirectoryUploader {
 	return &CommonDirectoryUploader{
 		crypter:              crypter,
 		tarBallFilePacker:    packer,
@@ -73,7 +73,7 @@ func (u *CommonDirectoryUploader) Upload(path string) TarFileSets {
 	// Wait for all uploads to finish.
 	tracelog.DebugLogger.Println("Waiting for all uploads to finish")
 	u.uploader.Finish()
-	if u.uploader.Failed.Load().(bool) {
+	if u.uploader.Failed() {
 		tracelog.ErrorLogger.Fatalf("Uploading failed during '%s' backup.\n", path)
 	}
 	return tarFileSets

--- a/internal/fetch_helper.go
+++ b/internal/fetch_helper.go
@@ -29,7 +29,7 @@ func (err ArchiveNonExistenceError) Error() string {
 }
 
 // DownloadFile downloads, decompresses and decrypts
-func DownloadFile(folder StorageFolderReader, filename, ext string, writeCloser io.WriteCloser) error {
+func DownloadFile(reader StorageFolderReader, filename, ext string, writeCloser io.WriteCloser) error {
 	utility.LoggedClose(writeCloser, "")
 
 	decompressor := compression.FindDecompressor(ext)
@@ -38,7 +38,7 @@ func DownloadFile(folder StorageFolderReader, filename, ext string, writeCloser 
 	}
 	tracelog.DebugLogger.Printf("Found decompressor for %s", decompressor.FileExtension())
 
-	archiveReader, exists, err := TryDownloadFile(folder, filename)
+	archiveReader, exists, err := TryDownloadFile(reader, filename)
 	if err != nil {
 		return err
 	}
@@ -57,8 +57,8 @@ func DownloadFile(folder StorageFolderReader, filename, ext string, writeCloser 
 	return err
 }
 
-func TryDownloadFile(folder StorageFolderReader, path string) (fileReader io.ReadCloser, exists bool, err error) {
-	fileReader, err = folder.ReadObject(path)
+func TryDownloadFile(reader StorageFolderReader, path string) (fileReader io.ReadCloser, exists bool, err error) {
+	fileReader, err = reader.ReadObject(path)
 	if err == nil {
 		exists = true
 		return
@@ -167,8 +167,8 @@ func putCachedDecompressorInFirstPlace(decompressors []compression.Decompressor)
 }
 
 // TODO : unit tests
-func DownloadAndDecompressStorageFile(folder StorageFolderReader, fileName string) (io.ReadCloser, error) {
-	archiveReader, decompressor, err := findDecompressorAndDownload(folder, fileName)
+func DownloadAndDecompressStorageFile(reader StorageFolderReader, fileName string) (io.ReadCloser, error) {
+	archiveReader, decompressor, err := findDecompressorAndDownload(reader, fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -185,9 +185,9 @@ func DownloadAndDecompressStorageFile(folder StorageFolderReader, fileName strin
 	}, nil
 }
 
-func findDecompressorAndDownload(folder StorageFolderReader, fileName string) (io.ReadCloser, compression.Decompressor, error) {
+func findDecompressorAndDownload(reader StorageFolderReader, fileName string) (io.ReadCloser, compression.Decompressor, error) {
 	for _, decompressor := range putCachedDecompressorInFirstPlace(compression.Decompressors) {
-		archiveReader, exists, err := TryDownloadFile(folder, fileName+"."+decompressor.FileExtension())
+		archiveReader, exists, err := TryDownloadFile(reader, fileName+"."+decompressor.FileExtension())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -199,12 +199,12 @@ func findDecompressorAndDownload(folder StorageFolderReader, fileName string) (i
 		return archiveReader, decompressor, nil
 	}
 
-	reader, exists, err := TryDownloadFile(folder, fileName)
+	fileReader, exists, err := TryDownloadFile(reader, fileName)
 	if err != nil {
 		return nil, nil, err
 	}
 	if exists {
-		return reader, nil, nil
+		return fileReader, nil, nil
 	}
 
 	return nil, nil, newArchiveNonExistenceError(fileName)
@@ -212,7 +212,7 @@ func findDecompressorAndDownload(folder StorageFolderReader, fileName string) (i
 
 // TODO : unit tests
 // DownloadFileTo downloads a file and writes it to local file
-func DownloadFileTo(folder StorageFolderReader, fileName string, dstPath string) error {
+func DownloadFileTo(folderReader StorageFolderReader, fileName string, dstPath string) error {
 	// Create file as soon as possible. It may be important due to race condition in wal-prefetch for PG.
 	file, err := os.OpenFile(dstPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0666)
 	if err != nil {
@@ -220,7 +220,7 @@ func DownloadFileTo(folder StorageFolderReader, fileName string, dstPath string)
 	}
 	defer utility.LoggedClose(file, "")
 
-	reader, err := DownloadAndDecompressStorageFile(folder, fileName)
+	reader, err := DownloadAndDecompressStorageFile(folderReader, fileName)
 	if err != nil {
 		// We could not start upload - remove the file totally.
 		_ = os.Remove(dstPath)

--- a/internal/storage_folder_reader.go
+++ b/internal/storage_folder_reader.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"io"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type StorageFolderReader interface {
+	ReadObject(objectRelativePath string) (io.ReadCloser, error)
+	SubFolder(subFolderRelativePath string) StorageFolderReader
+}
+
+func NewFolderReader(folder storage.Folder) StorageFolderReader {
+	return &FolderReaderImpl{folder}
+}
+
+type FolderReaderImpl struct {
+	storage.Folder
+}
+
+func (fsr *FolderReaderImpl) SubFolder(subFolderRelativePath string) StorageFolderReader {
+	return NewFolderReader(fsr.GetSubFolder(subFolderRelativePath))
+}

--- a/internal/storage_tar_ball_maker.go
+++ b/internal/storage_tar_ball_maker.go
@@ -4,10 +4,10 @@ package internal
 type StorageTarBallMaker struct {
 	partCount  int
 	backupName string
-	uploader   *Uploader
+	uploader   Uploader
 }
 
-func NewStorageTarBallMaker(backupName string, uploader *Uploader) *StorageTarBallMaker {
+func NewStorageTarBallMaker(backupName string, uploader Uploader) *StorageTarBallMaker {
 	return &StorageTarBallMaker{0, backupName, uploader}
 }
 

--- a/internal/storagetools/put_object_handler.go
+++ b/internal/storagetools/put_object_handler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/wal-g/wal-g/internal"
 )
 
-func HandlePutObject(localPath, dstPath string, uploader *internal.Uploader, overwrite, encrypt, compress bool) {
+func HandlePutObject(localPath, dstPath string, uploader internal.Uploader, overwrite, encrypt, compress bool) {
 	checkOverwrite(dstPath, uploader, overwrite)
 
 	fileReadCloser := openLocalFile(localPath)
@@ -22,8 +22,7 @@ func HandlePutObject(localPath, dstPath string, uploader *internal.Uploader, ove
 
 	storageFolderPath := utility.SanitizePath(filepath.Dir(dstPath))
 	if storageFolderPath != "" {
-		folder := uploader.UploadingFolder
-		uploader.UploadingFolder = folder.GetSubFolder(storageFolderPath)
+		uploader.ChangeDirectory(storageFolderPath)
 	}
 
 	fileName := utility.SanitizePath(filepath.Base(dstPath))
@@ -31,9 +30,9 @@ func HandlePutObject(localPath, dstPath string, uploader *internal.Uploader, ove
 	tracelog.ErrorLogger.FatalfOnError("Failed to upload: %v", err)
 }
 
-func checkOverwrite(dstPath string, uploader *internal.Uploader, overwrite bool) {
-	fullPath := dstPath + "." + uploader.Compressor.FileExtension()
-	exists, err := uploader.UploadingFolder.Exists(fullPath)
+func checkOverwrite(dstPath string, uploader internal.Uploader, overwrite bool) {
+	fullPath := dstPath + "." + uploader.Compression().FileExtension()
+	exists, err := uploader.Folder().Exists(fullPath)
 	tracelog.ErrorLogger.FatalfOnError("Failed to check object existence: %v", err)
 	if exists && !overwrite {
 		tracelog.ErrorLogger.Fatalf("Object %s already exists. To overwrite it, add the -f flag.", fullPath)
@@ -52,16 +51,16 @@ func openLocalFile(localPath string) io.ReadCloser {
 	return localFile
 }
 
-func uploadFile(name string, content io.Reader, uploader *internal.Uploader, encrypt, compress bool) error {
+func uploadFile(name string, content io.Reader, uploader internal.Uploader, encrypt, compress bool) error {
 	var crypter crypto.Crypter
 	if encrypt {
 		crypter = internal.ConfigureCrypter()
 	}
 
 	var compressor compression.Compressor
-	if compress && uploader.Compressor != nil {
-		compressor = uploader.Compressor
-		name += "." + uploader.Compressor.FileExtension()
+	if compress && uploader.Compression() != nil {
+		compressor = uploader.Compression()
+		name += "." + uploader.Compression().FileExtension()
 	}
 
 	uploadContents := internal.CompressAndEncrypt(content, compressor, crypter)

--- a/internal/stream_fetch_helper.go
+++ b/internal/stream_fetch_helper.go
@@ -42,7 +42,7 @@ func DownloadAndDecompressStream(backup Backup, writeCloser io.WriteCloser) erro
 	defer utility.LoggedClose(writeCloser, "")
 
 	for _, decompressor := range compression.Decompressors {
-		archiveReader, exists, err := TryDownloadFile(backup.Folder, GetStreamName(backup.Name, decompressor.FileExtension()))
+		archiveReader, exists, err := TryDownloadFile(NewFolderReader(backup.Folder), GetStreamName(backup.Name, decompressor.FileExtension()))
 		if err != nil {
 			return fmt.Errorf("failed to dowload file: %w", err)
 		}
@@ -120,7 +120,7 @@ func DownloadAndDecompressSplittedStream(backup Backup, blockSize int, extension
 func downloadAndDecompressFile(backup Backup, decompressor compression.Decompressor,
 	fileName string, writer io.WriteCloser, maxDownloadRetry int) error {
 	getArchiveReader := func() (io.ReadCloser, error) {
-		archiveReader, exists, err := TryDownloadFile(backup.Folder, fileName)
+		archiveReader, exists, err := TryDownloadFile(NewFolderReader(backup.Folder), fileName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to dowload file %v: %w", fileName, err)
 		} else if !exists {

--- a/internal/stream_metadata.go
+++ b/internal/stream_metadata.go
@@ -47,7 +47,7 @@ func GetBackupStreamFetcher(backup Backup) (StreamFetcher, error) {
 	return nil, nil // unreachable
 }
 
-func UploadBackupStreamMetadata(uploader UploaderProvider, metadata interface{}, backupName string) error {
+func UploadBackupStreamMetadata(uploader Uploader, metadata interface{}, backupName string) error {
 	sentinelName := StreamMetadataNameFromBackup(backupName)
 	return UploadDto(uploader.Folder(), metadata, sentinelName)
 }

--- a/internal/stream_push_helper_test.go
+++ b/internal/stream_push_helper_test.go
@@ -2,14 +2,15 @@ package internal
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
-	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/internal/compression"
-	functests "github.com/wal-g/wal-g/internal/testutils"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/compression"
+	functests "github.com/wal-g/wal-g/internal/testutils"
 
 	"github.com/wal-g/wal-g/pkg/storages/fs"
 	"github.com/wal-g/wal-g/pkg/storages/storage"

--- a/internal/upload_test.go
+++ b/internal/upload_test.go
@@ -59,7 +59,7 @@ func doConfigureWithBucketPath(t *testing.T, bucketPath string, expectedServer s
 	os.Setenv("WALE_S3_PREFIX", bucketPath)
 	uploader, err = internal.ConfigureUploader()
 	assert.NoError(t, err)
-	assert.Equal(t, expectedServer, strings.TrimSuffix(uploader.UploadingFolder.GetPath(), "/"))
+	assert.Equal(t, expectedServer, strings.TrimSuffix(uploader.Folder().GetPath(), "/"))
 	assert.NotNil(t, uploader)
 	assert.NoError(t, err)
 	// Test STANDARD_IA storage class

--- a/testtools/util.go
+++ b/testtools/util.go
@@ -45,7 +45,7 @@ func MakeDefaultUploader(uploaderAPI s3manageriface.UploaderAPI) *s3.Uploader {
 	return s3.NewUploader(uploaderAPI, "", "", "", "STANDARD")
 }
 
-func NewMockUploader(apiMultiErr, apiErr bool) *internal.Uploader {
+func NewMockUploader(apiMultiErr, apiErr bool) internal.Uploader {
 	s3Uploader := MakeDefaultUploader(NewMockS3Uploader(apiMultiErr, apiErr, nil))
 	return internal.NewUploader(
 		&MockCompressor{},
@@ -53,7 +53,7 @@ func NewMockUploader(apiMultiErr, apiErr bool) *internal.Uploader {
 	)
 }
 
-func NewStoringMockUploader(storage *memory.Storage) *internal.Uploader {
+func NewStoringMockUploader(storage *memory.Storage) internal.Uploader {
 	return internal.NewUploader(
 		&MockCompressor{},
 		memory.NewFolder("in_memory/", storage),
@@ -62,22 +62,22 @@ func NewStoringMockUploader(storage *memory.Storage) *internal.Uploader {
 
 func NewMockWalUploader(apiMultiErr, apiErr bool) *postgres.WalUploader {
 	s3Uploader := MakeDefaultUploader(NewMockS3Uploader(apiMultiErr, apiErr, nil))
+	upl := internal.NewUploader(&MockCompressor{},
+		s3.NewFolder(*s3Uploader, NewMockS3Client(false, true), map[string]string{}, "bucket/", "server/", false))
 	return postgres.NewWalUploader(
-		&MockCompressor{},
-		s3.NewFolder(*s3Uploader, NewMockS3Client(false, true), map[string]string{}, "bucket/", "server/", false),
+		upl,
 		nil,
 	)
 }
 
-func CreateMockStorageWalFolder() storage.Folder {
+func CreateMockStorageWalUploader() internal.Uploader {
 	var folder = MakeDefaultInMemoryStorageFolder()
-	return folder.GetSubFolder(utility.WalPath)
+	return internal.NewUploader(&MockCompressor{}, folder.GetSubFolder(utility.WalPath))
 }
 
 func NewMockWalDirUploader(apiMultiErr, apiErr bool) *postgres.WalUploader {
 	return postgres.NewWalUploader(
-		&MockCompressor{},
-		CreateMockStorageWalFolder(),
+		CreateMockStorageWalUploader(),
 		nil,
 	)
 }


### PR DESCRIPTION
This is a preliminary PR for https://github.com/wal-g/wal-g/pull/1466. I propose to refactor some storage abstractions:
1. Complete switch to the `Uploader` interface instead of plain struct
2. Introduce interface for read-only storage access `StorageReader`, which is analog for the `Uploader` interface