### PR TITLE
Updated wal push command in etcd to ensure consistency

### DIFF
--- a/docker/etcd/export_common.sh
+++ b/docker/etcd/export_common.sh
@@ -28,4 +28,8 @@ fill_wal_data() {
         STATUS=$(etcdctl put $KEY $FILE_CONTENT)
         i=$((i+1))
     done
+    #add one record to the last file
+    KEY="key$i"
+    STATUS=$(etcdctl put $KEY $FILE_CONTENT)
+    i=$((i+1))
 }

--- a/docker/etcd_tests/scripts/tests/etcd_wal_push_fetch_test.sh
+++ b/docker/etcd_tests/scripts/tests/etcd_wal_push_fetch_test.sh
@@ -14,6 +14,8 @@ set +x -v
 fill_wal_data 3
 set -x
 
+#make sure that etcd commited all transactions
+sleep 1
 wal-g wal-push
 
 # create dir where to store fetched wals


### PR DESCRIPTION
### Database name
ETCD
# Pull request description

now wal-g checks that it is running on leader node(was on other nodes might be inconsistent). It also pushes wal file to the storage only if all records inside this file are committed i.e. records that are present in most nodes of cluster and will