### PR TITLE
Pin the CI golang version to 1.20.5

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -15,7 +15,7 @@ env:
   IMAGE_UBUNTU: wal-g/ubuntu
   IMAGE_GOLANG: wal-g/golang
   IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.20.5" # until this will be resolved https://github.com/golang/go/issues/61431
 
 jobs:
   buildimages:


### PR DESCRIPTION
Fix failing Mongo and Redis tests in master due to the golang version update (https://github.com/golang/go/issues/61431). I guess we need to wait for a good workaround or fix.