### PR TITLE
Fix panic in multistorage folder_reader.go

### DIFF
--- a/internal/multistorage/folder_reader.go
+++ b/internal/multistorage/folder_reader.go
@@ -29,7 +29,7 @@ func NewStorageFolderReader(mainFolder storage.Folder, failover map[string]stora
 
 	if !ok {
 		// if no cached, use default
-		folder = NewDefaultFailoverFolder(folder)
+		folder = NewDefaultFailoverFolder(mainFolder)
 	}
 
 	leftover := make([]FailoverFolder, 0)


### PR DESCRIPTION
This would fix the incorrect behavior when no has been already written to a disk:

```
[ 2023-07-24 19:20:54.391 MSK ,,,414416,XX000 ]:FATAL:  could not receive data from WAL stream: ERROR:  requested WAL segment 000000040000001A00000005 has already been removed
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1512b89]

goroutine 1 [running]:
github.com/wal-g/wal-g/internal/multistorage.(*FailoverFolder).GetSubFolder(0xc000770b40?, {0x1ab1009?, 0x8?})
        <autogenerated>:1 +0x29
github.com/wal-g/wal-g/internal/multistorage.(*StorageFolderReader).SubFolder(0xc0003587d0, {0x1ab1009, 0x8})
        /root/wal-g/internal/multistorage/folder_reader.go:129 +0x272
github.com/wal-g/wal-g/internal/databases/postgres.HandleWALFetch({0x1e26100, 0xc0003587d0}, {0x7ffd470c9df8, 0x10}, {0x7ffd470c9e09, 0x16}, 0x1)
        /root/wal-g/internal/databases/postgres/wal_fetch_handler.go:38 +0x150
github.com/wal-g/wal-g/cmd/pg.glob..func15(0x2f12800?, {0xc000a19280, 0x2, 0x4?})
        /root/wal-g/cmd/pg/wal_fetch.go:21 +0x67
github.com/spf13/cobra.(*Command).execute(0x2f12800, {0xc000a19240, 0x4, 0x4})
        /root/wal-g/vendor/github.com/spf13/cobra/command.go:860 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0x2f11900)
        /root/wal-g/vendor/github.com/spf13/cobra/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /root/wal-g/vendor/github.com/spf13/cobra/command.go:902
github.com/wal-g/wal-g/cmd/pg.Execute()
        /root/wal-g/cmd/pg/pg.go:45 +0x25
main.main()
        /root/wal-g/main/pg/main.go:8 +0x17
```