### PR TITLE
Add Greenplum AO/AOCS files deduplication age limit 

### DIFF
--- a/docs/Greenplum.md
+++ b/docs/Greenplum.md
@@ -190,6 +190,9 @@ During the delete execution, WAL-G can process segments in parallel mode. To con
 #### AO/AOCS size threshold
 To control the minimal size of the AO/AOCS segment file to be uploaded into the shared storage, use the `WALG_GP_AOSEG_SIZE_THRESHOLD`. The higher this value, the bigger the size of a single backup and the smaller the size of the shared AO/AOCS storage folder. Default value is `1048576 (1MB)`.
 
+#### AO/AOCS deduplication age limit
+To control the maximum possible time starting from the initial upload of the AO/AOCS segment files for their reuse in the following backups, use the `WALG_GP_AOSEG_DEDUPLICATION_AGE_LIMIT`. Smaller values will result in AO/AOCS files being reuploaded more frequently, leading to larger backups, and vice versa. Default value is `720h` (30 days).
+
 ### ``restore-point-list``
 
 Lists currently available restore points in storage.

--- a/internal/config.go
+++ b/internal/config.go
@@ -132,14 +132,15 @@ const (
 
 	RedisPassword = "WALG_REDIS_PASSWORD"
 
-	GPLogsDirectory        = "WALG_GP_LOGS_DIR"
-	GPSegContentID         = "WALG_GP_SEG_CONTENT_ID"
-	GPSegmentsPollInterval = "WALG_GP_SEG_POLL_INTERVAL"
-	GPSegmentsPollRetries  = "WALG_GP_SEG_POLL_RETRIES"
-	GPSegmentsUpdInterval  = "WALG_GP_SEG_UPD_INTERVAL"
-	GPSegmentStatesDir     = "WALG_GP_SEG_STATES_DIR"
-	GPDeleteConcurrency    = "WALG_GP_DELETE_CONCURRENCY"
-	GPAoSegSizeThreshold   = "WALG_GP_AOSEG_SIZE_THRESHOLD"
+	GPLogsDirectory           = "WALG_GP_LOGS_DIR"
+	GPSegContentID            = "WALG_GP_SEG_CONTENT_ID"
+	GPSegmentsPollInterval    = "WALG_GP_SEG_POLL_INTERVAL"
+	GPSegmentsPollRetries     = "WALG_GP_SEG_POLL_RETRIES"
+	GPSegmentsUpdInterval     = "WALG_GP_SEG_UPD_INTERVAL"
+	GPSegmentStatesDir        = "WALG_GP_SEG_STATES_DIR"
+	GPDeleteConcurrency       = "WALG_GP_DELETE_CONCURRENCY"
+	GPAoSegSizeThreshold      = "WALG_GP_AOSEG_SIZE_THRESHOLD"
+	GPAoDeduplicationAgeLimit = "WALG_GP_AOSEG_DEDUPLICATION_AGE_LIMIT"
 
 	GoMaxProcs = "GOMAXPROCS"
 
@@ -247,14 +248,15 @@ var (
 	}
 
 	GPDefaultSettings = map[string]string{
-		GPLogsDirectory:        "/var/log",
-		PgWalSize:              "64",
-		GPSegmentsPollInterval: "5m",
-		GPSegmentsUpdInterval:  "10s",
-		GPSegmentsPollRetries:  "5",
-		GPSegmentStatesDir:     "/tmp",
-		GPDeleteConcurrency:    "1",
-		GPAoSegSizeThreshold:   "1048576", // (1 << 20)
+		GPLogsDirectory:           "/var/log",
+		PgWalSize:                 "64",
+		GPSegmentsPollInterval:    "5m",
+		GPSegmentsUpdInterval:     "10s",
+		GPSegmentsPollRetries:     "5",
+		GPSegmentStatesDir:        "/tmp",
+		GPDeleteConcurrency:       "1",
+		GPAoSegSizeThreshold:      "1048576", // (1 << 20)
+		GPAoDeduplicationAgeLimit: "720h",    // 30 days
 	}
 
 	AllowedSettings map[string]bool
@@ -462,14 +464,15 @@ var (
 	}
 
 	GPAllowedSettings = map[string]bool{
-		GPLogsDirectory:        true,
-		GPSegContentID:         true,
-		GPSegmentsPollRetries:  true,
-		GPSegmentsPollInterval: true,
-		GPSegmentsUpdInterval:  true,
-		GPSegmentStatesDir:     true,
-		GPDeleteConcurrency:    true,
-		GPAoSegSizeThreshold:   true,
+		GPLogsDirectory:           true,
+		GPSegContentID:            true,
+		GPSegmentsPollRetries:     true,
+		GPSegmentsPollInterval:    true,
+		GPSegmentsUpdInterval:     true,
+		GPSegmentStatesDir:        true,
+		GPDeleteConcurrency:       true,
+		GPAoSegSizeThreshold:      true,
+		GPAoDeduplicationAgeLimit: true,
 	}
 
 	RequiredSettings       = make(map[string]bool)

--- a/internal/databases/greenplum/ao_metadata.go
+++ b/internal/databases/greenplum/ao_metadata.go
@@ -12,15 +12,16 @@ func getAOFilesMetadataPath(backupName string) string {
 }
 
 type BackupAOFileDesc struct {
-	StoragePath   string         `json:"StoragePath"`
-	IsSkipped     bool           `json:"IsSkipped"`
-	IsIncremented bool           `json:"IsIncremented,omitempty"`
-	MTime         time.Time      `json:"MTime"`
-	StorageType   RelStorageType `json:"StorageType"`
-	EOF           int64          `json:"EOF"`
-	ModCount      int64          `json:"ModCount,omitempty"`
-	Compressor    string         `json:"Compressor,omitempty"`
-	FileMode      int64          `json:"FileMode"`
+	StoragePath     string         `json:"StoragePath"`
+	IsSkipped       bool           `json:"IsSkipped"`
+	IsIncremented   bool           `json:"IsIncremented,omitempty"`
+	MTime           time.Time      `json:"MTime"`
+	StorageType     RelStorageType `json:"StorageType"`
+	EOF             int64          `json:"EOF"`
+	ModCount        int64          `json:"ModCount,omitempty"`
+	Compressor      string         `json:"Compressor,omitempty"`
+	FileMode        int64          `json:"FileMode"`
+	InitialUploadTS time.Time      `json:"InitialUploadTS,omitempty"`
 }
 
 type AOFilesMetadataDTO struct {
@@ -33,16 +34,17 @@ func NewAOFilesMetadataDTO() *AOFilesMetadataDTO {
 	return &AOFilesMetadataDTO{Files: make(BackupAOFiles)}
 }
 
-func (m *AOFilesMetadataDTO) addFile(key, storagePath string, mTime time.Time, aoMeta AoRelFileMetadata,
+func (m *AOFilesMetadataDTO) addFile(key, storagePath string, mTime, initialUplTS time.Time, aoMeta AoRelFileMetadata,
 	fileMode int64, isSkipped, isIncremented bool) {
 	m.Files[key] = BackupAOFileDesc{
-		StoragePath:   storagePath,
-		IsSkipped:     isSkipped,
-		IsIncremented: isIncremented,
-		MTime:         mTime,
-		EOF:           aoMeta.eof,
-		StorageType:   aoMeta.storageType,
-		FileMode:      fileMode,
-		ModCount:      aoMeta.modCount,
+		StoragePath:     storagePath,
+		IsSkipped:       isSkipped,
+		IsIncremented:   isIncremented,
+		MTime:           mTime,
+		EOF:             aoMeta.eof,
+		StorageType:     aoMeta.storageType,
+		FileMode:        fileMode,
+		ModCount:        aoMeta.modCount,
+		InitialUploadTS: initialUplTS,
 	}
 }

--- a/internal/databases/greenplum/ao_storage.go
+++ b/internal/databases/greenplum/ao_storage.go
@@ -17,12 +17,12 @@ const (
 	AoSegDeltaDelimiter = "_D_"
 )
 
-func makeAoFileStorageKey(relNameMd5 string, modCount int64, location *walparser.BlockLocation) string {
-	return fmt.Sprintf("%d_%d_%s_%d_%d_%d%s",
+func makeAoFileStorageKey(relNameMd5 string, modCount int64, location *walparser.BlockLocation, newAoSegFilesID string) string {
+	return fmt.Sprintf("%d_%d_%s_%d_%d_%d_%s%s",
 		location.RelationFileNode.SpcNode, location.RelationFileNode.DBNode,
 		relNameMd5,
 		location.RelationFileNode.RelNode, location.BlockNo,
-		modCount, AoSegSuffix)
+		modCount, newAoSegFilesID, AoSegSuffix)
 }
 
 func makeDeltaAoFileStorageKey(baseKey string, modCount int64) string {

--- a/internal/databases/greenplum/ao_storage_uploader.go
+++ b/internal/databases/greenplum/ao_storage_uploader.go
@@ -30,7 +30,8 @@ type AoStorageUploader struct {
 }
 
 func NewAoStorageUploader(uploader internal.Uploader, baseAoFiles BackupAOFiles,
-	crypter crypto.Crypter, files internal.BundleFiles, isIncremental bool, deduplicationAgeLimit time.Duration, newAoSegFilesID string) *AoStorageUploader {
+	crypter crypto.Crypter, files internal.BundleFiles, isIncremental bool, deduplicationAgeLimit time.Duration,
+	newAoSegFilesID string) *AoStorageUploader {
 	// Separate uploader for AO/AOCS relfiles with disabled file size tracking since
 	// WAL-G does not count them
 	aoSegUploader := uploader.Clone()
@@ -69,7 +70,8 @@ func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelF
 	}
 
 	if remoteFile.InitialUploadTS.Before(u.deduplicationMinAge) {
-		tracelog.DebugLogger.Printf("%s: deduplication age limit passed (initial upload time: %s), will perform a regular upload", cfi.Header.Name, remoteFile.InitialUploadTS)
+		tracelog.DebugLogger.Printf("%s: deduplication age limit passed (initial upload time: %s), will perform a regular upload",
+			cfi.Header.Name, remoteFile.InitialUploadTS)
 		return u.regularAoUpload(cfi, aoMeta, location)
 	}
 
@@ -115,9 +117,11 @@ func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelF
 }
 
 func (u *AoStorageUploader) addAoFileMetadata(
-	cfi *internal.ComposeFileInfo, storageKey string, aoMeta AoRelFileMetadata, isSkipped, isIncremented bool, initialUplTS time.Time) {
+	cfi *internal.ComposeFileInfo, storageKey string, aoMeta AoRelFileMetadata, isSkipped, isIncremented bool,
+	initialUplTS time.Time) {
 	u.metaMutex.Lock()
-	u.meta.addFile(cfi.Header.Name, storageKey, cfi.FileInfo.ModTime(), initialUplTS, aoMeta, cfi.Header.Mode, isSkipped, isIncremented)
+	u.meta.addFile(cfi.Header.Name, storageKey, cfi.FileInfo.ModTime(),
+		initialUplTS, aoMeta, cfi.Header.Mode, isSkipped, isIncremented)
 	u.metaMutex.Unlock()
 }
 
@@ -125,7 +129,8 @@ func (u *AoStorageUploader) GetFiles() *AOFilesMetadataDTO {
 	return u.meta
 }
 
-func (u *AoStorageUploader) skipAoUpload(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, storageKey string, initialUploadTS time.Time) error {
+func (u *AoStorageUploader) skipAoUpload(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, storageKey string,
+	initialUploadTS time.Time) error {
 	u.addAoFileMetadata(cfi, storageKey, aoMeta, true, false, initialUploadTS)
 	u.bundleFiles.AddSkippedFile(cfi.Header, cfi.FileInfo)
 	tracelog.DebugLogger.Printf("Skipping %s AO relfile (already exists in storage as %s)", cfi.Path, storageKey)

--- a/internal/databases/greenplum/ao_storage_uploader.go
+++ b/internal/databases/greenplum/ao_storage_uploader.go
@@ -26,11 +26,11 @@ type AoStorageUploader struct {
 	// minimal age to use the AO/AOCS file deduplication
 	deduplicationMinAge time.Time
 	// unique identifier of the new AO/AOCS segments created by this uploader
-	newAoSegFilesId string
+	newAoSegFilesID string
 }
 
 func NewAoStorageUploader(uploader internal.Uploader, baseAoFiles BackupAOFiles,
-	crypter crypto.Crypter, files internal.BundleFiles, isIncremental bool, deduplicationAgeLimit time.Duration, newAoSegFilesId string) *AoStorageUploader {
+	crypter crypto.Crypter, files internal.BundleFiles, isIncremental bool, deduplicationAgeLimit time.Duration, newAoSegFilesID string) *AoStorageUploader {
 	// Separate uploader for AO/AOCS relfiles with disabled file size tracking since
 	// WAL-G does not count them
 	aoSegUploader := uploader.Clone()
@@ -44,7 +44,7 @@ func NewAoStorageUploader(uploader internal.Uploader, baseAoFiles BackupAOFiles,
 		bundleFiles:         files,
 		isIncremental:       isIncremental,
 		deduplicationMinAge: time.Now().Add(-deduplicationAgeLimit),
-		newAoSegFilesId:     newAoSegFilesId,
+		newAoSegFilesID:     newAoSegFilesID,
 	}
 }
 
@@ -134,7 +134,7 @@ func (u *AoStorageUploader) skipAoUpload(cfi *internal.ComposeFileInfo, aoMeta A
 
 func (u *AoStorageUploader) regularAoUpload(
 	cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error {
-	storageKey := makeAoFileStorageKey(aoMeta.relNameMd5, aoMeta.modCount, location, u.newAoSegFilesId)
+	storageKey := makeAoFileStorageKey(aoMeta.relNameMd5, aoMeta.modCount, location, u.newAoSegFilesID)
 	tracelog.DebugLogger.Printf("Uploading %s AO relfile to %s", cfi.Path, storageKey)
 	fileReadCloser, err := internal.StartReadingFile(cfi.Header, cfi.FileInfo, cfi.Path)
 	if err != nil {


### PR DESCRIPTION
I propose to add the control over max deduplication age.

To control the maximum possible time starting from the initial upload of the AO/AOCS segment files for their reuse in the following backups, I introduce the `WALG_GP_AOSEG_DEDUPLICATION_AGE_LIMIT`. Smaller values will result in AO/AOCS files being reuploaded more frequently, leading to larger backups, and vice versa. The default value is `720h` (30 days).
