### PR TITLE
Introduce a setting to turn off storage alive checks

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -98,6 +98,7 @@ const (
 	PgAliveCheckInterval           = "WALG_ALIVE_CHECK_INTERVAL"
 	PgStopBackupTimeout            = "WALG_STOP_BACKUP_TIMEOUT"
 	PgFailoverStorages             = "WALG_FAILOVER_STORAGES"
+	PgFailoverStoragesCheck        = "WALG_FAILOVER_STORAGES_CHECK"
 	PgFailoverStoragesCheckTimeout = "WALG_FAILOVER_STORAGES_CHECK_TIMEOUT"
 	PgFailoverStorageCacheLifetime = "WALG_FAILOVER_STORAGES_CACHE_LIFETIME"
 	PgFailoverStoragesCheckSize    = "WALG_FAILOVER_STORAGES_CHECK_SIZE"

--- a/internal/multistorage/cache/status_cache_no_check.go
+++ b/internal/multistorage/cache/status_cache_no_check.go
@@ -1,0 +1,48 @@
+package cache
+
+import (
+	"fmt"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type statusCacheNoCheck struct {
+	storagesInOrder []NamedFolder
+}
+
+func NewStatusCacheNoCheck(
+	primary storage.Folder,
+	failover map[string]storage.Folder,
+) (StatusCache, error) {
+	storagesInOrder, err := NameAndOrderFolders(primary, failover)
+	if err != nil {
+		return &statusCacheNoCheck{}, err
+	}
+
+	return &statusCacheNoCheck{
+		storagesInOrder: storagesInOrder,
+	}, nil
+}
+
+func (c *statusCacheNoCheck) AllAliveStorages() ([]NamedFolder, error) {
+	return c.storagesInOrder, nil
+}
+
+func (c *statusCacheNoCheck) FirstAliveStorage() (*NamedFolder, error) {
+	return &c.storagesInOrder[0], nil
+}
+
+func (c *statusCacheNoCheck) SpecificStorage(name string) (*NamedFolder, error) {
+	var specificStorage *NamedFolder
+	for _, s := range c.storagesInOrder {
+		if s.Name == name {
+			sCpy := s
+			specificStorage = &sCpy
+			break
+		}
+	}
+	if specificStorage == nil {
+		return nil, fmt.Errorf("unknown storage %q", name)
+	}
+	return specificStorage, nil
+}

--- a/internal/multistorage/cache/status_cache_no_check_test.go
+++ b/internal/multistorage/cache/status_cache_no_check_test.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/pkg/storages/memory"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+func TestStatusCacheNoCheck(t *testing.T) {
+	failover := map[string]storage.Folder{}
+	for i := 0; i < 3; i++ {
+		name := fmt.Sprintf("failover_%d", i+1)
+		failover[name] = memory.NewFolder(name+"/", memory.NewStorage())
+	}
+	primary := memory.NewFolder("default/", memory.NewStorage())
+	c, err := NewStatusCacheNoCheck(
+		primary,
+		failover,
+	)
+	require.NoError(t, err)
+
+	t.Run("AllAliveStorages simply returns all storages without checking", func(t *testing.T) {
+		got, err := c.AllAliveStorages()
+		assert.NoError(t, err)
+		assert.Equal(t, "default", got[0].Name)
+		assert.Equal(t, primary, got[0].Folder)
+		for i := 1; i <= 3; i++ {
+			name := fmt.Sprintf("failover_%d", i)
+			assert.Equal(t, name, got[i].Name)
+			assert.Equal(t, failover[name], got[i].Folder)
+		}
+	})
+
+	t.Run("AllAliveStorages returns default storage", func(t *testing.T) {
+		got, err := c.FirstAliveStorage()
+		assert.NoError(t, err)
+		assert.Equal(t, "default", got.Name)
+		assert.Equal(t, primary, got.Folder)
+	})
+
+	t.Run("SpecificStorage returns storage with requested name", func(t *testing.T) {
+		got, err := c.SpecificStorage("default")
+		assert.NoError(t, err)
+		assert.Equal(t, "default", got.Name)
+		assert.Equal(t, primary, got.Folder)
+
+		got, err = c.SpecificStorage("failover_2")
+		assert.NoError(t, err)
+		assert.Equal(t, "failover_2", got.Name)
+		assert.Equal(t, failover["failover_2"], got.Folder)
+	})
+}


### PR DESCRIPTION
In this PR I added the `WALG_FAILOVER_STORAGES_CHECK` flag to the config, that allows to turn off checking storage statuses before using them.

That feature with checking storages and caching results can be harmfull if only a single storage is used.
 
Despite you can configure the behaviour using custom cache TTL, it has some drawbacks anyway. If you set large cache TTL, you loose some flexibility: after storage got alive you need to wait for some time and nothing works during this period. If you set cache TTL to zero, you need to perform the storage check at least once per command execution.

So I made this configurable. If single storage is used, checking storages and caching their statuses is turned off by default. If many, it's turned on by default. If this setting is specified in the config, the value from there is used.