### PR TITLE
Fix target storage name specifying in PG commands

### DIFF
--- a/cmd/pg/pg.go
+++ b/cmd/pg/pg.go
@@ -33,7 +33,11 @@ var (
 				postgres.SetWalSize(viper.GetUint64(internal.PgWalSize))
 			}
 
-			targetStorage = viper.GetString(internal.PgTargetStorage)
+			// In case the --target-storage flag isn't specified (the variable is set in commands' init() funcs),
+			// we take the value from the config.
+			if targetStorage == "" {
+				targetStorage = viper.GetString(internal.PgTargetStorage)
+			}
 		},
 	}
 

--- a/internal/databases/postgres/daemon_handler.go
+++ b/internal/databases/postgres/daemon_handler.go
@@ -101,10 +101,8 @@ func (h *WalFetchMessageHandler) Handle(_ context.Context, messageBody []byte) e
 	if len(args) != 2 {
 		return fmt.Errorf("wal-fetch incorrect arguments count")
 	}
-	var (
-		walFileName = args[0]
-		location    = args[1]
-	)
+	walFileName := args[0]
+	location := args[1]
 	fullPath, err := getFullPath(location)
 	if err != nil {
 		return err


### PR DESCRIPTION
In the [recent PR](https://github.com/wal-g/wal-g/pull/1550) I've made a mistake: storage name specifying didn't work if set using command arguments, only using the env variable.