### PR TITLE
Fix delete garbage in gp

### DIFF
--- a/docker/gp_tests/scripts/tests/test_functions/util.sh
+++ b/docker/gp_tests/scripts/tests/test_functions/util.sh
@@ -51,7 +51,7 @@ cleanup() {
 }
 
 stop_cluster() {
-  /usr/local/gpdb_src/bin/gpstop -a -M immediate
+  /usr/local/gpdb_src/bin/gpstop -a -M fast
 }
 
 start_cluster() {

--- a/internal/databases/greenplum/backup.go
+++ b/internal/databases/greenplum/backup.go
@@ -28,24 +28,6 @@ func NewBackup(rootFolder storage.Folder, name string) (Backup, error) {
 	}, nil
 }
 
-func NewBackupInStorage(baseBackupFolder storage.Folder, name, storage string) (Backup, error) {
-	backup, err := internal.NewBackupInStorage(baseBackupFolder, name, storage)
-	if err != nil {
-		return Backup{}, err
-	}
-	return Backup{Backup: backup}, nil
-}
-
-func (backup *Backup) FetchMeta() (postgres.ExtendedMetadataDto, error) {
-	extendedMetadataDto := postgres.ExtendedMetadataDto{}
-	err := backup.FetchMetadata(&extendedMetadataDto)
-	if err != nil {
-		return postgres.ExtendedMetadataDto{}, err
-	}
-
-	return extendedMetadataDto, nil
-}
-
 func (backup *Backup) GetSentinel() (BackupSentinelDto, error) {
 	if backup.SentinelDto != nil {
 		return *backup.SentinelDto, nil

--- a/internal/databases/greenplum/backup.go
+++ b/internal/databases/greenplum/backup.go
@@ -28,6 +28,24 @@ func NewBackup(rootFolder storage.Folder, name string) (Backup, error) {
 	}, nil
 }
 
+func NewBackupInStorage(baseBackupFolder storage.Folder, name, storage string) (Backup, error) {
+	backup, err := internal.NewBackupInStorage(baseBackupFolder, name, storage)
+	if err != nil {
+		return Backup{}, err
+	}
+	return Backup{Backup: backup}, nil
+}
+
+func (backup *Backup) FetchMeta() (postgres.ExtendedMetadataDto, error) {
+	extendedMetadataDto := postgres.ExtendedMetadataDto{}
+	err := backup.FetchMetadata(&extendedMetadataDto)
+	if err != nil {
+		return postgres.ExtendedMetadataDto{}, err
+	}
+
+	return extendedMetadataDto, nil
+}
+
 func (backup *Backup) GetSentinel() (BackupSentinelDto, error) {
 	if backup.SentinelDto != nil {
 		return *backup.SentinelDto, nil

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -248,6 +248,55 @@ func FindRestorePointBeforeTS(timestampStr string, folder storage.Folder) (strin
 	return targetPoint.Name, nil
 }
 
+func FindRestorePointAfterTS(timestampStr string, folder storage.Folder) (string, error) {
+	ts, err := time.Parse(time.RFC3339, timestampStr)
+	if err != nil {
+		return "", fmt.Errorf("timestamp parse error: %v", err)
+	}
+	//add second because we loose milliseconds when formatting
+	ts = ts.Add(time.Second)
+
+	restorePointTimes, err := GetRestorePoints(folder.GetSubFolder(utility.BaseBackupPath))
+	if err != nil {
+		return "", err
+	}
+
+	restorePointMetas := make([]RestorePointMetadata, 0)
+	for _, rp := range restorePointTimes {
+		meta, err := FetchRestorePointMetadata(folder, rp.Name)
+		if err != nil {
+			return "", fmt.Errorf("fetch restore point %s metadata: %v", rp.Name, err)
+		}
+
+		restorePointMetas = append(restorePointMetas, meta)
+	}
+
+	var targetPoint *RestorePointMetadata
+	for i := range restorePointMetas {
+		meta := restorePointMetas[i]
+		// target restore point should be started before or right at the provided ts
+		if meta.StartTime.After(ts) {
+			tracelog.InfoLogger.Printf("restore point %s is to late for %s because %s", meta.Name, ts, meta.StartTime)
+			continue
+		}
+
+		tracelog.InfoLogger.Printf("restore point %s is ok for %s because %s", meta.Name, ts, meta.StartTime)
+
+		// we choose the restore point closest to the provided time
+		if targetPoint == nil || meta.StartTime.After(targetPoint.StartTime) {
+			targetPoint = &meta
+		}
+	}
+
+	if targetPoint == nil {
+		return "", NewNoRestorePointsFoundError()
+	}
+
+	tracelog.InfoLogger.Printf("Found restore point %s with start time %s, closest to the provided time %s",
+		targetPoint.Name, targetPoint.StartTime, ts)
+	return targetPoint.Name, nil
+}
+
 // GetRestorePoints receives restore points descriptions and sorts them by time
 func GetRestorePoints(folder storage.Folder) (restorePoints []RestorePointTime, err error) {
 	restorePointsObjects, _, err := folder.ListFolder()

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -248,12 +248,13 @@ func FindRestorePointBeforeTS(timestampStr string, folder storage.Folder) (strin
 	return targetPoint.Name, nil
 }
 
-func FindRestorePointAfterTS(timestampStr string, folder storage.Folder) (string, error) {
+// Finds restore point that contains timestamp
+func FindRestorePointWithTS(timestampStr string, folder storage.Folder) (string, error) {
 	ts, err := time.Parse(time.RFC3339, timestampStr)
 	if err != nil {
 		return "", fmt.Errorf("timestamp parse error: %v", err)
 	}
-	//add second because we loose milliseconds when formatting
+	// add second because we round down when formatting
 	ts = ts.Add(time.Second)
 
 	restorePointTimes, err := GetRestorePoints(folder.GetSubFolder(utility.BaseBackupPath))
@@ -276,11 +277,8 @@ func FindRestorePointAfterTS(timestampStr string, folder storage.Folder) (string
 		meta := restorePointMetas[i]
 		// target restore point should be started before or right at the provided ts
 		if meta.StartTime.After(ts) {
-			tracelog.InfoLogger.Printf("restore point %s is to late for %s because %s", meta.Name, ts, meta.StartTime)
 			continue
 		}
-
-		tracelog.InfoLogger.Printf("restore point %s is ok for %s because %s", meta.Name, ts, meta.StartTime)
 
 		// we choose the restore point closest to the provided time
 		if targetPoint == nil || meta.StartTime.After(targetPoint.StartTime) {

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -276,12 +276,12 @@ func FindRestorePointWithTS(timestampStr string, folder storage.Folder) (string,
 	for i := range restorePointMetas {
 		meta := restorePointMetas[i]
 		// target restore point should be started before or right at the provided ts
-		if meta.StartTime.After(ts) {
+		if meta.FinishTime.Before(ts) {
 			continue
 		}
 
 		// we choose the restore point closest to the provided time
-		if targetPoint == nil || meta.StartTime.After(targetPoint.StartTime) {
+		if targetPoint == nil || meta.FinishTime.Before(targetPoint.FinishTime) {
 			targetPoint = &meta
 		}
 	}

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -275,7 +275,7 @@ func FindRestorePointWithTS(timestampStr string, folder storage.Folder) (string,
 	var targetPoint *RestorePointMetadata
 	for i := range restorePointMetas {
 		meta := restorePointMetas[i]
-		// target restore point should be started before or right at the provided ts
+		// target restore point should be finished after or right at the provided ts
 		if meta.FinishTime.Before(ts) {
 			continue
 		}

--- a/internal/databases/greenplum/segment_delete_handler.go
+++ b/internal/databases/greenplum/segment_delete_handler.go
@@ -134,9 +134,8 @@ func cleanupAOSegments(target internal.BackupObject, segFolder storage.Folder, c
 	return aoSegFolder.DeleteObjects(aoSegmentsToDelete)
 }
 
-func GetPermanentBackupsAndWals(rootFolder storage.Folder, contentID int) (
-	map[postgres.PermanentObject]bool, map[postgres.PermanentObject]bool) {
-
+func GetPermanentBackupsAndWals(rootFolder storage.Folder, contentID int) (map[postgres.PermanentObject]bool,
+	map[postgres.PermanentObject]bool) {
 	tracelog.InfoLogger.Println("retrieving permanent objects")
 	folder := rootFolder.GetSubFolder(FormatSegmentStoragePrefix(contentID))
 	backupTimes, err := internal.GetBackups(folder.GetSubFolder(utility.BaseBackupPath))

--- a/internal/databases/postgres/backup.go
+++ b/internal/databases/postgres/backup.go
@@ -356,8 +356,8 @@ func GetLastWalFilename(backup Backup) (string, error) {
 		tracelog.InfoLogger.FatalError(err)
 		return "", err
 	}
-	endWalSegmentNo := newWalSegmentNo(meta.FinishLsn - 1)
-	return endWalSegmentNo.getFilename(timelineID), nil
+	endWalSegmentNo := NewWalSegmentNo(meta.FinishLsn - 1)
+	return endWalSegmentNo.GetFilename(timelineID), nil
 }
 
 func DeduceBackupName(object storage.Object) string {

--- a/internal/databases/postgres/delete_util.go
+++ b/internal/databases/postgres/delete_util.go
@@ -44,11 +44,12 @@ func GetPermanentBackupsAndWals(folder storage.Folder) (map[PermanentObject]bool
 				continue
 			}
 
-			startWalSegmentNo := newWalSegmentNo(meta.StartLsn - 1)
-			endWalSegmentNo := newWalSegmentNo(meta.FinishLsn - 1)
-			for walSegmentNo := startWalSegmentNo; walSegmentNo <= endWalSegmentNo; walSegmentNo = walSegmentNo.next() {
+			startWalSegmentNo := NewWalSegmentNo(meta.StartLsn - 1)
+			endWalSegmentNo := NewWalSegmentNo(meta.FinishLsn - 1)
+
+			for walSegmentNo := startWalSegmentNo; walSegmentNo <= endWalSegmentNo; walSegmentNo = walSegmentNo.Next() {
 				walObj := PermanentObject{
-					Name:        walSegmentNo.getFilename(timelineID),
+					Name:        walSegmentNo.GetFilename(timelineID),
 					StorageName: backupTime.StorageName,
 				}
 				permanentWals[walObj] = true

--- a/internal/databases/postgres/delta_map_downloader.go
+++ b/internal/databases/postgres/delta_map_downloader.go
@@ -13,9 +13,9 @@ func getDeltaMap(reader internal.StorageFolderReader,
 	tracelog.InfoLogger.Printf("Timeline: %d, FirstUsedLsn: %s, FirstNotUsedLsn: %s\n",
 		timeline, firstUsedLSN, firstNotUsedLSN)
 	tracelog.InfoLogger.Printf("First WAL should participate in building delta map: %s",
-		newWalSegmentNo(firstUsedLSN).getFilename(timeline))
+		NewWalSegmentNo(firstUsedLSN).GetFilename(timeline))
 	tracelog.InfoLogger.Printf("First WAL shouldn't participate in building delta map: %s",
-		newWalSegmentNo(firstNotUsedLSN).getFilename(timeline))
+		NewWalSegmentNo(firstNotUsedLSN).GetFilename(timeline))
 	deltaMap := NewPagedFileDeltaMap()
 	firstUsedDeltaNo, firstNotUsedDeltaNo := getDeltaRange(firstUsedLSN, firstNotUsedLSN)
 	// Get locations from [firstUsedDeltaNo, lastUsedDeltaNo). We use lastUsedDeltaNo in next step
@@ -50,6 +50,6 @@ func getDeltaRange(firstUsedLsn, firstNotUsedLsn LSN) (DeltaNo, DeltaNo) {
 func getWalSegmentRange(firstNotUsedDeltaNo DeltaNo, firstNotUsedLsn LSN) (WalSegmentNo, WalSegmentNo) {
 	firstUsedWalSegmentNo := firstNotUsedDeltaNo.firstWalSegmentNo()
 	lastUsedLsn := firstNotUsedLsn - 1
-	lastUsedWalSegmentNo := newWalSegmentNo(lastUsedLsn)
-	return firstUsedWalSegmentNo, lastUsedWalSegmentNo.next()
+	lastUsedWalSegmentNo := NewWalSegmentNo(lastUsedLsn)
+	return firstUsedWalSegmentNo, lastUsedWalSegmentNo.Next()
 }

--- a/internal/databases/postgres/delta_map_downloader_test.go
+++ b/internal/databases/postgres/delta_map_downloader_test.go
@@ -11,7 +11,7 @@ func TestGetDeltaRange(t *testing.T) {
 	deltaNo000000010000011100000030 := deltaNo000000010000011100000020.next()
 
 	walSegNo000000010000011100000014, _ := newWalSegmentNoFromFilename("000000010000011100000014")
-	walSegNo000000010000011100000015 := walSegNo000000010000011100000014.next()
+	walSegNo000000010000011100000015 := walSegNo000000010000011100000014.Next()
 	walSegNo000000010000011100000009 := deltaNo000000010000011100000010.firstWalSegmentNo().previous()
 	type args struct {
 		firstUsedLsn    LSN
@@ -100,18 +100,18 @@ func TestGetWalSegmentRange(t *testing.T) {
 		{"firstNotUsedLsn is first Lsn in a WAL segment",
 			args{
 				deltaNo000000010000011100000009,
-				deltaNo000000010000011100000009.firstWalSegmentNo().next().firstLsn(),
+				deltaNo000000010000011100000009.firstWalSegmentNo().Next().firstLsn(),
 			},
 			deltaNo000000010000011100000009.firstWalSegmentNo(),
-			deltaNo000000010000011100000009.firstWalSegmentNo().next(),
+			deltaNo000000010000011100000009.firstWalSegmentNo().Next(),
 		},
 		{"firstNotUsedLsn is second Lsn in a WAL segment",
 			args{
 				deltaNo000000010000011100000009,
-				deltaNo000000010000011100000009.firstWalSegmentNo().next().firstLsn() + 1,
+				deltaNo000000010000011100000009.firstWalSegmentNo().Next().firstLsn() + 1,
 			},
 			deltaNo000000010000011100000009.firstWalSegmentNo(),
-			deltaNo000000010000011100000009.firstWalSegmentNo().next().next(),
+			deltaNo000000010000011100000009.firstWalSegmentNo().Next().Next(),
 		},
 		{"firstNotUsedLsn in the same WAL segment that is first WAL segment of firstNotUsedDeltaNo",
 			args{

--- a/internal/databases/postgres/delta_no.go
+++ b/internal/databases/postgres/delta_no.go
@@ -12,7 +12,7 @@ func newDeltaNoFromWalSegmentNo(walSegmentNo WalSegmentNo) DeltaNo {
 }
 
 func newDeltaNoFromLsn(lsn LSN) DeltaNo {
-	return newDeltaNoFromWalSegmentNo(newWalSegmentNo(lsn))
+	return newDeltaNoFromWalSegmentNo(NewWalSegmentNo(lsn))
 }
 
 func newDeltaNoFromFilename(filename string) (DeltaNo, error) {
@@ -47,5 +47,5 @@ func (deltaNo DeltaNo) firstLsn() LSN {
 }
 
 func (deltaNo DeltaNo) getFilename(timeline uint32) string {
-	return deltaNo.firstWalSegmentNo().getFilename(timeline) + DeltaFilenameSuffix
+	return deltaNo.firstWalSegmentNo().GetFilename(timeline) + DeltaFilenameSuffix
 }

--- a/internal/databases/postgres/integrity_check_runner.go
+++ b/internal/databases/postgres/integrity_check_runner.go
@@ -152,8 +152,8 @@ func newIntegrityScanSegmentSequence(sequence *WalSegmentsSequence,
 	status ScannedSegmentStatus) *IntegrityScanSegmentSequence {
 	return &IntegrityScanSegmentSequence{
 		TimelineID:    sequence.TimelineID,
-		StartSegment:  sequence.MinSegmentNo.getFilename(sequence.TimelineID),
-		EndSegment:    sequence.MaxSegmentNo.getFilename(sequence.TimelineID),
+		StartSegment:  sequence.MinSegmentNo.GetFilename(sequence.TimelineID),
+		EndSegment:    sequence.MaxSegmentNo.GetFilename(sequence.TimelineID),
 		Status:        status,
 		SegmentsCount: len(sequence.WalSegmentNumbers),
 	}
@@ -245,7 +245,7 @@ func getEarliestBackupStartSegmentNo(timelineSwitchMap map[WalSegmentNo]*Timelin
 	// switchLsnBySegNo is used for fast lookup of the timeline switch segment
 	switchLsnBySegNo := make(map[uint32]WalSegmentNo, len(timelineSwitchMap))
 	for _, historyRecord := range timelineSwitchMap {
-		switchLsnBySegNo[historyRecord.timeline] = newWalSegmentNo(historyRecord.lsn)
+		switchLsnBySegNo[historyRecord.timeline] = NewWalSegmentNo(historyRecord.lsn)
 	}
 	earliestBackup, earliestBackupSegNo, err :=
 		findEarliestBackup(currentTimeline, backupDetails, switchLsnBySegNo)

--- a/internal/databases/postgres/paged_file_delta_map.go
+++ b/internal/databases/postgres/paged_file_delta_map.go
@@ -161,8 +161,8 @@ func (deltaMap *PagedFileDeltaMap) getLocationsFromWals(reader internal.StorageF
 	first,
 	last WalSegmentNo,
 	walParser *walparser.WalParser) error {
-	for walSegmentNo := first; walSegmentNo < last; walSegmentNo = walSegmentNo.next() {
-		filename := walSegmentNo.getFilename(timeline)
+	for walSegmentNo := first; walSegmentNo < last; walSegmentNo = walSegmentNo.Next() {
+		filename := walSegmentNo.GetFilename(timeline)
 		err := deltaMap.getLocationsFromWal(reader, filename, walParser)
 		if err != nil {
 			return err

--- a/internal/databases/postgres/timeline.go
+++ b/internal/databases/postgres/timeline.go
@@ -91,9 +91,9 @@ func getWalFilename(lsn LSN, queryRunner *PgQueryRunner) (walFilename string, ti
 		return "", 0, err
 	}
 
-	walSegmentNo := newWalSegmentNo(lsn - 1)
+	walSegmentNo := NewWalSegmentNo(lsn - 1)
 
-	return walSegmentNo.getFilename(timeline), timeline, nil
+	return walSegmentNo.GetFilename(timeline), timeline, nil
 }
 
 func formatWALFileName(timeline uint32, logSegNo uint64) string {

--- a/internal/databases/postgres/timeline_history_record.go
+++ b/internal/databases/postgres/timeline_history_record.go
@@ -78,7 +78,7 @@ func createTimelineSwitchMap(startTimeline uint32,
 	}
 	// store records in a map for fast lookup by wal segment number
 	for _, record := range historyRecords {
-		walSegmentNo := newWalSegmentNo(record.lsn)
+		walSegmentNo := NewWalSegmentNo(record.lsn)
 		timeLineHistoryMap[walSegmentNo] = record
 	}
 	return timeLineHistoryMap, nil

--- a/internal/databases/postgres/wal_restore_handler.go
+++ b/internal/databases/postgres/wal_restore_handler.go
@@ -24,7 +24,7 @@ func NewTimelineWithSegmentNo(tl uint32, seg uint64) *TimelineWithSegmentNo {
 }
 
 func NewTimelineWithSegmentNoBy(record *TimelineHistoryRecord) *TimelineWithSegmentNo {
-	return NewTimelineWithSegmentNo(record.timeline, getSegmentNoFromLsn(record.lsn))
+	return NewTimelineWithSegmentNo(record.timeline, GetSegmentNoFromLsn(record.lsn))
 }
 
 // HandleWALRestore is invoked to perform wal-g wal-restore
@@ -66,7 +66,7 @@ func HandleWALRestore(targetPath, sourcePath string, cloudFolder storage.Folder)
 	walsByTimelines := groupSegmentsByTimelines(getSegmentsFromFiles(folderFilenames))
 
 	filenamesToRestore, err := GetMissingWals(
-		getSegmentNoFromLsn(lastCommonLsn), lastCommonTl,
+		GetSegmentNoFromLsn(lastCommonLsn), lastCommonTl,
 		sourcePgData.GetCurrentTimeline(), mapOfSrcTimelineWithSegNo, walsByTimelines)
 	tracelog.ErrorLogger.FatalfOnError("Failed to get missing source WALs: %v\n", err)
 
@@ -137,7 +137,7 @@ func GetMissingWals(lastSeg uint64, lastTl, currentTl uint32,
 		for ; currentSeg >= tlToSeg[currentTl].segmentNo; currentSeg-- {
 			// Making sure that this wal segment sequence is correct and check for existing segment
 			if !ok || !walSegSeq.WalSegmentNumbers[WalSegmentNo(currentSeg)] {
-				result = append(result, WalSegmentNo(currentSeg).getFilename(currentTl))
+				result = append(result, WalSegmentNo(currentSeg).GetFilename(currentTl))
 			}
 
 			if currentSeg == lastSeg {

--- a/internal/databases/postgres/wal_segment_no.go
+++ b/internal/databases/postgres/wal_segment_no.go
@@ -6,11 +6,11 @@ import (
 
 type WalSegmentNo uint64
 
-func newWalSegmentNo(lsn LSN) WalSegmentNo {
-	return WalSegmentNo(getSegmentNoFromLsn(lsn))
+func NewWalSegmentNo(lsn LSN) WalSegmentNo {
+	return WalSegmentNo(GetSegmentNoFromLsn(lsn))
 }
 
-func getSegmentNoFromLsn(lsn LSN) uint64 {
+func GetSegmentNoFromLsn(lsn LSN) uint64 {
 	return uint64(lsn) / WalSegmentSize
 }
 
@@ -19,7 +19,7 @@ func newWalSegmentNoFromFilename(filename string) (WalSegmentNo, error) {
 	return WalSegmentNo(no), err
 }
 
-func (walSegmentNo WalSegmentNo) next() WalSegmentNo {
+func (walSegmentNo WalSegmentNo) Next() WalSegmentNo {
 	return walSegmentNo.add(1)
 }
 
@@ -39,7 +39,7 @@ func (walSegmentNo WalSegmentNo) firstLsn() LSN {
 	return LSN(uint64(walSegmentNo) * WalSegmentSize)
 }
 
-func (walSegmentNo WalSegmentNo) getFilename(timeline uint32) string {
+func (walSegmentNo WalSegmentNo) GetFilename(timeline uint32) string {
 	return fmt.Sprintf(walFileFormat,
 		timeline, uint64(walSegmentNo)/xLogSegmentsPerXLogID,
 		uint64(walSegmentNo)%xLogSegmentsPerXLogID)

--- a/internal/databases/postgres/wal_segment_runner.go
+++ b/internal/databases/postgres/wal_segment_runner.go
@@ -48,7 +48,7 @@ func NewWalSegmentDescription(name string) (WalSegmentDescription, error) {
 }
 
 func (desc WalSegmentDescription) GetFileName() string {
-	return desc.Number.getFilename(desc.Timeline)
+	return desc.Number.GetFilename(desc.Timeline)
 }
 
 // WalSegmentRunner is used for sequential iteration over WAL segments in the storage

--- a/internal/databases/postgres/wal_show_handler.go
+++ b/internal/databases/postgres/wal_show_handler.go
@@ -31,8 +31,8 @@ type TimelineInfo struct {
 func NewTimelineInfo(walSegments *WalSegmentsSequence, historyRecords []*TimelineHistoryRecord) (*TimelineInfo, error) {
 	timelineInfo := &TimelineInfo{
 		ID:               walSegments.TimelineID,
-		StartSegment:     walSegments.MinSegmentNo.getFilename(walSegments.TimelineID),
-		EndSegment:       walSegments.MaxSegmentNo.getFilename(walSegments.TimelineID),
+		StartSegment:     walSegments.MinSegmentNo.GetFilename(walSegments.TimelineID),
+		EndSegment:       walSegments.MaxSegmentNo.GetFilename(walSegments.TimelineID),
 		SegmentsCount:    len(walSegments.WalSegmentNumbers),
 		SegmentRangeSize: uint64(walSegments.MaxSegmentNo-walSegments.MinSegmentNo) + 1,
 		Status:           TimelineOkStatus,
@@ -198,8 +198,8 @@ func getBackupsInRange(startSegmentName, endSegmentName string, timeline uint32,
 		if err != nil {
 			return nil, err
 		}
-		startSegment := newWalSegmentNo(backup.StartLsn).getFilename(backupTimeline)
-		endSegment := newWalSegmentNo(backup.FinishLsn).getFilename(backupTimeline)
+		startSegment := NewWalSegmentNo(backup.StartLsn).GetFilename(backupTimeline)
+		endSegment := NewWalSegmentNo(backup.FinishLsn).GetFilename(backupTimeline)
 
 		// there we compare segments lexicographically, maybe it is wrong...
 		if timeline == backupTimeline && startSegment >= startSegmentName && endSegment <= endSegmentName {

--- a/internal/databases/postgres/wal_verify_handler.go
+++ b/internal/databases/postgres/wal_verify_handler.go
@@ -96,7 +96,7 @@ func QueryCurrentWalSegment() WalSegmentDescription {
 	currentTimeline, err := queryRunner.readTimeline()
 	tracelog.ErrorLogger.FatalfOnError("Failed to get current timeline %v", err)
 
-	tracelog.InfoLogger.Printf("Current WAL segment: %s\n", currentSegmentNo.getFilename(currentTimeline))
+	tracelog.InfoLogger.Printf("Current WAL segment: %s\n", currentSegmentNo.GetFilename(currentTimeline))
 
 	err = conn.Close()
 	tracelog.WarningLogger.PrintOnError(err)
@@ -170,5 +170,5 @@ func getCurrentWalSegmentNo(queryRunner *PgQueryRunner) (WalSegmentNo, error) {
 	if err != nil {
 		return 0, err
 	}
-	return newWalSegmentNo(lsn - 1), nil
+	return NewWalSegmentNo(lsn - 1), nil
 }


### PR DESCRIPTION
### Database name
Greenplum

# Pull request description
When we call delete garbage for greenplum, it sorts wals by timestamp. But for permanent backups restore point could be in later wal. So I changed time check to segment lsn check from restore point metadata
Also changed gpstop  -M flag from "immediate" to "fast" to prevent data loss