### PR TITLE
STORAGES doc using wrong Azure variable name

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -121,7 +121,7 @@ WAL-G determines Azure Storage credentials using the [azure default credential c
 
 Alternatively, you can set `AZURE_STORAGE_ACCESS_KEY` to authenticate using the storage account's [access keys](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage), or set `AZURE_STORAGE_SAS_TOKEN` to make use of [SAS tokens](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview).
 
-For deployments where Azure Storage is not under AzurePuplicCloud environment, WAL-G need to use different Azure Storage endpoint. You can use optional setting `AZURE_ENVIRONMENT_NAME` to select the correct Azure Storage endpoint. Available setting values:  `"AzurePublicCloud"`, `"AzureUSGovernmentCloud"`, `"AzureChinaCloud"`, `"AzureGermanCloud"`. If setting is omitted or has a value different to the ones defined here, WAL-G will default to the Azure Storage endpoint for AzurePublicCloud.
+For deployments where Azure Storage is not under AzurePuplicCloud environment, WAL-G need to use different Azure Storage endpoint. You can use optional setting `AZURE_ENVIRONMENT_NAME` to select the correct Azure Environment, which will set the right Storage endpoint. Available setting values:  `"AzurePublicCloud"`, `"AzureUSGovernmentCloud"`, `"AzureChinaCloud"`, `"AzureGermanCloud"`. If setting is omitted or has a value different to the ones defined here, WAL-G will default to AzurePublicCloud.
 
 WAL-G sets default upload buffer size to 64 Megabytes and uses 3 buffers by default. However, users can choose to override these values by setting optional environment variables.
 

--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -121,7 +121,7 @@ WAL-G determines Azure Storage credentials using the [azure default credential c
 
 Alternatively, you can set `AZURE_STORAGE_ACCESS_KEY` to authenticate using the storage account's [access keys](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage), or set `AZURE_STORAGE_SAS_TOKEN` to make use of [SAS tokens](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview).
 
-For deployments where Azure Storage is not under AzurePuplicCloud environment, WAL-G need to use different Azure Storage endpoint. You can use optional setting `AZURE_STORAGE_SAS_TOKEN` to select the correct Azure Storage endpoint. Available setting values:  `"AzurePublicCloud"`, `"AzureUSGovernmentCloud"`, `"AzureChinaCloud"`, `"AzureGermanCloud"`. If setting is omitted or has a value different to the ones defined here, WAL-G will default to the Azure Storage endpoint for AzurePublicCloud.
+For deployments where Azure Storage is not under AzurePuplicCloud environment, WAL-G need to use different Azure Storage endpoint. You can use optional setting `AZURE_ENVIRONMENT_NAME` to select the correct Azure Storage endpoint. Available setting values:  `"AzurePublicCloud"`, `"AzureUSGovernmentCloud"`, `"AzureChinaCloud"`, `"AzureGermanCloud"`. If setting is omitted or has a value different to the ones defined here, WAL-G will default to the Azure Storage endpoint for AzurePublicCloud.
 
 WAL-G sets default upload buffer size to 64 Megabytes and uses 3 buffers by default. However, users can choose to override these values by setting optional environment variables.
 


### PR DESCRIPTION
### Database name
This is just a documentation fix after #873 

# Pull request description
Originally the docs said to use `AZURE_STORAGE_SAS_TOKEN` to select a different Azure Storage Endpoint when using non-default regions, such as `AzureChinaCloud` or `AzureGermanCloud`. 

The right setting to use is `AZURE_ENVIRONMENT_NAME`, [as seen in the code](https://github.com/wal-g/wal-g/blob/4c82cc73519c721299bbb3ecab36657814df990e/pkg/storages/azure/configure.go#L18).

### Describe what this PR fix
Just a documentation update to help people with this use case.