### PR TITLE
Dead lock fix

### DIFF
--- a/internal/splitmerge/splitmerge_test.go
+++ b/internal/splitmerge/splitmerge_test.go
@@ -2,14 +2,16 @@ package splitmerge
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wal-g/wal-g/internal/abool"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/wal-g/wal-g/internal/abool"
 )
 
 type BufferCloser struct {
@@ -34,19 +36,21 @@ func (b *BufferCloser) Close() error {
 	return nil
 }
 
-//               ┌─> copy data per 1 byte    ─>┐
+//	┌─> copy data per 1 byte    ─>┐
+//
 // data ─> split ├─> copy data per ... bytes ─>├─> merge
-//               └─> copy data per 42 bytes  ─>┘
+//
+//	└─> copy data per 42 bytes  ─>┘
 func TestSplitMerge(t *testing.T) {
 	const blockSize = 128
 	const dataSize = 115249 // some prime number
-	var bufSizes = []int{1, blockSize + 1, blockSize - 1, 2*blockSize + 1, 4, 8, 15, 16, 23, 42}
-	var partitions = len(bufSizes)
+	bufSizes := []int{1, blockSize + 1, blockSize - 1, 2*blockSize + 1, 4, 8, 15, 16, 23, 42}
+	partitions := len(bufSizes)
 
 	// in:
 	inputData := generateDataset(dataSize)
 	dataReader := bytes.NewReader(inputData)
-	var readers = SplitReader(dataReader, partitions, blockSize)
+	readers := SplitReader(dataReader, partitions, blockSize, context.Background())
 
 	// out:
 	var sink BufferCloser
@@ -54,7 +58,7 @@ func TestSplitMerge(t *testing.T) {
 
 	errGroup := new(errgroup.Group)
 	for i := 0; i < partitions; i++ {
-		//idx := i
+		// idx := i
 		reader := readers[i]
 		writer := writers[i]
 		buffSize := bufSizes[i%len(bufSizes)]
@@ -72,7 +76,7 @@ func TestSplitMerge(t *testing.T) {
 				data := make([]byte, buffSize, buffSize)
 				rbytes := copy(data, allData[offset:])
 				offset += rbytes
-				//tracelog.InfoLogger.Printf("goroutine #%d: %d bytes fetched, err=%v", idx, rbytes, rerr)
+				// tracelog.InfoLogger.Printf("goroutine #%d: %d bytes fetched, err=%v", idx, rbytes, rerr)
 				if rbytes == 0 {
 					return nil
 				}
@@ -80,7 +84,7 @@ func TestSplitMerge(t *testing.T) {
 				if werr != nil {
 					return werr
 				} else {
-					//tracelog.InfoLogger.Printf("goroutine #%d: %d bytes copied", idx, rbytes)
+					// tracelog.InfoLogger.Printf("goroutine #%d: %d bytes copied", idx, rbytes)
 				}
 			}
 		})

--- a/internal/splitmerge/splitmerge_test.go
+++ b/internal/splitmerge/splitmerge_test.go
@@ -50,7 +50,7 @@ func TestSplitMerge(t *testing.T) {
 	// in:
 	inputData := generateDataset(dataSize)
 	dataReader := bytes.NewReader(inputData)
-	readers := SplitReader(dataReader, partitions, blockSize, context.Background())
+	readers := SplitReader(context.Background(), dataReader, partitions, blockSize)
 
 	// out:
 	var sink BufferCloser

--- a/internal/splitmerge/splitreader.go
+++ b/internal/splitmerge/splitreader.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wal-g/tracelog"
 )
 
-func SplitReader(reader io.Reader, parts int, blockSize int, ctx context.Context) []io.Reader {
+func SplitReader(ctx context.Context, reader io.Reader, parts int, blockSize int) []io.Reader {
 	result := make([]io.Reader, 0)
 	channels := make([]chan []byte, 0)
 

--- a/internal/splitmerge/splitreader.go
+++ b/internal/splitmerge/splitreader.go
@@ -1,12 +1,13 @@
 package splitmerge
 
 import (
+	"context"
 	"io"
 
 	"github.com/wal-g/tracelog"
 )
 
-func SplitReader(reader io.Reader, parts int, blockSize int) []io.Reader {
+func SplitReader(reader io.Reader, parts int, blockSize int, ctx context.Context) []io.Reader {
 	result := make([]io.Reader, 0)
 	channels := make([]chan []byte, 0)
 
@@ -22,7 +23,16 @@ func SplitReader(reader io.Reader, parts int, blockSize int) []io.Reader {
 			block := make([]byte, blockSize)
 			bytes, err := io.ReadFull(reader, block)
 			if bytes != 0 {
-				channels[idx] <- block[0:bytes]
+				select {
+				case channels[idx] <- block[0:bytes]:
+				case <-ctx.Done():
+					for i := 0; i < parts; i++ {
+						close(channels[i])
+					}
+					tracelog.InfoLogger.Println("SplitReader closed until the end of the work")
+					return
+				}
+
 				if bytes != blockSize {
 					tracelog.InfoLogger.Printf("SplitReader. #%d send: %d / %d bytes", idx, bytes, blockSize)
 				}

--- a/internal/stream_push_helper.go
+++ b/internal/stream_push_helper.go
@@ -36,7 +36,7 @@ func (uploader *SplitStreamUploader) PushStream(stream io.Reader) (string, error
 
 	// Upload Stream:
 	errGroup, ctx := errgroup.WithContext(context.Background())
-	readers := splitmerge.SplitReader(ctx, stream, uploader.partitions, uploader.blockSize)
+	var readers = splitmerge.SplitReader(ctx, stream, uploader.partitions, uploader.blockSize)
 	for partNumber := 0; partNumber < uploader.partitions; partNumber++ {
 		reader := readers[partNumber]
 		if uploader.maxFileSize != 0 {

--- a/internal/stream_push_helper.go
+++ b/internal/stream_push_helper.go
@@ -37,7 +37,7 @@ func (uploader *SplitStreamUploader) PushStream(stream io.Reader) (string, error
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	// Upload Stream:
-	readers := splitmerge.SplitReader(stream, uploader.partitions, uploader.blockSize, ctx)
+	readers := splitmerge.SplitReader(ctx, stream, uploader.partitions, uploader.blockSize)
 
 	errGroup := new(errgroup.Group)
 	for partNumber := 0; partNumber < uploader.partitions; partNumber++ {

--- a/internal/stream_push_helper_test.go
+++ b/internal/stream_push_helper_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/tracelog"
@@ -201,7 +200,6 @@ func GetS3Folder(networkErrorAfterByteSize int) (storage.Folder, func() error, e
 }
 
 func checkSplitPush(t *testing.T, partitions, blockSize, maxFileSize, s3errorAfterByteSize, sampleSize int) {
-	start := time.Now()
 	compressor := compression.Compressors[compression.CompressingAlgorithms[0]]
 	folder, clearer, err := GetS3Folder(s3errorAfterByteSize)
 	defer clearer()
@@ -215,9 +213,6 @@ func checkSplitPush(t *testing.T, partitions, blockSize, maxFileSize, s3errorAft
 		maxFileSize: maxFileSize,
 	}
 	splitUploader.PushStream(bytes.NewBuffer(getByteSampleArray(sampleSize)))
-	if time.Since(start) > time.Second*30 {
-		t.Fatal("Deadlock!")
-	}
 }
 
 func TestSplitPush_Synchronous_WithoutFiles(t *testing.T) {

--- a/internal/stream_push_helper_test.go
+++ b/internal/stream_push_helper_test.go
@@ -6,12 +6,13 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal/compression"
 	functests "github.com/wal-g/wal-g/internal/testutils"
-
 	"github.com/wal-g/wal-g/pkg/storages/fs"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
@@ -200,6 +201,7 @@ func GetS3Folder(networkErrorAfterByteSize int) (storage.Folder, func() error, e
 }
 
 func checkSplitPush(t *testing.T, partitions, blockSize, maxFileSize, s3errorAfterByteSize, sampleSize int) {
+	start := time.Now()
 	compressor := compression.Compressors[compression.CompressingAlgorithms[0]]
 	folder, clearer, err := GetS3Folder(s3errorAfterByteSize)
 	defer clearer()
@@ -212,9 +214,9 @@ func checkSplitPush(t *testing.T, partitions, blockSize, maxFileSize, s3errorAft
 		blockSize:   blockSize,
 		maxFileSize: maxFileSize,
 	}
-	name, err := splitUploader.PushStream(bytes.NewBuffer(getByteSampleArray(sampleSize)))
-	if err != nil {
-		t.Fatal(name, err)
+	splitUploader.PushStream(bytes.NewBuffer(getByteSampleArray(sampleSize)))
+	if time.Since(start) > time.Second*30 {
+		t.Fatal("Deadlock!")
 	}
 }
 

--- a/internal/testutils/s3_error_folder.go
+++ b/internal/testutils/s3_error_folder.go
@@ -1,0 +1,41 @@
+package testutils
+
+import (
+	"bytes"
+	"errors"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"io"
+)
+
+func NewS3ErrorFolder(sourceFolder storage.Folder, S3ErrorAfterByteSize int) storage.Folder {
+	return &S3TestFolder{
+		Folder:          sourceFolder,
+		maxWriteSize:    int64(S3ErrorAfterByteSize),
+		writeSize:       int64(S3ErrorAfterByteSize),
+		wasSkippedBlock: true,
+	}
+}
+
+type S3TestFolder struct {
+	storage.Folder
+	maxWriteSize    int64
+	writeSize       int64
+	wasSkippedBlock bool
+}
+
+func (tf *S3TestFolder) PutObject(name string, content io.Reader) error {
+	buf := &bytes.Buffer{}
+	count, err := io.Copy(buf, content)
+	if err != nil {
+		return err
+	}
+	if count >= tf.writeSize && !tf.wasSkippedBlock {
+		tf.wasSkippedBlock = true
+		tf.writeSize = tf.maxWriteSize
+		return errors.New("S3 error")
+	}
+	tf.wasSkippedBlock = false
+	tf.writeSize -= count
+	err = tf.Folder.PutObject(name, content)
+	return err
+}


### PR DESCRIPTION
### Database name
MySQL, MongoDB

### Describe what this PR fix
Splitreader now doesn't stuck when get error from remote folder.

### Please provide steps to reproduce (if it's a bug)
Just download internal/testutils/s3_error_folder.go, internal/stream_push_helper_test.go and launch go test

### Please add config and wal-g stdout/stderr logs for debug purpose
Default