### PR TITLE
Allow to specify storage names in PG commands

### DIFF
--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -62,7 +62,11 @@ var backupFetchCmd = &cobra.Command{
 
 		folder := multistorage.NewFolder(cache)
 		folder = multistorage.SetPolicies(folder, policies.UniteAllStorages)
-		folder, err = multistorage.UseAllAliveStorages(folder)
+		if targetStorage == "" {
+			folder, err = multistorage.UseAllAliveStorages(folder)
+		} else {
+			folder, err = multistorage.UseSpecificStorage(targetStorage, folder)
+		}
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		if partialRestoreArgs != nil {
@@ -118,6 +122,8 @@ func init() {
 		"", targetUserDataDescription)
 	backupFetchCmd.Flags().StringSliceVar(&partialRestoreArgs, "restore-only",
 		nil, restoreOnlyDescription)
+	backupFetchCmd.Flags().StringVar(&targetStorage, "target-storage",
+		"", targetStorageDescription)
 
 	Cmd.AddCommand(backupFetchCmd)
 }

--- a/cmd/pg/backup_list.go
+++ b/cmd/pg/backup_list.go
@@ -40,7 +40,11 @@ var (
 
 			folder := multistorage.NewFolder(cache)
 			folder = multistorage.SetPolicies(folder, policies.UniteAllStorages)
-			folder, err = multistorage.UseAllAliveStorages(folder)
+			if targetStorage == "" {
+				folder, err = multistorage.UseAllAliveStorages(folder)
+			} else {
+				folder, err = multistorage.UseSpecificStorage(targetStorage, folder)
+			}
 			tracelog.ErrorLogger.FatalOnError(err)
 
 			backupsFolder := folder.GetSubFolder(utility.BaseBackupPath)
@@ -67,4 +71,6 @@ func init() {
 		"Prints output in JSON format, multiline and indented if combined with --pretty flag")
 	backupListCmd.Flags().BoolVar(&detail, DetailFlag, false,
 		"Prints extra DB-specific backup details")
+	backupListCmd.Flags().StringVar(&targetStorage, "target-storage", "",
+		targetStorageDescription)
 }

--- a/cmd/pg/daemon.go
+++ b/cmd/pg/daemon.go
@@ -2,20 +2,31 @@ package pg
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
-const DaemonShortDescription = "Uploads a WAL file to storage"
+const DaemonShortDescription = "Runs WAL-G in daemon mode which executes commands sent from the lightweight walg-daemon-client."
 
 // daemonCmd represents the daemon archive command
 var daemonCmd = &cobra.Command{
 	Use:   "daemon daemon_socket_path",
-	Short: DaemonShortDescription, // TODO : improve description
+	Short: DaemonShortDescription,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		folder, err := postgres.ConfigureMultiStorageFolder()
+		tracelog.ErrorLogger.FatalfOnError("Failed to configure multi-storage folder: %v", err)
+
+		walUploader, err := postgres.PrepareMultiStorageWalUploader(folder, targetStorage)
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		folderReader, err := internal.PrepareMultiStorageFolderReader(folder, targetStorage)
+		tracelog.ErrorLogger.FatalOnError(err)
+
 		daemonOpts := postgres.DaemonOptions{
-			Uploader: GetWalUploader(),
-			Reader:   GetWalFolderReader(),
+			Uploader: walUploader,
+			Reader:   folderReader,
 		}
 		postgres.HandleDaemon(daemonOpts, args[0])
 	},

--- a/cmd/pg/pg.go
+++ b/cmd/pg/pg.go
@@ -5,14 +5,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/wal-g/wal-g/cmd/common"
-
-	"github.com/wal-g/wal-g/internal/databases/postgres"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/cmd/common"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
 const WalgShortDescription = "PostgreSQL backup tool"
@@ -34,8 +32,13 @@ var (
 			if viper.IsSet(internal.PgWalSize) {
 				postgres.SetWalSize(viper.GetUint64(internal.PgWalSize))
 			}
+
+			targetStorage = viper.GetString(internal.PgTargetStorage)
 		},
 	}
+
+	targetStorage            string
+	targetStorageDescription = `Name of the storage to execute the command only for. Use "default" to select the primary one.`
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/pg/wal_push.go
+++ b/cmd/pg/wal_push.go
@@ -3,12 +3,7 @@ package pg
 import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/internal"
-	"github.com/wal-g/wal-g/internal/asm"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
-	"github.com/wal-g/wal-g/internal/multistorage"
-	"github.com/wal-g/wal-g/internal/multistorage/policies"
-	"github.com/wal-g/wal-g/utility"
 )
 
 const WalPushShortDescription = "Uploads a WAL file to storage"
@@ -19,44 +14,18 @@ var walPushCmd = &cobra.Command{
 	Short: WalPushShortDescription, // TODO : improve description
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		walUploader := GetWalUploader()
-		err := postgres.HandleWALPush(cmd.Context(), walUploader, args[0])
+		folder, err := postgres.ConfigureMultiStorageFolder()
+		tracelog.ErrorLogger.FatalfOnError("Failed to configure multi-storage folder: %v", err)
+
+		walUploader, err := postgres.PrepareMultiStorageWalUploader(folder, targetStorage)
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		err = postgres.HandleWALPush(cmd.Context(), walUploader, args[0])
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
 }
 
-func GetWalUploader() *postgres.WalUploader {
-	folder := GetFolder()
-	folder = multistorage.SetPolicies(folder, policies.TakeFirstStorage)
-	folder, err := multistorage.UseFirstAliveStorage(folder)
-	tracelog.ErrorLogger.FatalOnError(err)
-
-	baseUploader, err := internal.ConfigureUploaderToFolder(folder)
-	tracelog.ErrorLogger.FatalOnError(err)
-
-	walUploader, err := postgres.ConfigureWalUploader(baseUploader)
-	tracelog.ErrorLogger.FatalOnError(err)
-
-	archiveStatusManager, err := internal.ConfigureArchiveStatusManager()
-	if err == nil {
-		walUploader.ArchiveStatusManager = asm.NewDataFolderASM(archiveStatusManager)
-	} else {
-		tracelog.ErrorLogger.PrintError(err)
-		walUploader.ArchiveStatusManager = asm.NewNopASM()
-	}
-
-	PGArchiveStatusManager, err := internal.ConfigurePGArchiveStatusManager()
-	if err == nil {
-		walUploader.PGArchiveStatusManager = asm.NewDataFolderASM(PGArchiveStatusManager)
-	} else {
-		tracelog.ErrorLogger.PrintError(err)
-		walUploader.PGArchiveStatusManager = asm.NewNopASM()
-	}
-
-	walUploader.ChangeDirectory(utility.WalPath)
-	return walUploader
-}
-
 func init() {
 	Cmd.AddCommand(walPushCmd)
+	walPushCmd.Flags().StringVar(&targetStorage, "target-storage", "", targetStorageDescription)
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -101,6 +101,7 @@ const (
 	PgFailoverStoragesCheckTimeout = "WALG_FAILOVER_STORAGES_CHECK_TIMEOUT"
 	PgFailoverStorageCacheLifetime = "WALG_FAILOVER_STORAGES_CACHE_LIFETIME"
 	PgDaemonWALUploadTimeout       = "WALG_DAEMON_WAL_UPLOAD_TIMEOUT"
+	PgTargetStorage                = "WALG_TARGET_STORAGE"
 
 	ProfileSamplingRatio = "PROFILE_SAMPLING_RATIO"
 	ProfileMode          = "PROFILE_MODE"

--- a/internal/multistorage/folder.go
+++ b/internal/multistorage/folder.go
@@ -90,7 +90,7 @@ func UsedStorages(folder storage.Folder) []string {
 func EnsureSingleStorageIsUsed(folder storage.Folder) error {
 	storages := UsedStorages(folder)
 	if len(storages) != 1 {
-		return fmt.Errorf("multi-storage folder must use a single storage, but it uses %d", len(storages))
+		return fmt.Errorf("multi-storage folder is expected to use a single storage, but it uses %d", len(storages))
 	}
 	return nil
 }

--- a/internal/multistorage/folder_test.go
+++ b/internal/multistorage/folder_test.go
@@ -145,7 +145,7 @@ func TestEnsureSingleStorageIsUsed(t *testing.T) {
 		folder := newTestFolder(t, "s1", "s2")
 		err := EnsureSingleStorageIsUsed(folder)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "must use a single storage")
+		assert.Contains(t, err.Error(), "expected to use a single storage")
 	})
 
 	t.Run("no error if folder is not multistorage", func(t *testing.T) {

--- a/internal/storage_folder_reader.go
+++ b/internal/storage_folder_reader.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"io"
 
+	"github.com/wal-g/wal-g/internal/multistorage"
+	"github.com/wal-g/wal-g/internal/multistorage/policies"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
@@ -21,4 +23,19 @@ type FolderReaderImpl struct {
 
 func (fsr *FolderReaderImpl) SubFolder(subFolderRelativePath string) StorageFolderReader {
 	return NewFolderReader(fsr.GetSubFolder(subFolderRelativePath))
+}
+
+func PrepareMultiStorageFolderReader(folder storage.Folder, targetStorage string) (StorageFolderReader, error) {
+	folder = multistorage.SetPolicies(folder, policies.MergeAllStorages)
+	var err error
+	if targetStorage == "" {
+		folder, err = multistorage.UseAllAliveStorages(folder)
+	} else {
+		folder, err = multistorage.UseSpecificStorage(targetStorage, folder)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return NewFolderReader(folder), nil
 }


### PR DESCRIPTION
This is one of the changes directed to support failover storages in all PostgreSQL commands. Such PG commands as `backup-push`, `backup-fetch`, `wal-push` and some others already support failover storages that are used in case the primary one is dead. Currently, all storages specified in the config file can be used.

In this PR I'm introducing an additional `--target-storage` flag to all commands that already support failover storages. This allows us to specify an exact storage to execute the command against, instead of using all configured storages. This feature may be useful for debugging purposes or in case of repairing something broken.