### PR TITLE
WALG-1627. MySQL fix file double Close() on file

### DIFF
--- a/internal/stream_fetch_helper.go
+++ b/internal/stream_fetch_helper.go
@@ -70,7 +70,6 @@ func DownloadAndDecompressStream(backup Backup, writeCloser io.WriteCloser) erro
 // DownloadAndDecompressSplittedStream downloads, decompresses and writes stream to stdout
 func DownloadAndDecompressSplittedStream(backup Backup, blockSize int, extension string,
 	writeCloser io.WriteCloser, maxDownloadRetry int) error {
-	defer utility.LoggedClose(writeCloser, "")
 
 	decompressor := compression.FindDecompressor(extension)
 	if decompressor == nil {

--- a/internal/stream_fetch_helper.go
+++ b/internal/stream_fetch_helper.go
@@ -70,7 +70,6 @@ func DownloadAndDecompressStream(backup Backup, writeCloser io.WriteCloser) erro
 // DownloadAndDecompressSplittedStream downloads, decompresses and writes stream to stdout
 func DownloadAndDecompressSplittedStream(backup Backup, blockSize int, extension string,
 	writeCloser io.WriteCloser, maxDownloadRetry int) error {
-
 	decompressor := compression.FindDecompressor(extension)
 	if decompressor == nil {
 		return fmt.Errorf("decompressor for file type '%s' not found", extension)


### PR DESCRIPTION
### Database name
MySQL

### Describe what this PR fix
Don't close the file in calling code, because MergeWriter gets ownership of file descriptor (as stated in godoc)

### Please provide steps to reproduce (if it's a bug)
see #1627