### PR TITLE
Add Docs for undocumented debug env variables

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ WAL-G is the successor of WAL-E with a number of key differences. WAL-G uses LZ4
     - [Installing](#installing)
     - [Testing](#testing)
     - [Development on windows](#development-on-windows)
+- [Troubleshooting](#troubleshooting)
 - [Authors](#authors)
 - [License](#license)
 - [Acknowledgments](#acknowledgments)
@@ -352,6 +353,21 @@ This command generates `coverage.out` file and opens HTML representation of the 
 ### Development on Windows
 
 [Information about installing and usage](Windows.md)
+
+
+Troubleshooting
+---------------
+
+A good way to start troubleshooting problems is by setting one or both of these environment variables:
+
+* `WALG_LOG_LEVEL=DEVEL`
+
+Prints out the used configuration of WAL-G and detailed logs of the used command 
+
+* `S3_LOG_LEVEL=DEVEL`
+
+If your commands seem to be stuck it could be that the s3 is not reachable, certificate problems or other s3 related issues.
+With this environment variable set you can see the Requests and Responses from s3 
 
 
 Authors

--- a/docs/README.md
+++ b/docs/README.md
@@ -366,8 +366,8 @@ Prints out the used configuration of WAL-G and detailed logs of the used command
 
 * `S3_LOG_LEVEL=DEVEL`
 
-If your commands seem to be stuck it could be that the s3 is not reachable, certificate problems or other s3 related issues.
-With this environment variable set you can see the Requests and Responses from s3 
+If your commands seem to be stuck it could be that the S3 is not reachable, certificate problems or other S3 related issues.
+With this environment variable set you can see the Requests and Responses from S3 
 
 
 Authors

--- a/docs/README.md
+++ b/docs/README.md
@@ -362,12 +362,12 @@ A good way to start troubleshooting problems is by setting one or both of these 
 
 * `WALG_LOG_LEVEL=DEVEL`
 
-Prints out the used configuration of WAL-G and detailed logs of the used command 
+Prints out the used configuration of WAL-G and detailed logs of the used command.
 
 * `S3_LOG_LEVEL=DEVEL`
 
 If your commands seem to be stuck it could be that the S3 is not reachable, certificate problems or other S3 related issues.
-With this environment variable set you can see the Requests and Responses from S3 
+With this environment variable set you can see the Requests and Responses from S3.
 
 
 Authors


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fix
Add Docs for undocumented debug env variables WALG_LOG_LEVEL and S3_LOG_LEVEL

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
