### PR TITLE
Fix invalid page reference in partial backup

### DIFF
--- a/docker/gp_tests/scripts/configs/partial_table_restore_test_config.json
+++ b/docker/gp_tests/scripts/configs/partial_table_restore_test_config.json
@@ -1,3 +1,4 @@
 "WALE_S3_PREFIX": "s3://gppartialtablebucket",
 "WALG_DELTA_MAX_STEPS": "2",
-"WALG_LOG_LEVEL": "DEVEL"
+"WALG_LOG_LEVEL": "DEVEL",
+"WALG_WAIT_SEMAPHORE_DELETION": "true"

--- a/docker/pg_tests/scripts/configs/partial_restore_test_config.json
+++ b/docker/pg_tests/scripts/configs/partial_restore_test_config.json
@@ -1,3 +1,4 @@
 "WALE_S3_PREFIX": "s3://partialbucket",
 "WALG_DELTA_MAX_STEPS": "6",
-"WALG_PGP_KEY_PATH": "/tmp/PGP_KEY"
+"WALG_PGP_KEY_PATH": "/tmp/PGP_KEY",
+"WALG_WAIT_SEMAPHORE_DELETION": "true"

--- a/internal/config.go
+++ b/internal/config.go
@@ -93,6 +93,7 @@ const (
 	PgFailoverStorages             = "WALG_FAILOVER_STORAGES"
 	PgFailoverStoragesCheckTimeout = "WALG_FAILOVER_STORAGES_CHECK_TIMEOUT"
 	PgFailoverStorageCacheLifetime = "WALG_FAILOVER_STORAGES_CACHE_LIFETIME"
+	WaitSemaphoreDeletion          = "WALG_WAIT_SEMAPHORE_DELETION"
 
 	ProfileSamplingRatio = "PROFILE_SAMPLING_RATIO"
 	ProfileMode          = "PROFILE_MODE"
@@ -219,6 +220,7 @@ var (
 		LibsodiumKeyTransform:          "none",
 		PgFailoverStoragesCheckTimeout: "30s",
 		PgFailoverStorageCacheLifetime: "15m",
+		WaitSemaphoreDeletion:          "false",
 	}
 
 	MongoDefaultSettings = map[string]string{
@@ -407,6 +409,7 @@ var (
 		PgFailoverStorages:             true,
 		PgFailoverStoragesCheckTimeout: true,
 		PgFailoverStorageCacheLifetime: true,
+		WaitSemaphoreDeletion:          true,
 	}
 
 	MongoAllowedSettings = map[string]bool{


### PR DESCRIPTION
### Database name
Greenplum, Postgresql

# Pull request description
Wait for https://github.com/greenplum-db/gpdb/pull/15942 to be merged. Also not sure how to tell user to remove `ignore_invalid_pages` option after restoration done

### Describe what this PR fix
This pr fix PANIC on parial restore described in https://github.com/greenplum-db/gpdb/pull/15942#issuecomment-1627279882

### Please provide steps to reproduce (if it's a bug)
see `docker/gp_tests/scripts/tests/partial_table_restore_test.sh`