### PR TITLE
fixed sequential tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ pg_integration_test: clean_compose
 		docker-compose up --exit-code-from pg_storage_swift_test pg_storage_swift_test &&\
 		docker-compose up --exit-code-from pg_storage_ssh_test pg_storage_ssh_test &&\
 		docker-compose up --exit-code-from pg_pgbackrest_backup_fetch_test pg_pgbackrest_backup_fetch_test &&\
-		docker-compose down s3 &&\
+		docker-compose down &&\
 		sleep 5 &&\
 		docker-compose up --exit-code-from pg_wal_perftest_with_throttling pg_wal_perftest_with_throttling ;\
 	fi


### PR DESCRIPTION
Currently cron action for tests fail because we need to kill old s3 container before launch new in sequential tests