### PR TITLE
Fix daemon client size regression & add test

### DIFF
--- a/cmd/daemonclient/main.go
+++ b/cmd/daemonclient/main.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/wal-g/wal-g/internal/daemon"
-	"github.com/wal-g/wal-g/internal/databases/postgres"
+	"github.com/wal-g/wal-g/internal/databases/postgres/constants"
 )
 
 const (
@@ -129,7 +129,7 @@ func main() {
 	if err != nil {
 		if response == daemon.ArchiveNonExistenceType {
 			fmt.Println(err.Error())
-			os.Exit(postgres.ExIoError)
+			os.Exit(constants.ExIoError)
 		}
 		log.Fatal(err)
 	}

--- a/cmd/pg/wal_fetch.go
+++ b/cmd/pg/wal_fetch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
+	"github.com/wal-g/wal-g/internal/databases/postgres/constants"
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/internal/multistorage/cache"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"
@@ -26,7 +27,7 @@ var walFetchCmd = &cobra.Command{
 		err := postgres.HandleWALFetch(folderReader, args[0], args[1], postgres.RegularPrefetcher{})
 		if _, isArchNonExistErr := err.(internal.ArchiveNonExistenceError); isArchNonExistErr {
 			tracelog.ErrorLogger.Print(err.Error())
-			os.Exit(postgres.ExIoError)
+			os.Exit(constants.ExIoError)
 		}
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/docker/pg_tests/scripts/tests/daemon_client_test.sh
+++ b/docker/pg_tests/scripts/tests/daemon_client_test.sh
@@ -15,6 +15,16 @@ export SKIP_TEST_WAL_OVERWRITES="1"
 # show client version
 walg-daemon-client --version
 
+MAXCLIENTSIZE=4194304 # 4MB
+CLIENTSIZE=$(stat -c%s $(which walg-daemon-client))
+# assert that resulting binary has the correct size
+if [ $CLIENTSIZE -ge $MAXCLIENTSIZE ]; then
+    echo "WAL-G daemon client size is too big ($CLIENTSIZE)"
+    exit 1
+else
+    echo "WAL-G daemon client size OK ($CLIENTSIZE)"
+fi
+
 prepare_config "/tmp/configs/full_backup_test_config.json"
 start_daemon
 test_full_backup "${TMP_CONFIG}"

--- a/internal/databases/postgres/constants/constants.go
+++ b/internal/databases/postgres/constants/constants.go
@@ -1,0 +1,7 @@
+package constants
+
+// This package contents common constants to be used by other tools (i.e. WAL-G daemon client)
+
+// Looking at sysexits.h, EX_IOERR (74) is defined as a generic exit code for input/output errors
+// It is used in wal-fetch (and daemon-client wal-fetch) to signal that the requested file does not exist.
+const ExIoError = 74

--- a/internal/databases/postgres/wal_fetch_handler.go
+++ b/internal/databases/postgres/wal_fetch_handler.go
@@ -15,9 +15,6 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-// Looking at sysexits.h, EX_IOERR (74) is defined as a generic exit code for input/output errors
-const ExIoError = 74
-
 type InvalidWalFileMagicError struct {
 	error
 }


### PR DESCRIPTION
Fix daemon client package import that led to a regression in size (37MB vs 2.6MB). Add test to check the future regressions.