### PR TITLE
Fix deleting backups from failover storages in PG

### DIFF
--- a/internal/backup_list_handler_test.go
+++ b/internal/backup_list_handler_test.go
@@ -75,10 +75,12 @@ func TestHandleDefaultBackupList(t *testing.T) {
 		memStorages := []cache.NamedFolder{
 			{
 				Name:   "storage_1",
+				Root:   "",
 				Folder: memory.NewFolder("", memory.NewStorage(memory.WithCustomTime(curTimeFunc))),
 			},
 			{
 				Name:   "storage_2",
+				Root:   "",
 				Folder: memory.NewFolder("", memory.NewStorage(memory.WithCustomTime(curTimeFunc))),
 			},
 		}

--- a/internal/databases/postgres/backup_list_handler_test.go
+++ b/internal/databases/postgres/backup_list_handler_test.go
@@ -114,10 +114,12 @@ func TestHandleDetailedBackupList(t *testing.T) {
 		memStorages := []cache.NamedFolder{
 			{
 				Name:   "storage_1",
+				Root:   "",
 				Folder: memory.NewFolder("", memory.NewStorage(memory.WithCustomTime(curTimeFunc))),
 			},
 			{
 				Name:   "storage_2",
+				Root:   "",
 				Folder: memory.NewFolder("", memory.NewStorage(memory.WithCustomTime(curTimeFunc))),
 			},
 		}

--- a/internal/multistorage/cache/status_cache.go
+++ b/internal/multistorage/cache/status_cache.go
@@ -195,6 +195,7 @@ func storageNames(folders []NamedFolder) []string {
 type NamedFolder struct {
 	Key  key
 	Name string
+	Root string
 	storage.Folder
 }
 
@@ -213,6 +214,7 @@ func NameAndOrderFolders(primary storage.Folder, failover map[string]storage.Fol
 		failoverFolders = append(failoverFolders, NamedFolder{
 			Key:    formatKey(name, hashableFolder.Hash()),
 			Name:   name,
+			Root:   folder.GetPath(),
 			Folder: folder,
 		})
 	}
@@ -223,6 +225,7 @@ func NameAndOrderFolders(primary storage.Folder, failover map[string]storage.Fol
 			{
 				Key:    formatKey(consts.DefaultStorage, hashablePrimary.Hash()),
 				Name:   consts.DefaultStorage,
+				Root:   primary.GetPath(),
 				Folder: primary,
 			},
 		},

--- a/internal/multistorage/folder.go
+++ b/internal/multistorage/folder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"strings"
 
 	"github.com/wal-g/wal-g/internal/multistorage/cache"
 	"github.com/wal-g/wal-g/internal/multistorage/consts"
@@ -96,10 +97,14 @@ func EnsureSingleStorageIsUsed(folder storage.Folder) error {
 }
 
 func changeDirectory(path string, storages ...cache.NamedFolder) []cache.NamedFolder {
+	if path == "" {
+		return storages
+	}
 	newStorages := make([]cache.NamedFolder, len(storages))
 	for i := range storages {
 		newStorages[i] = cache.NamedFolder{
 			Name:   storages[i].Name,
+			Root:   storages[i].Root,
 			Folder: storages[i].Folder.GetSubFolder(path),
 		}
 	}
@@ -361,14 +366,17 @@ func (mf Folder) listStorageFolder(storage cache.NamedFolder) ([]storage.Object,
 		for j, st := range mf.storages {
 			newStorages[j] = cache.NamedFolder{
 				Name:   st.Name,
+				Root:   st.Root,
 				Folder: st.GetSubFolder(path.Base(subFolder.GetPath())),
 			}
 		}
 
+		relPath := strings.TrimPrefix(subFolder.GetPath(), storage.Root)
+		relPath = strings.TrimPrefix(relPath, "/")
 		subFolders[i] = Folder{
 			cache:    mf.cache,
 			storages: newStorages,
-			path:     subFolder.GetPath(),
+			path:     relPath,
 			policies: mf.policies,
 		}
 	}

--- a/internal/multistorage/folder_getsubfolder_test.go
+++ b/internal/multistorage/folder_getsubfolder_test.go
@@ -17,16 +17,16 @@ func TestGetSubFolder(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, "a/", aSubFolder.GetPath())
 		assert.Len(t, aSubFolder.storages, 2)
-		assert.Equal(t, "a/", aSubFolder.storages[0].GetPath())
-		assert.Equal(t, "a/", aSubFolder.storages[1].GetPath())
+		assert.Equal(t, "test/a/", aSubFolder.storages[0].GetPath())
+		assert.Equal(t, "test/a/", aSubFolder.storages[1].GetPath())
 
 		subf = aSubFolder.GetSubFolder("b")
 		bSubFolder, ok := subf.(Folder)
 		assert.True(t, ok)
 		assert.Equal(t, "a/b/", bSubFolder.GetPath())
 		assert.Len(t, bSubFolder.storages, 2)
-		assert.Equal(t, "a/b/", bSubFolder.storages[0].GetPath())
-		assert.Equal(t, "a/b/", bSubFolder.storages[1].GetPath())
+		assert.Equal(t, "test/a/b/", bSubFolder.storages[0].GetPath())
+		assert.Equal(t, "test/a/b/", bSubFolder.storages[1].GetPath())
 	})
 
 	t.Run("copies cache storages and policies to subfolders", func(t *testing.T) {

--- a/internal/multistorage/folder_list_test.go
+++ b/internal/multistorage/folder_list_test.go
@@ -2,6 +2,7 @@ package multistorage
 
 import (
 	"bytes"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ func TestListFolder(t *testing.T) {
 			assert.Equal(t, testFolder.cache, multiFolder.cache)
 			assert.Equal(t, len(testFolder.storages), len(multiFolder.storages))
 			for _, st := range multiFolder.storages {
-				assert.Equal(t, subf.GetPath(), st.GetPath())
+				assert.Equal(t, path.Join(st.Root, subf.GetPath())+"/", st.GetPath())
 			}
 			gotPath := subf.GetPath()
 			delete(want, gotPath)

--- a/internal/multistorage/folder_test.go
+++ b/internal/multistorage/folder_test.go
@@ -45,6 +45,7 @@ func TestUseDifferentStorages(t *testing.T) {
 		cacheMock := folder.cache.(*cache.MockStatusCache)
 		s3Folder := cache.NamedFolder{
 			Name:   "s3",
+			Root:   "",
 			Folder: memory.NewFolder("", memory.NewStorage()),
 		}
 
@@ -164,7 +165,8 @@ func newTestFolder(t *testing.T, storageNames ...string) Folder {
 	for _, name := range storageNames {
 		memStorages = append(memStorages, cache.NamedFolder{
 			Name:   name,
-			Folder: memory.NewFolder("", memory.NewStorage()),
+			Root:   "test",
+			Folder: memory.NewFolder("test/", memory.NewStorage()),
 		})
 	}
 

--- a/internal/multistorage/recursive_list_test.go
+++ b/internal/multistorage/recursive_list_test.go
@@ -173,6 +173,7 @@ func newMultiStorageFolder(t *testing.T) storage.Folder {
 	memStorages := []cache.NamedFolder{
 		{
 			Name:   "test_storage",
+			Root:   "",
 			Folder: memory.NewFolder("", memory.NewStorage()),
 		},
 	}

--- a/pkg/storages/storage/folder_test.go
+++ b/pkg/storages/storage/folder_test.go
@@ -95,6 +95,7 @@ func TestListFolderRecursivelyWithFilter_MultiStorage(t *testing.T) {
 	cacheMock := cache.NewMockStatusCache(mockCtrl)
 	memFolder := cache.NamedFolder{
 		Name:   "test",
+		Root:   "",
 		Folder: memory.NewFolder("", memory.NewStorage()),
 	}
 	cacheMock.EXPECT().SpecificStorage("test").Return(&memFolder, nil)


### PR DESCRIPTION
In the [previous PR](https://github.com/wal-g/wal-g/pull/1560) I supported failover storages in `delete` command.

However, I made a mistake there. Deletion doesn't work with storages that point not to the root of the storage ("/" dir for SSH or root of a bucket for S3). In this PR I fixed this.