### PR TITLE
Fix panics in st transfer command when --overwrite flag is set

### DIFF
--- a/docs/StorageTools.md
+++ b/docs/StorageTools.md
@@ -82,6 +82,8 @@ Flags:
 
    Regardless of the flag, the command will end with zero error code only if all the files have moved successfully.
 
+   Keep in mind that files aren't transferred atomically. This means that when this flag is set, an error occured with one file may interrupt transferring other files in the middle, so they may already be copied to the target storage, but not yet deleted from the source. 
+
 5. Add `-c (--concurrency)` to set the max number of concurrent workers that will move files.
 
 6. Add `-m (--max)` to set the max number of files to move in a single command run.

--- a/internal/storagetools/transfer_handler.go
+++ b/internal/storagetools/transfer_handler.go
@@ -73,8 +73,11 @@ func (h *TransferHandler) listFilesToMove() ([]storage.Object, error) {
 		missingFiles[sourceFile.GetName()] = sourceFile
 	}
 	for _, targetFile := range targetFiles {
+		sourceFile, presentInBothStorages := missingFiles[targetFile.GetName()]
+		if !presentInBothStorages {
+			continue
+		}
 		if h.cfg.Overwrite {
-			sourceFile := missingFiles[targetFile.GetName()]
 			logSizesDifference(sourceFile, targetFile)
 		} else {
 			delete(missingFiles, targetFile.GetName())

--- a/internal/storagetools/transfer_handler_test.go
+++ b/internal/storagetools/transfer_handler_test.go
@@ -199,6 +199,21 @@ func TestTransferHandler_listFilesToMove(t *testing.T) {
 		require.Len(t, files, 2)
 	})
 
+	t.Run("dont include nonexistent files even when overwrite allowed", func(t *testing.T) {
+		h := defaultHandler()
+		h.cfg.Overwrite = true
+
+		_ = h.source.PutObject("2", &bytes.Buffer{})
+
+		_ = h.target.PutObject("1", &bytes.Buffer{})
+
+		files, err := h.listFilesToMove()
+		assert.NoError(t, err)
+
+		require.Len(t, files, 1)
+		assert.Equal(t, "2", files[0].GetName())
+	})
+
 	t.Run("limit number of files", func(t *testing.T) {
 		h := defaultHandler()
 		h.cfg.MaxFiles = 1


### PR DESCRIPTION
### Database name
The `transfer` storage tool is universal among databases. However, it exploits failover storages, which are currently supported for Postgres only.

# Pull request description
It fixes `wal-g st transfer` command I've implemented in the [previous PR](https://github.com/wal-g/wal-g/pull/1480).

It also adds a small note in the docs about the behaviour of the `--fail-fast` flag.

### Describe what this PR fix
The command fails with `nil pointer dereference` panic if the `--overwrite` flag is set, and the target storage contains any files that the source storage doesn't contain.

### Please provide steps to reproduce (if it's a bug)
You can reproduce it by creating two storages of any type, and calling `wal-g st transfer / --source='your_storage_1' --target='your_storage_2' --overwrite`. In case the target storage has any files with paths that aren't present in the source one, a panic occurs at the initial step with listing files:
```
INFO: 2023/06/06 18:09:31.281443 Total files in the source storage: 160
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x14dcd06]

goroutine 1 [running]:
github.com/wal-g/wal-g/internal/storagetools.logSizesDifference({0x0, 0x0}, {0x1e2a2e0, 0xc0005b17a0})
	/root/wal-g/internal/storagetools/transfer_handler.go:100 +0x46
github.com/wal-g/wal-g/internal/storagetools.(*TransferHandler).listFilesToMove(0xc000134510)
	/root/wal-g/internal/storagetools/transfer_handler.go:78 +0x585
github.com/wal-g/wal-g/internal/storagetools.(*TransferHandler).Handle(0xc000134510)
	/root/wal-g/internal/storagetools/transfer_handler.go:51 +0x1e
github.com/wal-g/wal-g/cmd/common/st.glob..func8(0x2ed2b60?, {0xc0001a7d50, 0x1, 0x7?})
	/root/wal-g/cmd/common/st/transfer.go:43 +0x26f
github.com/spf13/cobra.(*Command).execute(0x2ed2b60, {0xc0001a7c70, 0x7, 0x7})
	/root/wal-g/vendor/github.com/spf13/cobra/command.go:860 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0x2ed3f60)
	/root/wal-g/vendor/github.com/spf13/cobra/command.go:974 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	/root/wal-g/vendor/github.com/spf13/cobra/command.go:902
github.com/wal-g/wal-g/cmd/pg.Execute()
	/root/wal-g/cmd/pg/pg.go:45 +0x25
main.main()
	/root/wal-g/main/pg/main.go:8 +0x17
```
