### PR TITLE
fix: read exactly bytes

### DIFF
--- a/internal/crypto/envelope/enveloper/yckms/enveloper.go
+++ b/internal/crypto/envelope/enveloper/yckms/enveloper.go
@@ -68,7 +68,7 @@ func serializeEncryptedKey(encryptedKey []byte) []byte {
 
 func readEncryptedKey(r io.Reader) ([]byte, error) {
 	magicSchemeBytes := make([]byte, len(magic)+1)
-	_, err := r.Read(magicSchemeBytes)
+	_, err := io.ReadFull(r, magicSchemeBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -82,14 +82,15 @@ func readEncryptedKey(r io.Reader) ([]byte, error) {
 	}
 
 	encryptedKeyLenBytes := make([]byte, 4)
-	_, err = r.Read(encryptedKeyLenBytes)
+	_, err = io.ReadFull(r, encryptedKeyLenBytes)
 	if err != nil {
 		return nil, err
 	}
 
 	encryptedKeyLen := binary.LittleEndian.Uint32(encryptedKeyLenBytes)
 	encryptedKey := make([]byte, encryptedKeyLen)
-	_, err = r.Read(encryptedKey)
+
+	_, err = io.ReadFull(r, encryptedKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/crypto/envelope/enveloper/yckms/enveloper_test.go
+++ b/internal/crypto/envelope/enveloper/yckms/enveloper_test.go
@@ -1,7 +1,10 @@
 package yckms
 
 import (
+	"bufio"
 	"bytes"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +18,27 @@ func TestSerializeDeserializeKeyHeader(t *testing.T) {
 	buffer.Write(serializedKey)
 
 	deserializedKey, err := readEncryptedKey(buffer)
+	assert.NoErrorf(t, err, "YcKms envelope key deserialization error: %v", err)
+
+	assert.Equal(t, len(encryptedKey), len(deserializedKey), "YcKms deserialized envelope key len is not equal to the original one")
+
+	for i := range encryptedKey {
+		assert.Equal(t, encryptedKey[i], deserializedKey[i], "YcKms deserialized envelope key is not equal to the original one in position: %d", i)
+	}
+}
+
+func TestHugeKey(t *testing.T) {
+	reader, writer := io.Pipe()
+
+	encryptedKey := []byte(strings.Repeat("awesomekey", 512))
+	serializedKey := serializeEncryptedKey(encryptedKey)
+	go func() {
+		defer writer.Close()
+		writer.Write(serializedKey)
+	}()
+	breader := bufio.NewReaderSize(reader, 16)
+
+	deserializedKey, err := readEncryptedKey(breader)
 	assert.NoErrorf(t, err, "YcKms envelope key deserialization error: %v", err)
 
 	assert.Equal(t, len(encryptedKey), len(deserializedKey), "YcKms deserialized envelope key len is not equal to the original one")


### PR DESCRIPTION
bufio.NewReader with a sufficient buffer can return less that len(p) in `Read(p []byte)`
