### PR TITLE
fix action order in test jobs: checkout -> setup-go

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -142,14 +142,14 @@ jobs:
       - name: Install deps
         run: sudo apt-get install liblzo2-dev
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: |


### PR DESCRIPTION
# Pull request description
incorrect actions order cause a lot of useless warnings, like:
`Restore cache failed: Dependencies file is not found in /home/runner/work/wal-g/wal-g. Supported file pattern: go.sum`
in all jobs in matrix:test

reorder checkout and setup-go actions