### PR TITLE
GP, prevent multiple backups in the same time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       &&  mkdir -p /export/mysqldeletebinlogs
       &&  mkdir -p /export/archivereadyrename
       &&  mkdir -p /export/gpfullbucket
+      &&  mkdir -p /export/gpafterfailedbucket
       &&  mkdir -p /export/gpfullserializedbucket
       &&  mkdir -p /export/gpdeletewithoutconfirm
       &&  mkdir -p /export/gpdeleteretainbucket

--- a/docker/gp_tests/scripts/configs/backup_after_failed_config.json
+++ b/docker/gp_tests/scripts/configs/backup_after_failed_config.json
@@ -1,0 +1,3 @@
+"WALE_S3_PREFIX": "s3://gpafterfailedbucket",
+"WALG_DELTA_MAX_STEPS": "0",
+"WALG_LOG_LEVEL": "DEVEL"

--- a/docker/gp_tests/scripts/tests/backup_after_failed_backup_test.sh
+++ b/docker/gp_tests/scripts/tests/backup_after_failed_backup_test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e -x
+
+CONFIG_FILE="/tmp/configs/backup_after_failed_config.json"
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/pg_scripts/wrap_config_file.sh ${TMP_CONFIG}
+source /tmp/tests/test_functions/util.sh
+
+bootstrap_gp_cluster
+sleep 3
+enable_pitr_extension
+setup_wal_archiving
+
+# init tables heap, ao, co
+insert_data
+
+# imitate failed backup
+psql -p 6000 -c "SELECT pg_start_backup('abc', true);"
+
+# run backup
+run_backup_logged ${TMP_CONFIG} ${PGDATA}
+
+stop_and_delete_cluster_dir
+
+# show the backup list
+wal-g backup-list --config=${TMP_CONFIG}
+
+# show the storage objects (useful for debug)
+wal-g st ls -r --config=${TMP_CONFIG}
+
+wal-g backup-fetch LATEST --in-place --config=${TMP_CONFIG}
+
+start_cluster
+cleanup
+
+echo "Greenplum backup-push test was successful"

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -204,6 +204,8 @@ func (bh *BackupHandler) HandleBackupPush() {
 		bh.abortBackup()
 	}
 
+	//TODO prevent disconnecting wile long backup
+
 	// wait for segments to complete their backups
 	waitBackupsErr := bh.waitSegmentBackups()
 	if waitBackupsErr != nil {

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -208,9 +208,6 @@ func (bh *BackupHandler) HandleBackupPush() {
 	waitBackupsErr := bh.waitSegmentBackups()
 	if waitBackupsErr != nil {
 		tracelog.ErrorLogger.Printf("Segment backups wait error: %v", waitBackupsErr)
-	}
-
-	if waitBackupsErr != nil {
 		bh.abortBackup()
 	}
 

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -206,16 +206,12 @@ func (bh *BackupHandler) HandleBackupPush() {
 		bh.abortBackup()
 	}
 
-	// WAL-G will reconnect later
-	bh.disconnect()
-
 	// wait for segments to complete their backups
 	waitBackupsErr := bh.waitSegmentBackups()
 	if waitBackupsErr != nil {
 		tracelog.ErrorLogger.Printf("Segment backups wait error: %v", waitBackupsErr)
 	}
-	tracelog.ErrorLogger.FatalfOnError("Failed to connect to the greenplum master: %v",
-		bh.connect())
+
 	if waitBackupsErr != nil {
 		bh.abortBackup()
 	}

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -437,6 +437,7 @@ func (bh *BackupHandler) uploadSentinel(sentinelDto BackupSentinelDto) (err erro
 	return internal.UploadSentinel(sentinelUploader, sentinelDto, bh.currBackupInfo.backupName)
 }
 
+// nolint:unused
 func (bh *BackupHandler) connect() (err error) {
 	tracelog.InfoLogger.Println("Connecting to Greenplum master.")
 	bh.workers.Conn, err = postgres.Connect()

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -175,9 +175,7 @@ func (bh *BackupHandler) HandleBackupPush() {
 	bh.currBackupInfo.startTime = utility.TimeNowCrossPlatformUTC()
 	initGpLog(bh.arguments.logsDir)
 
-	//TODO try lock
-	err := bh.tryLock()
-	//err := bh.checkPrerequisites()
+	err := bh.checkPrerequisites()
 	tracelog.ErrorLogger.FatalfOnError("Backup prerequisites check failed: %v\n", err)
 
 	err = bh.configureDeltaBackup()
@@ -393,40 +391,6 @@ func (bh *BackupHandler) checkPrerequisites() (err error) {
 		return nil
 	}
 
-	tracelog.InfoLogger.Println("Checking for the existing running backup...")
-	queryRunner, err := NewGpQueryRunner(bh.workers.Conn)
-	if err != nil {
-		return err
-	}
-	backupStatuses, err := queryRunner.IsInBackup()
-	if err != nil {
-		return err
-	}
-
-	isInBackupSegments := make([]int, 0)
-	for contentID, isInBackup := range backupStatuses {
-		if isInBackup {
-			isInBackupSegments = append(isInBackupSegments, contentID)
-		}
-	}
-
-	if len(isInBackupSegments) > 0 {
-		return fmt.Errorf("backup is already in progress on one or more segments: %v", isInBackupSegments)
-	}
-	tracelog.InfoLogger.Printf("No running backups were found")
-	tracelog.InfoLogger.Printf("Checking backup prerequisites: OK")
-	return nil
-}
-
-func (bh *BackupHandler) tryLock() (err error) {
-	tracelog.InfoLogger.Println("Checking backup prerequisites")
-
-	if bh.currBackupInfo.gpVersion.Major >= 7 {
-		// GP7+ allows the non-exclusive backups
-		tracelog.InfoLogger.Println("Checking backup prerequisites: OK")
-		return nil
-	}
-
 	queryRunner, err := NewGpQueryRunner(bh.workers.Conn)
 	if err != nil {
 		return err
@@ -437,6 +401,7 @@ func (bh *BackupHandler) tryLock() (err error) {
 	if err != nil {
 		return err
 	}
+	tracelog.InfoLogger.Println("Lock successfully acquired")
 
 	backupStatuses, err := queryRunner.IsInBackup()
 	if err != nil {
@@ -457,7 +422,7 @@ func (bh *BackupHandler) tryLock() (err error) {
 			return fmt.Errorf("closing old backups failed: %v", err)
 		}
 	}
-	//tracelog.InfoLogger.Printf("No running backups were found")
+
 	tracelog.InfoLogger.Printf("Checking backup prerequisites: OK")
 	return nil
 }

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -204,8 +204,6 @@ func (bh *BackupHandler) HandleBackupPush() {
 		bh.abortBackup()
 	}
 
-	//TODO prevent disconnecting wile long backup
-
 	// wait for segments to complete their backups
 	waitBackupsErr := bh.waitSegmentBackups()
 	if waitBackupsErr != nil {

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -168,6 +168,21 @@ SELECT pg_is_in_backup(), -1;
 `
 }
 
+// TryGetLock tries to take advisory lock
+func (queryRunner *GpQueryRunner) TryGetLock() (err error) {
+	conn := queryRunner.Connection
+	var ans string
+	err = conn.QueryRow("SELECT pg_try_advisory_lock('21311'").Scan(&ans)
+	if err != nil {
+		return err
+	}
+
+	if ans == "f" {
+		return fmt.Errorf("lock is already taken")
+	}
+	return nil
+}
+
 // buildAbortBackupSegments aborts the running backup on the segments
 func (queryRunner *GpQueryRunner) buildAbortBackupSegments() string {
 	return `SELECT pg_stop_backup(), gp_segment_id FROM gp_dist_random('gp_id');`

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -171,13 +171,13 @@ SELECT pg_is_in_backup(), -1;
 // TryGetLock tries to take advisory lock
 func (queryRunner *GpQueryRunner) TryGetLock() (err error) {
 	conn := queryRunner.Connection
-	var ans string
-	err = conn.QueryRow("SELECT pg_try_advisory_lock('21311')").Scan(&ans)
+	var lockFree bool
+	err = conn.QueryRow("SELECT pg_try_advisory_lock('21311')").Scan(&lockFree)
 	if err != nil {
 		return err
 	}
 
-	if ans == "f" {
+	if !lockFree {
 		return fmt.Errorf("lock is already taken")
 	}
 	return nil

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -235,11 +235,13 @@ func (queryRunner *GpQueryRunner) AbortBackup() (err error) {
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "QueryRunner IsInBackup: segment backups stop error"))
 	}
+	tracelog.DebugLogger.Println("Stopped backups on segments")
 
 	_, err = conn.Exec(queryRunner.buildAbortBackupMaster())
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "QueryRunner IsInBackup: master backup stop error"))
 	}
+	tracelog.DebugLogger.Println("Stopped backups on master")
 
 	var finalErr error
 	for i := range errs {

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -172,7 +172,7 @@ SELECT pg_is_in_backup(), -1;
 func (queryRunner *GpQueryRunner) TryGetLock() (err error) {
 	conn := queryRunner.Connection
 	var ans string
-	err = conn.QueryRow("SELECT pg_try_advisory_lock('21311'").Scan(&ans)
+	err = conn.QueryRow("SELECT pg_try_advisory_lock('21311')").Scan(&ans)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -172,7 +172,7 @@ SELECT pg_is_in_backup(), -1;
 func (queryRunner *GpQueryRunner) TryGetLock() (err error) {
 	conn := queryRunner.Connection
 	var lockFree bool
-	err = conn.QueryRow("SELECT pg_try_advisory_lock('21311')").Scan(&lockFree)
+	err = conn.QueryRow("SELECT pg_try_advisory_lock('2131121')").Scan(&lockFree)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -172,7 +172,7 @@ SELECT pg_is_in_backup(), -1;
 func (queryRunner *GpQueryRunner) TryGetLock() (err error) {
 	conn := queryRunner.Connection
 	var lockFree bool
-	err = conn.QueryRow("SELECT pg_try_advisory_lock('2131121')").Scan(&lockFree)
+	err = conn.QueryRow("SELECT pg_try_advisory_lock(hashtext('gp_backup'))").Scan(&lockFree)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/greenplum/segment_backup_push_handler.go
+++ b/internal/databases/greenplum/segment_backup_push_handler.go
@@ -1,6 +1,7 @@
 package greenplum
 
 import (
+	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
@@ -26,6 +27,11 @@ func NewSegBackupHandler(arguments postgres.BackupArguments) (*postgres.BackupHa
 	}
 
 	bh.SetComposerInitFunc(composerInitFunc)
+
+	if bh.PgInfo.PgVersion < 100000 {
+		tracelog.DebugLogger.Printf("Query runner version is %d, disabling concurrent backups", bh.PgInfo.PgVersion)
+		bh.Arguments.EnablePreventConcurrentBackups()
+	}
 
 	return bh, err
 }

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -174,7 +174,7 @@ func (bh *BackupHandler) createAndPushBackup(ctx context.Context) {
 	tracelog.InfoLogger.Printf("Wrote backup with name %s to storage %s", bh.CurBackupInfo.Name, storageNames[0])
 }
 
-func (bh *BackupHandler) startBackup() (err error) {
+func (bh *BackupHandler) startBackup() error {
 	// Connect to postgres and start/finish a nonexclusive backup.
 	tracelog.DebugLogger.Println("Connecting to Postgres.")
 	conn, err := Connect()

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -179,7 +179,7 @@ func (bh *BackupHandler) startBackup() (err error) {
 	tracelog.DebugLogger.Println("Connecting to Postgres.")
 	conn, err := Connect()
 	if err != nil {
-		return
+		return err
 	}
 	bh.Workers.QueryRunner, err = NewPgQueryRunner(conn)
 	if err != nil {
@@ -203,7 +203,7 @@ func (bh *BackupHandler) startBackup() (err error) {
 				if err1 != nil {
 					return fmt.Errorf("failed to kill blocking process: %v", err1)
 				}
-				tracelog.InfoLogger.Printf("Sucessfully killed process with id %d\n", pid)
+				tracelog.InfoLogger.Printf("Successfully killed process with id %d\n", pid)
 
 				err1 = bh.Workers.QueryRunner.TryGetLock()
 				if err1 != nil {
@@ -212,7 +212,7 @@ func (bh *BackupHandler) startBackup() (err error) {
 			} else {
 				return fmt.Errorf("failed to acquire lock: %v", err)
 			}
-			tracelog.InfoLogger.Println("Sucessfully acquired backup lock")
+			tracelog.InfoLogger.Println("Successfully acquired backup lock")
 		}
 	}
 
@@ -220,13 +220,13 @@ func (bh *BackupHandler) startBackup() (err error) {
 	backupName, backupStartLSN, err := bh.Workers.Bundle.StartBackup(
 		bh.Workers.QueryRunner, utility.CeilTimeUpToMicroseconds(time.Now()).String())
 	if err != nil {
-		return
+		return err
 	}
 	bh.CurBackupInfo.startLSN = backupStartLSN
 	bh.CurBackupInfo.Name = backupName
 	tracelog.DebugLogger.Printf("Backup name: %s\nBackup start LSN: %s", backupName, backupStartLSN)
 	bh.initBackupTerminator()
-	return
+	return nil
 }
 
 func (bh *BackupHandler) handleDeltaBackup(folder storage.Folder) {

--- a/internal/databases/postgres/backup_sentinel_dto.go
+++ b/internal/databases/postgres/backup_sentinel_dto.go
@@ -39,7 +39,7 @@ func NewBackupSentinelDto(bh *BackupHandler, tbsSpec *TablespaceSpec) BackupSent
 	sentinel := BackupSentinelDto{
 		BackupStartLSN:   &bh.CurBackupInfo.startLSN,
 		IncrementFromLSN: bh.prevBackupInfo.sentinelDto.BackupStartLSN,
-		PgVersion:        bh.PgInfo.pgVersion,
+		PgVersion:        bh.PgInfo.PgVersion,
 		TablespaceSpec:   tbsSpec,
 	}
 	if bh.prevBackupInfo.sentinelDto.BackupStartLSN != nil {

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -527,7 +527,7 @@ func (queryRunner *PgQueryRunner) TryGetLock() (err error) {
 
 	conn := queryRunner.Connection
 	var lockFree bool
-	err = conn.QueryRow("SELECT pg_try_advisory_lock('2131122')").Scan(&lockFree)
+	err = conn.QueryRow("SELECT pg_try_advisory_lock(hashtext('pg_backup'))").Scan(&lockFree)
 	if err != nil {
 		return err
 	}
@@ -544,7 +544,7 @@ func (queryRunner *PgQueryRunner) GetLockingPID() (int, error) {
 
 	conn := queryRunner.Connection
 	var pid int
-	err := conn.QueryRow("SELECT pid FROM pg_locks WHERE locktype='advisory' AND objid = 2131122").Scan(&pid)
+	err := conn.QueryRow("SELECT pid FROM pg_locks WHERE locktype='advisory' AND objid = hashtext('pg_backup')").Scan(&pid)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -14,18 +14,6 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-type AdvisoryLockTakenError struct {
-	error
-}
-
-func NewAdvisoryLockTakenError() AdvisoryLockTakenError {
-	return AdvisoryLockTakenError{errors.New("Lock is already taken by other process")}
-}
-
-func (err AdvisoryLockTakenError) Error() string {
-	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
-}
-
 type NoPostgresVersionError struct {
 	error
 }
@@ -545,7 +533,7 @@ func (queryRunner *PgQueryRunner) TryGetLock() (err error) {
 	}
 
 	if !lockFree {
-		return NewAdvisoryLockTakenError()
+		return errors.New("Lock is already taken by other process")
 	}
 	return nil
 }


### PR DESCRIPTION
Greenplum
Now to prevent multiple backups we check pg_is_in_backup(), but if wal-g process dies unexpectedly, we do not call pg_stop_backup. Instead of that it is better to use advisory locks, so wal-g can check that other wal-g backup process is now running.