### PR TITLE
Make `wal-g-mysql binlog-server` work with new MySQL

### DIFF
--- a/cmd/mysql/backup_copy.go
+++ b/cmd/mysql/backup_copy.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	copyName             = "backup-copy"
-	copyShortDescription = "copy specific or all backups"
+	copyShortDescription = "Copy specific or all backups"
 
 	copyAllFlag         = "all"
 	copyAllSDescription = "copy all backups"

--- a/cmd/mysql/backup_fetch.go
+++ b/cmd/mysql/backup_fetch.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	backupFetchShortDescription = "Fetches desired backup from storage"
+	backupFetchShortDescription = "Fetch desired backup from storage"
 	targetUserDataDescription   = "Fetch storage backup which has the specified user data"
 )
 

--- a/cmd/mysql/binlog_fetch.go
+++ b/cmd/mysql/binlog_fetch.go
@@ -22,7 +22,7 @@ var fetchUntilBinlogLastModifiedTS string
 // binlogPushCmd represents the cron command
 var binlogFetchCmd = &cobra.Command{
 	Use:   "binlog-fetch",
-	Short: "fetches binlog from storage and save to the disk",
+	Short: "Fetch binlog from storage and save it to the disk",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		folder, err := internal.ConfigureFolder()

--- a/cmd/mysql/binlog_push.go
+++ b/cmd/mysql/binlog_push.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 )
 
-const binlogPushShortDescription = ""
+const binlogPushShortDescription = "Upload binlogs to the storage"
 
 var untilBinlog string
 

--- a/cmd/mysql/binlog_replay.go
+++ b/cmd/mysql/binlog_replay.go
@@ -21,7 +21,7 @@ var replayUntilBinlogLastModifiedTS string
 
 var binlogReplayCmd = &cobra.Command{
 	Use:   "binlog-replay",
-	Short: "fetches binlogs from storage and replays them to mysql",
+	Short: "Fetch binlogs from storage and replays them to MySQL",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		folder, err := internal.ConfigureFolder()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       &&  mkdir -p /export/mysqldeleteeverythingpermanent
       &&  mkdir -p /export/mysqlmarkbucket
       &&  mkdir -p /export/mysqlbinlogreplaybucket
+      &&  mkdir -p /export/mysql_pitr_binlogserver_bucket
       &&  mkdir -p /export/mysqlpitrxtrabackupbucket
       &&  mkdir -p /export/mysqlpitrmysqldumpbucket
       &&  mkdir -p /export/mysqllivereplay

--- a/docker/mysql_tests/scripts/base_tests/pitr_binlog_server_test.sh
+++ b/docker/mysql_tests/scripts/base_tests/pitr_binlog_server_test.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mysql_pitr_binlogserver_bucket
+export WALG_MYSQL_BINLOG_SERVER_HOST="localhost"
+export WALG_MYSQL_BINLOG_SERVER_PORT=9306
+export WALG_MYSQL_BINLOG_SERVER_USER="walg"
+export WALG_MYSQL_BINLOG_SERVER_PASSWORD="walgpwd"
+export WALG_MYSQL_BINLOG_SERVER_ID=99
+export WALG_MYSQL_BINLOG_SERVER_REPLICA_SOURCE="sbtest@tcp(127.0.0.1:3306)/sbtest"
+
+mysqld --initialize --init-file=/etc/mysql/init.sql
+service mysql start
+
+# first full backup
+wal-g backup-push
+
+mysql -e "CREATE TABLE sbtest.pitr(id VARCHAR(32), ts DATETIME)"
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr01', NOW())"
+mysql -e "FLUSH LOGS"
+wal-g binlog-push
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr02', NOW())"
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr03', NOW())"
+sleep 1
+DT1=$(date3339)
+sleep 1
+mysql -e "INSERT INTO sbtest.pitr VALUES('testpitr04', NOW())"
+mysql -e "FLUSH LOGS"
+wal-g binlog-push
+
+
+# pitr restore across full backup
+mysql_kill_and_clean_data
+wal-g backup-fetch LATEST
+chown -R mysql:mysql $MYSQLDATA
+service mysql start || (cat /var/log/mysql/error.log && false)
+mysql_set_gtid_purged
+
+WALG_LOG_LEVEL="DEVEL" wal-g binlog-server --since LATEST --until "$DT1" &
+walg_pid=$!
+
+sleep 3
+mysql -e "STOP SLAVE"
+mysql -e "SET GLOBAL SERVER_ID = 123"
+mysql -e "CHANGE MASTER TO MASTER_HOST=\"127.0.0.1\", MASTER_PORT=9306, MASTER_USER=\"walg\", MASTER_PASSWORD=\"walgpwd\", MASTER_AUTO_POSITION=1"
+mysql -e "START SLAVE"
+
+wait $walg_pid
+
+mysqldump sbtest > /tmp/dump_after_pitr
+grep -w 'testpitr01' /tmp/dump_after_pitr
+grep -w 'testpitr02' /tmp/dump_after_pitr
+grep -w 'testpitr03' /tmp/dump_after_pitr
+! grep -w 'testpitr04' /tmp/dump_after_pitr

--- a/internal/config.go
+++ b/internal/config.go
@@ -118,7 +118,6 @@ const (
 	MysqlBinlogReplayCmd           = "WALG_MYSQL_BINLOG_REPLAY_COMMAND"
 	MysqlBinlogDstSetting          = "WALG_MYSQL_BINLOG_DST"
 	MysqlBackupPrepareCmd          = "WALG_MYSQL_BACKUP_PREPARE_COMMAND"
-	MysqlTakeBinlogsFromMaster     = "WALG_MYSQL_TAKE_BINLOGS_FROM_MASTER"
 	MysqlCheckGTIDs                = "WALG_MYSQL_CHECK_GTIDS"
 	MysqlBinlogServerHost          = "WALG_MYSQL_BINLOG_SERVER_HOST"
 	MysqlBinlogServerPort          = "WALG_MYSQL_BINLOG_SERVER_PORT"
@@ -127,6 +126,8 @@ const (
 	MysqlBinlogServerID            = "WALG_MYSQL_BINLOG_SERVER_ID"
 	MysqlBinlogServerReplicaSource = "WALG_MYSQL_BINLOG_SERVER_REPLICA_SOURCE"
 	MysqlBackupDownloadMaxRetry    = "WALG_BACKUP_DOWNLOAD_MAX_RETRY"
+	// Deprecated: unused
+	MysqlTakeBinlogsFromMaster = "WALG_MYSQL_TAKE_BINLOGS_FROM_MASTER"
 
 	RedisPassword = "WALG_REDIS_PASSWORD"
 

--- a/internal/databases/mysql/binlog_server_handler.go
+++ b/internal/databases/mysql/binlog_server_handler.go
@@ -112,6 +112,8 @@ func waitReplicationIsDone() error {
 			return err
 		}
 
+		tracelog.DebugLogger.Printf("Expected GTID set: %v; MySQL GTID set: %v", lastSentGTIDSet.String(), gtidSet.String())
+
 		if gtidSet.Contain(lastSentGTIDSet) {
 			tracelog.InfoLogger.Println("Replication is done")
 			return nil


### PR DESCRIPTION
## Make `wal-g-mysql binlog-server` work with new MySQL.

### Please provide steps to reproduce (if it's a bug)

Current version didn't worked with Percona Server Ver 8.0.32-24.
What I did

* Start `wal-g binlog-server --until "2030-01-02T15:04:05Z"` 
* Execute in MySQL:
```
SET GLOBAL SERVER_ID=123;
CHANGE MASTER TO MASTER_HOST="127.0.0.1", MASTER_PORT=9306, MASTER_USER="walg", MASTER_PASSWORD="walgpwd", MASTER_AUTO_POSITION=1;
START SLAVE;
```

Replication stops with an error and the following error in logs:
```
2023-05-10T21:22:44.811530Z 5262 [System] [MY-010562] [Repl] Slave I/O thread for channel '': connected to master 'walg@127.0.0.1:9036',replication started in log 'binlog.000073' at position 197
2023-05-10T21:22:44.811625Z 5262 [Warning] [MY-010551] [Repl] "SELECT UNIX_TIMESTAMP()" failed on master, do not trust column Seconds_Behind_Master of SHOW SLAVE STATUS. Error:  (0)
2023-05-10T21:22:44.839287Z 5262 [ERROR] [MY-013115] [Repl] Slave I/O for channel '': Replication event checksum verification failed while reading from network. Error_code: MY-013115
2023-05-10T21:22:44.839351Z 5262 [ERROR] [MY-013122] [Repl] Slave I/O for channel '': Relay log write failure: could not queue event from master, Error_code: MY-013122
```

## Investigation:

I think that MySQL developers changed system variable they query[2]:
* in old versions - `master_binlog_checksum`
* in new versions - `source_binlog_checksum`

And `wal-g` we returned different values: `master_binlog_checksum=NONE` and `source_binlog_checksum=1` (aka CRC32). And `wal-g` sent RotateEvent always without checksum. Newer versions of MySQL expected to see checksum... So it failed.

MySQL checks _first_ RotateEvent's checksum with respecting these variables. After that, it will get FORMAT_DESCRIPTION_EVENT and will use checksum configuration from it.[1]

[1] [worklog description](https://dev.mysql.com/worklog/task/?id=2540#:~:text=Otherwise%20the%20setting%20make%20the%20dump%20thread%20to%20know%20what%20alg%20to%20use%0A%20%20%20in%20checksumming%20the%20fake%20Rotate%20event%20as%20well%20as%20the%20slave%20is%20aware%0A%20%20%20of%20the%20alg)
[2] https://github.com/mysql/mysql-server/commit/4af74ee60a0c90c679520fd53eb7e675efd03ef8#

## Solution:

I suggest to always use checksum - because checksums in binlogs are enabled by default since 5.6.6


## What in this PR:

* RotateEvent > add checksum and zero-terminate string
* always say to MySQL that we support CRC32
* use shallow parsing of binlogs
* verify binlog events checksum
* update MySQL docs & CLI help texts





