### PR TITLE
propagate error from ParseLSN function

### DIFF
--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
@@ -99,9 +100,6 @@ func GetBackups(folder storage.Folder) (backups []BackupTime, err error) {
 	}
 
 	backups = GetBackupTimeSlices(backupObjects)
-	if err != nil {
-		return nil, err
-	}
 
 	count := len(backups)
 	if count == 0 {

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -15,6 +15,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/jackc/pgx"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/utility"
@@ -303,9 +304,6 @@ func GetRestorePoints(folder storage.Folder) (restorePoints []RestorePointTime, 
 	}
 
 	restorePoints = GetRestorePointsTimeSlices(restorePointsObjects)
-	if err != nil {
-		return nil, err
-	}
 
 	count := len(restorePoints)
 	if count == 0 {

--- a/internal/databases/postgres/lsn.go
+++ b/internal/databases/postgres/lsn.go
@@ -11,7 +11,7 @@ func (lsn LSN) String() string {
 func ParseLSN(s string) (LSN, error) {
 	lsn, err := pgx.ParseLSN(s)
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 
 	return LSN(lsn), nil

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -508,7 +508,12 @@ func GetBackupProperties(db *sql.DB,
 	if err != nil {
 		return res, err
 	}
-	defer rows.Close()
+	defer func() {
+		err := rows.Close()
+		if err != nil {
+			tracelog.ErrorLogger.Printf("failed to close connection: %v", err)
+		}
+	}()
 	for rows.Next() {
 		var dbf BackupProperties
 		err = utility.ScanToMap(rows, map[string]interface{}{

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/sqlserver/blob"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -508,9 +509,6 @@ func GetBackupProperties(db *sql.DB,
 		return res, err
 	}
 	defer rows.Close()
-	if err != nil {
-		return nil, err
-	}
 	for rows.Next() {
 		var dbf BackupProperties
 		err = utility.ScanToMap(rows, map[string]interface{}{


### PR DESCRIPTION
### Context
I ran [govanish](https://github.com/sivukhin/govanish) linter (it still in the WIP phase) against `wal-g` repo and it found suspicious issue: compiler eliminates a lot of err checks after `ParseLSN` function like this:
```go
lsn, err := ParseLSN(lsnStr)
if err != nil {
	return "", nil, 0, errors.Wrap(err, "UploadLabelFiles: failed to parse finish LSN")
}
```

```
2023/12/24 15:38:26 it seems like your code vanished from compiled binary: func=[StartBackup], file=[/home/sivukhin/code/wal-g/internal/databases/postgres/bundle.go], line=[156], snippet:
	return "", 0, err
```

Compiler is right here - because `ParseLSN` function always return `nil` for error. There are quite a lot of code which handle potential error from `ParseLSN` function and it can really fail for incorrect log sequence numbers - so this looks like a bug. 

### Changes

This PR propagate error from `pgx.ParseLSN`.

Also, I removed several useless errchecks detected by `govanish`.
