### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/internal/databases/postgres/wal_restore_handler.go
+++ b/internal/databases/postgres/wal_restore_handler.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -195,7 +194,7 @@ func timelineWithSegmentNoSliceToMap(slice []*TimelineWithSegmentNo) map[uint32]
 // getDirectoryFilenames returns slice of filenames in directory by path
 func getDirectoryFilenames(path string) ([]string, error) {
 	result := make([]string, 0)
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/postgres/walk_test.go
+++ b/internal/databases/postgres/walk_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -197,12 +196,12 @@ func extract(t *testing.T, dir string) string {
 // initial bytes are the same.
 func compare(t *testing.T, dir1, dir2 string) bool {
 	// ReadDir returns directory by filename.
-	files1, err := ioutil.ReadDir(dir1)
+	files1, err := os.ReadDir(dir1)
 	if err != nil {
 		t.Log(err)
 	}
 
-	files2, err := ioutil.ReadDir(dir2)
+	files2, err := os.ReadDir(dir2)
 	if err != nil {
 		t.Log(err)
 	}

--- a/internal/databases/postgres/walk_test.go
+++ b/internal/databases/postgres/walk_test.go
@@ -211,9 +211,11 @@ func compare(t *testing.T, dir1, dir2 string) bool {
 	var deepEqual bool
 	for i, f2 := range files2 {
 		f1 := files1[i]
+		info1, _ := f1.Info()
+		info2, _ := f2.Info()
 		name := f1.Name() == f2.Name()
-		size := f1.Size() == f2.Size()
-		mode := f1.Mode() == f2.Mode()
+		size := info1.Size() == info2.Size()
+		mode := info1.Mode() == info2.Mode()
 		isDir := f1.IsDir() == f2.IsDir()
 
 		// If directory is in ExcludedFilenames list, make sure it exists but is empty.
@@ -242,8 +244,8 @@ func compare(t *testing.T, dir1, dir2 string) bool {
 
 			}
 		} else {
-			t.Logf("walk: Original: \t%s\t %d\t %d\t %v", f1.Name(), f1.Size(), f1.Mode(), f1.IsDir())
-			t.Logf("walk: Extracted: \t%s\t %d\t %d\t %v", f2.Name(), f2.Size(), f2.Mode(), f2.IsDir())
+			t.Logf("walk: Original: \t%s\t %d\t %d\t %v", f1.Name(), info1.Size(), info1.Mode(), f1.IsDir())
+			t.Logf("walk: Extracted: \t%s\t %d\t %d\t %v", f2.Name(), info2.Size(), info2.Mode(), f2.IsDir())
 		}
 
 	}

--- a/pkg/storages/fs/folder.go
+++ b/pkg/storages/fs/folder.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -43,7 +42,7 @@ func (folder *Folder) GetPath() string {
 }
 
 func (folder *Folder) ListFolder() (objects []storage.Object, subFolders []storage.Folder, err error) {
-	files, err := ioutil.ReadDir(path.Join(folder.rootPath, folder.subpath))
+	files, err := os.ReadDir(path.Join(folder.rootPath, folder.subpath))
 	if err != nil {
 		return nil, nil, NewError(err, "Unable to read folder")
 	}
@@ -53,7 +52,8 @@ func (folder *Folder) ListFolder() (objects []storage.Object, subFolders []stora
 			subPath := path.Join(folder.subpath, fileInfo.Name()) + "/"
 			subFolders = append(subFolders, NewFolder(folder.rootPath, subPath))
 		} else {
-			objects = append(objects, storage.NewLocalObject(fileInfo.Name(), fileInfo.ModTime(), fileInfo.Size()))
+			info, _ := fileInfo.Info()
+			objects = append(objects, storage.NewLocalObject(fileInfo.Name(), info.ModTime(), info.Size()))
 		}
 	}
 	return

--- a/tests_func/utils/util.go
+++ b/tests_func/utils/util.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -73,7 +72,7 @@ func SplitEnvLine(line string) (string, string) {
 }
 
 func CopyDirectory(src, dest string, filter string) error {
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return err
 	}

--- a/tests_func/utils/util.go
+++ b/tests_func/utils/util.go
@@ -116,9 +116,10 @@ func CopyDirectory(src, dest string, filter string) error {
 			return err
 		}
 
-		isSymlink := entry.Mode()&os.ModeSymlink != 0
+		info, _ := entry.Info()
+		isSymlink := info.Mode()&os.ModeSymlink != 0
 		if !isSymlink {
-			if err := os.Chmod(destPath, entry.Mode()); err != nil {
+			if err := os.Chmod(destPath, info.Mode()); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fix
// problem is ...
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
