### PR TITLE
Don't throw error in SSH folder if deleting object doesn't exist

### DIFF
--- a/pkg/storages/sh/folder.go
+++ b/pkg/storages/sh/folder.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/contextio"
@@ -192,6 +193,10 @@ func (folder *Folder) DeleteObjects(objectRelativePaths []string) error {
 		objPath := client.Join(folder.path, relativePath)
 
 		stat, err := client.Stat(objPath)
+		if errors.Is(err, os.ErrNotExist) {
+			// Don't throw error if the file doesn't exist, to follow the storage.Folder contract
+			continue
+		}
 		if err != nil {
 			return NewFolderError(err, "Fail to get object stat '%s': %v", objPath, err)
 		}
@@ -202,6 +207,10 @@ func (folder *Folder) DeleteObjects(objectRelativePaths []string) error {
 		}
 
 		err = client.Remove(objPath)
+		if errors.Is(err, os.ErrNotExist) {
+			// Don't throw error if the file doesn't exist, to follow the storage.Folder contract
+			continue
+		}
 		if err != nil {
 			return NewFolderError(err, "Fail delete object '%s': %v", objPath, err)
 		}


### PR DESCRIPTION
SSH folder implementation currently throws `os.ErrNotExist` error from its `DeleteObjects` func, if the deleting file doesn't exist in the storage. It's not what is expected accoring to the comment in `storage.Folder.DeleteObjects`, which is the main interface for all storage implementations. It also differs from the behavior of S3 storage implementation. 
In this PR I added handling of this error for SSH.

