### PR TITLE
Recheck storages and don't wait cache to expire if they all are dead

### DIFF
--- a/internal/multistorage/cache/file.go
+++ b/internal/multistorage/cache/file.go
@@ -12,8 +12,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// StatusFile is stored on a disk and therefore shared between all WAL-G processes and commands.
-var StatusFile = func() (string, error) {
+// HomeStatusFile is the default file for storing cache on disk that is shared between all WAL-G processes and commands.
+var HomeStatusFile = func() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("can't get user home dir: %w", err)
@@ -52,16 +52,8 @@ func updateFileContent(oldContent storageStatuses, checkResult map[key]bool) (ne
 	return newContent
 }
 
-func readFile() (storageStatuses, error) {
-	path, err := StatusFile()
-	if err != nil {
-		return nil, err
-	}
-
+func readFile(path string) (storageStatuses, error) {
 	file, err := os.OpenFile(path, os.O_RDONLY, 0666)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, fmt.Errorf("open cache file: %w", err)
 	}
@@ -86,15 +78,10 @@ func readFile() (storageStatuses, error) {
 	return content, nil
 }
 
-func writeFile(content storageStatuses) error {
+func writeFile(path string, content storageStatuses) error {
 	bytes, err := json.Marshal(content)
 	if err != nil {
 		return fmt.Errorf("marshal cache file content: %w", err)
-	}
-
-	path, err := StatusFile()
-	if err != nil {
-		return err
 	}
 
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)

--- a/internal/multistorage/cache/memory.go
+++ b/internal/multistorage/cache/memory.go
@@ -5,13 +5,13 @@ import (
 	"time"
 )
 
-// memCache is stored in memory and therefore shared within a single WAL-G process.
-var memCache storageStatuses
-var memCacheMu *sync.Mutex
+// globalMemCache is the default in-memory cache that is shared within a single WAL-G process.
+var globalMemCache storageStatuses
+var globalMemCacheMu *sync.Mutex
 
 func init() {
-	memCache = map[key]status{}
-	memCacheMu = new(sync.Mutex)
+	globalMemCache = map[key]status{}
+	globalMemCacheMu = new(sync.Mutex)
 }
 
 func (ss storageStatuses) isRelevant(ttl time.Duration, storages ...NamedFolder) bool {
@@ -64,7 +64,9 @@ func (ss storageStatuses) getAllAlive(storagesInOrder []NamedFolder) []NamedFold
 	return alive
 }
 
-// getRelevantFirstAlive provides
+// getRelevantFirstAlive traverses storages in order of priority. If any relevant and alive storage is found, the
+// traverse stops and this storage is returned. If any outdated storage is found before the first relevant and alive,
+// nil is returned. If no alive storages are found, nil is returned as well.
 func (ss storageStatuses) getRelevantFirstAlive(ttl time.Duration, storagesInOrder []NamedFolder) (
 	firstAlive *NamedFolder,
 	allRelevant bool,

--- a/internal/multistorage/cache/status_cache.go
+++ b/internal/multistorage/cache/status_cache.go
@@ -2,7 +2,9 @@ package cache
 
 import (
 	"fmt"
+	"math"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/wal-g/tracelog"
@@ -21,6 +23,36 @@ type statusCache struct {
 	storagesInOrder []NamedFolder
 	ttl             time.Duration
 	checker         AliveChecker
+
+	// sharedMem keeps the intra-process cache that's shared between different threads and subsequent storages requests.
+	sharedMem   *storageStatuses
+	sharedMemMu *sync.Mutex
+
+	// sharedFile keeps the inter-process cache that's shared between different command executions.
+	sharedFile    string
+	sharedFileUse bool
+}
+
+type StatusCacheOpt func(c *statusCache)
+
+func WithSharedMemory(mem *storageStatuses, memMu *sync.Mutex) StatusCacheOpt {
+	return func(c *statusCache) {
+		c.sharedMem = mem
+		c.sharedMemMu = memMu
+	}
+}
+
+func WithSharedFile(file string) StatusCacheOpt {
+	return func(c *statusCache) {
+		c.sharedFile = file
+		c.sharedFileUse = true
+	}
+}
+
+func WithoutSharedFile() StatusCacheOpt {
+	return func(c *statusCache) {
+		c.sharedFileUse = false
+	}
 }
 
 func NewStatusCache(
@@ -28,160 +60,242 @@ func NewStatusCache(
 	failover map[string]storage.Folder,
 	ttl time.Duration,
 	checker AliveChecker,
+	opts ...StatusCacheOpt,
 ) (StatusCache, error) {
 	storagesInOrder, err := NameAndOrderFolders(primary, failover)
 	if err != nil {
 		return &statusCache{}, err
 	}
 
-	return &statusCache{
+	homeFileUse := true
+	homeFile, err := HomeStatusFile()
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can't use storage status cache file from $HOME: %v", err)
+		homeFileUse = false
+	}
+
+	c := &statusCache{
 		storagesInOrder: storagesInOrder,
 		ttl:             ttl,
 		checker:         checker,
-	}, nil
+
+		sharedMem:     &globalMemCache,
+		sharedMemMu:   globalMemCacheMu,
+		sharedFile:    homeFile,
+		sharedFileUse: homeFileUse,
+	}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	return c, nil
 }
 
-func (c *statusCache) AllAliveStorages() ([]NamedFolder, error) {
-	memCacheMu.Lock()
-	defer memCacheMu.Unlock()
+func (c *statusCache) AllAliveStorages() (allAlive []NamedFolder, err error) {
+	c.sharedMemMu.Lock()
+	defer c.sharedMemMu.Unlock()
 
-	if memCache.isRelevant(c.ttl, c.storagesInOrder...) {
-		return memCache.getAllAlive(c.storagesInOrder), nil
+	if c.sharedMem.isRelevant(c.ttl, c.storagesInOrder...) {
+		allAlive = c.sharedMem.getAllAlive(c.storagesInOrder)
+		if len(allAlive) > 0 {
+			return allAlive, nil
+		}
 	}
 
-	oldFile, err := readFile()
-	if err != nil {
-		tracelog.WarningLogger.Printf("Failed to read cache file, it will be overwritten: %v", err)
+	var oldFile storageStatuses
+	if c.sharedFileUse {
+		oldFile, err = readFile(c.sharedFile)
+		if err != nil {
+			tracelog.WarningLogger.Printf("Failed to read cache file, it will be overwritten: %v", err)
+		}
 	}
-	_, outdated := oldFile.splitByRelevance(c.ttl, c.storagesInOrder)
+	relevant, outdated := oldFile.splitByRelevance(c.ttl, c.storagesInOrder)
 	if len(outdated) == 0 {
-		memCache = oldFile
-		allAlive := memCache.getAllAlive(c.storagesInOrder)
-		tracelog.InfoLogger.Printf("Take all alive storages from file cache: %v", storageNames(allAlive))
+		c.sharedMem = &oldFile
+		allAlive = c.sharedMem.getAllAlive(c.storagesInOrder)
+		if len(allAlive) > 0 {
+			tracelog.InfoLogger.Printf("Take all alive storages from file cache: %v", storageNames(allAlive))
+			return allAlive, nil
+		}
+	}
+
+	newFile := oldFile
+	if len(outdated) > 0 {
+		tracelog.InfoLogger.Printf(
+			"Storage status cache is outdated, checking for alive again: %v",
+			storageNames(outdated),
+		)
+		checkResult := c.checker.checkForAlive(outdated...)
+		newFile = updateFileContent(oldFile, checkResult)
+		allAlive = newFile.getAllAlive(c.storagesInOrder)
+	}
+
+	defer func() {
+		if c.sharedFileUse {
+			err := writeFile(c.sharedFile, newFile)
+			if err != nil {
+				tracelog.WarningLogger.Printf(
+					"Failed to write cache file, each subsequent command will check the storages again: %v",
+					err,
+				)
+			}
+		}
+		c.sharedMem = &newFile
+		tracelog.InfoLogger.Printf("Found alive storages: %v", storageNames(allAlive))
+	}()
+
+	if len(allAlive) > 0 {
 		return allAlive, nil
 	}
 
-	tracelog.InfoLogger.Printf("Storage status cache is outdated, checking for alive again: %v", storageNames(outdated))
-
-	checkResult := c.checker.checkForAlive(outdated...)
-
-	newFile := updateFileContent(oldFile, checkResult)
-	err = writeFile(newFile)
-	if err != nil {
-		tracelog.WarningLogger.Printf("Failed to write cache file, each subsequent command will check the storages again: %v", err)
+	if len(relevant) > 0 {
+		tracelog.InfoLogger.Printf(
+			"All storages are dead in cache, rechecking relevant ones: %v",
+			storageNames(relevant),
+		)
+		checkResult := c.checker.checkForAlive(relevant...)
+		newFile = updateFileContent(newFile, checkResult)
+		allAlive = newFile.getAllAlive(c.storagesInOrder)
 	}
 
-	memCache = newFile
-	allAlive := memCache.getAllAlive(c.storagesInOrder)
-	tracelog.InfoLogger.Printf("Found alive storages: %v", storageNames(allAlive))
 	return allAlive, nil
 }
 
-func (c *statusCache) FirstAliveStorage() (*NamedFolder, error) {
-	memCacheMu.Lock()
-	defer memCacheMu.Unlock()
+func (c *statusCache) FirstAliveStorage() (firstAlive *NamedFolder, err error) {
+	c.sharedMemMu.Lock()
+	defer c.sharedMemMu.Unlock()
 
-	memFirstAlive, allRelevant := memCache.getRelevantFirstAlive(c.ttl, c.storagesInOrder)
+	memFirstAlive, allRelevant := c.sharedMem.getRelevantFirstAlive(c.ttl, c.storagesInOrder)
 	if memFirstAlive != nil {
 		return memFirstAlive, nil
 	}
 	if allRelevant {
-		tracelog.InfoLogger.Print("There is no alive storages in memory cache")
-		return nil, nil
+		tracelog.InfoLogger.Print("There are no alive storages in memory cache")
 	}
 
-	oldFile, err := readFile()
-	if err != nil {
-		tracelog.WarningLogger.Printf("Failed to read cache file, it will be overwritten: %v", err)
+	var oldFile storageStatuses
+	if c.sharedFileUse {
+		oldFile, err = readFile(c.sharedFile)
+		if err != nil {
+			tracelog.WarningLogger.Printf("Failed to read cache file, it will be overwritten: %v", err)
+		}
 	}
 	fileFirstAlive, allRelevant := oldFile.getRelevantFirstAlive(c.ttl, c.storagesInOrder)
 	if fileFirstAlive != nil {
 		tracelog.InfoLogger.Printf("Take first alive storage from file cache: %s", fileFirstAlive.Name)
-		memCache[fileFirstAlive.Key] = oldFile[fileFirstAlive.Key]
+		(*c.sharedMem)[fileFirstAlive.Key] = oldFile[fileFirstAlive.Key]
 		return fileFirstAlive, nil
 	}
 	if allRelevant {
-		tracelog.InfoLogger.Print("There is no alive storages in file cache")
-		return nil, nil
+		tracelog.InfoLogger.Print("There are no alive storages in file cache")
 	}
 
-	_, outdated := oldFile.splitByRelevance(c.ttl, c.storagesInOrder)
+	relevant, outdated := oldFile.splitByRelevance(c.ttl, c.storagesInOrder)
 
-	tracelog.InfoLogger.Printf("Storage status cache is outdated, checking for alive again: %v", storageNames(outdated))
-
-	checkResult := c.checker.checkForAlive(outdated...)
-
-	newFile := updateFileContent(oldFile, checkResult)
-	err = writeFile(newFile)
-	if err != nil {
-		tracelog.WarningLogger.Printf("Failed to write cache file, each subsequent command will check the storages again: %v", err)
+	newFile := oldFile
+	if len(outdated) > 0 {
+		tracelog.InfoLogger.Printf("Storage status cache is outdated, checking for alive again: %v", storageNames(outdated))
+		checkResult := c.checker.checkForAlive(outdated...)
+		newFile = updateFileContent(newFile, checkResult)
+		firstAlive, _ = newFile.getRelevantFirstAlive(time.Duration(math.MaxInt64), c.storagesInOrder)
 	}
 
-	memCache = newFile
-	firstAlive, _ := memCache.getRelevantFirstAlive(c.ttl, c.storagesInOrder)
-	if firstAlive == nil {
-		tracelog.InfoLogger.Print("Found no alive storages")
-	} else {
-		tracelog.InfoLogger.Printf("First found alive storage: %s", firstAlive.Name)
+	defer func() {
+		if c.sharedFileUse {
+			err := writeFile(c.sharedFile, newFile)
+			if err != nil {
+				tracelog.WarningLogger.Printf(
+					"Failed to write cache file, each subsequent command will check the storages again: %v",
+					err,
+				)
+			}
+		}
+		c.sharedMem = &newFile
+		if firstAlive == nil {
+			tracelog.InfoLogger.Print("Found no alive storages")
+		} else {
+			tracelog.InfoLogger.Printf("First found alive storage: %s", firstAlive.Name)
+		}
+	}()
+
+	if firstAlive != nil {
+		return firstAlive, nil
 	}
+
+	if len(relevant) > 0 {
+		tracelog.InfoLogger.Printf("All storages are dead in cache, rechecking relevant ones: %v", storageNames(relevant))
+		checkResult := c.checker.checkForAlive(relevant...)
+		newFile = updateFileContent(newFile, checkResult)
+		firstAlive, _ = newFile.getRelevantFirstAlive(time.Duration(math.MaxInt64), c.storagesInOrder)
+	}
+
 	return firstAlive, nil
 }
 
-func (c *statusCache) SpecificStorage(name string) (*NamedFolder, error) {
-	memCacheMu.Lock()
-	defer memCacheMu.Unlock()
+func (c *statusCache) SpecificStorage(name string) (specific *NamedFolder, err error) {
+	c.sharedMemMu.Lock()
+	defer c.sharedMemMu.Unlock()
 
-	var specificStorage *NamedFolder
-	for _, s := range c.storagesInOrder {
-		if s.Name == name {
-			sCpy := s
-			specificStorage = &sCpy
-			break
-		}
-	}
-	if specificStorage == nil {
+	specific = storageWithName(c.storagesInOrder, name)
+	if specific == nil {
 		return nil, fmt.Errorf("unknown storage %q", name)
 	}
 
-	if memCache.isRelevant(c.ttl, *specificStorage) {
-		if memCache[specificStorage.Key].Alive {
-			return specificStorage, nil
+	if c.sharedMem.isRelevant(c.ttl, *specific) {
+		if (*c.sharedMem)[specific.Key].Alive {
+			return specific, nil
 		}
-		tracelog.InfoLogger.Printf("Storage is dead in memory cache: %s", specificStorage.Name)
-		return nil, nil
+		tracelog.InfoLogger.Printf("Storage is dead in memory cache: %s", specific.Name)
 	}
 
-	oldFile, err := readFile()
-	if err != nil {
-		tracelog.WarningLogger.Printf("Failed to read cache file, it will be overwritten: %v", err)
-	}
-	if oldFile.isRelevant(c.ttl, *specificStorage) {
-		memCache[specificStorage.Key] = oldFile[specificStorage.Key]
-		if oldFile[specificStorage.Key].Alive {
-			tracelog.InfoLogger.Printf("Storage is alive in file cache: %s", specificStorage.Name)
-			return specificStorage, nil
+	var oldFile storageStatuses
+	if c.sharedFileUse {
+		oldFile, err = readFile(c.sharedFile)
+		if err != nil {
+			tracelog.WarningLogger.Printf("Failed to read cache file, it will be overwritten: %v", err)
 		}
-		tracelog.InfoLogger.Printf("Storage is dead in file cache: %s", specificStorage.Name)
-		return nil, nil
+	}
+	if oldFile.isRelevant(c.ttl, *specific) {
+		(*c.sharedMem)[specific.Key] = oldFile[specific.Key]
+		if oldFile[specific.Key].Alive {
+			tracelog.InfoLogger.Printf("Storage is alive in file cache: %s", specific.Name)
+			return specific, nil
+		}
+		tracelog.InfoLogger.Printf("Storage is dead in file cache: %s", specific.Name)
+	} else {
+		tracelog.InfoLogger.Printf("Storage status is outdated in file cache: %s", specific.Name)
 	}
 
-	tracelog.InfoLogger.Printf("Storage status cache is outdated, checking for alive again: %s", specificStorage.Name)
+	tracelog.InfoLogger.Printf("Checking for alive again: %s", specific.Name)
 
-	checkResult := c.checker.checkForAlive(*specificStorage)
+	checkResult := c.checker.checkForAlive(*specific)
 
 	newFile := updateFileContent(oldFile, checkResult)
-	err = writeFile(newFile)
-	if err != nil {
-		tracelog.WarningLogger.Printf("Failed to write cache file, each subsequent command will check the storages again: %v", err)
+	if c.sharedFileUse {
+		err = writeFile(c.sharedFile, newFile)
+		if err != nil {
+			tracelog.WarningLogger.Printf("Failed to write cache file, each subsequent command will check the storages again: %v", err)
+		}
 	}
 
-	memCache = newFile
-	if memCache[specificStorage.Key].Alive {
-		tracelog.InfoLogger.Printf("Storage is alive: %s", specificStorage.Name)
-		return specificStorage, nil
+	c.sharedMem = &newFile
+	if (*c.sharedMem)[specific.Key].Alive {
+		tracelog.InfoLogger.Printf("Storage is alive: %s", specific.Name)
+		return specific, nil
 	}
-	tracelog.InfoLogger.Printf("Storage is dead: %s", specificStorage.Name)
+	tracelog.InfoLogger.Printf("Storage is dead: %s", specific.Name)
 	return nil, nil
+}
+
+func storageWithName(storages []NamedFolder, name string) *NamedFolder {
+	for _, s := range storages {
+		if s.Name == name {
+			sCpy := s
+			return &sCpy
+		}
+	}
+	return nil
 }
 
 func storageNames(folders []NamedFolder) []string {

--- a/internal/multistorage/cache/status_cache_test.go
+++ b/internal/multistorage/cache/status_cache_test.go
@@ -144,7 +144,7 @@ func TestStatusCache_AllAliveStorages(t *testing.T) {
 		_, err := cache.AllAliveStorages()
 		require.NoError(t, err)
 
-		file, err := readFile(cache.sharedFile)
+		file, err := readFile(cache.sharedFilePath)
 		require.NoError(t, err)
 		assert.Equal(t, file, *cache.sharedMem)
 	})
@@ -176,10 +176,10 @@ func TestStatusCache_AllAliveStorages(t *testing.T) {
 
 	t.Run("do not fail if cannot read or write file", func(t *testing.T) {
 		cache := testCache(t, 2, true)
-		cache.sharedFile = path.Join(t.TempDir(), "non-accessible-file")
-		_, err := os.Create(cache.sharedFile)
+		cache.sharedFilePath = path.Join(t.TempDir(), "non-accessible-file")
+		_, err := os.Create(cache.sharedFilePath)
 		require.NoError(t, err)
-		err = os.Chmod(cache.sharedFile, 0000)
+		err = os.Chmod(cache.sharedFilePath, 0000)
 		require.NoError(t, err)
 
 		_, err = cache.AllAliveStorages()
@@ -346,10 +346,10 @@ func TestStatusCache_FirstAliveStorage(t *testing.T) {
 
 	t.Run("do not fail if cannot read or write file", func(t *testing.T) {
 		cache := testCache(t, 2, true)
-		cache.sharedFile = path.Join(t.TempDir(), "non-accessible-file")
-		_, err := os.Create(cache.sharedFile)
+		cache.sharedFilePath = path.Join(t.TempDir(), "non-accessible-file")
+		_, err := os.Create(cache.sharedFilePath)
 		require.NoError(t, err)
-		err = os.Chmod(cache.sharedFile, 0000)
+		err = os.Chmod(cache.sharedFilePath, 0000)
 		require.NoError(t, err)
 
 		_, err = cache.FirstAliveStorage()
@@ -490,10 +490,10 @@ func TestStatusCache_SpecificStorage(t *testing.T) {
 
 	t.Run("do not fail if cannot read or write file", func(t *testing.T) {
 		cache := testCache(t, 2, true)
-		cache.sharedFile = path.Join(t.TempDir(), "non-accessible-file")
-		_, err := os.Create(cache.sharedFile)
+		cache.sharedFilePath = path.Join(t.TempDir(), "non-accessible-file")
+		_, err := os.Create(cache.sharedFilePath)
 		require.NoError(t, err)
-		err = os.Chmod(cache.sharedFile, 0000)
+		err = os.Chmod(cache.sharedFilePath, 0000)
 		require.NoError(t, err)
 
 		_, err = cache.SpecificStorage("default")
@@ -556,18 +556,18 @@ func getFromMem(t *testing.T, cache *statusCache, storage string) status {
 }
 
 func setInFile(t *testing.T, cache *statusCache, storage string, alive bool, checked time.Time) {
-	file, _ := readFile(cache.sharedFile)
+	file, _ := readFile(cache.sharedFilePath)
 	k := storageKey(t, cache, storage)
 	if file == nil {
 		file = map[key]status{}
 	}
 	file[k] = status{alive, checked}
-	err := writeFile(cache.sharedFile, file)
+	err := writeFile(cache.sharedFilePath, file)
 	require.NoError(t, err)
 }
 
 func getFromFile(t *testing.T, cache *statusCache, storage string) status {
-	file, err := readFile(cache.sharedFile)
+	file, err := readFile(cache.sharedFilePath)
 	require.NoError(t, err)
 	k := storageKey(t, cache, storage)
 	s, ok := file[k]


### PR DESCRIPTION
In several previous PRs I introduced the failover storages feature, which allows to use multiple storages with different priorities so if the first storage is dead, the second can be used.

In that code, repetative checks and caching is used: if the requested storage status is outdated in the cache, a special requests would be performed to check if the storage is alive.

However, there was a problem: if all configured storages are dead, all these negative statuses are cached. And nothing works until the cache gets expired. The cache TTL is configurable, but the default value is 15min, and it may take less time for some storage to become alive.

In this PR I changed the logic a little. Any time the requested storages are dead, they are checked again. So caching is actually used only if there're some alive storages.

I also rewrote tests for `multistorage.cache.StatusCache` because the previous version was hard to read and append.