### PR TITLE
fix: use yc endpoint and optional file creds with envelope gpg

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,10 @@ Ensure that you have set up and configured Yandex Cloud KMS mentioned below befo
 This setting controls kms response expiration. Default value is `0` to store keys permanent in memory.
 Please note that if the system will not be able to redecrypt the key in kms after expiration, the previous response will be used.
 
+* `WALG_ENVELOPE_PGP_YC_ENDPOINT`
+
+Endpoint is an API endpoint of Yandex.Cloud against which the SDK is used. Most users won't need to explicitly set it.
+
 * `WALG_ENVELOPE_PGP_YC_CSE_KMS_KEY_ID`
 
 Similar to `YC_CSE_KMS_KEY_ID`, but only used for envelope pgp keys.

--- a/internal/config.go
+++ b/internal/config.go
@@ -70,6 +70,7 @@ const (
 	PgpEnvelopKeyPathSetting      = "WALG_ENVELOPE_PGP_KEY_PATH"
 	PgpEnvelopeYcKmsKeyIDSetting  = "WALG_ENVELOPE_PGP_YC_CSE_KMS_KEY_ID"
 	PgpEnvelopeYcSaKeyFileSetting = "WALG_ENVELOPE_PGP_YC_SERVICE_ACCOUNT_KEY_FILE"
+	PgpEnvelopeYcEndpointSetting  = "WALG_ENVELOPE_PGP_YC_ENDPOINT"
 	PgpEnvelopeCacheExpiration    = "WALG_ENVELOPE_CACHE_EXPIRATION"
 
 	PgDataSetting                  = "PGDATA"
@@ -297,6 +298,7 @@ var (
 		PgpEnvelopeCacheExpiration:    true,
 		PgpEnvelopeYcKmsKeyIDSetting:  true,
 		PgpEnvelopeYcSaKeyFileSetting: true,
+		PgpEnvelopeYcEndpointSetting:  true,
 		LibsodiumKeySetting:           true,
 		LibsodiumKeyPathSetting:       true,
 		LibsodiumKeyTransform:         true,

--- a/internal/configure.go
+++ b/internal/configure.go
@@ -368,7 +368,9 @@ func configureEnvelopePgpCrypter(config *viper.Viper) (crypto.Crypter, error) {
 	}
 
 	yckmsEnveloper, err := yckmsenvlpr.EnveloperFromKeyIDAndCredential(
-		config.GetString(PgpEnvelopeYcKmsKeyIDSetting), config.GetString(PgpEnvelopeYcSaKeyFileSetting),
+		config.GetString(PgpEnvelopeYcKmsKeyIDSetting),
+		config.GetString(PgpEnvelopeYcSaKeyFileSetting),
+		config.GetString(PgpEnvelopeYcEndpointSetting),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/crypto/envelope/enveloper/yckms/enveloper.go
+++ b/internal/crypto/envelope/enveloper/yckms/enveloper.go
@@ -114,7 +114,7 @@ func getCredentials(saFilePath string) (ycsdk.Credentials, error) {
 	return credentials, nil
 }
 
-func EnveloperFromKeyIDAndCredential(keyID string, saFilePath string, endpoint string) (envelope.Enveloper, error) {
+func EnveloperFromKeyIDAndCredential(keyID, saFilePath, endpoint string) (envelope.Enveloper, error) {
 	credentials, credErr := getCredentials(saFilePath)
 	if credErr != nil {
 		return nil, errors.Wrap(credErr, "Can't initialize yc sdk")

--- a/internal/crypto/envelope/enveloper/yckms/enveloper.go
+++ b/internal/crypto/envelope/enveloper/yckms/enveloper.go
@@ -97,18 +97,32 @@ func readEncryptedKey(r io.Reader) ([]byte, error) {
 	return encryptedKey, nil
 }
 
-func EnveloperFromKeyIDAndCredential(keyID string, saFilePath string) (envelope.Enveloper, error) {
-	var authorizedKey, authErr = iamkey.ReadFromJSONFile(saFilePath)
-	if authErr != nil {
-		return nil, errors.Wrap(authErr, "Can't initialize yc sdk")
+func getCredentials(saFilePath string) (ycsdk.Credentials, error) {
+	var credentials ycsdk.Credentials
+	credentials = ycsdk.InstanceServiceAccount()
+	if len(saFilePath) > 0 {
+		var authorizedKey, keyErr = iamkey.ReadFromJSONFile(saFilePath)
+		if keyErr != nil {
+			return nil, errors.Wrap(keyErr, "Can't initialize yc sdk")
+		}
+		var accountCredentials, credErr = ycsdk.ServiceAccountKey(authorizedKey)
+		if credErr != nil {
+			return nil, errors.Wrap(credErr, "Can't initialize yc sdk")
+		}
+		credentials = accountCredentials
 	}
-	var credentials, credErr = ycsdk.ServiceAccountKey(authorizedKey)
+	return credentials, nil
+}
+
+func EnveloperFromKeyIDAndCredential(keyID string, saFilePath string, endpoint string) (envelope.Enveloper, error) {
+	credentials, credErr := getCredentials(saFilePath)
 	if credErr != nil {
 		return nil, errors.Wrap(credErr, "Can't initialize yc sdk")
 	}
 
 	var sdk, sdkErr = ycsdk.Build(context.Background(), ycsdk.Config{
 		Credentials: credentials,
+		Endpoint:    endpoint,
 	})
 	if sdkErr != nil {
 		return nil, errors.Wrap(sdkErr, "Can't initialize yc sdk")


### PR DESCRIPTION
* use metadata server if no sa file was passed
* pass yc endpoint to use in different environments
