### PR TITLE
Don't trim slash at the beginning of ssh folder path

### DIFF
--- a/pkg/storages/sh/folder.go
+++ b/pkg/storages/sh/folder.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/sftp"
 	"github.com/wal-g/tracelog"
@@ -106,7 +105,6 @@ func ConfigureFolder(prefix string, settings map[string]string) (storage.Hashabl
 }
 
 func NewFolder(client SftpClient, host, path, user string) *Folder {
-	path = strings.TrimPrefix(path, "/")
 	return &Folder{
 		client: client,
 		host:   host,


### PR DESCRIPTION
In my [previous PR](https://github.com/wal-g/wal-g/pull/1560/files#diff-44145ee5679b183cde7c1fbea65f34f18b9c823e871f93fdb5a47ed1cbe77171) I added trimming slashes in the prefixes of folder paths in all storage implementations, because it can lead to problems with `ListFolder` (this function is usually comparing prefixes between the folder and files, and file paths never starts with "/").

However, the situation is not the same for the ssh folder. Its path must start with "/" to show that paths are pointing to the root folder and not to the user $HOME. 

So here I revert this change for the ssh storage implementation.