### PR TITLE
Respect upload context in bguploader

### DIFF
--- a/internal/databases/postgres/bguploader.go
+++ b/internal/databases/postgres/bguploader.go
@@ -68,7 +68,7 @@ type BgUploader struct {
 // NewBgUploader creates a new BgUploader which looks for WAL files adjacent to
 // walFilePath. maxParallelWorkers and maxNumUploaded limits maximum concurrency
 // and total work done by this BgUploader respectively.
-func NewBgUploader(walFilePath string,
+func NewBgUploader(ctx context.Context, walFilePath string,
 	maxParallelWorkers int32,
 	maxNumUploaded int32,
 	uploader *WalUploader,
@@ -77,7 +77,7 @@ func NewBgUploader(walFilePath string,
 	started := make(map[string]struct{})
 	firstWalName := filepath.Base(walFilePath)
 	started[firstWalName+readySuffix] = struct{}{}
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	return &BgUploader{
 		dir:                 filepath.Dir(walFilePath),
 		uploader:            uploader,

--- a/internal/databases/postgres/bguploader_test.go
+++ b/internal/databases/postgres/bguploader_test.go
@@ -1,6 +1,7 @@
 package postgres_test
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -97,8 +98,7 @@ func TestBackgroundWALUpload(t *testing.T) {
 			tu := testtools.NewMockWalUploader(false, false)
 			fakeASM := asm.NewFakeASM()
 			tu.ArchiveStatusManager = fakeASM
-
-			bu := postgres.NewBgUploader(a, int32(tt.maxParallelism), int32(tt.maxNumFilesUploaded), tu, false, false)
+			bu := postgres.NewBgUploader(context.Background(), a, int32(tt.maxParallelism), int32(tt.maxNumFilesUploaded), tu, false, false)
 			// Run BgUploader and wait 1 second before stopping
 			bu.Start()
 			// KLUDGE If maxParallelism=0, we expect to do no work. Therefore, do not wait.

--- a/internal/databases/postgres/wal_push_handler.go
+++ b/internal/databases/postgres/wal_push_handler.go
@@ -52,7 +52,7 @@ func HandleWALPush(ctx context.Context, uploader *WalUploader, walFilePath strin
 	preventWalOverwrite := viper.GetBool(internal.PreventWalOverwriteSetting) || strings.HasSuffix(walFilePath, ".history")
 	readyRename := viper.GetBool(internal.PgReadyRename)
 
-	bgUploader := NewBgUploader(walFilePath, int32(concurrency-1), totalBgUploadedLimit-1, uploader, preventWalOverwrite, readyRename)
+	bgUploader := NewBgUploader(ctx, walFilePath, int32(concurrency-1), totalBgUploadedLimit-1, uploader, preventWalOverwrite, readyRename)
 	// Look for new WALs while doing main upload
 	bgUploader.Start()
 


### PR DESCRIPTION
Currently, BgUploader ignores the upload context. This behavior affects the WAL uploading in daemon mode since it leaves multiple BgUploaders detached on the upload failures. In this PR, I propose to take this context into account to destroy the created bguploader on upload failure. 