### PR TITLE
Fix bug with failover storages in `backup-fetch`

### DIFF
--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -61,7 +61,7 @@ var backupFetchCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		folder := multistorage.NewFolder(cache)
-		multistorage.SetPolicies(folder, policies.UniteAllStorages)
+		folder = multistorage.SetPolicies(folder, policies.UniteAllStorages)
 		folder, err = multistorage.UseAllAliveStorages(folder)
 		tracelog.ErrorLogger.FatalOnError(err)
 


### PR DESCRIPTION
This is related to [my recent PR](https://github.com/wal-g/wal-g/pull/1514) with supporting failover storages in `backup-fetch` command.

I forgot to update the folder object after setting new policies.

Fortunately, the default policies were almost the same, so it led to only a few problems. For example, if two backups existed in different storages with the same name and LATEST backup was fetched, the backup from the first storage was returned even if the backup from the second was newer.