### PR TITLE
Fix "SOMEVAR is unkown" warning for non-PostgreSQL backups

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -240,9 +240,6 @@ var (
 		MaxDelayedSegmentsCount:        "0",
 		SerializerTypeSetting:          "json_default",
 		LibsodiumKeyTransform:          "none",
-		PgFailoverStoragesCheckTimeout: "30s",
-		PgFailoverStorageCacheLifetime: "15m",
-		PgpEnvelopeCacheExpiration:     "0",
 	}
 
 	MongoDefaultSettings = map[string]string{
@@ -267,11 +264,14 @@ var (
 	}
 
 	PGDefaultSettings = map[string]string{
-		PgWalSize:                   "16",
-		PgBackRestStanza:            "main",
-		PgAliveCheckInterval:        "1m",
-		PgFailoverStoragesCheckSize: "1mb",
-		PgDaemonWALUploadTimeout:    "60s",
+		PgWalSize:                      "16",
+		PgBackRestStanza:               "main",
+		PgAliveCheckInterval:           "1m",
+		PgFailoverStoragesCheckSize:    "1mb",
+		PgDaemonWALUploadTimeout:       "60s",
+		PgFailoverStoragesCheckTimeout: "30s",
+		PgFailoverStorageCacheLifetime: "15m",
+		PgpEnvelopeCacheExpiration:     "0",
 	}
 
 	GPDefaultSettings = map[string]string{

--- a/internal/config.go
+++ b/internal/config.go
@@ -240,6 +240,7 @@ var (
 		MaxDelayedSegmentsCount:        "0",
 		SerializerTypeSetting:          "json_default",
 		LibsodiumKeyTransform:          "none",
+		PgpEnvelopeCacheExpiration:     "0",
 	}
 
 	MongoDefaultSettings = map[string]string{
@@ -271,7 +272,6 @@ var (
 		PgDaemonWALUploadTimeout:       "60s",
 		PgFailoverStoragesCheckTimeout: "30s",
 		PgFailoverStorageCacheLifetime: "15m",
-		PgpEnvelopeCacheExpiration:     "0",
 	}
 
 	GPDefaultSettings = map[string]string{


### PR DESCRIPTION
### Database name
All non-PostgreSQL databases

# Pull request description

### Describe what this PR fix
Fix "SOMEVAR is unknown" warning for non PostgreSQL database backups

### Please provide steps to reproduce (if it's a bug)
```
# wal-g backup-push
WARNING: 2024/01/17 01:44:47.312782 WALG_FAILOVER_STORAGES_CHECK_TIMEOUT is unknown
WARNING: 2024/01/17 01:44:47.312829 WALG_FAILOVER_STORAGES_CACHE_LIFETIME is unknown
WARNING: 2024/01/17 01:44:47.312834 We found that some variables in your config file detected as 'Unknown'. 
  If this is not right, please create issue https://github.com/wal-g/wal-g/issues/new
````
