### PR TITLE
Fix closing SSH storage + log conection errors

### DIFF
--- a/pkg/storages/sh/sftp_lazy.go
+++ b/pkg/storages/sh/sftp_lazy.go
@@ -53,12 +53,12 @@ func (l *SFTPLazy) Client() (SFTPClient, error) {
 func connect(addr string, config *ssh.ClientConfig) (*sftp.Client, error) {
 	sshClient, err := ssh.Dial("tcp", addr, config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to %s via SSH", addr)
+		return nil, fmt.Errorf("failed to connect to %s via SSH: %w", addr, err)
 	}
 
 	sftpClient, err := sftp.NewClient(sshClient)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to %s via SFTP", addr)
+		return nil, fmt.Errorf("failed to connect to %s via SFTP: %w", addr, err)
 	}
 
 	return sftpClient, nil

--- a/pkg/storages/sh/storage.go
+++ b/pkg/storages/sh/storage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"golang.org/x/crypto/ssh"
 )
@@ -82,13 +83,16 @@ func (s *Storage) ConfigHash() string {
 }
 
 func (s *Storage) Close() error {
-	client, _ := s.sftpClientLazy.Client()
-	if client == nil {
+	client, connErr := s.sftpClientLazy.Client()
+	// Don't try to close the client if the initial connection failed
+	if connErr != nil {
+		tracelog.DebugLogger.Printf("SSH storage isn't closed due to the initial connection error: %v", connErr)
 		return nil
 	}
 	err := client.Close()
 	if err != nil {
 		return fmt.Errorf("close SFTP client: %w", err)
 	}
+	tracelog.DebugLogger.Printf("SSH storage closed")
 	return nil
 }


### PR DESCRIPTION
When failover storages are used in PG, WAL-G panics when trying to close the SSH storage in case there's an error during the initial connection.

In this PR I've fixed these panics + added logging of initial connection errors.