### PR TITLE
Allow extra tags to be added to statsd metrics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -150,6 +150,10 @@ Similar to `WALG_ENVELOPE_PGP_KEY`, but value is the path to the key on file sys
 
 To enable metrics publishing to [statsd](https://github.com/statsd/statsd) or [statsd_exporter](https://github.com/prometheus/statsd_exporter). Metrics will be sent on a best-effort basis via UDP. The default port for statsd is `9125`.
 
+* `WALG_STATSD_EXTRA_TAGS`
+
+Use this setting to add static tags (`host`, `operation`, `database`, etc) to the metrics WAL-G publishes to statsd.
+
 ### Profiling
 
 Profiling is useful for identifying bottlenecks within WAL-G.

--- a/internal/config.go
+++ b/internal/config.go
@@ -99,6 +99,7 @@ const (
 	StreamSplitterBlockSize                = "WALG_STREAM_SPLITTER_BLOCK_SIZE"
 	StreamSplitterMaxFileSize              = "WALG_STREAM_SPLITTER_MAX_FILE_SIZE"
 	StatsdAddressSetting                   = "WALG_STATSD_ADDRESS"
+	StatsdExtraTagsSetting                 = "WALG_STATSD_EXTRA_TAGS"
 	PgAliveCheckInterval                   = "WALG_ALIVE_CHECK_INTERVAL"
 	PgStopBackupTimeout                    = "WALG_STOP_BACKUP_TIMEOUT"
 	PgFailoverStorages                     = "WALG_FAILOVER_STORAGES"
@@ -342,6 +343,7 @@ var (
 		FetchTargetUserDataSetting:    true,
 		SerializerTypeSetting:         true,
 		StatsdAddressSetting:          true,
+		StatsdExtraTagsSetting:        true,
 
 		ProfileSamplingRatio: true,
 		ProfileMode:          true,


### PR DESCRIPTION
### Database name

Common / generic / all. Enhancement to statsd metrics implementation


# Pull request description

### Describe what this PR fix

We're rolling out WAL-G into an environment where we have several different PostgreSQL databases running on the same host. Metrics are sent to a per-host Telegraf instance (which applies a `host` tag to the received metrics), and from there into a cluster-wide metrics store. At present, we have no way to distinguish WAL-G metrics relating to postgresql A from those relating to postgresql B.

This PR adds a config flag - `WALG_STATSD_EXTRA_TAGS` - that allows a set of static tags to be applied to every metric emitted during the wal-g process lifetime. We can configure that differently for wal-g when running against A, compared to B, and get the differentiation we need that way, e.g.:

```yaml
walg_statsd_extra_tags:
  database: "a"
```

We could also consider using this to allow us to differentiate between the `backup-push` and `wal-push` invocations of `wal-g`, so if uploads are failing in one but not the other, we can more easily tell which is at fault.

### Please provide steps to reproduce (if it's a bug)

Just run `wal-g backup-push` against two different database instances. The metrics emitted by it have nothing that can distinguish between the two. The only way to do so with the current setup is to have a different `WAL_G_STATSD_ADDRESS` per database, and have *that* apply extra tags, which comes with a great deal of maintenance overhead.


cc @igorwwwwwwwwwwwwwwwwwwww (hi!) who put together the original metrics implementation