### PR TITLE
Log storage names

### DIFF
--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -56,6 +56,7 @@ var backupFetchCmd = &cobra.Command{
 			folder, err = multistorage.UseSpecificStorage(targetStorage, folder)
 		}
 		tracelog.ErrorLogger.FatalOnError(err)
+		tracelog.InfoLogger.Printf("Backup to fetch will be searched in storages: %v", multistorage.UsedStorages(folder))
 
 		if partialRestoreArgs != nil {
 			skipRedundantTars = true

--- a/cmd/pg/backup_list.go
+++ b/cmd/pg/backup_list.go
@@ -34,6 +34,7 @@ var (
 				folder, err = multistorage.UseSpecificStorage(targetStorage, folder)
 			}
 			tracelog.ErrorLogger.FatalOnError(err)
+			tracelog.InfoLogger.Printf("List backups from storages: %v", multistorage.UsedStorages(folder))
 
 			backupsFolder := folder.GetSubFolder(utility.BaseBackupPath)
 			if detail {

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -55,6 +55,7 @@ var (
 				folder, err = multistorage.UseSpecificStorage(targetStorage, folder)
 			}
 			tracelog.ErrorLogger.FatalOnError(err)
+			tracelog.InfoLogger.Printf("Backup will be pushed to storage: %v", multistorage.UsedStorages(folder)[0])
 
 			uploader, err := internal.ConfigureUploaderToFolder(folder)
 			tracelog.ErrorLogger.FatalOnError(err)

--- a/cmd/pg/delete.go
+++ b/cmd/pg/delete.go
@@ -139,6 +139,7 @@ func configureFolder() storage.Folder {
 	folder, err := postgres.ConfigureMultiStorageFolder(true)
 	tracelog.ErrorLogger.FatalfOnError("Failed to configure multi-storage folder: %v", err)
 	folder, err = multistorage.UseAllAliveStorages(folder)
+	tracelog.InfoLogger.Printf("Backup to delete will be searched in storages: %v", multistorage.UsedStorages(folder))
 	tracelog.ErrorLogger.FatalOnError(err)
 	return multistorage.SetPolicies(folder, policies.UniteAllStorages)
 }

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/multistorage"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -155,8 +156,13 @@ func (bh *BackupHandler) createAndPushBackup(ctx context.Context) {
 	bh.markBackups(folder, sentinelDto)
 	bh.uploadMetadata(ctx, sentinelDto, filesMetaDto)
 
+	storageNames := multistorage.UsedStorages(folder)
+	if len(storageNames) == 0 {
+		tracelog.ErrorLogger.Fatalf("No storages are used in the uploading folder")
+	}
+
 	// logging backup set Name
-	tracelog.InfoLogger.Printf("Wrote backup with name %s", bh.CurBackupInfo.Name)
+	tracelog.InfoLogger.Printf("Wrote backup with name %s to storage %s", bh.CurBackupInfo.Name, storageNames[0])
 }
 
 func (bh *BackupHandler) startBackup() (err error) {

--- a/internal/databases/postgres/wal_uploader.go
+++ b/internal/databases/postgres/wal_uploader.go
@@ -84,6 +84,7 @@ func PrepareMultiStorageWalUploader(folder storage.Folder, targetStorage string)
 	if err != nil {
 		return nil, err
 	}
+	tracelog.InfoLogger.Printf("Files will be uploaded to storage: %v", multistorage.UsedStorages(folder)[0])
 
 	baseUploader, err := internal.ConfigureUploaderToFolder(folder)
 	if err != nil {

--- a/internal/multistorage/cache/alive_check.go
+++ b/internal/multistorage/cache/alive_check.go
@@ -68,7 +68,7 @@ func (ac *AliveChecker) checkForAlive(storages ...NamedFolder) map[key]bool {
 		tracelog.ErrorLogger.Print(res.err)
 	}
 
-	tracelog.DebugLogger.Printf("Found %d alive storages: %v", aliveCount, results)
+	tracelog.DebugLogger.Printf("Found %d alive storages among requested: %v", aliveCount, results)
 	return results
 }
 

--- a/internal/storage_folder_reader.go
+++ b/internal/storage_folder_reader.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"io"
 
+	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -33,6 +34,7 @@ func PrepareMultiStorageFolderReader(folder storage.Folder, targetStorage string
 	} else {
 		folder, err = multistorage.UseSpecificStorage(targetStorage, folder)
 	}
+	tracelog.InfoLogger.Printf("Files will be read from storages: %v", multistorage.UsedStorages(folder))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storages/sh/folder.go
+++ b/pkg/storages/sh/folder.go
@@ -153,7 +153,7 @@ func (folder *Folder) ListFolder() (objects []storage.Object, subFolders []stora
 
 	if os.IsNotExist(err) {
 		// Folder does not exist, it means where are no objects in folder
-		tracelog.InfoLogger.Println("\tskipped " + folder.path + ": " + err.Error())
+		tracelog.DebugLogger.Println("\tskipped " + folder.path + ": " + err.Error())
 		err = nil
 		return
 	}


### PR DESCRIPTION
This PR just improves observability a little in case failover storages are used.
Added printing storage names that are used in commands, and also storage status cache hits/misses.