### PR TITLE
Correct mistakes and inaccuracies I found in the documentation

### DIFF
--- a/docs/Greenplum.md
+++ b/docs/Greenplum.md
@@ -7,6 +7,7 @@ Configuration
 WAL-G for Greenplum understands the basic configuration options that are [supported by the WAL-G for Postgres](PostgreSQL.md#Configuration), except the advanced features such as delta backups, remote backups, catchup backup, etc.
 
 To configure the backups, the user needs to do two things on each segment host:
+
 1. Create the [configuration file](Greenplum.md#configuration-file)
 2. Configure the [WAL archiving](Greenplum.md#wal-archiving)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,15 @@ WAL-G supports bash and zsh autocompletion. Run `wal-g help completion` for more
 
 Configuration
 -------------
+
+There are two ways how you can configure WAL-G:
+
+1. Using environment variables
+2. Using a YAML config file
+   `--config /path` flag can be used to specify the path where the config file is located.
+
+Every configuration variable mentioned in the following documentation can be specified either as an environment variable or a field in the config file.
+
 ### Storage
 To configure where WAL-G stores backups, please consult the [Storages](STORAGES.md) section.
 
@@ -233,7 +242,9 @@ Optional:
 - To build with libsodium, set the `USE_LIBSODIUM` environment variable.
 - To build with lzo decompressor, set the `USE_LZO` environment variable.
 
-### Ubuntu
+### Installing
+
+#### Ubuntu
 
 ```sh
 # Install latest Go compiler
@@ -263,7 +274,7 @@ make deps
 GOBIN=/usr/local/bin make pg_install
 ```
 
-### macOS
+#### macOS
 
 ```sh
 # brew command is Homebrew for Mac OS
@@ -277,7 +288,7 @@ make install_and_build_pg
 
 To build on ARM64, set the corresponding `GOOS`/`GOARCH` environment variables:
 ```
-env GOOS=darwin GOARCH=arm64 make pg_build
+env GOOS=darwin GOARCH=arm64 make install_and_build_pg
 ```
 
 The compiled binary to run is `main/pg/wal-g`
@@ -299,6 +310,7 @@ export USE_BROTLI=1
 make coverage
 ```
 This command generates `coverage.out` file and opens HTML representation of the coverage.
+
 ### Development on Windows
 
 [Information about installing and usage](Windows.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,10 +2,13 @@ site_name: WAL-G
 nav:
     - Overview: README.md
     - Storages: STORAGES.md
+    - Storage Tools: StorageTools.md
     - Foundation DB: FoundationDB.md
+    - Greenplum: Greenplum.md
     - Mongo DB: MongoDB.md
     - MySQL: MySQL.md
     - PostgreSQL: PostgreSQL.md
+    - Redis: Redis.md
     - SQLServer: SQLServer.md
     - Windows: Windows.md
     - Contributors: CONTRIBUTORS.md


### PR DESCRIPTION
### Database name
I've corrected the documentation only. It's mostly about Postgres, but I also touched a few general parts.

# Pull request description

### Describe what this PR fix
It corrects some mistakes and inaccuracies in the documentation I encountered while reading.
- I added some links to the official PostgreSQL documentation to make some things clearer
- described WAL-G configuration using YAML files
- fixed broken links between Markdown sections and files
- fixed lists rendering problems on readthedocs.io (it's needed to put an empty line after the header to make it look well)
- moved the link to the repo with the non-working Postgres playground out of the beginning of the page
- corrected a few grammar mistakes
