### PR TITLE
fix: b64 encoded envelope key length

### DIFF
--- a/internal/crypto/envelope/openpgp/crypter.go
+++ b/internal/crypto/envelope/openpgp/crypter.go
@@ -120,25 +120,37 @@ func (crypter *Crypter) setupEncryptedKey() error {
 
 	switch {
 	case crypter.IsUseArmoredKey:
-		encryptedKey, err := base64.StdEncoding.DecodeString(crypter.ArmoredKey)
+		encryptedKey, err := readFromString(crypter.ArmoredKey)
 		if err != nil {
 			return err
 		}
 		crypter.encryptedKey = encryptedKey
 	case crypter.IsUseArmoredKeyPath:
-		content, err := os.ReadFile(crypter.ArmoredKeyPath)
+		encryptedKey, err := readFromFilePath(crypter.ArmoredKeyPath)
 		if err != nil {
 			return err
 		}
-		encryptedKey := make([]byte, base64.StdEncoding.DecodedLen(len(content)))
-		var decodedLen int
-		decodedLen, err = base64.StdEncoding.Decode(encryptedKey, content)
-		if err != nil {
-			return err
-		}
-		crypter.encryptedKey = encryptedKey[:decodedLen]
+		crypter.encryptedKey = encryptedKey
 	}
 	return nil
+}
+
+func readFromString(content string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(content)
+}
+
+func readFromFilePath(path string) ([]byte, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	encryptedKey := make([]byte, base64.StdEncoding.DecodedLen(len(content)))
+	var decodedLen int
+	decodedLen, err = base64.StdEncoding.Decode(encryptedKey, content)
+	if err != nil {
+		return nil, err
+	}
+	return encryptedKey[:decodedLen], nil
 }
 
 // CrypterFromKey creates Crypter from encrypted armored key.

--- a/internal/crypto/envelope/openpgp/crypter.go
+++ b/internal/crypto/envelope/openpgp/crypter.go
@@ -131,11 +131,12 @@ func (crypter *Crypter) setupEncryptedKey() error {
 			return err
 		}
 		encryptedKey := make([]byte, base64.StdEncoding.DecodedLen(len(content)))
-		_, err = base64.StdEncoding.Decode(encryptedKey, content)
+		var decodedLen int
+		decodedLen, err = base64.StdEncoding.Decode(encryptedKey, content)
 		if err != nil {
 			return err
 		}
-		crypter.encryptedKey = encryptedKey
+		crypter.encryptedKey = encryptedKey[:decodedLen]
 	}
 	return nil
 }

--- a/internal/crypto/envelope/openpgp/crypter.go
+++ b/internal/crypto/envelope/openpgp/crypter.go
@@ -168,5 +168,8 @@ func readFromFilePath(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// DecodedLen returns the maximum length in bytes of the decoded data
+	// which Decode writes at most, that's why need to be sliced
+	// with actually written length
 	return encryptedKey[:decodedLen], nil
 }

--- a/internal/crypto/envelope/openpgp/crypter.go
+++ b/internal/crypto/envelope/openpgp/crypter.go
@@ -135,24 +135,6 @@ func (crypter *Crypter) setupEncryptedKey() error {
 	return nil
 }
 
-func readFromString(content string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(content)
-}
-
-func readFromFilePath(path string) ([]byte, error) {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	encryptedKey := make([]byte, base64.StdEncoding.DecodedLen(len(content)))
-	var decodedLen int
-	decodedLen, err = base64.StdEncoding.Decode(encryptedKey, content)
-	if err != nil {
-		return nil, err
-	}
-	return encryptedKey[:decodedLen], nil
-}
-
 // CrypterFromKey creates Crypter from encrypted armored key.
 func CrypterFromKey(armoredKey string, enveloper envelope.Enveloper) crypto.Crypter {
 	return &Crypter{
@@ -169,4 +151,22 @@ func CrypterFromKeyPath(armoredKeyPath string, enveloper envelope.Enveloper) cry
 		IsUseArmoredKeyPath: true,
 		enveloper:           enveloper,
 	}
+}
+
+func readFromString(content string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(content)
+}
+
+func readFromFilePath(path string) ([]byte, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	encryptedKey := make([]byte, base64.StdEncoding.DecodedLen(len(content)))
+	var decodedLen int
+	decodedLen, err = base64.StdEncoding.Decode(encryptedKey, content)
+	if err != nil {
+		return nil, err
+	}
+	return encryptedKey[:decodedLen], nil
 }


### PR DESCRIPTION
DecodedLen returns the maximum length in bytes of the decoded data, not the real