### PR TITLE
Fix typo in wal-g storage tool cat handler

### DIFF
--- a/cmd/common/st/cat_object.go
+++ b/cmd/common/st/cat_object.go
@@ -35,6 +35,6 @@ var decompress bool
 
 func init() {
 	StorageToolsCmd.AddCommand(catObjectCmd)
-	getObjectCmd.Flags().BoolVar(&decrypt, decryptFlag, false, "decrypt the object")
-	getObjectCmd.Flags().BoolVar(&decompress, decompressFlag, false, "decompress the object")
+	catObjectCmd.Flags().BoolVar(&decrypt, decryptFlag, false, "decrypt the object")
+	catObjectCmd.Flags().BoolVar(&decompress, decompressFlag, false, "decompress the object")
 }


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fix
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
