### PR TITLE
Add prefetch prefix for wal-prefetch cmd

### DIFF
--- a/cmd/pg/wal_prefetch.go
+++ b/cmd/pg/wal_prefetch.go
@@ -1,6 +1,7 @@
 package pg
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
@@ -17,12 +18,27 @@ var WalPrefetchCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(2),
 	Hidden: true,
 	Run: func(cmd *cobra.Command, args []string) {
+		reconfigureLoggers()
+
 		folder, err := internal.ConfigureFolder()
 		tracelog.ErrorLogger.FatalOnError(err)
+
 		postgres.HandleWALPrefetch(internal.NewFolderReader(folder), args[0], args[1])
 	},
 }
 
 func init() {
 	Cmd.AddCommand(WalPrefetchCmd)
+}
+
+// wal-prefetch (WalPrefetchCmd) is internal tool, so to avoid confusion about errors in restoration process
+// we reconfigure loggers specially for internal use. All logs having PREFETCH prefix can be safely ignored
+func reconfigureLoggers() {
+	tracelog.ErrorLogger.SetPrefix(fmt.Sprintf("PREFETCH %s", tracelog.ErrorLogger.Prefix()))
+
+	tracelog.DebugLogger.SetPrefix(fmt.Sprintf("PREFETCH %s", tracelog.DebugLogger.Prefix()))
+
+	tracelog.WarningLogger.SetPrefix(fmt.Sprintf("PREFETCH %s", tracelog.WarningLogger.Prefix()))
+
+	tracelog.InfoLogger.SetPrefix(fmt.Sprintf("PREFETCH %s", tracelog.InfoLogger.Prefix()))
 }


### PR DESCRIPTION
### Database name
any

# Pull request description
`ERROR` logs from prefetch are often misleading. Original issue: https://github.com/wal-g/wal-g/issues/1328

### Describe what this PR fix
Adding `PREFETCH` prefix for all loggers to `wal-preferch` command. I am not sure that the prefix would solve issue. But it would definitely help to separate internal tool from real `wal fetch` command.

### Please provide steps to reproduce (if it's a bug)
Run `pg_full_backup_without_files_metadata_test` test.