### PR TITLE
MongoDB binary restore: Added flag for particular replica set member ids

### DIFF
--- a/cmd/mongo/binary_backup_fetch.go
+++ b/cmd/mongo/binary_backup_fetch.go
@@ -20,12 +20,15 @@ const (
 	RsNameDescription            = "Name of replicaset (like rs01)"
 	RsMembersFlag                = "mongo-rs-members"
 	RsMembersDescription         = "Comma separated host:port records from wished rs members (like rs.initiate())"
+	RsMemberIdsFlag              = "mongo-rs-member-ids"
+	RsMemberIdsDescription       = "Comma separated integers for replica IDs of corresponding --mongo-rs-members"
 )
 
 var (
 	minimalConfigPath = ""
 	rsName            = ""
-	rsMembers         = ""
+	rsMembers         []string
+	rsMemberIds       []int
 )
 
 var binaryBackupFetchCmd = &cobra.Command{
@@ -44,7 +47,7 @@ var binaryBackupFetchCmd = &cobra.Command{
 		mongodVersion := args[2]
 
 		err := mongo.HandleBinaryFetchPush(ctx, mongodConfigPath, minimalConfigPath, backupName, mongodVersion, rsName,
-			rsMembers)
+			rsMembers, rsMemberIds)
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
 }
@@ -52,6 +55,7 @@ var binaryBackupFetchCmd = &cobra.Command{
 func init() {
 	binaryBackupFetchCmd.Flags().StringVar(&minimalConfigPath, MinimalConfigPathFlag, "", MinimalConfigPathDescription)
 	binaryBackupFetchCmd.Flags().StringVar(&rsName, RsNameFlag, "", RsNameDescription)
-	binaryBackupFetchCmd.Flags().StringVar(&rsMembers, RsMembersFlag, "", RsMembersDescription)
+	binaryBackupFetchCmd.Flags().StringSliceVar(&rsMembers, RsMembersFlag, []string{}, RsMembersDescription)
+	binaryBackupFetchCmd.Flags().IntSliceVar(&rsMemberIds, RsMemberIdsFlag, []int{}, RsMemberIdsDescription)
 	cmd.AddCommand(binaryBackupFetchCmd)
 }

--- a/internal/databases/mongo/binary/mongod_test.go
+++ b/internal/databases/mongo/binary/mongod_test.go
@@ -8,13 +8,30 @@ import (
 )
 
 func TestMakeBsonRsMembers(t *testing.T) {
-	assert.Equal(t, bson.A{}, makeBsonRsMembers(""))
-	assert.Equal(t, bson.A{bson.M{"_id": 0, "host": "localhost:1234"}}, makeBsonRsMembers("localhost:1234"))
+	assert.Equal(t, bson.A{}, makeBsonRsMembers(RsConfig{}))
+	assert.Equal(t, bson.A{bson.M{"_id": 0, "host": "localhost:1234"}}, makeBsonRsMembers(RsConfig{
+		RsMembers: []string{"localhost:1234"},
+	}))
 	assert.Equal(t,
 		bson.A{
 			bson.M{"_id": 0, "host": "localhost:1234"},
 			bson.M{"_id": 1, "host": "localhost:5678"},
 			bson.M{"_id": 2, "host": "remotehost:9876"},
 		},
-		makeBsonRsMembers("localhost:1234,localhost:5678,remotehost:9876"))
+		makeBsonRsMembers(RsConfig{
+			RsName:      "",
+			RsMembers:   []string{"localhost:1234", "localhost:5678", "remotehost:9876"},
+			RsMemberIds: []int{},
+		}))
+	assert.Equal(t,
+		bson.A{
+			bson.M{"_id": 4, "host": "localhost:1234"},
+			bson.M{"_id": 5, "host": "localhost:5678"},
+			bson.M{"_id": 0, "host": "remotehost:9876"},
+		},
+		makeBsonRsMembers(RsConfig{
+			RsName:      "",
+			RsMembers:   []string{"localhost:1234", "localhost:5678", "remotehost:9876"},
+			RsMemberIds: []int{4, 5, 0},
+		}))
 }

--- a/internal/databases/mongo/binary/mongod_test.go
+++ b/internal/databases/mongo/binary/mongod_test.go
@@ -10,7 +10,8 @@ import (
 func TestMakeBsonRsMembers(t *testing.T) {
 	assert.Equal(t, bson.A{}, makeBsonRsMembers(RsConfig{}))
 	assert.Equal(t, bson.A{bson.M{"_id": 0, "host": "localhost:1234"}}, makeBsonRsMembers(RsConfig{
-		RsMembers: []string{"localhost:1234"},
+		RsMembers:   []string{"localhost:1234"},
+		RsMemberIds: []int{0},
 	}))
 	assert.Equal(t,
 		bson.A{
@@ -21,7 +22,7 @@ func TestMakeBsonRsMembers(t *testing.T) {
 		makeBsonRsMembers(RsConfig{
 			RsName:      "",
 			RsMembers:   []string{"localhost:1234", "localhost:5678", "remotehost:9876"},
-			RsMemberIds: []int{},
+			RsMemberIds: []int{0, 1, 2},
 		}))
 	assert.Equal(t,
 		bson.A{

--- a/internal/databases/mongo/binary_backup_fetch_handler.go
+++ b/internal/databases/mongo/binary_backup_fetch_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 func HandleBinaryFetchPush(ctx context.Context, mongodConfigPath, minimalConfigPath, backupName, restoreMongodVersion,
-	rsName, rsMembers string,
+	rsName string, rsMembers []string, rsMemberIds []int,
 ) error {
 	config, err := binary.CreateMongodConfig(mongodConfigPath)
 	if err != nil {
@@ -36,7 +36,7 @@ func HandleBinaryFetchPush(ctx context.Context, mongodConfigPath, minimalConfigP
 		return err
 	}
 
-	rsConfig := binary.RsConfig{RsName: rsName, RsMembers: rsMembers}
+	rsConfig := binary.NewRsConfig(rsName, rsMembers, rsMemberIds)
 	if err = rsConfig.Validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Database name
MongoDB

# Pull request description

### Describe what this PR fix
This PR adds ability to pass particular replicaset member ids when restoring MongoDB using binary backups. This is useful for purposes such as restoring node of existing cluster when replicaset ids already predefined on primary.
