### PR TITLE
Support DigitalOcean Spaces (NoSuchKey during ListFolder)

### DIFF
--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -150,6 +150,12 @@ func (folder *Folder) ListFolder() (objects []storage.Object, subFolders []stora
 	}
 
 	if err != nil {
+		// DigitalOcean Spaces compatibility: DO's API complains about NoSuchKey when trying to list folders
+		// which don't yet exist.
+		if isAwsNotExist(err) {
+			return objects, subFolders, nil
+		}
+
 		return nil, nil, errors.Wrapf(err, "failed to list s3 folder: '%s'", folder.path)
 	}
 	return objects, subFolders, nil


### PR DESCRIPTION
### Database name
postgresql

# Pull request description

### Describe what this PR fix
When using DigitalOcean Spaces, a `NoSuchKey` error is raised when trying to do delta backups. This PR converts the error into an empty list directory, preventing future code from having issues or surfacing the error.

Example:

```
$ wal-g --config /var/lib/postgresql/walg.json backup-push /pgdata/14/main
ERROR: 2024/02/20 01:59:30.571003 list folder in storage "default": failed to list s3 folder: 'basebackups_005/': NoSuchKey:
        status code: 404, request id: tx000006385474c78046ff0-0065d40782-3c6f48c0-sfo3a, host id:
```

`walg.json`:
```json
{
        "WALG_S3_PREFIX": "s3://REDACTED.sf03.digitaloceanspaces.com",
        "AWS_ACCESS_KEY_ID": "REDACTED",
        "AWS_SECRET_ACCESS_KEY": "REDACTED",
        "AWS_REGION": "sfo3",
        "AWS_ENDPOINT": "https://REDACTED.sfo3.digitaloceanspaces.com",

        "WALG_DELTA_MAX_STEPS": "6",
        "WALG_UPLOAD_DISK_CONCURRENCY": "6",

        "WALG_UPLOAD_CONCURRENCY": "16",
        "TOTAL_BG_UPLOADED_LIMIT": "1024",
        "WALG_COMPRESSION_METHOD": "brotli",

        "PGHOST": "/var/run/postgresql",
        "PGUSER": "postgres"
}
```

### Please provide steps to reproduce (if it's a bug)

Use the above config, except with `REDACTED` filled in, and the above command.

