### PR TITLE
Don't fail commands if unable to write storage statuses cache file

### DIFF
--- a/internal/multistorage/cache/status_cache.go
+++ b/internal/multistorage/cache/status_cache.go
@@ -62,7 +62,7 @@ func (c *statusCache) AllAliveStorages() ([]NamedFolder, error) {
 	newFile := updateFileContent(oldFile, checkResult)
 	err = writeFile(newFile)
 	if err != nil {
-		return nil, fmt.Errorf("write cache file: %w", err)
+		tracelog.WarningLogger.Printf("Failed to write cache file, each subsequent command will check the storages again: %v", err)
 	}
 
 	memCache = newFile
@@ -101,7 +101,7 @@ func (c *statusCache) FirstAliveStorage() (*NamedFolder, error) {
 	newFile := updateFileContent(oldFile, checkResult)
 	err = writeFile(newFile)
 	if err != nil {
-		return nil, fmt.Errorf("write cache file: %w", err)
+		tracelog.WarningLogger.Printf("Failed to write cache file, each subsequent command will check the storages again: %v", err)
 	}
 
 	memCache = newFile
@@ -150,7 +150,7 @@ func (c *statusCache) SpecificStorage(name string) (*NamedFolder, error) {
 	newFile := updateFileContent(oldFile, checkResult)
 	err = writeFile(newFile)
 	if err != nil {
-		return nil, fmt.Errorf("write cache file: %w", err)
+		tracelog.WarningLogger.Printf("Failed to write cache file, each subsequent command will check the storages again: %v", err)
 	}
 
 	memCache = newFile


### PR DESCRIPTION
A person from the community encountered a problem with the cache file storing failover storage statuses:
```
WAL-G service isn't starting:
 select first alive storage in multistorage folder: write cache file: open cache file: open /var/lib/postgresql/.walg_storage_status_cache: permission denied
It's probably because of this: 
drwxr-xr-x 5 root root 4096 Aug 29 21:29 /var/lib/postgresql/
Do anyone know what's the problem?
```

I've implemented [this caching](https://github.com/wal-g/wal-g/pull/1514/files#diff-9f4395414d32f7e83ac8166ec6436787d4e4fbe7313c41152c00a8b602743694R65) recently, and now we with @usernamedt decided to change the behaviour and make it less strict: don't throw an error in case we unable to write this file, and just print a warning and proceed without caching. 