### PR TITLE
MySQL: Add `--fifo-streams` support to `xtrabackup-push` [PoC]

### DIFF
--- a/cmd/mysql/backup_push.go
+++ b/cmd/mysql/backup_push.go
@@ -29,6 +29,7 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			const backupStreamsCnt = 1
 			internal.ConfigureLimiters()
 
 			uploader, err := internal.ConfigureSplitUploader()
@@ -48,6 +49,7 @@ var (
 				backupCmd,
 				permanent,
 				true,
+				backupStreamsCnt,
 				userData,
 				mysql.NewNoDeltaBackupConfigurator(),
 			)

--- a/cmd/mysql/xtrabackup_push.go
+++ b/cmd/mysql/xtrabackup_push.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
@@ -13,6 +14,7 @@ const (
 	xtrabackupPushShortDescription = "Creates new backup and pushes it to storage"
 
 	fullBackupFlag        = "full"
+	fifoStreamsFlag       = "fifo-streams"
 	deltaFromUserDataFlag = "delta-from-user-data"
 	deltaFromNameFlag     = "delta-from-name"
 
@@ -29,6 +31,10 @@ var (
 			internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
+			err = validateXtrabackupArgs()
+			if err != nil {
+				tracelog.ErrorLogger.Fatalf("invalid command line arguments: %w", err)
+			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			internal.ConfigureLimiters()
@@ -62,12 +68,14 @@ var (
 				backupCmd,
 				permanent,
 				fullBackup,
+				fifoStreams,
 				userData,
 				mysql.NewRegularDeltaBackupConfigurator(folder, deltaBaseSelector),
 			)
 		},
 	}
 	fullBackup        = true
+	fifoStreams       = 1
 	deltaFromName     = ""
 	deltaFromUserData = ""
 )
@@ -81,10 +89,19 @@ func init() {
 		false, "Pushes permanent backup")
 	xtrabackupPushCmd.Flags().BoolVarP(&fullBackup, fullBackupFlag, fullBackupShorthand,
 		true, "Make full backup-push")
+	xtrabackupPushCmd.Flags().IntVar(&fifoStreams, fifoStreamsFlag,
+		1, "Use xtrabackup --fifo-streams=X for parallel data stream")
 	xtrabackupPushCmd.Flags().StringVar(&deltaFromName, deltaFromNameFlag,
 		"", "Select the backup specified by name as the target for the delta backup")
 	xtrabackupPushCmd.Flags().StringVar(&deltaFromUserData, deltaFromUserDataFlag,
 		"", "Select the backup specified by UserData as the target for the delta backup")
 	xtrabackupPushCmd.Flags().StringVar(&userData, addUserDataFlag,
 		"", "Write the provided user data to the backup sentinel and metadata files.")
+}
+
+func validateXtrabackupArgs() error {
+	if fifoStreams < 0 {
+		return fmt.Errorf("fifoStreams should be 1 (STDOUT) or greater (fifo streams)")
+	}
+	return nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       &&  mkdir -p /export/mysqlbinlogpushfetchbucket
       &&  mkdir -p /export/mysqldeleteendtoendbucket
       &&  mkdir -p /export/mysqldeleteeverythingpermanent
+      &&  mkdir -p /export/mysqlfullxtrabackupfifobucket
       &&  mkdir -p /export/mysqldeleteincrementalxtrabackupbucket
       &&  mkdir -p /export/mysqlmarkbucket
       &&  mkdir -p /export/mysqlmarknoerrorbucket

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,16 +1,22 @@
-FROM wal-g/ubuntu:18.04
+FROM wal-g/ubuntu:20.04
 
 ENV MYSQLDATA /var/lib/mysql
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends --no-install-suggests \
-    curl \
+    curl wget \
     mysql-server \
     mysql-client \
-    percona-xtrabackup \
     s3cmd \
-    jq
+    jq \
+    lsb-release gnupg
 
+RUN wget https://repo.percona.com/apt/percona-release_latest.focal_all.deb && \
+    dpkg -i percona-release_latest.focal_all.deb && \
+    percona-release enable tools release && \
+    apt-get update && \
+    apt install --yes --no-install-recommends --no-install-suggests \
+    percona-xtrabackup-80
 
 RUN curl -s https://packagecloud.io/install/repositories/akopytov/sysbench/script.deb.sh | bash && apt -y install sysbench
 RUN rm -rf $MYSQLDATA

--- a/docker/mysql/export_common.sh
+++ b/docker/mysql/export_common.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # common wal-g settings
+# export MYSQLDATA=/var/lib/mysql
 export WALG_MYSQL_DATASOURCE_NAME=sbtest:@/sbtest
 export WALG_STREAM_CREATE_COMMAND="xtrabackup --backup \
     --stream=xbstream \

--- a/docker/mysql_tests/scripts/base_tests/conf-only-test.sh
+++ b/docker/mysql_tests/scripts/base_tests/conf-only-test.sh
@@ -5,7 +5,7 @@ set -e -x
 
 # https://github.com/wal-g/wal-g/issues/790
 ## ensure correct conf option will overwrite this trash
-#export AWS_ENDPOINT=we23i902309239
+export AWS_ENDPOINT=we23i902309239
 
 cat > /root/conf.yaml <<EOH
 WALE_S3_PREFIX: s3://mysqlconfonly
@@ -31,8 +31,9 @@ mysqld --initialize --init-file=/etc/mysql/init.sql
 service mysql start
 mysql mysql -e 'create table testt1(i int)'
 
-export NAME
-NAME=$(wal-g backup-push --config=/root/conf.yaml 2>&1 | grep -oe 'stream_[0-9]*T[0-9]*Z' | sort -u)
+wal-g backup-push --config=/root/conf.yaml
+
+NAME=$(wal-g backup-list --config=/root/conf.yaml | grep -oe 'stream_[0-9]*T[0-9]*Z' | sort -u)
 
 mysql_kill_and_clean_data
 

--- a/docker/mysql_tests/scripts/base_tests/full_xtrabackup_fifo_test.sh
+++ b/docker/mysql_tests/scripts/base_tests/full_xtrabackup_fifo_test.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mysqlfullxtrabackupfifobucket
+
+mysqld --initialize --init-file=/etc/mysql/init.sql
+service mysql start
+
+sysbench --table-size=10 prepare
+sysbench --time=5 run
+
+mysql -e 'FLUSH LOGS'
+
+mysqldump sbtest > /tmp/dump_before_backup
+
+wal-g xtrabackup-push --fifo-streams=4
+
+mysql_kill_and_clean_data
+
+# debug output:
+wal-g backup-list
+wal-g st ls "basebackups_005"
+
+# restore
+wal-g backup-fetch LATEST
+chown -R mysql:mysql $MYSQLDATA
+service mysql start || (cat /var/log/mysql/error.log && false)
+
+mysql_set_gtid_purged
+
+mysqldump sbtest > /tmp/dump_after_restore
+
+diff /tmp/dump_before_backup /tmp/dump_after_restore
+
+

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -2,15 +2,16 @@ package mysql
 
 import (
 	"context"
-	"github.com/wal-g/wal-g/pkg/storages/storage"
-	"os"
-	"os/exec"
-	"strings"
-
+	"fmt"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/limiters"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
+	"golang.org/x/sync/errgroup"
+	"os"
+	"os/exec"
+	"strings"
 )
 
 //nolint:funlen
@@ -20,6 +21,7 @@ func HandleBackupPush(
 	backupCmd *exec.Cmd,
 	isPermanent bool,
 	isFullBackup bool,
+	fifoStreams int,
 	userDataRaw string,
 	deltaBackupConfigurator DeltaBackupConfigurator,
 ) {
@@ -57,7 +59,7 @@ func HandleBackupPush(
 		prevBackupInfo, incrementCount, err = deltaBackupConfigurator.Configure(isFullBackup, hostname, serverUUID, version)
 		tracelog.ErrorLogger.FatalfOnError("failed to get previous backup for delta backup: %v", err)
 
-		backupName, xtrabackupInfo, err = handleXtrabackupBackup(uploader, backupCmd, isFullBackup, &prevBackupInfo)
+		backupName, xtrabackupInfo, err = handleXtrabackupBackup(uploader, backupCmd, isFullBackup, fifoStreams, &prevBackupInfo)
 	} else {
 		backupName, err = handleRegularBackup(uploader, backupCmd)
 	}
@@ -134,6 +136,7 @@ func handleXtrabackupBackup(
 	uploader internal.Uploader,
 	backupCmd *exec.Cmd,
 	isFullBackup bool,
+	fifoStreams int,
 	prevBackupInfo *PrevBackupInfo,
 ) (backupName string, backupInfo XtrabackupInfo, err error) {
 	if prevBackupInfo == nil {
@@ -144,14 +147,36 @@ func handleXtrabackupBackup(
 	xtrabackupExtraDirectory, err := prepareTemporaryDirectory(tmpDirRoot)
 	tracelog.ErrorLogger.FatalfOnError("failed to prepare tmp directory for diff-backup: %v", err)
 
-	enrichBackupArgs(backupCmd, xtrabackupExtraDirectory, isFullBackup, prevBackupInfo)
+	enrichBackupArgs(backupCmd, xtrabackupExtraDirectory, isFullBackup, fifoStreams, prevBackupInfo)
 	tracelog.InfoLogger.Printf("Command to execute: %v", strings.Join(backupCmd.Args, " "))
 
 	stdout, stderr, err := utility.StartCommandWithStdoutStderr(backupCmd)
 	tracelog.ErrorLogger.FatalfOnError("failed to start backup create command: %v", err)
 
-	backupName, err = uploader.PushStream(context.Background(), limiters.NewDiskLimitReader(stdout))
-	tracelog.ErrorLogger.FatalfOnError("failed to push backup: %v", err)
+	if fifoStreams == 1 {
+		backupName, err = uploader.PushStream(context.Background(), limiters.NewDiskLimitReader(stdout))
+		tracelog.ErrorLogger.FatalfOnError("failed to push backup: %v", err)
+	} else {
+		backupName = internal.NewBackupStreamName()
+		errGroup, groupContext := errgroup.WithContext(context.Background())
+		for idx := 0; idx < fifoStreams; idx++ {
+			idx := idx
+			threadUploader := uploader.Clone()
+			fifoFileName := getXtrabackupFifoFileName(idx)
+			file, err := openFifoFile(fifoFileName)
+			tracelog.ErrorLogger.FatalfOnError("failed to open named pipe: %v", err)
+
+			errGroup.Go(func() error {
+				return threadUploader.PushStreamToDestination(
+					groupContext,
+					limiters.NewDiskLimitReader(file),
+					fmt.Sprintf("%s/thread_%v", backupName, idx),
+				)
+			})
+		}
+		err = errGroup.Wait()
+		tracelog.ErrorLogger.FatalfOnError("failed to push backup: %v", err)
+	}
 
 	err = backupCmd.Wait()
 	if err != nil {

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 )
 
@@ -162,15 +163,22 @@ func handleXtrabackupBackup(
 		for idx := 0; idx < fifoStreams; idx++ {
 			idx := idx
 			threadUploader := uploader.Clone()
-			fifoFileName := getXtrabackupFifoFileName(idx)
+			fifoFileName := getXtrabackupFifoFileName("/tmp", idx) // FIXME: make configurable
 			file, err := openFifoFile(fifoFileName)
 			tracelog.ErrorLogger.FatalfOnError("failed to open named pipe: %v", err)
 
 			errGroup.Go(func() error {
+				// FIXME: SplitStreamUploader and RegularUploader's PushStreamToDestination() method has different understanding of dstPath... that is bug
+				dstPath := path.Join(utility.SanitizePath(backupName), fmt.Sprintf("thread_%v", idx))
+				if _, ok := threadUploader.(*internal.SplitStreamUploader); ok {
+					// for SplitStreamUploader leave `dstPath` is directory
+				} else {
+					dstPath = internal.GetStreamName(dstPath, uploader.Compression().FileExtension())
+				}
 				return threadUploader.PushStreamToDestination(
 					groupContext,
 					limiters.NewDiskLimitReader(file),
-					fmt.Sprintf("%s/thread_%v", backupName, idx),
+					dstPath,
 				)
 			})
 		}

--- a/internal/databases/mysql/xtrabackup.go
+++ b/internal/databases/mysql/xtrabackup.go
@@ -2,15 +2,21 @@ package mysql
 
 import (
 	"bytes"
+	"fmt"
+	"github.com/cenkalti/backoff"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
+	"golang.org/x/sync/errgroup"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"syscall"
 )
 
 const (
@@ -86,7 +92,7 @@ func readXtrabackupInfo(xtrabackupExtraDirectory string) (XtrabackupInfo, error)
 	return NewXtrabackupInfo(string(raw)), nil
 }
 
-func enrichBackupArgs(backupCmd *exec.Cmd, xtrabackupExtraDirectory string, isFullBackup bool, prevBackupInfo *PrevBackupInfo) {
+func enrichBackupArgs(backupCmd *exec.Cmd, xtrabackupExtraDirectory string, isFullBackup bool, fifoStreams int, prevBackupInfo *PrevBackupInfo) {
 	if prevBackupInfo == nil {
 		tracelog.ErrorLogger.Fatalf("PrevBackupInfo is null")
 	}
@@ -96,6 +102,13 @@ func enrichBackupArgs(backupCmd *exec.Cmd, xtrabackupExtraDirectory string, isFu
 	if !isFullBackup && (*prevBackupInfo != PrevBackupInfo{} && prevBackupInfo.sentinel.LSN != nil) {
 		// –-incremental-lsn=LSN
 		injectCommandArgument(backupCmd, "--incremental-lsn="+prevBackupInfo.sentinel.LSN.String())
+	}
+
+	if fifoStreams > 1 {
+		injectCommandArgument(backupCmd, fmt.Sprintf("--fifo-streams=%v", fifoStreams))
+		// when --fifo-stream specified, --fifo-dir must be configured as well
+		injectCommandArgument(backupCmd, "--fifo-dir=/tmp") // FIXME: make configurable
+		injectCommandArgument(backupCmd, "--fifo-timeout=60")
 	}
 }
 
@@ -161,7 +174,7 @@ func xtrabackupFetch(
 	if err != nil {
 		return err
 	}
-	fetcher, err := internal.GetBackupStreamFetcher(backup)
+	fetcher, err := GetBackupStreamFetcher(backup)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("Failed to detect backup format: %v\n", err)
 		return err
@@ -188,4 +201,97 @@ func xtrabackupFetch(
 	}
 
 	return os.RemoveAll(tempDeltaDir)
+}
+
+func GetBackupStreamFetcher(backup internal.Backup) (internal.StreamFetcher, error) {
+	// There are 2 backup layouts for xtrabackup:
+	// single-stream:
+	//   /basebackups_005
+	//  	/stream_20240228T115512Z
+	//			<stream content>
+	// multi-stream backups:
+	//   /basebackups_005
+	//  	/stream_20240228T115512Z
+	// 			/thread_N   (where N in range 0..fifoStreams)
+	// 				<stream content>
+
+	_, folders, err := backup.Folder.ListFolder()
+	if err != nil {
+		return nil, fmt.Errorf("cannot list files in backup folder '%s' due to: %w", backup.Folder.GetPath(), err)
+	}
+
+	fifoStreams := 0
+	for _, folder := range folders {
+		if ok, _ := regexp.MatchString(".*/thread_\\d/", folder.GetPath()); ok {
+			fifoStreams++
+		}
+	}
+
+	if fifoStreams > 0 {
+		return FifoMultiStreamFetcher(fifoStreams), nil
+	} else {
+		return internal.GetBackupStreamFetcher(backup)
+	}
+}
+
+func FifoMultiStreamFetcher(fifoStreams int) internal.StreamFetcher {
+	return func(backup internal.Backup, writeCloser io.WriteCloser) error {
+		defer utility.LoggedClose(writeCloser, "")
+
+		errGroup := new(errgroup.Group)
+		for i := 0; i < fifoStreams; i++ {
+			subBackup, err := internal.NewBackup(backup.Folder.GetSubFolder(fmt.Sprintf("thread_%v", i)), backup.Name)
+			if err != nil {
+				return err
+			}
+			fetcher, err := internal.GetBackupStreamFetcher(subBackup)
+			if err != nil {
+				return err
+			}
+
+			fifoFileName := getXtrabackupFifoFileName(i) // FIXME: new file dir?
+			err = syscall.Mkfifo(fifoFileName, 0640)
+			if err != nil {
+				return err
+			}
+			// FIXME: delete fifos
+
+			pipe, err := os.OpenFile(fifoFileName, os.O_WRONLY, os.ModeNamedPipe)
+			if err != nil {
+				return err
+			}
+
+			errGroup.Go(func() error {
+				return fetcher(subBackup, pipe)
+			})
+		}
+
+		return errGroup.Wait()
+	}
+}
+
+func getXtrabackupFifoFileName(idx int) string {
+	// fifo name format is hardcoded in xtrabackup source code:
+	// https://github.com/percona/percona-xtrabackup/blob/percona-xtrabackup-8.0.35-30/storage/innobase/xtrabackup/src/xbstream.cc#L728
+	return fmt.Sprintf("/tmp/thread_%v", idx) // FIXME: make configurable
+}
+
+func openFifoFile(fifoFileName string) (*os.File, error) {
+	tracelog.DebugLogger.Printf("Openning %s", fifoFileName)
+	var file *os.File
+	err := retry(10, func() (err error) {
+		file, err = os.OpenFile(fifoFileName, os.O_RDONLY, os.ModeNamedPipe)
+		if err != nil {
+			tracelog.DebugLogger.Printf("failed to open named pipe: %v", err)
+		}
+		return err
+	})
+	return file, err
+}
+
+func retry(maxRetries uint64, op func() error) error {
+	var b backoff.BackOff
+	b = backoff.NewExponentialBackOff()
+	b = backoff.WithMaxRetries(b, maxRetries)
+	return backoff.Retry(op, b)
 }

--- a/internal/databases/mysql/xtrabackup.go
+++ b/internal/databases/mysql/xtrabackup.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -164,6 +165,27 @@ func xtrabackupFetch(
 		injectCommandArgument(prepareCmd, XtrabackupApplyLogOnly)
 	}
 
+	fifoStreams, err := detectFifoStreams(backup)
+	if err != nil {
+		tracelog.ErrorLogger.Printf("Failed to detect backup format: %v\n", err)
+		return err
+	}
+
+	fifoDir := ""
+	if fifoStreams > 1 {
+		tmpDirRoot := "/tmp" // FIXME: make configurable
+		fifoDir, err = prepareTemporaryDirectory(tmpDirRoot)
+		if err != nil {
+			return err
+		}
+		defer removeTemporaryDirectory(fifoDir)
+
+		injectCommandArgument(restoreCmd, fmt.Sprintf("--fifo-streams=%v", fifoStreams))
+		// when --fifo-stream specified, --fifo-dir must be configured as well
+		injectCommandArgument(restoreCmd, fmt.Sprintf("--fifo-dir=%s", fifoDir))
+		injectCommandArgument(restoreCmd, "--fifo-timeout=60")
+	}
+
 	stdin, err := restoreCmd.StdinPipe()
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch backup: %v", err)
 	stderr := &bytes.Buffer{}
@@ -174,9 +196,8 @@ func xtrabackupFetch(
 	if err != nil {
 		return err
 	}
-	fetcher, err := GetBackupStreamFetcher(backup)
+	fetcher, err := getBackupStreamFetcher(backup, fifoDir, fifoStreams)
 	if err != nil {
-		tracelog.ErrorLogger.Printf("Failed to detect backup format: %v\n", err)
 		return err
 	}
 	err = fetcher(backup, stdin)
@@ -203,7 +224,12 @@ func xtrabackupFetch(
 	return os.RemoveAll(tempDeltaDir)
 }
 
-func GetBackupStreamFetcher(backup internal.Backup) (internal.StreamFetcher, error) {
+func detectFifoStreams(backup internal.Backup) (int, error) {
+	_, folders, err := backup.Folder.GetSubFolder(backup.Name).ListFolder()
+	if err != nil {
+		return 0, fmt.Errorf("cannot list files in backup folder '%s' due to: %w", backup.Folder.GetPath(), err)
+	}
+
 	// There are 2 backup layouts for xtrabackup:
 	// single-stream:
 	//   /basebackups_005
@@ -214,33 +240,30 @@ func GetBackupStreamFetcher(backup internal.Backup) (internal.StreamFetcher, err
 	//  	/stream_20240228T115512Z
 	// 			/thread_N   (where N in range 0..fifoStreams)
 	// 				<stream content>
-
-	_, folders, err := backup.Folder.ListFolder()
-	if err != nil {
-		return nil, fmt.Errorf("cannot list files in backup folder '%s' due to: %w", backup.Folder.GetPath(), err)
-	}
-
 	fifoStreams := 0
 	for _, folder := range folders {
 		if ok, _ := regexp.MatchString(".*/thread_\\d/", folder.GetPath()); ok {
 			fifoStreams++
 		}
 	}
+	return fifoStreams, nil
+}
 
+func getBackupStreamFetcher(backup internal.Backup, fifoDir string, fifoStreams int) (internal.StreamFetcher, error) {
 	if fifoStreams > 0 {
-		return FifoMultiStreamFetcher(fifoStreams), nil
+		return FifoMultiStreamFetcher(fifoDir, fifoStreams), nil // FIXME: fail fast?
 	} else {
 		return internal.GetBackupStreamFetcher(backup)
 	}
 }
 
-func FifoMultiStreamFetcher(fifoStreams int) internal.StreamFetcher {
+func FifoMultiStreamFetcher(fifoDir string, fifoStreams int) internal.StreamFetcher {
 	return func(backup internal.Backup, writeCloser io.WriteCloser) error {
 		defer utility.LoggedClose(writeCloser, "")
 
 		errGroup := new(errgroup.Group)
 		for i := 0; i < fifoStreams; i++ {
-			subBackup, err := internal.NewBackup(backup.Folder.GetSubFolder(fmt.Sprintf("thread_%v", i)), backup.Name)
+			subBackup, err := internal.NewBackup(backup.Folder, path.Join(backup.Name, fmt.Sprintf("thread_%v", i)))
 			if err != nil {
 				return err
 			}
@@ -249,7 +272,7 @@ func FifoMultiStreamFetcher(fifoStreams int) internal.StreamFetcher {
 				return err
 			}
 
-			fifoFileName := getXtrabackupFifoFileName(i) // FIXME: new file dir?
+			fifoFileName := getXtrabackupFifoFileName(fifoDir, i) // FIXME: new file dir?
 			err = syscall.Mkfifo(fifoFileName, 0640)
 			if err != nil {
 				return err
@@ -270,10 +293,10 @@ func FifoMultiStreamFetcher(fifoStreams int) internal.StreamFetcher {
 	}
 }
 
-func getXtrabackupFifoFileName(idx int) string {
+func getXtrabackupFifoFileName(fifoDir string, idx int) string {
 	// fifo name format is hardcoded in xtrabackup source code:
 	// https://github.com/percona/percona-xtrabackup/blob/percona-xtrabackup-8.0.35-30/storage/innobase/xtrabackup/src/xbstream.cc#L728
-	return fmt.Sprintf("/tmp/thread_%v", idx) // FIXME: make configurable
+	return path.Join(fifoDir, fmt.Sprintf("thread_%v", idx))
 }
 
 func openFifoFile(fifoFileName string) (*os.File, error) {

--- a/internal/uploader.go
+++ b/internal/uploader.go
@@ -212,8 +212,9 @@ func (uploader *RegularUploader) Failed() bool {
 
 func (uploader *SplitStreamUploader) Clone() Uploader {
 	return &SplitStreamUploader{
-		Uploader:   uploader.Uploader.Clone(),
-		partitions: uploader.partitions,
-		blockSize:  uploader.blockSize,
+		Uploader:    uploader.Uploader.Clone(),
+		partitions:  uploader.partitions,
+		blockSize:   uploader.blockSize,
+		maxFileSize: uploader.maxFileSize,
 	}
 }


### PR DESCRIPTION
## MySQL: Add `--fifo-streams` support to `xtrabackup-push` [PoC]

### History and rationale 

MySQL backup tools has same limitation - they all produce single stream backups. This approach has limitation - we are bounded by single pipe, single compressor and single encryptor performances. When I benchmarked `wal-g` in 2021, I have seen that slowest part is encryption. So, we introduced SplitStream backups https://github.com/wal-g/wal-g/pull/1131 that splits single backup stream into multiple and as a result allows us to use multiple CPU cores for encryption&compression. We speeded up backups from 70Mbp to 270Mps. At this point we reached limits of pipe (stdin) performance.

In 2023, Percona introduced[1] new feature `xtrabackup --fifo-streams`. Basically, they pushed stream separation close to MySQL. In theory it should work even faster than our previous approach.

From Percona's anounce:
```
The STDOUT method takes 01:25:24 to push 1TB of data using 239 MBps (1.8 Gbps).
The FIFO method, using 8 streams, takes 00:16:01 to push 1TB of data using 1.15 GBps (9.2 Gbps).
```

[1] https://docs.percona.com/percona-xtrabackup/innovation-release/xbcloud-binary-fifo-datasink.html

### What this diff about?

Here I am parking my efforts to pass `--fifo-streams` to xtrabackup, and store data in backward-compatible way.


### TODO:
- [ ] benchmarks, benchmarks!
- [ ] cleanup
- [ ] check interference with incremental backups & split stream