### PR TITLE
Don't require user $HOME dir to exist

### DIFF
--- a/internal/multistorage/cache/status_cache_test.go
+++ b/internal/multistorage/cache/status_cache_test.go
@@ -78,7 +78,8 @@ func testAllAliveStorages(t *testing.T) {
 	})
 
 	invalidateInMem(cache.storageKey(t, "default"))
-	err := os.WriteFile(StatusFile, []byte("malformed content"), 0666)
+	file, _ := StatusFile()
+	err := os.WriteFile(file, []byte("malformed content"), 0666)
 	require.NoError(t, err)
 
 	t.Run("check for alive if file is malformed", func(_ *testing.T) {
@@ -156,7 +157,8 @@ func testFirstAliveStorage(t *testing.T) {
 	})
 
 	invalidateInMem(cache.storageKey(t, "default"))
-	err := os.WriteFile(StatusFile, []byte("malformed content"), 0666)
+	file, _ := StatusFile()
+	err := os.WriteFile(file, []byte("malformed content"), 0666)
 	require.NoError(t, err)
 
 	t.Run("check for alive if file is malformed", func(_ *testing.T) {
@@ -246,7 +248,8 @@ func testSpecificStorage(t *testing.T) {
 	})
 
 	invalidateInMem(cache.storageKey(t, "default"))
-	err := os.WriteFile(StatusFile, []byte("malformed content"), 0666)
+	file, _ := StatusFile()
+	err := os.WriteFile(file, []byte("malformed content"), 0666)
 	require.NoError(t, err)
 
 	t.Run("check for alive if file is malformed", func(_ *testing.T) {
@@ -272,10 +275,12 @@ func testSpecificStorage(t *testing.T) {
 
 func initTest(t *testing.T) {
 	tmpFile := path.Join(t.TempDir(), "status_cache.yaml")
+	resqueStatusFile := StatusFile
+	StatusFile = func() (string, error) { return tmpFile, nil }
 	t.Cleanup(func() {
 		_ = os.Remove(tmpFile)
+		StatusFile = resqueStatusFile
 	})
-	StatusFile = tmpFile
 	memCache = storageStatuses{}
 }
 


### PR DESCRIPTION
Previously, user $HOME dir was required to present and be accessible for failover storages functionallity. Only PostgreSQL actually used failover storages, but because of the fact that $HOME dir was checked in `init()` func of `multistorage` package, every DB executed this.

In this PR, I took out this code from the `init()` func.