### PR TITLE
Enable database alive check for Postgresql by default

### DIFF
--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -85,7 +85,8 @@ If the parameter value is NOMETADATA or not specified, it will fallback to defau
 To control how frequently WAL-G will check if Postgres is alive during the backup-push. If the check fails, backup-push terminates.
 
 Examples:
-- `0` - disable the alive checks (default value)
+- `0` - disable the alive checks
+- `1m` - check every 1 minute (default value)
 - `10s` - check every 10 seconds
 - `10m` - check every 10 minutes
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -240,8 +240,9 @@ var (
 	}
 
 	PGDefaultSettings = map[string]string{
-		PgWalSize:        "16",
-		PgBackRestStanza: "main",
+		PgWalSize:            "16",
+		PgBackRestStanza:     "main",
+		PgAliveCheckInterval: "1m",
 	}
 
 	GPDefaultSettings = map[string]string{


### PR DESCRIPTION
Enable check if PostgreSQL is alive by default (check each minute). If Postgres is not alive, fail the backup. See https://github.com/wal-g/wal-g/issues/969#event-9460118783 for details.