### PR TITLE
Chec AO/AOCS table EOF

### DIFF
--- a/cmd/gp/check_ao_length.go
+++ b/cmd/gp/check_ao_length.go
@@ -1,0 +1,27 @@
+package gp
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+)
+
+var (
+	logsDir string
+)
+
+var checkAOTableLengthMasterCmd = &cobra.Command{
+	Use:   "check-ao-aocs-length",
+	Short: "Runs on master and checks ao and aocs tables` EOF on disk is no less than in metadata for all segments",
+	Run: func(cmd *cobra.Command, args []string) {
+		handler, err := greenplum.NewAOLengthCheckHandler(logsDir)
+		tracelog.ErrorLogger.FatalOnError(err)
+		handler.CheckAOTableLength()
+	},
+}
+
+func init() {
+	checkAOLengthSegmentCmd.PersistentFlags().StringVarP(&logsDir, "logs", "l", "/var/log/greenplum", `TODO`)
+
+	cmd.AddCommand(checkAOTableLengthMasterCmd)
+}

--- a/cmd/gp/check_ao_length_segment.go
+++ b/cmd/gp/check_ao_length_segment.go
@@ -1,0 +1,29 @@
+package gp
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+)
+
+var (
+	port   string
+	segnum string
+)
+
+var checkAOLengthSegmentCmd = &cobra.Command{
+	Use:   "check-ao-aocs-length-segment",
+	Short: "Checks ao and aocs tables` EOF on disk is no less than in metadata for current segment",
+	Run: func(cmd *cobra.Command, args []string) {
+		handler, err := greenplum.NewAOLengthCheckSegmentHandler(port, segnum)
+		tracelog.ErrorLogger.FatalOnError(err)
+		handler.CheckAOTableLengthSegment()
+	},
+}
+
+func init() {
+	checkAOLengthSegmentCmd.PersistentFlags().StringVarP(&port, "port", "p", "5432", `database port (default: "5432")`)
+	checkAOLengthSegmentCmd.PersistentFlags().StringVarP(&segnum, "segnum", "s", "", `database segment number`)
+
+	cmd.AddCommand(checkAOLengthSegmentCmd)
+}

--- a/internal/databases/greenplum/ao_check_length_handler.go
+++ b/internal/databases/greenplum/ao_check_length_handler.go
@@ -19,7 +19,7 @@ func NewAOLengthCheckHandler(logsDir string) (*AOLengthCheckHandler, error) {
 	return &AOLengthCheckHandler{logsDir: logsDir}, nil
 }
 
-func (h *AOLengthCheckHandler) CheckAOTableLength() {
+func (checker *AOLengthCheckHandler) CheckAOTableLength() {
 	conn, err := postgres.Connect()
 	if err != nil {
 		tracelog.ErrorLogger.FatalfOnError("unable to get connection %v", err)
@@ -60,7 +60,7 @@ func buildCheckAOLengthCmd(contentID int, globalCluster *cluster.Cluster) string
 
 	backupPushArgs := []string{
 		fmt.Sprintf("--port=%d", segment.Port),
-		fmt.Sprintf("--segnum=%d", segment.ContentID+1),
+		fmt.Sprintf("--segnum=%d", segment.ContentID),
 	}
 
 	backupPushArgsLine := strings.Join(backupPushArgs, " ")

--- a/internal/databases/greenplum/ao_check_length_handler.go
+++ b/internal/databases/greenplum/ao_check_length_handler.go
@@ -1,0 +1,83 @@
+package greenplum
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/postgres"
+)
+
+type AOLengthCheckHandler struct {
+	logsDir string
+}
+
+func NewAOLengthCheckHandler(logsDir string) (*AOLengthCheckHandler, error) {
+	initGpLog(logsDir)
+	return &AOLengthCheckHandler{logsDir: logsDir}, nil
+}
+
+func (h *AOLengthCheckHandler) CheckAOTableLength() {
+	conn, err := postgres.Connect()
+	if err != nil {
+		tracelog.ErrorLogger.FatalfOnError("unable to get connection %v", err)
+	}
+	defer func() {
+		err := conn.Close()
+		if err != nil {
+			tracelog.ErrorLogger.Printf("failed to close connection %v", err)
+		}
+	}()
+
+	globalCluster, _, _, err := getGpClusterInfo(conn)
+	if err != nil {
+		tracelog.ErrorLogger.FatalfOnError("could not get cluster info %v", err)
+	}
+
+	remoteOutput := globalCluster.GenerateAndExecuteCommand("Run ao/aocs table length check",
+		cluster.ON_SEGMENTS,
+		func(contentID int) string {
+			return buildCheckAOLengthCmd(contentID, globalCluster)
+		})
+
+	for _, command := range remoteOutput.Commands {
+		if command.Error != nil {
+			tracelog.ErrorLogger.Printf("error (segment %d):\n%v\n%s\n", command.Content, command.Error, command.Stderr)
+		}
+	}
+
+	if remoteOutput.NumErrors > 0 {
+		tracelog.ErrorLogger.Fatalln("failed check")
+	} else {
+		tracelog.InfoLogger.Println("check passed")
+	}
+}
+
+func buildCheckAOLengthCmd(contentID int, globalCluster *cluster.Cluster) string {
+	segment := globalCluster.ByContent[contentID][0]
+
+	backupPushArgs := []string{
+		fmt.Sprintf("--port=%d", segment.Port),
+		fmt.Sprintf("--segnum=%d", segment.ContentID+1),
+	}
+
+	backupPushArgsLine := strings.Join(backupPushArgs, " ")
+
+	cmd := []string{
+		// nohup to avoid the SIGHUP on SSH session disconnect
+		"nohup", "wal-g",
+		// config for wal-g
+		fmt.Sprintf("--config=%s", internal.CfgFile),
+		// method
+		"c",
+		// actual arguments to be passed to the backup-push command
+		backupPushArgsLine,
+		// forward stdout and stderr to the log file
+		"&>>", formatSegmentLogPath(contentID),
+	}
+	cmdLine := strings.Join(cmd, " ")
+	tracelog.InfoLogger.Printf("Command to run on segment %d: %s", contentID, cmdLine)
+	return cmdLine
+}

--- a/internal/databases/greenplum/ao_check_length_handler.go
+++ b/internal/databases/greenplum/ao_check_length_handler.go
@@ -71,7 +71,7 @@ func buildCheckAOLengthCmd(contentID int, globalCluster *cluster.Cluster) string
 		// config for wal-g
 		fmt.Sprintf("--config=%s", internal.CfgFile),
 		// method
-		"c",
+		"check-ao-aocs-length-segment",
 		// actual arguments to be passed to the backup-push command
 		backupPushArgsLine,
 		// forward stdout and stderr to the log file

--- a/internal/databases/greenplum/ao_check_segment_length_handler.go
+++ b/internal/databases/greenplum/ao_check_segment_length_handler.go
@@ -1,0 +1,191 @@
+package greenplum
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/pgtype"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/postgres"
+)
+
+type DBInfo struct {
+	DBName string
+	Oid    pgtype.OID
+}
+
+type RelNames struct {
+	FileName   pgtype.OID
+	TableName  string
+	SegRelName string
+	Size       int64
+}
+
+type AOLengthCheckSegmentHandler struct {
+	port   string
+	segnum string
+}
+
+func NewAOLengthCheckSegmentHandler(port, segnum string) (*AOLengthCheckSegmentHandler, error) {
+	return &AOLengthCheckSegmentHandler{
+		port:   port,
+		segnum: segnum}, nil
+}
+
+func (h *AOLengthCheckSegmentHandler) CheckAOTableLengthSegment() {
+	initialConn, err := postgres.Connect(func(config *pgx.ConnConfig) error {
+		a, err := strconv.Atoi(h.port)
+		if err != nil {
+			return err
+		}
+		config.Port = uint16(a)
+		return nil
+	})
+	if err != nil {
+		tracelog.ErrorLogger.FatalfOnError("unable to get connection %v", err)
+	}
+
+	DBNames, err := h.GetDatabasesInfo(initialConn)
+	if err != nil {
+		tracelog.ErrorLogger.FatalfOnError("unable to list databases %v", err)
+	}
+
+	//connection needs to be closed to prevent conflicts when opening another
+	err = initialConn.Close()
+	if err != nil {
+		tracelog.WarningLogger.Println("failed close conn")
+	}
+
+	for _, db := range DBNames {
+		tracelog.DebugLogger.Println(db.DBName)
+		conn, err := postgres.Connect(func(config *pgx.ConnConfig) error {
+			a, err := strconv.Atoi(h.port)
+			if err != nil {
+				return err
+			}
+			config.Port = uint16(a)
+			config.Database = db.DBName
+			return nil
+		})
+		if err != nil {
+			tracelog.ErrorLogger.FatalfOnError("unable to get connection %v", err)
+		}
+
+		rows, err := conn.Query(`SELECT a.relfilenode file, a.relname tname, b.relname segname 
+	FROM (SELECT relname, relid, segrelid, relpersistence, relfilenode FROM pg_class JOIN pg_appendonly ON oid = relid) a,
+	(SELECT relname, segrelid FROM pg_class JOIN pg_appendonly ON oid = segrelid) b
+	WHERE a.relpersistence = 'p' AND a.segrelid = b.segrelid;`)
+
+		if err != nil {
+			tracelog.ErrorLogger.FatalfOnError("unable to get ao/aocs tables %v", err)
+		}
+		defer rows.Close()
+
+		AOTables := make([]RelNames, 0)
+		for rows.Next() {
+			row := RelNames{}
+			if err := rows.Scan(&row.FileName, &row.TableName, &row.SegRelName); err != nil {
+				tracelog.ErrorLogger.FatalfOnError("unable to parse query output %v", err)
+			}
+			AOTables = append(AOTables, row)
+		}
+
+		AOTablesSize := make(map[string]RelNames, 0)
+		for _, table := range AOTables {
+			table.Size, err = h.GetTableMetadataEOF(table, conn)
+			if err != nil {
+				tracelog.ErrorLogger.FatalfOnError("unable to get table metadata %v", err)
+			}
+			AOTablesSize[fmt.Sprintf("%d", table.FileName)] = table
+			tracelog.DebugLogger.Printf("table: %s size: %d", table.TableName, table.Size)
+		}
+
+		tracelog.DebugLogger.Printf("AO/AOCS relations in db: %d", len(AOTablesSize))
+
+		entries, err := os.ReadDir(fmt.Sprintf("/var/lib/greenplum/data1/primary/%s/base/%d/", fmt.Sprintf("gpseg%s", h.segnum), db.Oid))
+		if err != nil {
+			tracelog.ErrorLogger.FatalfOnError("unable to list tables` file directory %v", err)
+		}
+
+		for _, file := range entries {
+			parts := strings.Split(file.Name(), ".")
+			f, err := file.Info()
+			if err != nil {
+				tracelog.ErrorLogger.FatalfOnError("unable to get file data %v", err)
+			}
+			if !f.IsDir() {
+				tem, ok := AOTablesSize[parts[0]]
+				if !ok {
+					tracelog.DebugLogger.Printf("no metadata for file %s", parts[0])
+					continue
+				}
+				tracelog.DebugLogger.Printf("found file for table: %s with size: %d", tem.TableName, f.Size())
+				tem.Size -= f.Size()
+				AOTablesSize[parts[0]] = tem
+			}
+		}
+
+		errors := make([]string, 0)
+		for _, v := range AOTablesSize {
+			if v.Size > 0 {
+				errors = append(errors, fmt.Sprintf("file for table %s is shorter than expected for %d", v.TableName, v.Size))
+			}
+		}
+		if len(errors) > 0 {
+			tracelog.ErrorLogger.Fatalf("check failed, tables files are too short:\n%s\n", strings.Join(errors, "\n"))
+		}
+
+		err = conn.Close()
+		if err != nil {
+			tracelog.WarningLogger.Println("failed to close connection")
+		}
+	}
+
+}
+
+func (h *AOLengthCheckSegmentHandler) GetDatabasesInfo(conn *pgx.Conn) ([]DBInfo, error) {
+	rows, err := conn.Query("SELECT datname, oid FROM pg_database WHERE datallowconn")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	names := make([]DBInfo, 0)
+	for rows.Next() {
+		tem := DBInfo{}
+		if err = rows.Scan(&tem.DBName, &tem.Oid); err != nil {
+			return nil, err
+		}
+		tracelog.DebugLogger.Printf("existing table: %s oid: %d", tem.DBName, tem.Oid)
+		names = append(names, tem)
+	}
+
+	return names, nil
+}
+
+func (h *AOLengthCheckSegmentHandler) GetTableMetadataEOF(row RelNames, conn *pgx.Conn) (int64, error) {
+	query := ""
+	if !strings.Contains(row.SegRelName, "aocs") {
+		query = fmt.Sprintf("SELECT sum(eofuncompressed) FROM pg_aoseg.%s", row.SegRelName)
+	} else {
+		query = fmt.Sprintf("SELECT sum(eof_uncompressed) FROM gp_toolkit.__gp_aocsseg('\"%s\"')", row.TableName)
+	}
+
+	// get expected size of table in metadata
+	size, err := conn.Query(query)
+	if err != nil {
+		return 0, err
+	}
+	defer size.Close()
+	var metaEOF int64
+	for size.Next() {
+		err = size.Scan(&metaEOF)
+		if err != nil {
+			metaEOF = int64(0)
+		}
+	}
+	return metaEOF, nil
+}

--- a/internal/databases/greenplum/ao_check_segment_length_handler.go
+++ b/internal/databases/greenplum/ao_check_segment_length_handler.go
@@ -99,6 +99,7 @@ func (checker *AOLengthCheckSegmentHandler) CheckAOTableLengthSegment() {
 			tracelog.WarningLogger.Println("failed to close connection")
 		}
 	}
+	tracelog.InfoLogger.Println("check passed")
 }
 
 func (checker *AOLengthCheckSegmentHandler) checkFileSizes(AOTablesSize map[string]RelNames) []string {


### PR DESCRIPTION
Greenplum

Added commands to check that AO/AOCS table's actual EOF is no less than in metadata

Usage:
on master - wal-g check-ao-aocs-length --logs=logs_path
on segment - wal-g check-ao-aocs-length-segment --port=6000 --segnum=0
