### PR TITLE
MongoDB binary restore: If shardIdentity document does not exist, ass…

### DIFF
--- a/cmd/mongo/binary_backup_fetch.go
+++ b/cmd/mongo/binary_backup_fetch.go
@@ -25,7 +25,7 @@ const (
 	ShNameFlag                   = "mongo-sh-name"
 	ShNameDescription            = "Name of shard"
 	ShCfgConnStr                 = "mongo-cfg-conn-str"
-	ShCfgConnStrDescription      = "Connection string to mongocfg replicas in shanded cluster"
+	ShCfgConnStrDescription      = "Connection string to mongocfg replicas in sharded cluster"
 	ShShardConnStr               = "mongo-shard-conn-str"
 	ShShardConnStrDescription    = "Connection string to some shard (can be specified multiple times)"
 )


### PR DESCRIPTION
…ume oplog replay will fix this

If we restore from backup which was taken from non-sharded version of cluster, we might get errors regarding missing shardIdentity document. In this PR we start to ignore this behavior, assuming oplog-replay will fix missing shardIdentity document instead