### PR TITLE
MongoDB binary restore: use most recent to given oplog from oplog arc…

### DIFF
--- a/internal/databases/mongo/stages/fetcher.go
+++ b/internal/databases/mongo/stages/fetcher.go
@@ -193,7 +193,7 @@ func (sf *StorageFetcher) FetchBetween(ctx context.Context,
 				}
 
 				if !firstFound {
-					if op.TS != from { // from ts is not reached, continue
+					if models.LessTS(op.TS, from) {
 						continue
 					}
 					firstFound = true
@@ -214,10 +214,6 @@ func (sf *StorageFetcher) FetchBetween(ctx context.Context,
 				}
 			}
 			buf.Reset()
-			if !firstFound { // TODO: do we need this check, add skip flag
-				errc <- fmt.Errorf("'from' timestamp '%s' was not found in first archive: %s", from, arch.Filename())
-				return
-			}
 		}
 		errc <- fmt.Errorf("restore sequence was fetched, but restore point '%s' is not reached",
 			until)

--- a/internal/databases/mongo/stages/fetcher_test.go
+++ b/internal/databases/mongo/stages/fetcher_test.go
@@ -190,17 +190,6 @@ func TestStorageFetcher_OplogBetween(t *testing.T) {
 			wantErr: fmt.Errorf("fromTS '1579002001.1' must be less than untilTS '1579002000.1'"),
 		},
 		{
-			name:   "error:_first_was_not_found_in_first_archive",
-			fields: SetupDownloaderMocks(ops),
-			args: args{
-				ctx:   context.TODO(),
-				from:  models.Timestamp{TS: 1579002000, Inc: 1},
-				until: ops[len(ops)-1].TS,
-			},
-			wantOps:  []*models.Oplog{},
-			wantErrc: fmt.Errorf("'from' timestamp '1579002000.1' was not found in first archive: oplog_0.0_1579002006.1.br"),
-		},
-		{
 			name:   "error:_until_is_not_reached",
 			fields: SetupDownloaderMocks(ops[0:2], ops[2:3], ops[3:]),
 			args: args{


### PR DESCRIPTION
…hive instead of trying to find fixed one

### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fix
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
