### PR TITLE
Fix backup last mysql binlog

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -240,9 +240,6 @@ var (
 		MaxDelayedSegmentsCount:        "0",
 		SerializerTypeSetting:          "json_default",
 		LibsodiumKeyTransform:          "none",
-		PgFailoverStoragesCheckTimeout: "30s",
-		PgFailoverStorageCacheLifetime: "15m",
-		PgpEnvelopeCacheExpiration:     "0",
 	}
 
 	MongoDefaultSettings = map[string]string{
@@ -267,11 +264,14 @@ var (
 	}
 
 	PGDefaultSettings = map[string]string{
-		PgWalSize:                   "16",
-		PgBackRestStanza:            "main",
-		PgAliveCheckInterval:        "1m",
-		PgFailoverStoragesCheckSize: "1mb",
-		PgDaemonWALUploadTimeout:    "60s",
+		PgWalSize:                      "16",
+		PgBackRestStanza:               "main",
+		PgAliveCheckInterval:           "1m",
+		PgFailoverStoragesCheckSize:    "1mb",
+		PgDaemonWALUploadTimeout:       "60s",
+		PgFailoverStoragesCheckTimeout: "30s",
+		PgFailoverStorageCacheLifetime: "15m",
+		PgpEnvelopeCacheExpiration:     "0",
 	}
 
 	GPDefaultSettings = map[string]string{

--- a/internal/config.go
+++ b/internal/config.go
@@ -240,6 +240,7 @@ var (
 		MaxDelayedSegmentsCount:        "0",
 		SerializerTypeSetting:          "json_default",
 		LibsodiumKeyTransform:          "none",
+		PgpEnvelopeCacheExpiration:     "0",
 	}
 
 	MongoDefaultSettings = map[string]string{
@@ -271,7 +272,6 @@ var (
 		PgDaemonWALUploadTimeout:       "60s",
 		PgFailoverStoragesCheckTimeout: "30s",
 		PgFailoverStorageCacheLifetime: "15m",
-		PgpEnvelopeCacheExpiration:     "0",
 	}
 
 	GPDefaultSettings = map[string]string{

--- a/internal/config.go
+++ b/internal/config.go
@@ -240,6 +240,8 @@ var (
 		MaxDelayedSegmentsCount:        "0",
 		SerializerTypeSetting:          "json_default",
 		LibsodiumKeyTransform:          "none",
+		PgFailoverStoragesCheckTimeout: "30s",
+		PgFailoverStorageCacheLifetime: "15m",
 		PgpEnvelopeCacheExpiration:     "0",
 	}
 
@@ -265,13 +267,11 @@ var (
 	}
 
 	PGDefaultSettings = map[string]string{
-		PgWalSize:                      "16",
-		PgBackRestStanza:               "main",
-		PgAliveCheckInterval:           "1m",
-		PgFailoverStoragesCheckSize:    "1mb",
-		PgDaemonWALUploadTimeout:       "60s",
-		PgFailoverStoragesCheckTimeout: "30s",
-		PgFailoverStorageCacheLifetime: "15m",
+		PgWalSize:                   "16",
+		PgBackRestStanza:            "main",
+		PgAliveCheckInterval:        "1m",
+		PgFailoverStoragesCheckSize: "1mb",
+		PgDaemonWALUploadTimeout:    "60s",
 	}
 
 	GPDefaultSettings = map[string]string{


### PR DESCRIPTION
### Database name
MySQL

# Pull request description
Last binlog wasn't backup at all by skipping at 'until check'. Last binlog may contain up to several hours of modified data. So there can be data loss on PiTR restore to the latest time point.

### Describe what this PR fix
Fix backing up latest (aka current) MySQL binlog. Backing up only if:
  - backing up for the first time
  - binlog size is greater then saved size at wal-g cache

### Please provide steps to reproduce (if it's a bug)
Just run
```bash
wal-g binlog-push
```

### Please add config and wal-g stdout/stderr logs for debug purpose
<details><summary>If you can, provide logs</summary>
<p>
```bash
# WALG_LOG_LEVEL=DEVEL wal-g binlog-push
[...]
DEBUG: 2024/01/18 13:42:19.742645 Testing... binlog.000001
DEBUG: 2024/01/18 13:42:19.742661 Skip binlog binlog.000001 (archived binlog check)
DEBUG: 2024/01/18 13:42:19.742665 Testing... binlog.000002
DEBUG: 2024/01/18 13:42:19.742673 Skip binlog binlog.000002 (archived binlog check)
DEBUG: 2024/01/18 13:42:19.742681 Testing... binlog.000003
DEBUG: 2024/01/18 13:42:19.742684 Skip binlog binlog.000003 (archived binlog check)
DEBUG: 2024/01/18 13:42:19.742688 Testing... binlog.000004
DEBUG: 2024/01/18 13:42:19.742696 Skip binlog binlog.000004 (until check)
# ls -la /var/lib/mysql/binlog*
-rw-r----- 1 mysql mysql 1073606695 Jan 16 00:00 /var/lib/mysql/binlog.000001
-rw-r----- 1 mysql mysql        201 Jan 17 00:00 /var/lib/mysql/binlog.000002
-rw-r----- 1 mysql mysql        201 Jan 18 00:00 /var/lib/mysql/binlog.000003
-rw-r----- 1 mysql mysql       9283 Jan 18 13:24 /var/lib/mysql/binlog.000004
-rw-r----- 1 mysql mysql         64 Jan 18 00:00 /var/lib/mysql/binlog.index
```
</p>
</details>
