### PR TITLE
Added s3 response code metrics

### DIFF
--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -8,6 +8,8 @@ import (
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/cmd/common/st"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/statistics"
 )
 
 const usageTemplate = `Usage:{{if .Runnable}}
@@ -44,12 +46,12 @@ const hiddenConfigFlagAnnotation = "walg_annotation_hidden_config_flag"
 
 func Init(cmd *cobra.Command, dbName string) {
 	internal.ConfigureSettings(dbName)
-	cobra.OnInitialize(internal.InitConfig, internal.Configure)
+	cobra.OnInitialize(conf.InitConfig, conf.Configure)
 
 	cmd.InitDefaultVersionFlag()
-	internal.AddConfigFlags(cmd, hiddenConfigFlagAnnotation)
+	conf.AddConfigFlags(cmd, hiddenConfigFlagAnnotation)
 
-	cmd.PersistentFlags().StringVar(&internal.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")
+	cmd.PersistentFlags().StringVar(&conf.CfgFile, "config", "", "config file (default is $HOME/.walg.json)")
 
 	initHelp(cmd)
 
@@ -82,7 +84,7 @@ func Init(cmd *cobra.Command, dbName string) {
 		}
 
 		// metrics hook
-		internal.PushMetrics()
+		statistics.PushMetrics()
 
 		if p != nil {
 			p.Stop()

--- a/cmd/etcd/backup_fetch.go
+++ b/cmd/etcd/backup_fetch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/etcd"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -20,7 +21,7 @@ var backupFetchCmd = &cobra.Command{
 	Short: backupFetchShortDescription,
 	Args:  cobra.ExactArgs(1),
 	PreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.NameStreamRestoreCmd] = true
+		conf.RequiredSettings[conf.NameStreamRestoreCmd] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
@@ -34,7 +35,7 @@ var backupFetchCmd = &cobra.Command{
 		storage, err := internal.ConfigureStorage()
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		restoreCmd, err := internal.GetCommandSettingContext(ctx, internal.NameStreamRestoreCmd)
+		restoreCmd, err := internal.GetCommandSettingContext(ctx, conf.NameStreamRestoreCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 		targetBackupSelector, err := internal.NewBackupNameSelector(args[0], true)
 		tracelog.ErrorLogger.FatalOnError(err)

--- a/cmd/etcd/backup_push.go
+++ b/cmd/etcd/backup_push.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/etcd"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -20,7 +21,7 @@ var backupPushCmd = &cobra.Command{
 	Use:   "backup-push",
 	Short: backupPushShortDescription,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.NameStreamCreateCmd] = true
+		conf.RequiredSettings[conf.NameStreamCreateCmd] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
@@ -35,7 +36,7 @@ var backupPushCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 		uploader.ChangeDirectory(utility.BaseBackupPath)
 
-		backupCmd, err := internal.GetCommandSetting(internal.NameStreamCreateCmd)
+		backupCmd, err := internal.GetCommandSetting(conf.NameStreamCreateCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 		etcd.HandleBackupPush(uploader, backupCmd)
 	},

--- a/cmd/etcd/etcd.go
+++ b/cmd/etcd/etcd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 var dbShortDescription = "ETCD backup tool"
@@ -39,5 +40,5 @@ func Execute() {
 }
 
 func init() {
-	common.Init(cmd, internal.ETCD)
+	common.Init(cmd, conf.ETCD)
 }

--- a/cmd/etcd/wal_push.go
+++ b/cmd/etcd/wal_push.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/etcd"
 
 	"github.com/wal-g/wal-g/utility"
@@ -23,7 +24,7 @@ var walPushCmd = &cobra.Command{
 	Short: walPushShortDescribtion,
 	Args:  cobra.NoArgs,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.ETCDMemberDataDirectory] = true
+		conf.RequiredSettings[conf.ETCDMemberDataDirectory] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
@@ -35,7 +36,7 @@ var walPushCmd = &cobra.Command{
 		uploader, err := internal.ConfigureUploader()
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		dataDir, err := internal.GetRequiredSetting(internal.ETCDMemberDataDirectory)
+		dataDir, err := conf.GetRequiredSetting(conf.ETCDMemberDataDirectory)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		err = etcd.HandleWALPush(ctx, uploader, dataDir)

--- a/cmd/fdb/backup_fetch.go
+++ b/cmd/fdb/backup_fetch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/fdb"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -29,7 +30,7 @@ var backupFetchCmd = &cobra.Command{
 		storage, err := internal.ConfigureStorage()
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		restoreCmd, err := internal.GetCommandSettingContext(ctx, internal.NameStreamRestoreCmd)
+		restoreCmd, err := internal.GetCommandSettingContext(ctx, conf.NameStreamRestoreCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 		targetBackupSelector, err := internal.NewBackupNameSelector(args[0], true)
 		tracelog.ErrorLogger.FatalOnError(err)

--- a/cmd/fdb/backup_push.go
+++ b/cmd/fdb/backup_push.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/fdb"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -29,12 +30,12 @@ var backupPushCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 		uploader.ChangeDirectory(utility.BaseBackupPath)
 
-		backupCmd, err := internal.GetCommandSetting(internal.NameStreamCreateCmd)
+		backupCmd, err := internal.GetCommandSetting(conf.NameStreamCreateCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 		fdb.HandleBackupPush(uploader, backupCmd)
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.NameStreamCreateCmd] = true
+		conf.RequiredSettings[conf.NameStreamCreateCmd] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/cmd/fdb/fdb.go
+++ b/cmd/fdb/fdb.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/wal-g/wal-g/cmd/common"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
@@ -39,5 +40,5 @@ func Execute() {
 }
 
 func init() {
-	common.Init(cmd, internal.FDB)
+	common.Init(cmd, conf.FDB)
 }

--- a/cmd/gp/backup_fetch.go
+++ b/cmd/gp/backup_fetch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 const (
@@ -47,7 +48,7 @@ var backupFetchCmd = &cobra.Command{
 		}
 
 		if fetchTargetUserData == "" {
-			fetchTargetUserData = viper.GetString(internal.FetchTargetUserDataSetting)
+			fetchTargetUserData = viper.GetString(conf.FetchTargetUserDataSetting)
 		}
 
 		storage, err := internal.ConfigureStorage()
@@ -65,7 +66,7 @@ var backupFetchCmd = &cobra.Command{
 		targetBackupSelector, err := createTargetFetchBackupSelector(cmd, args, fetchTargetUserData, restorePoint)
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		logsDir := viper.GetString(internal.GPLogsDirectory)
+		logsDir := viper.GetString(conf.GPLogsDirectory)
 
 		if len(*fetchContentIds) > 0 {
 			tracelog.InfoLogger.Printf("Will perform fetch operations only on the specified segments: %v", *fetchContentIds)

--- a/cmd/gp/backup_fetch_segment.go
+++ b/cmd/gp/backup_fetch_segment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
@@ -33,7 +34,7 @@ var segBackupFetchCmd = &cobra.Command{
 		internal.ConfigureLimiters()
 
 		if targetUserData == "" {
-			targetUserData = viper.GetString(internal.FetchTargetUserDataSetting)
+			targetUserData = viper.GetString(conf.FetchTargetUserDataSetting)
 		}
 
 		greenplum.SetSegmentStoragePrefix(contentID)
@@ -44,12 +45,12 @@ var segBackupFetchCmd = &cobra.Command{
 		storage, err := internal.ConfigureStorage()
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		reverseDeltaUnpack := viper.GetBool(internal.UseReverseUnpackSetting)
-		skipRedundantTars := viper.GetBool(internal.SkipRedundantTarsSetting)
+		reverseDeltaUnpack := viper.GetBool(conf.UseReverseUnpackSetting)
+		skipRedundantTars := viper.GetBool(conf.SkipRedundantTarsSetting)
 
 		if reverseDeltaUnpack || skipRedundantTars {
 			tracelog.ErrorLogger.Fatalf("%s and %s settings are not supported yet",
-				internal.UseReverseUnpackSetting, internal.SkipRedundantTarsSetting)
+				conf.UseReverseUnpackSetting, conf.SkipRedundantTarsSetting)
 		}
 
 		var extractProv postgres.ExtractProvider

--- a/cmd/gp/backup_push.go
+++ b/cmd/gp/backup_push.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 const (
@@ -34,13 +35,13 @@ var (
 			internal.ConfigureLimiters()
 
 			if deltaFromName == "" {
-				deltaFromName = viper.GetString(internal.DeltaFromNameSetting)
+				deltaFromName = viper.GetString(conf.DeltaFromNameSetting)
 			}
 			if deltaFromUserData == "" {
-				deltaFromUserData = viper.GetString(internal.DeltaFromUserDataSetting)
+				deltaFromUserData = viper.GetString(conf.DeltaFromUserDataSetting)
 			}
 			if userDataRaw == "" {
-				userDataRaw = viper.GetString(internal.SentinelUserDataSetting)
+				userDataRaw = viper.GetString(conf.SentinelUserDataSetting)
 			}
 			userData, err := internal.UnmarshalSentinelUserData(userDataRaw)
 			tracelog.ErrorLogger.FatalfOnError("Failed to unmarshal the provided UserData: %s", err)
@@ -49,12 +50,12 @@ var (
 				deltaFromName, deltaFromUserData, greenplum.NewGenericMetaFetcher())
 			tracelog.ErrorLogger.FatalfOnError("Failed to find the base for a delta backup: %s", err)
 
-			logsDir := viper.GetString(internal.GPLogsDirectory)
+			logsDir := viper.GetString(conf.GPLogsDirectory)
 
-			segPollInterval, err := internal.GetDurationSetting(internal.GPSegmentsPollInterval)
+			segPollInterval, err := conf.GetDurationSetting(conf.GPSegmentsPollInterval)
 			tracelog.ErrorLogger.FatalOnError(err)
 
-			segPollRetries := viper.GetInt(internal.GPSegmentsPollRetries)
+			segPollRetries := viper.GetInt(conf.GPSegmentsPollRetries)
 
 			arguments := greenplum.NewBackupArguments(permanent, fullBackup, userData, prepareSegmentFwdArgs(), logsDir,
 				segPollInterval, segPollRetries, deltaBaseSelector)

--- a/cmd/gp/backup_push_segment.go
+++ b/cmd/gp/backup_push_segment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 const (
@@ -34,13 +35,13 @@ var (
 			dataDirectory := args[0]
 
 			if deltaFromName == "" {
-				deltaFromName = viper.GetString(internal.DeltaFromNameSetting)
+				deltaFromName = viper.GetString(conf.DeltaFromNameSetting)
 			}
 			if deltaFromUserData == "" {
-				deltaFromUserData = viper.GetString(internal.DeltaFromUserDataSetting)
+				deltaFromUserData = viper.GetString(conf.DeltaFromUserDataSetting)
 			}
 			if userDataRaw == "" {
-				userDataRaw = viper.GetString(internal.SentinelUserDataSetting)
+				userDataRaw = viper.GetString(conf.SentinelUserDataSetting)
 			}
 
 			if deltaFromName == "" && deltaFromUserData == "" {

--- a/cmd/gp/gp.go
+++ b/cmd/gp/gp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 var dbShortDescription = "GreenplumDB backup tool"
@@ -32,7 +33,7 @@ var cmd = &cobra.Command{
 	Version: strings.Join([]string{walgVersion, gitRevision, buildDate, "GreenplumDB"}, "\t"),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Greenplum uses the 64MB WAL segment size by default
-		postgres.SetWalSize(viper.GetUint64(internal.PgWalSize))
+		postgres.SetWalSize(viper.GetUint64(conf.PgWalSize))
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
@@ -50,7 +51,7 @@ func Execute() {
 var SegContentID string
 
 func init() {
-	common.Init(cmd, internal.GP)
+	common.Init(cmd, conf.GP)
 
 	_ = cmd.MarkFlagRequired("config") // config is required for Greenplum WAL-G
 	// wrap the Postgres command so it can be used in the same binary
@@ -71,7 +72,7 @@ func init() {
 	// Add the hidden prefetch command to the root command
 	// since WAL-G prefetch fork logic does not know anything about the "wal-g seg" subcommand
 	pg.WalPrefetchCmd.PreRun = func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.StoragePrefixSetting] = true
+		conf.RequiredSettings[conf.StoragePrefixSetting] = true
 		tracelog.ErrorLogger.FatalOnError(internal.AssertRequiredSettingsSet())
 	}
 	cmd.AddCommand(pg.WalPrefetchCmd)

--- a/cmd/gp/segment_cmd_run.go
+++ b/cmd/gp/segment_cmd_run.go
@@ -3,7 +3,7 @@ package gp
 import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 )
 
@@ -22,7 +22,7 @@ var (
 
 			greenplum.SetSegmentStoragePrefix(contentID)
 
-			stateUpdateInterval, err := internal.GetDurationSetting(internal.GPSegmentsUpdInterval)
+			stateUpdateInterval, err := conf.GetDurationSetting(conf.GPSegmentsUpdInterval)
 			tracelog.ErrorLogger.FatalOnError(err)
 			greenplum.NewSegCmdRunner(contentID, cmdName, cmdArgs, stateUpdateInterval).Run()
 		},

--- a/cmd/mongo/backup_fetch.go
+++ b/cmd/mongo/backup_fetch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -28,7 +29,7 @@ var backupFetchCmd = &cobra.Command{
 		storage, err := internal.ConfigureStorage()
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		restoreCmd, err := internal.GetCommandSettingContext(ctx, internal.NameStreamRestoreCmd)
+		restoreCmd, err := internal.GetCommandSettingContext(ctx, conf.NameStreamRestoreCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 		restoreCmd.Stdout = os.Stdout
 		restoreCmd.Stderr = os.Stderr

--- a/cmd/mongo/backup_push.go
+++ b/cmd/mongo/backup_push.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/client"
@@ -36,7 +37,7 @@ var backupPushCmd = &cobra.Command{
 		signalHandler := utility.NewSignalHandler(ctx, cancel, []os.Signal{syscall.SIGINT, syscall.SIGTERM})
 		defer func() { _ = signalHandler.Close() }()
 
-		mongodbURL, err := internal.GetRequiredSetting(internal.MongoDBUriSetting)
+		mongodbURL, err := conf.GetRequiredSetting(conf.MongoDBUriSetting)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		// set up mongodb client and oplog fetcher
@@ -47,7 +48,7 @@ var backupPushCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalOnError(err)
 		uplProvider.ChangeDirectory(utility.BaseBackupPath)
 
-		backupCmd, err := internal.GetCommandSettingContext(ctx, internal.NameStreamCreateCmd)
+		backupCmd, err := internal.GetCommandSettingContext(ctx, conf.NameStreamCreateCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 		backupCmd.Stderr = os.Stderr
 		uploader := archive.NewStorageUploader(uplProvider)
@@ -57,7 +58,7 @@ var backupPushCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalfOnError("Backup creation failed: %v", err)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.NameStreamCreateCmd] = true
+		conf.RequiredSettings[conf.NameStreamCreateCmd] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/cmd/mongo/mongo.go
+++ b/cmd/mongo/mongo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 var dbShortDescription = "MongoDB backup tool"
@@ -26,7 +27,7 @@ var cmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
-		err = internal.ConfigureAndRunDefaultWebServer()
+		err = conf.ConfigureAndRunDefaultWebServer()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
 }
@@ -41,7 +42,7 @@ func Execute() {
 }
 
 func init() {
-	common.Init(cmd, internal.MONGO)
-	internal.AddTurboFlag(cmd)
-	internal.RequiredSettings[internal.MongoDBUriSetting] = true
+	common.Init(cmd, conf.MONGO)
+	conf.AddTurboFlag(cmd)
+	conf.RequiredSettings[conf.MongoDBUriSetting] = true
 }

--- a/cmd/mongo/oplog_purge.go
+++ b/cmd/mongo/oplog_purge.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 )
@@ -22,7 +23,7 @@ var oplogPurgeCmd = &cobra.Command{
 }
 
 func pitrDiscoveryAfterTime() *time.Time {
-	pitrDur, err := internal.GetOplogPITRDiscoveryIntervalSetting()
+	pitrDur, err := conf.GetOplogPITRDiscoveryIntervalSetting()
 	tracelog.ErrorLogger.FatalOnError(err)
 	if pitrDur == nil {
 		return nil

--- a/cmd/mongo/oplog_push.go
+++ b/cmd/mongo/oplog_push.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/client"
@@ -136,29 +137,29 @@ func buildOplogPushRunArgs() (args oplogPushRunArgs, err error) {
 	if err != nil {
 		return
 	}
-	args.archiveTimeout, err = internal.GetDurationSetting(internal.OplogArchiveTimeoutInterval)
+	args.archiveTimeout, err = conf.GetDurationSetting(conf.OplogArchiveTimeoutInterval)
 	if err != nil {
 		return
 	}
 
-	args.mongodbURL, err = internal.GetRequiredSetting(internal.MongoDBUriSetting)
+	args.mongodbURL, err = conf.GetRequiredSetting(conf.MongoDBUriSetting)
 	if err != nil {
 		return
 	}
 
-	args.primaryWait, err = internal.GetBoolSettingDefault(internal.OplogPushWaitForBecomePrimary, false)
+	args.primaryWait, err = conf.GetBoolSettingDefault(conf.OplogPushWaitForBecomePrimary, false)
 	if err != nil {
 		return
 	}
 
 	if args.primaryWait {
-		args.primaryWaitTimeout, err = internal.GetDurationSetting(internal.OplogPushPrimaryCheckInterval)
+		args.primaryWaitTimeout, err = conf.GetDurationSetting(conf.OplogPushPrimaryCheckInterval)
 		if err != nil {
 			return
 		}
 	}
 
-	args.lwUpdate, err = internal.GetDurationSetting(internal.MongoDBLastWriteUpdateInterval)
+	args.lwUpdate, err = conf.GetDurationSetting(conf.MongoDBLastWriteUpdateInterval)
 	return
 }
 
@@ -171,22 +172,22 @@ type oplogPushStatsArgs struct {
 }
 
 func buildOplogPushStatsArgs() (args oplogPushStatsArgs, err error) {
-	args.enabled, err = internal.GetBoolSettingDefault(internal.OplogPushStatsEnabled, false)
+	args.enabled, err = conf.GetBoolSettingDefault(conf.OplogPushStatsEnabled, false)
 	if err != nil || !args.enabled {
 		return
 	}
 
-	args.updateInterval, err = internal.GetDurationSetting(internal.OplogPushStatsUpdateInterval)
+	args.updateInterval, err = conf.GetDurationSetting(conf.OplogPushStatsUpdateInterval)
 	if err != nil {
 		return
 	}
 
-	args.logInterval, err = internal.GetDurationSetting(internal.OplogPushStatsLoggingInterval)
+	args.logInterval, err = conf.GetDurationSetting(conf.OplogPushStatsLoggingInterval)
 	if err != nil {
 		return
 	}
 
-	args.exposeHTTP, err = internal.GetBoolSettingDefault(internal.OplogPushStatsExposeHTTP, false)
+	args.exposeHTTP, err = conf.GetBoolSettingDefault(conf.OplogPushStatsExposeHTTP, false)
 	args.httpPrefix = stats.DefaultOplogPushStatsPrefix
 
 	return

--- a/cmd/mongo/oplog_replay.go
+++ b/cmd/mongo/oplog_replay.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/client"
@@ -69,18 +70,18 @@ func buildOplogReplayRunArgs(cmdargs []string) (args oplogReplayRunArgs, err err
 	}
 
 	// TODO: fix ugly config
-	if ignoreErrCodesStr, ok := internal.GetSetting(internal.OplogReplayIgnoreErrorCodes); ok {
+	if ignoreErrCodesStr, ok := conf.GetSetting(conf.OplogReplayIgnoreErrorCodes); ok {
 		if err = json.Unmarshal([]byte(ignoreErrCodesStr), &args.ignoreErrCodes); err != nil {
 			return
 		}
 	}
 
-	args.mongodbURL, err = internal.GetRequiredSetting(internal.MongoDBUriSetting)
+	args.mongodbURL, err = conf.GetRequiredSetting(conf.MongoDBUriSetting)
 	if err != nil {
 		return
 	}
 
-	oplogAlwaysUpsert, hasOplogAlwaysUpsert, err := internal.GetBoolSetting(internal.OplogReplayOplogAlwaysUpsert)
+	oplogAlwaysUpsert, hasOplogAlwaysUpsert, err := conf.GetBoolSetting(conf.OplogReplayOplogAlwaysUpsert)
 	if err != nil {
 		return
 	}
@@ -88,8 +89,8 @@ func buildOplogReplayRunArgs(cmdargs []string) (args oplogReplayRunArgs, err err
 		args.oplogAlwaysUpsert = &oplogAlwaysUpsert
 	}
 
-	if oplogApplicationMode, hasOplogApplicationMode := internal.GetSetting(
-		internal.OplogReplayOplogApplicationMode); hasOplogApplicationMode {
+	if oplogApplicationMode, hasOplogApplicationMode := conf.GetSetting(
+		conf.OplogReplayOplogApplicationMode); hasOplogApplicationMode {
 		args.oplogApplicationMode = &oplogApplicationMode
 	}
 

--- a/cmd/mysql/backup_fetch.go
+++ b/cmd/mysql/backup_fetch.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 )
 
@@ -20,7 +21,7 @@ var (
 		Short: backupFetchShortDescription,
 		Args:  cobra.RangeArgs(0, 1),
 		PreRun: func(cmd *cobra.Command, args []string) {
-			internal.RequiredSettings[internal.NameStreamRestoreCmd] = true
+			conf.RequiredSettings[conf.NameStreamRestoreCmd] = true
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
 		},
@@ -28,9 +29,9 @@ var (
 			internal.ConfigureLimiters()
 			storage, err := internal.ConfigureStorage()
 			tracelog.ErrorLogger.FatalOnError(err)
-			restoreCmd, err := internal.GetCommandSetting(internal.NameStreamRestoreCmd)
+			restoreCmd, err := internal.GetCommandSetting(conf.NameStreamRestoreCmd)
 			tracelog.ErrorLogger.FatalOnError(err)
-			prepareCmd, _ := internal.GetCommandSetting(internal.MysqlBackupPrepareCmd)
+			prepareCmd, _ := internal.GetCommandSetting(conf.MysqlBackupPrepareCmd)
 
 			targetBackupSelector, err := createTargetBackupSelector(args, fetchTargetUserData)
 			tracelog.ErrorLogger.FatalOnError(err)
@@ -43,7 +44,7 @@ var (
 
 func createTargetBackupSelector(args []string, fetchTargetUserData string) (internal.BackupSelector, error) {
 	if fetchTargetUserData == "" {
-		fetchTargetUserData = viper.GetString(internal.FetchTargetUserDataSetting)
+		fetchTargetUserData = viper.GetString(conf.FetchTargetUserDataSetting)
 	}
 	fetchTargetBackupName := ""
 	if len(args) >= 1 {

--- a/cmd/mysql/backup_push.go
+++ b/cmd/mysql/backup_push.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -23,8 +24,8 @@ var (
 		Use:   "backup-push",
 		Short: backupPushShortDescription,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			internal.RequiredSettings[internal.NameStreamCreateCmd] = true
-			internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
+			conf.RequiredSettings[conf.NameStreamCreateCmd] = true
+			conf.RequiredSettings[conf.MysqlDatasourceNameSetting] = true
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
 		},
@@ -35,11 +36,11 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 			folder := uploader.Folder()
 			uploader.ChangeDirectory(utility.BaseBackupPath)
-			backupCmd, err := internal.GetCommandSetting(internal.NameStreamCreateCmd)
+			backupCmd, err := internal.GetCommandSetting(conf.NameStreamCreateCmd)
 			tracelog.ErrorLogger.FatalOnError(err)
 
 			if userData == "" {
-				userData = viper.GetString(internal.SentinelUserDataSetting)
+				userData = viper.GetString(conf.SentinelUserDataSetting)
 			}
 
 			mysql.HandleBackupPush(

--- a/cmd/mysql/binlog_fetch.go
+++ b/cmd/mysql/binlog_fetch.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -30,7 +31,7 @@ var binlogFetchCmd = &cobra.Command{
 		mysql.HandleBinlogFetch(storage.RootFolder(), fetchBackupName, fetchUntilTS, fetchUntilBinlogLastModifiedTS)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.MysqlBinlogDstSetting] = true
+		conf.RequiredSettings[conf.MysqlBinlogDstSetting] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/cmd/mysql/binlog_push.go
+++ b/cmd/mysql/binlog_push.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 )
 
@@ -19,11 +20,11 @@ var binlogPushCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		uploader, err := internal.ConfigureUploader()
 		tracelog.ErrorLogger.FatalOnError(err)
-		checkGTIDs, _ := internal.GetBoolSettingDefault(internal.MysqlCheckGTIDs, false)
+		checkGTIDs, _ := conf.GetBoolSettingDefault(conf.MysqlCheckGTIDs, false)
 		mysql.HandleBinlogPush(uploader, untilBinlog, checkGTIDs)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
+		conf.RequiredSettings[conf.MysqlDatasourceNameSetting] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/cmd/mysql/binlog_replay.go
+++ b/cmd/mysql/binlog_replay.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -29,7 +30,7 @@ var binlogReplayCmd = &cobra.Command{
 		mysql.HandleBinlogReplay(storage.RootFolder(), replayBackupName, replayUntilTS, replayUntilBinlogLastModifiedTS)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.MysqlBinlogReplayCmd] = true
+		conf.RequiredSettings[conf.MysqlBinlogReplayCmd] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/cmd/mysql/binlog_server.go
+++ b/cmd/mysql/binlog_server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -25,12 +26,12 @@ var (
 		Short: binlogServerShortDescription,
 		Args:  cobra.NoArgs,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			internal.RequiredSettings[internal.MysqlBinlogServerHost] = true
-			internal.RequiredSettings[internal.MysqlBinlogServerPort] = true
-			internal.RequiredSettings[internal.MysqlBinlogServerUser] = true
-			internal.RequiredSettings[internal.MysqlBinlogServerPassword] = true
-			internal.RequiredSettings[internal.MysqlBinlogServerID] = true
-			internal.RequiredSettings[internal.MysqlBinlogServerReplicaSource] = true
+			conf.RequiredSettings[conf.MysqlBinlogServerHost] = true
+			conf.RequiredSettings[conf.MysqlBinlogServerPort] = true
+			conf.RequiredSettings[conf.MysqlBinlogServerUser] = true
+			conf.RequiredSettings[conf.MysqlBinlogServerPassword] = true
+			conf.RequiredSettings[conf.MysqlBinlogServerID] = true
+			conf.RequiredSettings[conf.MysqlBinlogServerReplicaSource] = true
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
 		},

--- a/cmd/mysql/find_binlog.go
+++ b/cmd/mysql/find_binlog.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 )
 
@@ -17,7 +18,7 @@ var (
 		Use:   "binlog-find",
 		Short: findBinlogShortDescription,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
+			conf.RequiredSettings[conf.MysqlDatasourceNameSetting] = true
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
 		},

--- a/cmd/mysql/mysql.go
+++ b/cmd/mysql/mysql.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 var ShortDescription = "MySQL backup tool"
@@ -28,7 +29,7 @@ var cmd = &cobra.Command{
 		if err != nil {
 			tracelog.WarningLogger.PrintError(err)
 		}
-		err = internal.ConfigureAndRunDefaultWebServer()
+		err = conf.ConfigureAndRunDefaultWebServer()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
 }
@@ -43,6 +44,6 @@ func Execute() {
 }
 
 func init() {
-	common.Init(cmd, internal.MYSQL)
-	internal.AddTurboFlag(cmd)
+	common.Init(cmd, conf.MYSQL)
+	conf.AddTurboFlag(cmd)
 }

--- a/cmd/mysql/xtrabackup_push.go
+++ b/cmd/mysql/xtrabackup_push.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mysql"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -25,8 +26,8 @@ var (
 		Use:   "xtrabackup-push",
 		Short: xtrabackupPushShortDescription,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			internal.RequiredSettings[internal.NameStreamCreateCmd] = true
-			internal.RequiredSettings[internal.MysqlDatasourceNameSetting] = true
+			conf.RequiredSettings[conf.NameStreamCreateCmd] = true
+			conf.RequiredSettings[conf.MysqlDatasourceNameSetting] = true
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
 		},
@@ -35,10 +36,10 @@ var (
 
 			// FIXME: do we need this?
 			if deltaFromName == "" {
-				deltaFromName = viper.GetString(internal.DeltaFromNameSetting)
+				deltaFromName = viper.GetString(conf.DeltaFromNameSetting)
 			}
 			if deltaFromUserData == "" {
-				deltaFromUserData = viper.GetString(internal.DeltaFromUserDataSetting)
+				deltaFromUserData = viper.GetString(conf.DeltaFromUserDataSetting)
 			}
 
 			deltaBaseSelector, err := internal.NewDeltaBaseSelector(
@@ -49,11 +50,11 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 			folder := uploader.Folder()
 			uploader.ChangeDirectory(utility.BaseBackupPath)
-			backupCmd, err := internal.GetCommandSetting(internal.NameStreamCreateCmd)
+			backupCmd, err := internal.GetCommandSetting(conf.NameStreamCreateCmd)
 			tracelog.ErrorLogger.FatalOnError(err)
 
 			if userData == "" {
-				userData = viper.GetString(internal.SentinelUserDataSetting)
+				userData = viper.GetString(conf.SentinelUserDataSetting)
 			}
 
 			mysql.HandleBackupPush(

--- a/cmd/pg/backup_fetch.go
+++ b/cmd/pg/backup_fetch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"
@@ -41,7 +42,7 @@ var backupFetchCmd = &cobra.Command{
 		internal.ConfigureLimiters()
 
 		if fetchTargetUserData == "" {
-			fetchTargetUserData = viper.GetString(internal.FetchTargetUserDataSetting)
+			fetchTargetUserData = viper.GetString(conf.FetchTargetUserDataSetting)
 		}
 		targetBackupSelector, err := createTargetFetchBackupSelector(cmd, args, fetchTargetUserData)
 		tracelog.ErrorLogger.FatalOnError(err)
@@ -62,8 +63,8 @@ var backupFetchCmd = &cobra.Command{
 			skipRedundantTars = true
 			reverseDeltaUnpack = true
 		}
-		reverseDeltaUnpack = reverseDeltaUnpack || viper.GetBool(internal.UseReverseUnpackSetting)
-		skipRedundantTars = skipRedundantTars || viper.GetBool(internal.SkipRedundantTarsSetting)
+		reverseDeltaUnpack = reverseDeltaUnpack || viper.GetBool(conf.UseReverseUnpackSetting)
+		skipRedundantTars = skipRedundantTars || viper.GetBool(conf.SkipRedundantTarsSetting)
 
 		var extractProv postgres.ExtractProvider
 

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 const (
@@ -67,21 +68,21 @@ var (
 				dataDirectory = args[0]
 			}
 
-			verifyPageChecksums = verifyPageChecksums || viper.GetBool(internal.VerifyPageChecksumsSetting)
-			storeAllCorruptBlocks = storeAllCorruptBlocks || viper.GetBool(internal.StoreAllCorruptBlocksSetting)
+			verifyPageChecksums = verifyPageChecksums || viper.GetBool(conf.VerifyPageChecksumsSetting)
+			storeAllCorruptBlocks = storeAllCorruptBlocks || viper.GetBool(conf.StoreAllCorruptBlocksSetting)
 
 			tarBallComposerType := chooseTarBallComposer()
 
 			if deltaFromName == "" {
-				deltaFromName = viper.GetString(internal.DeltaFromNameSetting)
+				deltaFromName = viper.GetString(conf.DeltaFromNameSetting)
 			}
 			if deltaFromUserData == "" {
-				deltaFromUserData = viper.GetString(internal.DeltaFromUserDataSetting)
+				deltaFromUserData = viper.GetString(conf.DeltaFromUserDataSetting)
 			}
 			if userDataRaw == "" {
-				userDataRaw = viper.GetString(internal.SentinelUserDataSetting)
+				userDataRaw = viper.GetString(conf.SentinelUserDataSetting)
 			}
-			withoutFilesMetadata = withoutFilesMetadata || viper.GetBool(internal.WithoutFilesMetadataSetting)
+			withoutFilesMetadata = withoutFilesMetadata || viper.GetBool(conf.WithoutFilesMetadataSetting)
 			if withoutFilesMetadata {
 				// files metadata tracking is required for delta backups and copy/rating composers
 				if tarBallComposerType != postgres.RegularComposer {
@@ -106,8 +107,8 @@ var (
 			tracelog.ErrorLogger.FatalfOnError("Failed to unmarshal the provided UserData: %s", err)
 
 			arguments := postgres.NewBackupArguments(uploader, dataDirectory, utility.BaseBackupPath,
-				permanent, verifyPageChecksums || viper.GetBool(internal.VerifyPageChecksumsSetting),
-				fullBackup, storeAllCorruptBlocks || viper.GetBool(internal.StoreAllCorruptBlocksSetting),
+				permanent, verifyPageChecksums || viper.GetBool(conf.VerifyPageChecksumsSetting),
+				fullBackup, storeAllCorruptBlocks || viper.GetBool(conf.StoreAllCorruptBlocksSetting),
 				tarBallComposerType, postgres.NewRegularDeltaBackupConfigurator(deltaBaseSelector),
 				userData, withoutFilesMetadata)
 
@@ -132,17 +133,17 @@ var (
 func chooseTarBallComposer() postgres.TarBallComposerType {
 	tarBallComposerType := postgres.RegularComposer
 
-	useRatingComposer = useRatingComposer || viper.GetBool(internal.UseRatingComposerSetting)
+	useRatingComposer = useRatingComposer || viper.GetBool(conf.UseRatingComposerSetting)
 	if useRatingComposer {
 		tarBallComposerType = postgres.RatingComposer
 	}
 
-	useDatabaseComposer = useDatabaseComposer || viper.GetBool(internal.UseDatabaseComposerSetting)
+	useDatabaseComposer = useDatabaseComposer || viper.GetBool(conf.UseDatabaseComposerSetting)
 	if useDatabaseComposer {
 		tarBallComposerType = postgres.DatabaseComposer
 	}
 
-	useCopyComposer = useCopyComposer || viper.GetBool(internal.UseCopyComposerSetting)
+	useCopyComposer = useCopyComposer || viper.GetBool(conf.UseCopyComposerSetting)
 	if useCopyComposer {
 		fullBackup = true
 		tarBallComposerType = postgres.CopyComposer

--- a/cmd/pg/pg.go
+++ b/cmd/pg/pg.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/cmd/common"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
@@ -29,14 +30,14 @@ var (
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
 
-			if viper.IsSet(internal.PgWalSize) {
-				postgres.SetWalSize(viper.GetUint64(internal.PgWalSize))
+			if viper.IsSet(conf.PgWalSize) {
+				postgres.SetWalSize(viper.GetUint64(conf.PgWalSize))
 			}
 
 			// In case the --target-storage flag isn't specified (the variable is set in commands' init() funcs),
 			// we take the value from the config.
 			if targetStorage == "" {
-				targetStorage = viper.GetString(internal.PgTargetStorage)
+				targetStorage = viper.GetString(conf.PgTargetStorage)
 			}
 		},
 	}
@@ -56,6 +57,6 @@ func Execute() {
 }
 
 func configureCommand() {
-	common.Init(Cmd, internal.PG)
-	internal.AddTurboFlag(Cmd)
+	common.Init(Cmd, conf.PG)
+	conf.AddTurboFlag(Cmd)
 }

--- a/cmd/pg/pgbackrest.go
+++ b/cmd/pg/pgbackrest.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
@@ -21,6 +22,6 @@ func init() {
 func configurePgbackrestSettings() (folder storage.Folder, stanza string) {
 	st, err := internal.ConfigureStorage()
 	tracelog.ErrorLogger.FatalOnError(err)
-	stanza, _ = internal.GetSetting(internal.PgBackRestStanza)
+	stanza, _ = conf.GetSetting(conf.PgBackRestStanza)
 	return st.RootFolder(), stanza
 }

--- a/cmd/pg/wal_prefetch.go
+++ b/cmd/pg/wal_prefetch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
@@ -42,7 +43,7 @@ func init() {
 // wal-prefetch (WalPrefetchCmd) is internal tool, so to avoid confusion about errors in restoration process
 // we reconfigure loggers specially for internal use. All logs having PREFETCH prefix can be safely ignored
 func reconfigureLoggers() {
-	if viper.Get(internal.LogLevelSetting) == tracelog.DevelLogLevel {
+	if viper.Get(conf.LogLevelSetting) == tracelog.DevelLogLevel {
 		addPrefetchPrefixToAllLoggers()
 		return
 	}

--- a/cmd/redis/backup_fetch.go
+++ b/cmd/redis/backup_fetch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/redis"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -29,10 +30,10 @@ var backupFetchCmd = &cobra.Command{
 		storage, err := internal.ConfigureStorage()
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		restoreCmd, err := internal.GetCommandSettingContext(ctx, internal.NameStreamRestoreCmd)
+		restoreCmd, err := internal.GetCommandSettingContext(ctx, conf.NameStreamRestoreCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		redisPassword, ok := internal.GetSetting(internal.RedisPassword)
+		redisPassword, ok := conf.GetSetting(conf.RedisPassword)
 		if ok && redisPassword != "" { // special hack for redis-cli
 			restoreCmd.Env = append(restoreCmd.Env, fmt.Sprintf("REDISCLI_AUTH=%s", redisPassword))
 		}

--- a/cmd/redis/backup_push.go
+++ b/cmd/redis/backup_push.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/redis"
 	"github.com/wal-g/wal-g/internal/databases/redis/archive"
 	"github.com/wal-g/wal-g/utility"
@@ -42,10 +43,10 @@ var backupPushCmd = &cobra.Command{
 		// Configure folder
 		uploader.ChangeDirectory(utility.BaseBackupPath)
 
-		backupCmd, err := internal.GetCommandSettingContext(ctx, internal.NameStreamCreateCmd)
+		backupCmd, err := internal.GetCommandSettingContext(ctx, conf.NameStreamCreateCmd)
 		tracelog.ErrorLogger.FatalOnError(err)
 
-		redisPassword, ok := internal.GetSetting(internal.RedisPassword)
+		redisPassword, ok := conf.GetSetting(conf.RedisPassword)
 		if ok && redisPassword != "" { // special hack for redis-cli
 			backupCmd.Env = append(backupCmd.Env, fmt.Sprintf("REDISCLI_AUTH=%s", redisPassword))
 		}
@@ -56,7 +57,7 @@ var backupPushCmd = &cobra.Command{
 		tracelog.ErrorLogger.FatalfOnError("Redis backup creation failed: %v", err)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		internal.RequiredSettings[internal.NameStreamCreateCmd] = true
+		conf.RequiredSettings[conf.NameStreamCreateCmd] = true
 		err := internal.AssertRequiredSettingsSet()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/cmd/redis/redis.go
+++ b/cmd/redis/redis.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 var ShortDescription = "Redis backup tool"
@@ -39,5 +40,5 @@ func Execute() {
 }
 
 func init() {
-	common.Init(cmd, internal.REDIS)
+	common.Init(cmd, conf.REDIS)
 }

--- a/cmd/sqlserver/sqlserver.go
+++ b/cmd/sqlserver/sqlserver.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/cmd/common"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/spf13/cobra"
 	"github.com/wal-g/wal-g/internal"
@@ -28,7 +29,7 @@ var cmd = &cobra.Command{
 		if err != nil {
 			tracelog.WarningLogger.PrintError(err)
 		}
-		err = internal.ConfigureAndRunDefaultWebServer()
+		err = conf.ConfigureAndRunDefaultWebServer()
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
 }
@@ -43,5 +44,5 @@ func Execute() {
 }
 
 func init() {
-	common.Init(cmd, internal.SQLSERVER)
+	common.Init(cmd, conf.SQLSERVER)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,10 @@ x-s3_common_depends: &s3_common_depends
 x-s3_throttling_depends: &s3_throttling_depends
   depends_on:
     - s3-for-throttling
-    - graphite
+    # - graphite
   links:
     - s3-for-throttling
-    - graphite
+    # - graphite
 
 services:
   golang:
@@ -47,15 +47,6 @@ services:
     hostname: swift
     ports:
       - "8010:8080"
-
-  statsd:
-    build:
-      dockerfile: docker/common/Dockerfile
-      context: .
-    container_name: wal-g_statsd
-    ports:
-      - "8125:8125"
-      - "2003:2003"
 
   # "WALG_STATSD_ADDRESS": "wal-g_graphite:8125"
   graphite:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,20 @@ volumes:
 x-s3_common_depends: &s3_common_depends
   depends_on:
     - s3
+    - graphite
+   # - statsd
   links:
     - s3
+    - graphite
+  #  - statsd
 
 x-s3_throttling_depends: &s3_throttling_depends
   depends_on:
     - s3-for-throttling
+    - graphite
   links:
     - s3-for-throttling
+    - graphite
 
 services:
   golang:
@@ -43,6 +49,30 @@ services:
     hostname: swift
     ports:
       - "8010:8080"
+
+  statsd:
+    build:
+      dockerfile: docker/common/Dockerfile
+      context: .
+    container_name: wal-g_statsd
+    ports:
+      - "8125:8125"
+      - "2003:2003"
+
+  graphite:
+    image: hopsoft/graphite-statsd
+    hostname: wal-g_graphite
+    container_name: wal-g_graphite
+    ports:
+      - "8125:8125"
+      - "8126:8126"
+      - "2003:2003"
+      - "2023:2023"
+      - "2004:2004"
+      - "2024:2024"
+      - "80:80"
+      - "81:81"
+      - "3000:3000"
 
   s3:
     image: minio/minio:RELEASE.2021-06-07T21-40-51Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,10 @@ volumes:
 x-s3_common_depends: &s3_common_depends
   depends_on:
     - s3
-    - graphite
-   # - statsd
+    # - graphite
   links:
     - s3
-    - graphite
-  #  - statsd
+    # - graphite
 
 x-s3_throttling_depends: &s3_throttling_depends
   depends_on:
@@ -59,6 +57,7 @@ services:
       - "8125:8125"
       - "2003:2003"
 
+  # "WALG_STATSD_ADDRESS": "wal-g_graphite:8125"
   graphite:
     image: hopsoft/graphite-statsd
     hostname: wal-g_graphite

--- a/docker/pg_tests/scripts/configs/common_config.json
+++ b/docker/pg_tests/scripts/configs/common_config.json
@@ -8,4 +8,7 @@
 "PGDATABASE": "postgres",
 "AWS_S3_FORCE_PATH_STYLE": "true",
 "WALG_COMPRESSION_METHOD": "brotli",
-"PGHOST": "/var/run/postgresql"
+"PGHOST": "/var/run/postgresql",
+"WALG_LOG_LEVEL": "DEVEL",
+"WALG_STATSD_ADDRESS": "wal-g_graphite:8125",
+"WALG_DOWNLOAD_CONCURRENCY": "1"

--- a/docker/pg_tests/scripts/configs/common_config.json
+++ b/docker/pg_tests/scripts/configs/common_config.json
@@ -8,7 +8,4 @@
 "PGDATABASE": "postgres",
 "AWS_S3_FORCE_PATH_STYLE": "true",
 "WALG_COMPRESSION_METHOD": "brotli",
-"PGHOST": "/var/run/postgresql",
-"WALG_LOG_LEVEL": "DEVEL",
-"WALG_STATSD_ADDRESS": "wal-g_graphite:8125",
-"WALG_DOWNLOAD_CONCURRENCY": "1"
+"PGHOST": "/var/run/postgresql"

--- a/docs/README.md
+++ b/docs/README.md
@@ -148,11 +148,13 @@ Similar to `WALG_ENVELOPE_PGP_KEY`, but value is the path to the key on file sys
 
 * `WALG_STATSD_ADDRESS`
 
-To enable metrics publishing to [statsd](https://github.com/statsd/statsd) or [statsd_exporter](https://github.com/prometheus/statsd_exporter). Metrics will be sent on a best-effort basis via UDP. The default port for statsd is `9125`.
+To enable metrics publishing to [statsd](https://github.com/statsd/statsd) or [statsd_exporter](https://github.com/prometheus/statsd_exporter). Metrics will be sent on a best-effort basis via UDP. The default port for statsd is `8125`.
 
 * `WALG_STATSD_EXTRA_TAGS`
 
 Use this setting to add static tags (`host`, `operation`, `database`, etc) to the metrics WAL-G publishes to statsd.
+
+If you want to make demo for testing purposes, you can use graphite service from docker-compose file.
 
 ### Profiling
 

--- a/internal/backup_fetch_test.go
+++ b/internal/backup_fetch_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/testtools"
@@ -13,8 +14,8 @@ import (
 
 func init() {
 	internal.ConfigureSettings("")
-	internal.InitConfig()
-	internal.Configure()
+	conf.InitConfig()
+	conf.Configure()
 }
 
 func TestGetBackupByName_Latest(t *testing.T) {

--- a/internal/compression/lzo/lzo_test.go
+++ b/internal/compression/lzo/lzo_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	walg_lzo "github.com/wal-g/wal-g/internal/compression/lzo"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/testtools"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -147,6 +148,6 @@ func (b *BufferReaderMaker) Mode() int64                    { return 0 }
 
 func init() {
 	internal.ConfigureSettings("")
-	internal.InitConfig()
-	internal.Configure()
+	conf.InitConfig()
+	conf.Configure()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,17 +1,14 @@
-package internal
+package config
 
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"os/user"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
-
-	"github.com/wal-g/wal-g/internal/limiters"
-	"github.com/wal-g/wal-g/utility"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -19,7 +16,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/webserver"
-	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
 const (
@@ -217,9 +213,9 @@ const (
 
 var (
 	CfgFile             string
-	defaultConfigValues map[string]string
+	DefaultConfigValues map[string]string
 
-	commonDefaultConfigValues = map[string]string{
+	CommonDefaultConfigValues = map[string]string{
 		DownloadConcurrencySetting:     "10",
 		UploadConcurrencySetting:       "16",
 		UploadDiskConcurrencySetting:   "1",
@@ -556,66 +552,21 @@ var (
 	}
 )
 
+type UnsetRequiredSettingError struct {
+	error
+}
+
+func NewUnsetRequiredSettingError(settingName string) UnsetRequiredSettingError {
+	return UnsetRequiredSettingError{errors.Errorf("%v is required to be set, but it isn't", settingName)}
+}
+
+func (err UnsetRequiredSettingError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}
+
 func AddTurboFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(&Turbo, "turbo", "", false,
 		"Ignore all kinds of throttling defined in config")
-}
-
-// nolint: gocyclo
-func ConfigureSettings(currentType string) {
-	if len(defaultConfigValues) == 0 {
-		defaultConfigValues = commonDefaultConfigValues
-		dbSpecificDefaultSettings := map[string]string{}
-		switch currentType {
-		case PG:
-			dbSpecificDefaultSettings = PGDefaultSettings
-		case MONGO:
-			dbSpecificDefaultSettings = MongoDefaultSettings
-		case MYSQL:
-			dbSpecificDefaultSettings = MysqlDefaultSettings
-		case SQLSERVER:
-			dbSpecificDefaultSettings = SQLServerDefaultSettings
-		case GP:
-			dbSpecificDefaultSettings = GPDefaultSettings
-		}
-
-		for k, v := range dbSpecificDefaultSettings {
-			defaultConfigValues[k] = v
-		}
-	}
-
-	if len(AllowedSettings) == 0 {
-		AllowedSettings = CommonAllowedSettings
-		dbSpecificSettings := map[string]bool{}
-		switch currentType {
-		case PG:
-			dbSpecificSettings = PGAllowedSettings
-		case GP:
-			for setting := range PGAllowedSettings {
-				GPAllowedSettings[setting] = true
-			}
-			dbSpecificSettings = GPAllowedSettings
-		case MONGO:
-			dbSpecificSettings = MongoAllowedSettings
-		case MYSQL:
-			dbSpecificSettings = MysqlAllowedSettings
-		case SQLSERVER:
-			dbSpecificSettings = SQLServerAllowedSettings
-		case REDIS:
-			dbSpecificSettings = RedisAllowedSettings
-		}
-
-		for k, v := range dbSpecificSettings {
-			AllowedSettings[k] = v
-		}
-
-		for _, adapter := range StorageAdapters {
-			for _, setting := range adapter.settingNames {
-				AllowedSettings[setting] = true
-			}
-			AllowedSettings["WALG_"+adapter.PrefixSettingKey()] = true
-		}
-	}
 }
 
 func isAllowedSetting(setting string, AllowedSettings map[string]bool) (exists bool) {
@@ -631,11 +582,11 @@ func GetSetting(key string) (value string, ok bool) {
 	return "", false
 }
 
-func getWaleCompatibleSetting(key string) (value string, exists bool) {
-	return getWaleCompatibleSettingFrom(key, viper.GetViper())
+func GetWaleCompatibleSetting(key string) (value string, exists bool) {
+	return GetWaleCompatibleSettingFrom(key, viper.GetViper())
 }
 
-func getWaleCompatibleSettingFrom(key string, config *viper.Viper) (value string, exists bool) {
+func GetWaleCompatibleSettingFrom(key string, config *viper.Viper) (value string, exists bool) {
 	settingKeys := []string{
 		"WALG_" + key,
 		"WALE_" + key,
@@ -648,11 +599,18 @@ func getWaleCompatibleSettingFrom(key string, config *viper.Viper) (value string
 	}
 	// Then we try to get default value
 	for _, settingKey := range settingKeys {
-		if val, ok := defaultConfigValues[settingKey]; ok && len(val) > 0 {
+		if val, ok := DefaultConfigValues[settingKey]; ok && len(val) > 0 {
 			return val, true
 		}
 	}
 	return "", false
+}
+
+func ConfigureLogging() error {
+	if viper.IsSet(LogLevelSetting) {
+		return tracelog.UpdateLogLevel(viper.GetString(LogLevelSetting))
+	}
+	return nil
 }
 
 func Configure() {
@@ -725,7 +683,7 @@ func ConfigureAndRunDefaultWebServer() error {
 func AddConfigFlags(Cmd *cobra.Command, hiddenCfgFlagAnnotation string) {
 	cfgFlags := &pflag.FlagSet{}
 	for k := range AllowedSettings {
-		flagName := toFlagName(k)
+		flagName := ToFlagName(k)
 		isRequired, exist := RequiredSettings[k]
 		flagUsage := ""
 		if exist && isRequired {
@@ -784,7 +742,7 @@ func ReadConfigFromFile(config *viper.Viper, configFile string) {
 
 // SetDefaultValues set default settings to the viper instance
 func SetDefaultValues(config *viper.Viper) {
-	for setting, value := range defaultConfigValues {
+	for setting, value := range DefaultConfigValues {
 		config.SetDefault(setting, value)
 	}
 }
@@ -815,53 +773,8 @@ func CheckAllowedSettings(config *viper.Viper) {
 	}
 }
 
-func AssertRequiredSettingsSet() error {
-	if !isAnyStorageSet() {
-		return errors.New("Failed to find any configured storage")
-	}
-
-	for setting, required := range RequiredSettings {
-		isSet := viper.IsSet(setting)
-
-		if !isSet && required {
-			message := "Required variable " + setting + " is not set. You can set is using --" + toFlagName(setting) +
-				" flag or variable " + setting
-			return errors.New(message)
-		}
-	}
-
-	return nil
-}
-
-func isAnyStorageSet() bool {
-	for _, adapter := range StorageAdapters {
-		_, exists := getWaleCompatibleSetting(adapter.PrefixSettingKey())
-		if exists {
-			return true
-		}
-	}
-
-	return false
-}
-
-func toFlagName(s string) string {
+func ToFlagName(s string) string {
 	return strings.ReplaceAll(strings.ToLower(s), "_", "-")
-}
-
-// StorageFromConfig prefers the config parameters instead of the current environment variables
-func StorageFromConfig(configFile string) (storage.Storage, error) {
-	var config = viper.New()
-	SetDefaultValues(config)
-	ReadConfigFromFile(config, configFile)
-	CheckAllowedSettings(config)
-
-	folder, err := ConfigureStorageForSpecificConfig(config)
-
-	if err != nil {
-		tracelog.ErrorLogger.Println("Failed configure folder according to config " + configFile)
-		tracelog.ErrorLogger.FatalError(err)
-	}
-	return folder, err
 }
 
 // Set the compiled config to ENV.
@@ -890,48 +803,44 @@ func bindConfigToEnv(globalViper *viper.Viper) {
 	}
 }
 
-func ConfigureFailoverStorages() (failovers map[string]storage.HashableStorage, err error) {
-	storageConfigs := viper.GetStringMap(PgFailoverStorages)
-
-	if len(storageConfigs) == 0 {
-		return nil, nil
+func GetRequiredSetting(setting string) (string, error) {
+	val, ok := GetSetting(setting)
+	if !ok {
+		return "", NewUnsetRequiredSettingError(setting)
 	}
+	return val, nil
+}
 
-	// errClosers are needed to close already configured storages if failed to configure all of them.
-	var errClosers []io.Closer
-	defer func() {
-		if err == nil {
-			return
-		}
-		for _, closer := range errClosers {
-			utility.LoggedClose(closer, "Failed to close storage")
-		}
-	}()
-
-	storages := make(map[string]storage.HashableStorage, len(storageConfigs))
-	for name := range storageConfigs {
-		if name == "default" {
-			return nil, fmt.Errorf("'%s' storage name is reserved", name)
-		}
-
-		cfg := viper.Sub(PgFailoverStorages + "." + name)
-
-		var rootWraps []storage.WrapRootFolder
-		if limiters.NetworkLimiter != nil {
-			rootWraps = append(rootWraps, func(prevFolder storage.Folder) (newFolder storage.Folder) {
-				return NewLimitedFolder(prevFolder, limiters.NetworkLimiter)
-			})
-		}
-		rootWraps = append(rootWraps, ConfigureStoragePrefix)
-
-		st, err := ConfigureStorageForSpecificConfig(cfg, rootWraps...)
-		if err != nil {
-			return nil, fmt.Errorf("failover storage %s: %v", name, err)
-		}
-		errClosers = append(errClosers, st)
-
-		storages[name] = st
+func GetBoolSettingDefault(setting string, def bool) (bool, error) {
+	val, ok := GetSetting(setting)
+	if !ok {
+		return def, nil
 	}
+	return strconv.ParseBool(val)
+}
 
-	return storages, nil
+func GetBoolSetting(setting string) (val bool, ok bool, err error) {
+	valstr, ok := GetSetting(setting)
+	if !ok {
+		return false, false, nil
+	}
+	val, err = strconv.ParseBool(valstr)
+	return val, true, err
+}
+
+func GetFloatSettingDefault(setting string, def float64) (float64, error) {
+	val, ok := GetSetting(setting)
+	if !ok {
+		return def, nil
+	}
+	return strconv.ParseFloat(val, 64)
+}
+
+func GetFloatSetting(setting string) (val float64, ok bool, err error) {
+	valstr, ok := GetSetting(setting)
+	if !ok {
+		return 0, false, nil
+	}
+	val, err = strconv.ParseFloat(valstr, 64)
+	return val, true, err
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,61 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/config"
+)
+
+func TestGetMaxConcurrency_InvalidKey(t *testing.T) {
+	_, err := config.GetMaxConcurrency("INVALID_KEY")
+
+	assert.Error(t, err)
+}
+
+func TestGetMaxConcurrency_ValidKey(t *testing.T) {
+	viper.Set(config.UploadConcurrencySetting, "100")
+	actual, err := config.GetMaxConcurrency(config.UploadConcurrencySetting)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 100, actual)
+	resetToDefaults()
+}
+
+func TestGetMaxConcurrency_ValidKeyAndNegativeValue(t *testing.T) {
+	viper.Set(config.UploadConcurrencySetting, "-5")
+	_, err := config.GetMaxConcurrency(config.UploadConcurrencySetting)
+
+	assert.Error(t, err)
+	resetToDefaults()
+}
+
+func TestGetMaxConcurrency_ValidKeyAndInvalidValue(t *testing.T) {
+	viper.Set(config.UploadConcurrencySetting, "invalid")
+	_, err := config.GetMaxConcurrency(config.UploadConcurrencySetting)
+
+	assert.Error(t, err)
+	resetToDefaults()
+}
+
+func TestConfigureLogging_WhenLogLevelSettingIsNotSet(t *testing.T) {
+	assert.NoError(t, config.ConfigureLogging())
+}
+
+func TestConfigureLogging_WhenLogLevelSettingIsSet(t *testing.T) {
+	viper.Set(config.LogLevelSetting, "someOtherLevel")
+	err := config.ConfigureLogging()
+
+	assert.Error(t, tracelog.UpdateLogLevel(viper.GetString(config.LogLevelSetting)), err)
+	resetToDefaults()
+}
+
+func resetToDefaults() {
+	viper.Reset()
+	internal.ConfigureSettings(config.PG)
+	config.InitConfig()
+	config.Configure()
+}

--- a/internal/configure.go
+++ b/internal/configure.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"time"
 
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/crypto/yckms"
+	"github.com/wal-g/wal-g/utility"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -41,7 +44,7 @@ var DeprecatedExternalGpgMessage = fmt.Sprintf(
 	`You are using deprecated functionality that uses an external gpg library.
 It will be removed in next major version.
 Please set GPG key using environment variables %s or %s.
-`, PgpKeySetting, PgpKeyPathSetting)
+`, conf.PgpKeySetting, conf.PgpKeyPathSetting)
 
 type UnconfiguredStorageError struct {
 	error
@@ -68,18 +71,6 @@ func newUnknownCompressionMethodError(method string) UnknownCompressionMethodErr
 }
 
 func (err UnknownCompressionMethodError) Error() string {
-	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
-}
-
-type UnsetRequiredSettingError struct {
-	error
-}
-
-func NewUnsetRequiredSettingError(settingName string) UnsetRequiredSettingError {
-	return UnsetRequiredSettingError{errors.Errorf("%v is required to be set, but it isn't", settingName)}
-}
-
-func (err UnsetRequiredSettingError) Error() string {
 	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
 }
 
@@ -111,17 +102,17 @@ func (err UnmarshallingError) Error() string {
 
 // TODO : unit tests
 func ConfigureLimiters() {
-	if Turbo {
+	if conf.Turbo {
 		return
 	}
-	if viper.IsSet(DiskRateLimitSetting) {
-		diskLimit := viper.GetInt64(DiskRateLimitSetting)
+	if viper.IsSet(conf.DiskRateLimitSetting) {
+		diskLimit := viper.GetInt64(conf.DiskRateLimitSetting)
 		limiters.DiskLimiter = rate.NewLimiter(rate.Limit(diskLimit),
 			int(diskLimit+DefaultDataBurstRateLimit)) // Add 8 pages to possible bursts
 	}
 
-	if viper.IsSet(NetworkRateLimitSetting) {
-		netLimit := viper.GetInt64(NetworkRateLimitSetting)
+	if viper.IsSet(conf.NetworkRateLimitSetting) {
+		netLimit := viper.GetInt64(conf.NetworkRateLimitSetting)
 		limiters.NetworkLimiter = rate.NewLimiter(rate.Limit(netLimit),
 			int(netLimit+DefaultDataBurstRateLimit)) // Add 8 pages to possible bursts
 	}
@@ -146,7 +137,7 @@ func ConfigureStorage() (storage.HashableStorage, error) {
 }
 
 func ConfigureStoragePrefix(folder storage.Folder) storage.Folder {
-	prefix := viper.GetString(StoragePrefixSetting)
+	prefix := viper.GetString(conf.StoragePrefixSetting)
 	if prefix != "" {
 		folder = folder.GetSubFolder(prefix)
 	}
@@ -163,7 +154,7 @@ func ConfigureStorageForSpecificConfig(
 ) (storage.HashableStorage, error) {
 	skippedPrefixes := make([]string, 0)
 	for _, adapter := range StorageAdapters {
-		prefix, ok := getWaleCompatibleSettingFrom(adapter.PrefixSettingKey(), config)
+		prefix, ok := conf.GetWaleCompatibleSettingFrom(adapter.PrefixSettingKey(), config)
 		if !ok {
 			skippedPrefixes = append(skippedPrefixes, "WALG_"+adapter.PrefixSettingKey())
 			continue
@@ -180,10 +171,10 @@ func ConfigureStorageForSpecificConfig(
 }
 
 func getWalFolderPath() string {
-	if !viper.IsSet(PgDataSetting) {
+	if !viper.IsSet(conf.PgDataSetting) {
 		return DefaultDataFolderPath
 	}
-	return getRelativeWalFolderPath(viper.GetString(PgDataSetting))
+	return getRelativeWalFolderPath(viper.GetString(conf.PgDataSetting))
 }
 
 func getRelativeWalFolderPath(pgdata string) string {
@@ -202,7 +193,7 @@ func GetDataFolderPath() string {
 
 // GetPgSlotName reads the slot name from the environment
 func GetPgSlotName() (pgSlotName string) {
-	pgSlotName = viper.GetString(PgSlotName)
+	pgSlotName = viper.GetString(conf.PgSlotName)
 	if pgSlotName == "" {
 		pgSlotName = "walg"
 	}
@@ -210,18 +201,11 @@ func GetPgSlotName() (pgSlotName string) {
 }
 
 func ConfigureCompressor() (compression.Compressor, error) {
-	compressionMethod := viper.GetString(CompressionMethodSetting)
+	compressionMethod := viper.GetString(conf.CompressionMethodSetting)
 	if _, ok := compression.Compressors[compressionMethod]; !ok {
 		return nil, newUnknownCompressionMethodError(compressionMethod)
 	}
 	return compression.Compressors[compressionMethod], nil
-}
-
-func ConfigureLogging() error {
-	if viper.IsSet(LogLevelSetting) {
-		return tracelog.UpdateLogLevel(viper.GetString(LogLevelSetting))
-	}
-	return nil
 }
 
 func getPGArchiveStatusFolderPath() string {
@@ -284,9 +268,9 @@ func ConfigureSplitUploader() (Uploader, error) {
 		return nil, err
 	}
 
-	var partitions = viper.GetInt(StreamSplitterPartitions)
-	var blockSize = viper.GetSizeInBytes(StreamSplitterBlockSize)
-	var maxFileSize = viper.GetInt(StreamSplitterMaxFileSize)
+	var partitions = viper.GetInt(conf.StreamSplitterPartitions)
+	var blockSize = viper.GetSizeInBytes(conf.StreamSplitterBlockSize)
+	var maxFileSize = viper.GetInt(conf.StreamSplitterMaxFileSize)
 
 	splitStreamUploader := NewSplitStreamUploader(uploader, partitions, int(blockSize), maxFileSize)
 	return splitStreamUploader, nil
@@ -302,9 +286,9 @@ func ConfigureCrypter() crypto.Crypter {
 
 func CrypterFromConfig(configFile string) crypto.Crypter {
 	var config = viper.New()
-	SetDefaultValues(config)
-	ReadConfigFromFile(config, configFile)
-	CheckAllowedSettings(config)
+	conf.SetDefaultValues(config)
+	conf.ReadConfigFromFile(config, configFile)
+	conf.CheckAllowedSettings(config)
 
 	crypter, err := ConfigureCrypterForSpecificConfig(config)
 	if err != nil {
@@ -316,15 +300,15 @@ func CrypterFromConfig(configFile string) crypto.Crypter {
 // ConfigureCrypter uses environment variables to create and configure a crypter.
 // In case no configuration in environment variables found, return `<nil>` crypter.
 func ConfigureCrypterForSpecificConfig(config *viper.Viper) (crypto.Crypter, error) {
-	pgpKey := config.IsSet(PgpKeySetting)
-	pgpKeyPath := config.IsSet(PgpKeyPathSetting)
-	legacyGpg := config.IsSet(GpgKeyIDSetting)
+	pgpKey := config.IsSet(conf.PgpKeySetting)
+	pgpKeyPath := config.IsSet(conf.PgpKeyPathSetting)
+	legacyGpg := config.IsSet(conf.GpgKeyIDSetting)
 
-	envelopePgpKey := config.IsSet(PgpEnvelopKeyPathSetting)
-	envelopePgpKeyPath := config.IsSet(PgpEnvelopeKeySetting)
+	envelopePgpKey := config.IsSet(conf.PgpEnvelopKeyPathSetting)
+	envelopePgpKeyPath := config.IsSet(conf.PgpEnvelopeKeySetting)
 
-	libsodiumKey := config.IsSet(LibsodiumKeySetting)
-	libsodiumKeyPath := config.IsSet(LibsodiumKeySetting)
+	libsodiumKey := config.IsSet(conf.LibsodiumKeySetting)
+	libsodiumKeyPath := config.IsSet(conf.LibsodiumKeySetting)
 
 	isPgpKey := pgpKey || pgpKeyPath || legacyGpg
 	isEnvelopePgpKey := envelopePgpKey || envelopePgpKeyPath
@@ -339,10 +323,10 @@ func ConfigureCrypterForSpecificConfig(config *viper.Viper) (crypto.Crypter, err
 		return configurePgpCrypter(config)
 	case isEnvelopePgpKey:
 		return configureEnvelopePgpCrypter(config)
-	case config.IsSet(CseKmsIDSetting):
-		return awskms.CrypterFromKeyID(config.GetString(CseKmsIDSetting), config.GetString(CseKmsRegionSetting)), nil
-	case config.IsSet(YcKmsKeyIDSetting):
-		return yckms.YcCrypterFromKeyIDAndCredential(config.GetString(YcKmsKeyIDSetting), config.GetString(YcSaKeyFileSetting)), nil
+	case config.IsSet(conf.CseKmsIDSetting):
+		return awskms.CrypterFromKeyID(config.GetString(conf.CseKmsIDSetting), config.GetString(conf.CseKmsRegionSetting)), nil
+	case config.IsSet(conf.YcKmsKeyIDSetting):
+		return yckms.YcCrypterFromKeyIDAndCredential(config.GetString(conf.YcKmsKeyIDSetting), config.GetString(conf.YcSaKeyFileSetting)), nil
 	case isLibsodium:
 		return configureLibsodiumCrypter(config)
 	default:
@@ -352,19 +336,19 @@ func ConfigureCrypterForSpecificConfig(config *viper.Viper) (crypto.Crypter, err
 
 func configurePgpCrypter(config *viper.Viper) (crypto.Crypter, error) {
 	loadPassphrase := func() (string, bool) {
-		return GetSetting(PgpKeyPassphraseSetting)
+		return conf.GetSetting(conf.PgpKeyPassphraseSetting)
 	}
 	// key can be either private (for download) or public (for upload)
-	if config.IsSet(PgpKeySetting) {
-		return openpgp.CrypterFromKey(config.GetString(PgpKeySetting), loadPassphrase), nil
+	if config.IsSet(conf.PgpKeySetting) {
+		return openpgp.CrypterFromKey(config.GetString(conf.PgpKeySetting), loadPassphrase), nil
 	}
 
 	// key can be either private (for download) or public (for upload)
-	if config.IsSet(PgpKeyPathSetting) {
-		return openpgp.CrypterFromKeyPath(config.GetString(PgpKeyPathSetting), loadPassphrase), nil
+	if config.IsSet(conf.PgpKeyPathSetting) {
+		return openpgp.CrypterFromKeyPath(config.GetString(conf.PgpKeyPathSetting), loadPassphrase), nil
 	}
 
-	if keyRingID, ok := getWaleCompatibleSetting(GpgKeyIDSetting); ok {
+	if keyRingID, ok := conf.GetWaleCompatibleSetting(conf.GpgKeyIDSetting); ok {
 		tracelog.WarningLogger.Printf(DeprecatedExternalGpgMessage)
 		return openpgp.CrypterFromKeyRingID(keyRingID, loadPassphrase), nil
 	}
@@ -372,67 +356,67 @@ func configurePgpCrypter(config *viper.Viper) (crypto.Crypter, error) {
 }
 
 func configureEnvelopePgpCrypter(config *viper.Viper) (crypto.Crypter, error) {
-	if !config.IsSet(PgpEnvelopeYcKmsKeyIDSetting) {
+	if !config.IsSet(conf.PgpEnvelopeYcKmsKeyIDSetting) {
 		return nil, errors.New("yandex cloud KMS key for client-side encryption and decryption must be configured")
 	}
 
 	yckmsEnveloper, err := yckmsenvlpr.EnveloperFromKeyIDAndCredential(
-		config.GetString(PgpEnvelopeYcKmsKeyIDSetting),
-		config.GetString(PgpEnvelopeYcSaKeyFileSetting),
-		config.GetString(PgpEnvelopeYcEndpointSetting),
+		config.GetString(conf.PgpEnvelopeYcKmsKeyIDSetting),
+		config.GetString(conf.PgpEnvelopeYcSaKeyFileSetting),
+		config.GetString(conf.PgpEnvelopeYcEndpointSetting),
 	)
 	if err != nil {
 		return nil, err
 	}
-	expiration, err := GetDurationSetting(PgpEnvelopeCacheExpiration)
+	expiration, err := GetDurationSetting(conf.PgpEnvelopeCacheExpiration)
 	if err != nil {
 		return nil, err
 	}
 	enveloper := cachenvlpr.EnveloperWithCache(yckmsEnveloper, expiration)
 
-	if config.IsSet(PgpEnvelopKeyPathSetting) {
-		return envopenpgp.CrypterFromKeyPath(viper.GetString(PgpEnvelopKeyPathSetting), enveloper), nil
+	if config.IsSet(conf.PgpEnvelopKeyPathSetting) {
+		return envopenpgp.CrypterFromKeyPath(viper.GetString(conf.PgpEnvelopKeyPathSetting), enveloper), nil
 	}
-	if config.IsSet(PgpEnvelopeKeySetting) {
-		return envopenpgp.CrypterFromKey(viper.GetString(PgpEnvelopeKeySetting), enveloper), nil
+	if config.IsSet(conf.PgpEnvelopeKeySetting) {
+		return envopenpgp.CrypterFromKey(viper.GetString(conf.PgpEnvelopeKeySetting), enveloper), nil
 	}
 	return nil, errors.New("there is no any supported envelope gpg crypter configuration")
 }
 
 func GetMaxDownloadConcurrency() (int, error) {
-	return GetMaxConcurrency(DownloadConcurrencySetting)
+	return GetMaxConcurrency(conf.DownloadConcurrencySetting)
 }
 
 func GetMaxUploadConcurrency() (int, error) {
-	return GetMaxConcurrency(UploadConcurrencySetting)
+	return GetMaxConcurrency(conf.UploadConcurrencySetting)
 }
 
 // This setting is intentionally undocumented in README. Effectively, this configures how many prepared tar Files there
 // may be in uploading state during backup-push.
 func getMaxUploadQueue() (int, error) {
-	return GetMaxConcurrency(UploadQueueSetting)
+	return GetMaxConcurrency(conf.UploadQueueSetting)
 }
 
 // TODO : unit tests
 func GetDeltaConfig() (maxDeltas int, fromFull bool) {
-	maxDeltas = viper.GetInt(DeltaMaxStepsSetting)
-	if origin, hasOrigin := GetSetting(DeltaOriginSetting); hasOrigin {
+	maxDeltas = viper.GetInt(conf.DeltaMaxStepsSetting)
+	if origin, hasOrigin := conf.GetSetting(conf.DeltaOriginSetting); hasOrigin {
 		switch origin {
 		case LatestString:
 		case "LATEST_FULL":
 			fromFull = true
 		default:
-			tracelog.ErrorLogger.Fatalf("Unknown %s: %s\n", DeltaOriginSetting, origin)
+			tracelog.ErrorLogger.Fatalf("Unknown %s: %s\n", conf.DeltaOriginSetting, origin)
 		}
 	}
 	return
 }
 
 func GetMaxUploadDiskConcurrency() (int, error) {
-	if Turbo {
+	if conf.Turbo {
 		return 4, nil
 	}
-	return GetMaxConcurrency(UploadDiskConcurrencySetting)
+	return GetMaxConcurrency(conf.UploadDiskConcurrencySetting)
 }
 
 func GetMaxConcurrency(concurrencyType string) (int, error) {
@@ -445,12 +429,12 @@ func GetMaxConcurrency(concurrencyType string) (int, error) {
 }
 
 func GetFetchRetries() int {
-	concurrency := viper.GetInt(DownloadFileRetriesSetting)
+	concurrency := viper.GetInt(conf.DownloadFileRetriesSetting)
 	return concurrency
 }
 
 func GetSentinelUserData() (interface{}, error) {
-	dataStr, ok := GetSetting(SentinelUserDataSetting)
+	dataStr, ok := conf.GetSetting(conf.SentinelUserDataSetting)
 	if !ok {
 		return nil, nil
 	}
@@ -471,7 +455,7 @@ func UnmarshalSentinelUserData(userDataStr string) (interface{}, error) {
 }
 
 func GetCommandSettingContext(ctx context.Context, variableName string) (*exec.Cmd, error) {
-	dataStr, ok := GetSetting(variableName)
+	dataStr, ok := conf.GetSetting(variableName)
 	if !ok {
 		tracelog.InfoLogger.Printf("command %s not configured", variableName)
 		return nil, errors.New("command not configured")
@@ -495,20 +479,20 @@ func GetCommandSetting(variableName string) (*exec.Cmd, error) {
 }
 
 func GetOplogArchiveAfterSize() (int, error) {
-	oplogArchiveAfterSizeStr, _ := GetSetting(OplogArchiveAfterSize)
+	oplogArchiveAfterSizeStr, _ := conf.GetSetting(conf.OplogArchiveAfterSize)
 	oplogArchiveAfterSize, err := strconv.Atoi(oplogArchiveAfterSizeStr)
 	if err != nil {
 		return 0,
 			fmt.Errorf("integer expected for %s setting but given '%s': %w",
-				OplogArchiveAfterSize, oplogArchiveAfterSizeStr, err)
+				conf.OplogArchiveAfterSize, oplogArchiveAfterSizeStr, err)
 	}
 	return oplogArchiveAfterSize, nil
 }
 
 func GetDurationSetting(setting string) (time.Duration, error) {
-	intervalStr, ok := GetSetting(setting)
+	intervalStr, ok := conf.GetSetting(setting)
 	if !ok {
-		return 0, NewUnsetRequiredSettingError(setting)
+		return 0, conf.NewUnsetRequiredSettingError(setting)
 	}
 	interval, err := time.ParseDuration(intervalStr)
 	if err != nil {
@@ -518,55 +502,161 @@ func GetDurationSetting(setting string) (time.Duration, error) {
 }
 
 func GetOplogPITRDiscoveryIntervalSetting() (*time.Duration, error) {
-	durStr, ok := GetSetting(OplogPITRDiscoveryInterval)
+	durStr, ok := conf.GetSetting(conf.OplogPITRDiscoveryInterval)
 	if !ok {
 		return nil, nil
 	}
 	dur, err := time.ParseDuration(durStr)
 	if err != nil {
-		return nil, fmt.Errorf("duration expected for %s setting but given '%s': %w", OplogPITRDiscoveryInterval, durStr, err)
+		return nil, fmt.Errorf("duration expected for %s setting but given '%s': %w", conf.OplogPITRDiscoveryInterval, durStr, err)
 	}
 	return &dur, nil
 }
 
-func GetRequiredSetting(setting string) (string, error) {
-	val, ok := GetSetting(setting)
-	if !ok {
-		return "", NewUnsetRequiredSettingError(setting)
+// nolint: gocyclo
+func ConfigureSettings(currentType string) {
+	if len(conf.DefaultConfigValues) == 0 {
+		conf.DefaultConfigValues = conf.CommonDefaultConfigValues
+		dbSpecificDefaultSettings := map[string]string{}
+		switch currentType {
+		case conf.PG:
+			dbSpecificDefaultSettings = conf.PGDefaultSettings
+		case conf.MONGO:
+			dbSpecificDefaultSettings = conf.MongoDefaultSettings
+		case conf.MYSQL:
+			dbSpecificDefaultSettings = conf.MysqlDefaultSettings
+		case conf.SQLSERVER:
+			dbSpecificDefaultSettings = conf.SQLServerDefaultSettings
+		case conf.GP:
+			dbSpecificDefaultSettings = conf.GPDefaultSettings
+		}
+
+		for k, v := range dbSpecificDefaultSettings {
+			conf.DefaultConfigValues[k] = v
+		}
 	}
-	return val, nil
+
+	if len(conf.AllowedSettings) == 0 {
+		conf.AllowedSettings = conf.CommonAllowedSettings
+		dbSpecificSettings := map[string]bool{}
+		switch currentType {
+		case conf.PG:
+			dbSpecificSettings = conf.PGAllowedSettings
+		case conf.GP:
+			for setting := range conf.PGAllowedSettings {
+				conf.GPAllowedSettings[setting] = true
+			}
+			dbSpecificSettings = conf.GPAllowedSettings
+		case conf.MONGO:
+			dbSpecificSettings = conf.MongoAllowedSettings
+		case conf.MYSQL:
+			dbSpecificSettings = conf.MysqlAllowedSettings
+		case conf.SQLSERVER:
+			dbSpecificSettings = conf.SQLServerAllowedSettings
+		case conf.REDIS:
+			dbSpecificSettings = conf.RedisAllowedSettings
+		}
+
+		for k, v := range dbSpecificSettings {
+			conf.AllowedSettings[k] = v
+		}
+
+		for _, adapter := range StorageAdapters {
+			for _, setting := range adapter.settingNames {
+				conf.AllowedSettings[setting] = true
+			}
+			conf.AllowedSettings["WALG_"+adapter.PrefixSettingKey()] = true
+		}
+	}
 }
 
-func GetBoolSettingDefault(setting string, def bool) (bool, error) {
-	val, ok := GetSetting(setting)
-	if !ok {
-		return def, nil
+// StorageFromConfig prefers the config parameters instead of the current environment variables
+func StorageFromConfig(configFile string) (storage.Storage, error) {
+	var config = viper.New()
+	conf.SetDefaultValues(config)
+	conf.ReadConfigFromFile(config, configFile)
+	conf.CheckAllowedSettings(config)
+
+	folder, err := ConfigureStorageForSpecificConfig(config)
+
+	if err != nil {
+		tracelog.ErrorLogger.Println("Failed configure folder according to config " + configFile)
+		tracelog.ErrorLogger.FatalError(err)
 	}
-	return strconv.ParseBool(val)
+	return folder, err
 }
 
-func GetBoolSetting(setting string) (val bool, ok bool, err error) {
-	valstr, ok := GetSetting(setting)
-	if !ok {
-		return false, false, nil
+func ConfigureFailoverStorages() (failovers map[string]storage.HashableStorage, err error) {
+	storageConfigs := viper.GetStringMap(conf.PgFailoverStorages)
+
+	if len(storageConfigs) == 0 {
+		return nil, nil
 	}
-	val, err = strconv.ParseBool(valstr)
-	return val, true, err
+
+	// errClosers are needed to close already configured storages if failed to configure all of them.
+	var errClosers []io.Closer
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, closer := range errClosers {
+			utility.LoggedClose(closer, "Failed to close storage")
+		}
+	}()
+
+	storages := make(map[string]storage.HashableStorage, len(storageConfigs))
+	for name := range storageConfigs {
+		if name == "default" {
+			return nil, fmt.Errorf("'%s' storage name is reserved", name)
+		}
+
+		cfg := viper.Sub(conf.PgFailoverStorages + "." + name)
+
+		var rootWraps []storage.WrapRootFolder
+		if limiters.NetworkLimiter != nil {
+			rootWraps = append(rootWraps, func(prevFolder storage.Folder) (newFolder storage.Folder) {
+				return NewLimitedFolder(prevFolder, limiters.NetworkLimiter)
+			})
+		}
+		rootWraps = append(rootWraps, ConfigureStoragePrefix)
+
+		st, err := ConfigureStorageForSpecificConfig(cfg, rootWraps...)
+		if err != nil {
+			return nil, fmt.Errorf("failover storage %s: %v", name, err)
+		}
+		errClosers = append(errClosers, st)
+
+		storages[name] = st
+	}
+
+	return storages, nil
 }
 
-func GetFloatSettingDefault(setting string, def float64) (float64, error) {
-	val, ok := GetSetting(setting)
-	if !ok {
-		return def, nil
+func AssertRequiredSettingsSet() error {
+	if !isAnyStorageSet() {
+		return errors.New("Failed to find any configured storage")
 	}
-	return strconv.ParseFloat(val, 64)
+
+	for setting, required := range conf.RequiredSettings {
+		isSet := viper.IsSet(setting)
+
+		if !isSet && required {
+			message := "Required variable " + setting + " is not set. You can set is using --" + conf.ToFlagName(setting) +
+				" flag or variable " + setting
+			return errors.New(message)
+		}
+	}
+
+	return nil
 }
 
-func GetFloatSetting(setting string) (val float64, ok bool, err error) {
-	valstr, ok := GetSetting(setting)
-	if !ok {
-		return 0, false, nil
+func isAnyStorageSet() bool {
+	for _, adapter := range StorageAdapters {
+		_, exists := conf.GetWaleCompatibleSetting(adapter.PrefixSettingKey())
+		if exists {
+			return true
+		}
 	}
-	val, err = strconv.ParseFloat(valstr, 64)
-	return val, true, err
+
+	return false
 }

--- a/internal/configure_crypter.go
+++ b/internal/configure_crypter.go
@@ -11,16 +11,17 @@ package internal
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/wal-g/wal-g/internal/crypto"
 )
 
 func configureLibsodiumCrypter(config *viper.Viper) (crypto.Crypter, error) {
-	if config.IsSet(LibsodiumKeySetting) {
+	if config.IsSet(conf.LibsodiumKeySetting) {
 		return nil, errors.New("non-empty WALG_LIBSODIUM_KEY but wal-g was not compiled with libsodium")
 	}
 
-	if config.IsSet(LibsodiumKeyPathSetting) {
+	if config.IsSet(conf.LibsodiumKeyPathSetting) {
 		return nil, errors.New("non-empty WALG_LIBSODIUM_KEY_PATH but wal-g was not compiled with libsodium")
 	}
 

--- a/internal/configure_crypter_libsodium.go
+++ b/internal/configure_crypter_libsodium.go
@@ -7,17 +7,18 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/internal/crypto/libsodium"
 )
 
 func configureLibsodiumCrypter(config *viper.Viper) (crypto.Crypter, error) {
-	if viper.IsSet(LibsodiumKeySetting) {
-		return libsodium.CrypterFromKey(viper.GetString(LibsodiumKeySetting), viper.GetString(LibsodiumKeyTransform)), nil
+	if viper.IsSet(conf.LibsodiumKeySetting) {
+		return libsodium.CrypterFromKey(viper.GetString(conf.LibsodiumKeySetting), viper.GetString(conf.LibsodiumKeyTransform)), nil
 	}
 
-	if viper.IsSet(LibsodiumKeyPathSetting) {
-		return libsodium.CrypterFromKeyPath(viper.GetString(LibsodiumKeyPathSetting), viper.GetString(LibsodiumKeyTransform)), nil
+	if viper.IsSet(conf.LibsodiumKeyPathSetting) {
+		return libsodium.CrypterFromKeyPath(viper.GetString(conf.LibsodiumKeyPathSetting), viper.GetString(conf.LibsodiumKeyTransform)), nil
 	}
 
 	return nil, errors.New("there is no any supported libsodium crypter configuration")

--- a/internal/configure_test.go
+++ b/internal/configure_test.go
@@ -14,40 +14,8 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 )
-
-func TestGetMaxConcurrency_InvalidKey(t *testing.T) {
-	_, err := internal.GetMaxConcurrency("INVALID_KEY")
-
-	assert.Error(t, err)
-}
-
-func TestGetMaxConcurrency_ValidKey(t *testing.T) {
-	viper.Set(config.UploadConcurrencySetting, "100")
-	actual, err := internal.GetMaxConcurrency(config.UploadConcurrencySetting)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 100, actual)
-	resetToDefaults()
-}
-
-func TestGetMaxConcurrency_ValidKeyAndNegativeValue(t *testing.T) {
-	viper.Set(config.UploadConcurrencySetting, "-5")
-	_, err := internal.GetMaxConcurrency(config.UploadConcurrencySetting)
-
-	assert.Error(t, err)
-	resetToDefaults()
-}
-
-func TestGetMaxConcurrency_ValidKeyAndInvalidValue(t *testing.T) {
-	viper.Set(config.UploadConcurrencySetting, "invalid")
-	_, err := internal.GetMaxConcurrency(config.UploadConcurrencySetting)
-
-	assert.Error(t, err)
-	resetToDefaults()
-}
 
 func TestGetSentinelUserData(t *testing.T) {
 	viper.Set(config.SentinelUserDataSetting, "1.0")
@@ -138,21 +106,6 @@ func TestGetDataFolderPath_WalIgnoreXlog(t *testing.T) {
 	actual := internal.GetDataFolderPath()
 
 	assert.Equal(t, filepath.Join(parentDir, "pg_wal", "walg_data"), actual)
-	resetToDefaults()
-}
-
-func TestConfigureLogging_WhenLogLevelSettingIsNotSet(t *testing.T) {
-	assert.NoError(t, config.ConfigureLogging())
-}
-
-func TestConfigureLogging_WhenLogLevelSettingIsSet(t *testing.T) {
-	parentDir := prepareDataFolder(t, "someOtherFolder")
-	defer testtools.Cleanup(t, parentDir)
-
-	viper.Set(config.LogLevelSetting, parentDir)
-	err := config.ConfigureLogging()
-
-	assert.Error(t, tracelog.UpdateLogLevel(viper.GetString(config.LogLevelSetting)), err)
 	resetToDefaults()
 }
 

--- a/internal/databases/etcd/wal_push_handler.go
+++ b/internal/databases/etcd/wal_push_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/wal-g/wal-g/utility"
 )
@@ -30,7 +31,7 @@ func cacheDir(dataDir string) string { return filepath.Join(dataDir, ".walg_etcd
 func getWalDir(dataDir string) string { return filepath.Join(dataDir, "member", "wal") }
 
 func HandleWALPush(ctx context.Context, uploader internal.Uploader, dataDir string) error {
-	walDir, ok := internal.GetSetting(internal.ETCDWalDirectory)
+	walDir, ok := conf.GetSetting(conf.ETCDWalDirectory)
 	if !ok {
 		walDir = getWalDir(dataDir)
 	}

--- a/internal/databases/greenplum/ao_check_length_handler.go
+++ b/internal/databases/greenplum/ao_check_length_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -85,7 +86,7 @@ func (checker *AOLengthCheckHandler) buildCheckAOLengthCmd(contentID int, backup
 		// nohup to avoid the SIGHUP on SSH session disconnect
 		"nohup", "wal-g",
 		// config for wal-g
-		fmt.Sprintf("--config=%s", internal.CfgFile),
+		fmt.Sprintf("--config=%s", conf.CfgFile),
 		// method
 		"check-ao-aocs-length-segment",
 		// actual arguments to be passed to the backup-push command

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
@@ -198,7 +199,7 @@ func (fh *FetchHandler) createRecoveryConfigs() error {
 		recoveryTarget = fh.restorePoint
 	}
 	tracelog.InfoLogger.Printf("Recovery target is %s", recoveryTarget)
-	restoreCfgMaker := NewRecoveryConfigMaker("/usr/bin/wal-g", internal.CfgFile, recoveryTarget)
+	restoreCfgMaker := NewRecoveryConfigMaker("/usr/bin/wal-g", conf.CfgFile, recoveryTarget)
 
 	remoteOutput := fh.cluster.GenerateAndExecuteCommand("Creating recovery.conf on segments and master",
 		cluster.ON_SEGMENTS|cluster.EXCLUDE_MIRRORS|cluster.INCLUDE_MASTER,
@@ -247,7 +248,7 @@ func (fh *FetchHandler) buildFetchCommand(contentID int) string {
 		fmt.Sprint(segment.DataDir),
 		fmt.Sprintf("--content-id=%d", segment.ContentID),
 		fmt.Sprintf("--target-user-data=%s", segUserData.QuotedString()),
-		fmt.Sprintf("--config=%s", internal.CfgFile),
+		fmt.Sprintf("--config=%s", conf.CfgFile),
 	}
 	if fh.partialRestoreArgs != nil {
 		cmd = append(cmd, fmt.Sprintf("--restore-only=%s", strings.Join(fh.partialRestoreArgs[:], ",")))

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -138,7 +139,7 @@ func (bh *BackupHandler) buildBackupPushCommand(contentID int) string {
 		// actual arguments to be passed to the backup-push command
 		backupPushArgsLine,
 		// pass the config file location
-		fmt.Sprintf("--config=%s", internal.CfgFile),
+		fmt.Sprintf("--config=%s", conf.CfgFile),
 		// forward stdout and stderr to the log file
 		"&>>", formatSegmentLogPath(contentID),
 		// run in the background and get the launched process PID

--- a/internal/databases/greenplum/configure.go
+++ b/internal/databases/greenplum/configure.go
@@ -7,21 +7,21 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 
 	"github.com/spf13/viper"
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 func SetSegmentStoragePrefix(contentID int) {
-	viper.Set(internal.StoragePrefixSetting, FormatSegmentStoragePrefix(contentID))
+	viper.Set(conf.StoragePrefixSetting, FormatSegmentStoragePrefix(contentID))
 }
 
 func ConfigureSegContentID(contentIDFlag string) (int, error) {
 	var rawContentID string
 	if contentIDFlag != "" {
 		rawContentID = contentIDFlag
-	} else if contentIDSetting, ok := internal.GetSetting(internal.GPSegContentID); ok {
+	} else if contentIDSetting, ok := conf.GetSetting(conf.GPSegContentID); ok {
 		rawContentID = contentIDSetting
 	} else {
-		return 0, fmt.Errorf("segment content ID is not specified, add the --content-id flag or use the %s setting", internal.GPSegContentID)
+		return 0, fmt.Errorf("segment content ID is not specified, add the --content-id flag or use the %s setting", conf.GPSegContentID)
 	}
 
 	contentID, err := strconv.Atoi(rawContentID)

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -165,7 +165,7 @@ func (h *DeleteHandler) dispatchDeleteCmd(target internal.BackupObject, delType 
 
 	errorGroup, _ := errgroup.WithContext(context.Background())
 
-	deleteConcurrency, err := internal.GetMaxConcurrency(conf.GPDeleteConcurrency)
+	deleteConcurrency, err := conf.GetMaxConcurrency(conf.GPDeleteConcurrency)
 	if err != nil {
 		tracelog.WarningLogger.Printf("config error: %v", err)
 	}

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -164,7 +165,7 @@ func (h *DeleteHandler) dispatchDeleteCmd(target internal.BackupObject, delType 
 
 	errorGroup, _ := errgroup.WithContext(context.Background())
 
-	deleteConcurrency, err := internal.GetMaxConcurrency(internal.GPDeleteConcurrency)
+	deleteConcurrency, err := internal.GetMaxConcurrency(conf.GPDeleteConcurrency)
 	if err != nil {
 		tracelog.WarningLogger.Printf("config error: %v", err)
 	}

--- a/internal/databases/greenplum/generic_meta_interactor_test.go
+++ b/internal/databases/greenplum/generic_meta_interactor_test.go
@@ -6,14 +6,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/testtools"
 )
 
 func init() {
 	internal.ConfigureSettings("")
-	internal.InitConfig()
-	internal.Configure()
+	conf.InitConfig()
+	conf.Configure()
 }
 
 func TestFetch(t *testing.T) {

--- a/internal/databases/greenplum/incremental_tar_interpreter.go
+++ b/internal/databases/greenplum/incremental_tar_interpreter.go
@@ -6,7 +6,7 @@ import (
 	"path"
 
 	"github.com/spf13/viper"
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
@@ -15,7 +15,7 @@ func NewIncrementalTarInterpreter(dbDataDirectory string, sentinel postgres.Back
 	filesToUnwrap map[string]bool, createNewIncrementalFiles bool) *IncrementalTarInterpreter {
 	return &IncrementalTarInterpreter{
 		FileTarInterpreter: postgres.NewFileTarInterpreter(dbDataDirectory, sentinel, filesMetadata, filesToUnwrap, createNewIncrementalFiles),
-		fsync:              !viper.GetBool(internal.TarDisableFsyncSetting),
+		fsync:              !viper.GetBool(conf.TarDisableFsyncSetting),
 		aoFilesMetadata:    aoFilesMetadata,
 	}
 }

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wal-g/tracelog"
 
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -117,7 +118,7 @@ func NewRestorePointCreator(pointName string) (rpc *RestorePointCreator, err err
 		Conn:             conn,
 		systemIdentifier: systemIdentifier,
 		gpVersion:        version,
-		logsDir:          viper.GetString(internal.GPLogsDirectory),
+		logsDir:          viper.GetString(conf.GPLogsDirectory),
 	}
 	rpc.Uploader.ChangeDirectory(utility.BaseBackupPath)
 

--- a/internal/databases/greenplum/segment_command_runner.go
+++ b/internal/databases/greenplum/segment_command_runner.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/wal-g/tracelog"
 )
@@ -39,8 +39,8 @@ func (r *SegCmdRunner) Run() {
 	args := []string{r.cmdName, fmt.Sprintf("--content-id=%d", r.contentID)}
 	args = append(args, strings.Fields(r.cmdArgs)...)
 
-	if internal.CfgFile != "" {
-		args = append(args, "--config", internal.CfgFile)
+	if conf.CfgFile != "" {
+		args = append(args, "--config", conf.CfgFile)
 	}
 
 	segCmdStatesPath := FormatSegmentStateFolderPath(r.contentID)

--- a/internal/databases/greenplum/segment_command_state.go
+++ b/internal/databases/greenplum/segment_command_state.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 const stateFilesDirPrefix = "walg_seg_states"
@@ -21,7 +21,7 @@ func FormatCmdStatePath(contentID int, cmdName string) string {
 }
 
 func FormatSegmentStateFolderPath(contentID int) string {
-	segStatesDirPath := viper.GetString(internal.GPSegmentStatesDir)
+	segStatesDirPath := viper.GetString(conf.GPSegmentStatesDir)
 	currSegmentStatePath := fmt.Sprintf("%s_seg%d", stateFilesDirPrefix, contentID)
 	return path.Join(segStatesDirPath, currSegmentStatePath)
 }

--- a/internal/databases/greenplum/tar_ball_composer.go
+++ b/internal/databases/greenplum/tar_ball_composer.go
@@ -52,7 +52,7 @@ func (maker *GpTarBallComposerMaker) Make(bundle *postgres.Bundle) (internal.Tar
 	}
 
 	filePacker := postgres.NewTarBallFilePacker(bundle.DeltaMap, bundle.IncrementFromLsn, maker.bundleFiles, filePackerOptions)
-	deduplicationAgeLimit, err := internal.GetDurationSetting(conf.GPAoDeduplicationAgeLimit)
+	deduplicationAgeLimit, err := conf.GetDurationSetting(conf.GPAoDeduplicationAgeLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func NewGpTarBallComposer(
 		ctx:                ctx,
 	}
 
-	maxUploadDiskConcurrency, err := internal.GetMaxUploadDiskConcurrency()
+	maxUploadDiskConcurrency, err := conf.GetMaxUploadDiskConcurrency()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/greenplum/tar_ball_composer.go
+++ b/internal/databases/greenplum/tar_ball_composer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 
 	"github.com/wal-g/tracelog"
@@ -51,7 +52,7 @@ func (maker *GpTarBallComposerMaker) Make(bundle *postgres.Bundle) (internal.Tar
 	}
 
 	filePacker := postgres.NewTarBallFilePacker(bundle.DeltaMap, bundle.IncrementFromLsn, maker.bundleFiles, filePackerOptions)
-	deduplicationAgeLimit, err := internal.GetDurationSetting(internal.GPAoDeduplicationAgeLimit)
+	deduplicationAgeLimit, err := internal.GetDurationSetting(conf.GPAoDeduplicationAgeLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func NewGpTarBallComposer(
 		relStorageMap:      relStorageMap,
 		files:              bundleFiles,
 		aoStorageUploader:  aoStorageUploader,
-		aoSegSizeThreshold: viper.GetInt64(internal.GPAoSegSizeThreshold),
+		aoSegSizeThreshold: viper.GetInt64(conf.GPAoSegSizeThreshold),
 		uploader:           uploader.Clone(),
 		tarFileSets:        tarFileSets,
 		errorGroup:         errorGroup,

--- a/internal/databases/greenplum/util.go
+++ b/internal/databases/greenplum/util.go
@@ -5,7 +5,7 @@ import (
 	"path"
 
 	"github.com/spf13/viper"
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/wal-g/wal-g/utility"
 )
@@ -18,7 +18,7 @@ func FormatSegmentStoragePrefix(contentID int) string {
 }
 
 func formatSegmentLogPath(contentID int) string {
-	logsDir := viper.GetString(internal.GPLogsDirectory)
+	logsDir := viper.GetString(conf.GPLogsDirectory)
 	return fmt.Sprintf("%s/%s-seg%d.log", logsDir, SegBackupLogPrefix, contentID)
 }
 

--- a/internal/databases/mongo/binary/concurrent_uploader.go
+++ b/internal/databases/mongo/binary/concurrent_uploader.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -17,7 +18,7 @@ type ConcurrentUploader struct {
 
 func CreateConcurrentUploader(uploader internal.Uploader, backupName, directory string) (*ConcurrentUploader, error) {
 	crypter := internal.ConfigureCrypter()
-	tarSizeThreshold := viper.GetInt64(internal.TarSizeThresholdSetting)
+	tarSizeThreshold := viper.GetInt64(conf.TarSizeThresholdSetting)
 	bundle := internal.NewBundle(directory, crypter, tarSizeThreshold, map[string]utility.Empty{})
 
 	tracelog.InfoLogger.Println("Starting a new tar bundle")

--- a/internal/databases/mongo/binary/restore.go
+++ b/internal/databases/mongo/binary/restore.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo/common"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
 )
@@ -35,7 +36,7 @@ func (restoreService *RestoreService) DoRestore(
 	shConf ShConfig,
 	cfgConf MongoCfgConfig,
 ) error {
-	disableHostResetup, err := internal.GetBoolSettingDefault(internal.MongoDBRestoreDisableHostResetup, false)
+	disableHostResetup, err := conf.GetBoolSettingDefault(conf.MongoDBRestoreDisableHostResetup, false)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/mongo/binary_backup_push_handler.go
+++ b/internal/databases/mongo/binary_backup_push_handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo/binary"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -12,7 +13,7 @@ import (
 func HandleBinaryBackupPush(ctx context.Context, permanent bool, appName string) error {
 	backupName := binary.GenerateNewBackupName()
 
-	mongodbURI, err := internal.GetRequiredSetting(internal.MongoDBUriSetting)
+	mongodbURI, err := conf.GetRequiredSetting(conf.MongoDBUriSetting)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/mysql/binlog_fetch_handler.go
+++ b/internal/databases/mysql/binlog_fetch_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
@@ -42,7 +43,7 @@ func (ih *indexHandler) createIndexFile() error {
 }
 
 func HandleBinlogFetch(folder storage.Folder, backupName string, untilTS string, untilBinlogLastModifiedTS string) {
-	dstDir, err := internal.GetLogsDstSettings(internal.MysqlBinlogDstSetting)
+	dstDir, err := internal.GetLogsDstSettings(conf.MysqlBinlogDstSetting)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	startTS, endTS, endBinlogTS, err := getTimestamps(folder, backupName, untilTS, untilBinlogLastModifiedTS)

--- a/internal/databases/mysql/binlog_replay_handler.go
+++ b/internal/databases/mysql/binlog_replay_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -46,7 +47,7 @@ func (rh *replayHandler) replayLogs() {
 }
 
 func (rh *replayHandler) replayLog(binlogPath string) error {
-	cmd, err := internal.GetCommandSetting(internal.MysqlBinlogReplayCmd)
+	cmd, err := internal.GetCommandSetting(conf.MysqlBinlogReplayCmd)
 	if err != nil {
 		return err
 	}
@@ -73,7 +74,7 @@ func (rh *replayHandler) handleBinlog(binlogPath string) error {
 }
 
 func HandleBinlogReplay(folder storage.Folder, backupName string, untilTS string, untilBinlogLastModifiedTS string) {
-	dstDir, err := internal.GetLogsDstSettings(internal.MysqlBinlogDstSetting)
+	dstDir, err := internal.GetLogsDstSettings(conf.MysqlBinlogDstSetting)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	startTS, endTS, endBinlogTS, err := getTimestamps(folder, backupName, untilTS, untilBinlogLastModifiedTS)

--- a/internal/databases/mysql/mysql.go
+++ b/internal/databases/mysql/mysql.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -144,7 +145,7 @@ func getLastUploadedBinlogBeforeGTID(folder storage.Folder, gtid gomysql.GTIDSet
 }
 
 func getMySQLConnection() (*sql.DB, error) {
-	datasourceName, err := internal.GetRequiredSetting(internal.MysqlDatasourceNameSetting)
+	datasourceName, err := conf.GetRequiredSetting(conf.MysqlDatasourceNameSetting)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +163,7 @@ func getMySQLConnection() (*sql.DB, error) {
 }
 
 func getMySQLConnectionFromDatasource(datasourceName string) (*sql.DB, error) {
-	if caFile, ok := internal.GetSetting(internal.MysqlSslCaSetting); ok {
+	if caFile, ok := conf.GetSetting(conf.MysqlSslCaSetting); ok {
 		rootCertPool := x509.NewCertPool()
 		pem, err := os.ReadFile(caFile)
 		if err != nil {
@@ -180,7 +181,7 @@ func getMySQLConnectionFromDatasource(datasourceName string) (*sql.DB, error) {
 		if strings.Contains(datasourceName, "?tls=") || strings.Contains(datasourceName, "&tls=") {
 			return nil,
 				fmt.Errorf("mySQL datasource string contains tls option. It can't be used with %v option",
-					internal.MysqlSslCaSetting)
+					conf.MysqlSslCaSetting)
 		}
 		if strings.Contains(datasourceName, "?") {
 			datasourceName += "&tls=custom"

--- a/internal/databases/mysql/xtrabackup.go
+++ b/internal/databases/mysql/xtrabackup.go
@@ -2,15 +2,17 @@ package mysql
 
 import (
 	"bytes"
-	"github.com/spf13/viper"
-	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/internal"
-	"github.com/wal-g/wal-g/pkg/storages/storage"
-	"github.com/wal-g/wal-g/utility"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/viper"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
 )
 
 const (
@@ -119,7 +121,7 @@ func xtrabackupFetch(
 	err = backup.FetchSentinel(&sentinel)
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch sentinel: %v", err)
 
-	incrementalBackupDir := viper.GetString(internal.MysqlIncrementalBackupDst)
+	incrementalBackupDir := viper.GetString(conf.MysqlIncrementalBackupDst)
 	tempDeltaDir, err := prepareTemporaryDirectory(incrementalBackupDir)
 	tracelog.ErrorLogger.FatalfOnError("Failed to prepare temp dir: %v", err)
 

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -645,7 +645,7 @@ func addPgIsAliveChecker(queryRunner *PgQueryRunner, errCh chan error) {
 	if !viper.IsSet(conf.PgAliveCheckInterval) {
 		return
 	}
-	stateUpdateInterval, err := internal.GetDurationSetting(conf.PgAliveCheckInterval)
+	stateUpdateInterval, err := conf.GetDurationSetting(conf.PgAliveCheckInterval)
 	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.InfoLogger.Printf("Initializing the PG alive checker (interval=%s)...", stateUpdateInterval)
 	pgWatcher := NewPgWatcher(queryRunner, stateUpdateInterval)

--- a/internal/databases/postgres/bguploader_test.go
+++ b/internal/databases/postgres/bguploader_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 
 	"github.com/stretchr/testify/assert"
@@ -81,7 +82,7 @@ func TestBackgroundWALUpload(t *testing.T) {
 		},
 	}
 
-	viper.Set(internal.UploadWalMetadata, "NOMETADATA")
+	viper.Set(conf.UploadWalMetadata, "NOMETADATA")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer testtools.Cleanup(t, internal.GetDataFolderPath())

--- a/internal/databases/postgres/bundle_test.go
+++ b/internal/databases/postgres/bundle_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/compression"
 	"github.com/wal-g/wal-g/internal/compression/lz4"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/internal/walparser"
 	"github.com/wal-g/wal-g/pkg/storages/memory"
@@ -25,9 +26,9 @@ var BundleTestLocations = []walparser.BlockLocation{
 }
 
 func TestEmptyBundleQueue(t *testing.T) {
-	internal.ConfigureSettings(internal.PG)
-	internal.InitConfig()
-	internal.Configure()
+	internal.ConfigureSettings(conf.PG)
+	conf.InitConfig()
+	conf.Configure()
 
 	bundle := &postgres.Bundle{
 		Bundle: internal.Bundle{
@@ -51,12 +52,12 @@ func TestBundleQueue(t *testing.T) {
 }
 
 func TestBundleQueueHighConcurrency(t *testing.T) {
-	viper.Set(internal.UploadConcurrencySetting, "100")
+	viper.Set(conf.UploadConcurrencySetting, "100")
 	queueTest(t)
 }
 
 func TestBundleQueueLowConcurrency(t *testing.T) {
-	viper.Set(internal.UploadConcurrencySetting, "1")
+	viper.Set(conf.UploadConcurrencySetting, "1")
 	queueTest(t)
 }
 

--- a/internal/databases/postgres/configure.go
+++ b/internal/databases/postgres/configure.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/fsutil"
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/internal/multistorage/stats/cache"
@@ -48,7 +49,7 @@ func ConfigureMultiStorage(checkWrite bool) (ms *multistorage.Storage, err error
 	config := &multistorage.Config{}
 
 	aliveChecksDefault := len(failovers) > 0
-	config.AliveChecks, err = internal.GetBoolSettingDefault(internal.PgFailoverStoragesCheck, aliveChecksDefault)
+	config.AliveChecks, err = conf.GetBoolSettingDefault(conf.PgFailoverStoragesCheck, aliveChecksDefault)
 	if err != nil {
 		return nil, fmt.Errorf("get failover storage check setting: %w", err)
 	}
@@ -59,7 +60,7 @@ func ConfigureMultiStorage(checkWrite bool) (ms *multistorage.Storage, err error
 			return nil, fmt.Errorf("configure failover storages status cache: %w", err)
 		}
 
-		config.AliveCheckTimeout, err = internal.GetDurationSetting(internal.PgFailoverStoragesCheckTimeout)
+		config.AliveCheckTimeout, err = internal.GetDurationSetting(conf.PgFailoverStoragesCheckTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("get failover storage check timeout setting: %w", err)
 		}
@@ -67,7 +68,7 @@ func ConfigureMultiStorage(checkWrite bool) (ms *multistorage.Storage, err error
 		config.CheckWrite = checkWrite
 
 		if config.CheckWrite {
-			config.AliveCheckWriteBytes = viper.GetSizeInBytes(internal.PgFailoverStoragesCheckSize)
+			config.AliveCheckWriteBytes = viper.GetSizeInBytes(conf.PgFailoverStoragesCheckSize)
 		}
 	}
 
@@ -82,7 +83,7 @@ func configureStatusCache() (*cache.Config, error) {
 	config := &cache.Config{}
 
 	var err error
-	config.TTL, err = internal.GetDurationSetting(internal.PgFailoverStorageCacheLifetime)
+	config.TTL, err = internal.GetDurationSetting(conf.PgFailoverStorageCacheLifetime)
 	if err != nil {
 		return nil, fmt.Errorf("get cache lifetime setting: %w", err)
 	}
@@ -90,32 +91,32 @@ func configureStatusCache() (*cache.Config, error) {
 	emaDefault := cache.DefaultEMAParams
 	ema := &cache.EMAParams{}
 
-	ema.AliveLimit, err = internal.GetFloatSettingDefault(internal.PgFailoverStorageCacheEMAAliveLimit, emaDefault.AliveLimit)
+	ema.AliveLimit, err = conf.GetFloatSettingDefault(conf.PgFailoverStorageCacheEMAAliveLimit, emaDefault.AliveLimit)
 	if err != nil {
 		return nil, fmt.Errorf("get EMA alive limit setting: %w", err)
 	}
 
-	ema.DeadLimit, err = internal.GetFloatSettingDefault(internal.PgFailoverStorageCacheEMADeadLimit, emaDefault.DeadLimit)
+	ema.DeadLimit, err = conf.GetFloatSettingDefault(conf.PgFailoverStorageCacheEMADeadLimit, emaDefault.DeadLimit)
 	if err != nil {
 		return nil, fmt.Errorf("get EMA dead limit setting: %w", err)
 	}
 
-	ema.AlphaAlive.Min, err = internal.GetFloatSettingDefault(internal.PgFailoverStorageCacheEMAAlphaAliveMin, emaDefault.AlphaAlive.Min)
+	ema.AlphaAlive.Min, err = conf.GetFloatSettingDefault(conf.PgFailoverStorageCacheEMAAlphaAliveMin, emaDefault.AlphaAlive.Min)
 	if err != nil {
 		return nil, fmt.Errorf("get EMA alpha alive min setting: %w", err)
 	}
 
-	ema.AlphaAlive.Max, err = internal.GetFloatSettingDefault(internal.PgFailoverStorageCacheEMAAlphaAliveMax, emaDefault.AlphaAlive.Max)
+	ema.AlphaAlive.Max, err = conf.GetFloatSettingDefault(conf.PgFailoverStorageCacheEMAAlphaAliveMax, emaDefault.AlphaAlive.Max)
 	if err != nil {
 		return nil, fmt.Errorf("get EMA alpha alive max setting: %w", err)
 	}
 
-	ema.AlphaDead.Min, err = internal.GetFloatSettingDefault(internal.PgFailoverStorageCacheEMAAlphaDeadMin, emaDefault.AlphaDead.Min)
+	ema.AlphaDead.Min, err = conf.GetFloatSettingDefault(conf.PgFailoverStorageCacheEMAAlphaDeadMin, emaDefault.AlphaDead.Min)
 	if err != nil {
 		return nil, fmt.Errorf("get EMA alpha dead min setting: %w", err)
 	}
 
-	ema.AlphaDead.Max, err = internal.GetFloatSettingDefault(internal.PgFailoverStorageCacheEMAAlphaDeadMax, emaDefault.AlphaDead.Max)
+	ema.AlphaDead.Max, err = conf.GetFloatSettingDefault(conf.PgFailoverStorageCacheEMAAlphaDeadMax, emaDefault.AlphaDead.Max)
 	if err != nil {
 		return nil, fmt.Errorf("get EMA alpha dead max setting: %w", err)
 	}
@@ -145,7 +146,7 @@ func ConfigureWalUploader(baseUploader internal.Uploader) (uploader *WalUploader
 
 // TODO : unit tests
 func configureWalDeltaUsage() (useWalDelta bool, deltaDataFolder fsutil.DataFolder, err error) {
-	useWalDelta = viper.GetBool(internal.UseWalDeltaSetting)
+	useWalDelta = viper.GetBool(conf.UseWalDeltaSetting)
 	if !useWalDelta {
 		return
 	}
@@ -161,11 +162,11 @@ func configureWalDeltaUsage() (useWalDelta bool, deltaDataFolder fsutil.DataFold
 }
 
 func getStopBackupTimeoutSetting() (time.Duration, error) {
-	if !viper.IsSet(internal.PgStopBackupTimeout) {
+	if !viper.IsSet(conf.PgStopBackupTimeout) {
 		return 0, nil
 	}
 
-	timeout, err := internal.GetDurationSetting(internal.PgStopBackupTimeout)
+	timeout, err := internal.GetDurationSetting(conf.PgStopBackupTimeout)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/databases/postgres/configure.go
+++ b/internal/databases/postgres/configure.go
@@ -60,7 +60,7 @@ func ConfigureMultiStorage(checkWrite bool) (ms *multistorage.Storage, err error
 			return nil, fmt.Errorf("configure failover storages status cache: %w", err)
 		}
 
-		config.AliveCheckTimeout, err = internal.GetDurationSetting(conf.PgFailoverStoragesCheckTimeout)
+		config.AliveCheckTimeout, err = conf.GetDurationSetting(conf.PgFailoverStoragesCheckTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("get failover storage check timeout setting: %w", err)
 		}
@@ -83,7 +83,7 @@ func configureStatusCache() (*cache.Config, error) {
 	config := &cache.Config{}
 
 	var err error
-	config.TTL, err = internal.GetDurationSetting(conf.PgFailoverStorageCacheLifetime)
+	config.TTL, err = conf.GetDurationSetting(conf.PgFailoverStorageCacheLifetime)
 	if err != nil {
 		return nil, fmt.Errorf("get cache lifetime setting: %w", err)
 	}
@@ -166,7 +166,7 @@ func getStopBackupTimeoutSetting() (time.Duration, error) {
 		return 0, nil
 	}
 
-	timeout, err := internal.GetDurationSetting(conf.PgStopBackupTimeout)
+	timeout, err := conf.GetDurationSetting(conf.PgStopBackupTimeout)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/databases/postgres/daemon_handler.go
+++ b/internal/databases/postgres/daemon_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/daemon"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
@@ -71,7 +72,7 @@ func (h *ArchiveMessageHandler) Handle(ctx context.Context, messageBody []byte) 
 		return err
 	}
 	tracelog.DebugLogger.Printf("starting wal-push: %s\n", fullPath)
-	pushTimeout, err := internal.GetDurationSetting(internal.PgDaemonWALUploadTimeout)
+	pushTimeout, err := internal.GetDurationSetting(conf.PgDaemonWALUploadTimeout)
 	if err != nil {
 		return err
 	}
@@ -278,7 +279,7 @@ func SendSdNotify(c <-chan time.Time) {
 }
 
 func SdNotify(state string) error {
-	socketName, ok := internal.GetSetting(internal.SystemdNotifySocket)
+	socketName, ok := conf.GetSetting(conf.SystemdNotifySocket)
 	if !ok {
 		return nil
 	}
@@ -298,7 +299,7 @@ func SdNotify(state string) error {
 }
 
 func getFullPath(relativePath string) (string, error) {
-	PgDataSettingString, ok := internal.GetSetting(internal.PgDataSetting)
+	PgDataSettingString, ok := conf.GetSetting(conf.PgDataSetting)
 	if !ok {
 		return "", fmt.Errorf("PGDATA is not set in the conf")
 	}

--- a/internal/databases/postgres/daemon_handler.go
+++ b/internal/databases/postgres/daemon_handler.go
@@ -72,7 +72,7 @@ func (h *ArchiveMessageHandler) Handle(ctx context.Context, messageBody []byte) 
 		return err
 	}
 	tracelog.DebugLogger.Printf("starting wal-push: %s\n", fullPath)
-	pushTimeout, err := internal.GetDurationSetting(conf.PgDaemonWALUploadTimeout)
+	pushTimeout, err := conf.GetDurationSetting(conf.PgDaemonWALUploadTimeout)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/postgres/integrity_check_runner.go
+++ b/internal/databases/postgres/integrity_check_runner.go
@@ -70,7 +70,7 @@ func NewIntegrityCheckRunner(
 
 	// uploadingSegmentRangeSize is needed to determine max amount of missing WAL segments
 	// after the last found WAL segment which can be marked as "uploading"
-	uploadingSegmentRangeSize, err := internal.GetMaxUploadConcurrency()
+	uploadingSegmentRangeSize, err := conf.GetMaxUploadConcurrency()
 	if err != nil {
 		return IntegrityCheckRunner{}, errors.Wrap(err, "Failed to resolve MaxUploadConcurrency")
 	}

--- a/internal/databases/postgres/integrity_check_runner.go
+++ b/internal/databases/postgres/integrity_check_runner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -78,7 +79,7 @@ func NewIntegrityCheckRunner(
 		startWalSegment:           currentWalSegment,
 		stopWalSegmentNo:          stopWalSegmentNo,
 		uploadingSegmentRangeSize: uploadingSegmentRangeSize,
-		delayedSegmentRangeSize:   viper.GetInt(internal.MaxDelayedSegmentsCount),
+		delayedSegmentRangeSize:   viper.GetInt(conf.MaxDelayedSegmentsCount),
 		walFolderFilenames:        walFolderFilenames,
 		timelineSwitchMap:         timelineSwitchMap,
 		noBackupsFound:            noBackupsFound,

--- a/internal/databases/postgres/prefetch.go
+++ b/internal/databases/postgres/prefetch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/fsutil"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -75,7 +76,7 @@ func prefaultData(prefaultStartLsn LSN, timelineID uint32, waitGroup *sync.WaitG
 	archiveDirectory = filepath.Dir(archiveDirectory)
 	archiveDirectory = filepath.Dir(archiveDirectory)
 	bundle := NewBundle(archiveDirectory, nil, "", &prefaultStartLsn, nil,
-		false, viper.GetInt64(internal.TarSizeThresholdSetting))
+		false, viper.GetInt64(conf.TarSizeThresholdSetting))
 	bundle.Timeline = timelineID
 	startLsn := prefaultStartLsn + LSN(WalSegmentSize*WalFileInDelta)
 	err = bundle.DownloadDeltaMap(folderReader.SubFolder(utility.WalPath), startLsn)

--- a/internal/databases/postgres/prefetch.go
+++ b/internal/databases/postgres/prefetch.go
@@ -26,7 +26,7 @@ func HandleWALPrefetch(folderReader internal.StorageFolderReader, walFileName st
 	var fileName = walFileName
 	location = path.Dir(location)
 	waitGroup := &sync.WaitGroup{}
-	concurrency, err := internal.GetMaxDownloadConcurrency()
+	concurrency, err := conf.GetMaxDownloadConcurrency()
 	if err != nil {
 		return fmt.Errorf("get max concurrency: %v", err)
 	}

--- a/internal/databases/postgres/rating_tar_ball_composer.go
+++ b/internal/databases/postgres/rating_tar_ball_composer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wal-g/wal-g/internal"
 
 	"github.com/pkg/errors"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/crypto"
 	"golang.org/x/sync/errgroup"
 )
@@ -129,7 +130,7 @@ func NewRatingTarBallComposer(
 		ctx:                    ctx,
 	}
 
-	maxUploadDiskConcurrency, err := internal.GetMaxUploadDiskConcurrency()
+	maxUploadDiskConcurrency, err := conf.GetMaxUploadDiskConcurrency()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/postgres/tar_interpreter.go
+++ b/internal/databases/postgres/tar_interpreter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -81,7 +82,7 @@ func (tarInterpreter *FileTarInterpreter) unwrapRegularFileOld(fileReader io.Rea
 func (tarInterpreter *FileTarInterpreter) Interpret(fileReader io.Reader, fileInfo *tar.Header) error {
 	tracelog.DebugLogger.Println("Interpreting: ", fileInfo.Name)
 	targetPath := path.Join(tarInterpreter.DBDataDirectory, fileInfo.Name)
-	fsync := !viper.GetBool(internal.TarDisableFsyncSetting)
+	fsync := !viper.GetBool(conf.TarDisableFsyncSetting)
 	switch fileInfo.Typeflag {
 	case tar.TypeReg, tar.TypeRegA:
 		// temporary switch to determine if new unwrap logic should be used

--- a/internal/databases/postgres/wal_fetch_handler.go
+++ b/internal/databases/postgres/wal_fetch_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -34,8 +35,8 @@ func HandleWALFetch(baseReader internal.StorageFolderReader, walFileName string,
 	reader := baseReader.SubFolder(utility.WalPath)
 	location = utility.ResolveSymlink(location)
 	prefetchLocation := location
-	if viper.IsSet(internal.PrefetchDir) {
-		prefetchLocation = viper.GetString(internal.PrefetchDir)
+	if viper.IsSet(conf.PrefetchDir) {
+		prefetchLocation = viper.GetString(conf.PrefetchDir)
 	}
 	defer prefetcher.Prefetch(baseReader, walFileName, prefetchLocation)
 

--- a/internal/databases/postgres/wal_metadata_uploader.go
+++ b/internal/databases/postgres/wal_metadata_uploader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/fs"
 )
 
@@ -144,7 +145,7 @@ func checkWalMetadataLevel(walMetadataLevel string) error {
 }
 
 func uploadLocalWalMetadata(ctx context.Context, walFilePath string, uploader internal.Uploader) error {
-	walMetadataSetting := viper.GetString(internal.UploadWalMetadata)
+	walMetadataSetting := viper.GetString(conf.UploadWalMetadata)
 	if walMetadataSetting == WalNoMetadataLevel {
 		return nil
 	}
@@ -165,7 +166,7 @@ func uploadLocalWalMetadata(ctx context.Context, walFilePath string, uploader in
 }
 
 func uploadRemoteWalMetadata(ctx context.Context, walFileName string, uploader internal.Uploader) error {
-	walMetadataSetting := viper.GetString(internal.UploadWalMetadata)
+	walMetadataSetting := viper.GetString(conf.UploadWalMetadata)
 	if walMetadataSetting == WalNoMetadataLevel {
 		return nil
 	}

--- a/internal/databases/postgres/wal_prefetcher.go
+++ b/internal/databases/postgres/wal_prefetcher.go
@@ -67,7 +67,7 @@ func (p DaemonPrefetcher) Prefetch(reader internal.StorageFolderReader, walFileN
 }
 
 func checkPrefetchPossible(walFileName string) bool {
-	concurrency, err := internal.GetMaxDownloadConcurrency()
+	concurrency, err := conf.GetMaxDownloadConcurrency()
 	if err != nil {
 		tracelog.ErrorLogger.Printf("WAL-prefetch: get max concurrency: %v", err)
 		return false

--- a/internal/databases/postgres/wal_prefetcher.go
+++ b/internal/databases/postgres/wal_prefetcher.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/wal-g/tracelog"
 )
@@ -30,10 +31,10 @@ func (p RegularPrefetcher) Prefetch(_ internal.StorageFolderReader, walFileName 
 		return
 	}
 	prefetchArgs := []string{"wal-prefetch", walFileName, location}
-	if internal.CfgFile != "" {
-		prefetchArgs = append(prefetchArgs, "--config", internal.CfgFile)
+	if conf.CfgFile != "" {
+		prefetchArgs = append(prefetchArgs, "--config", conf.CfgFile)
 	}
-	storagePrefix := viper.GetString(internal.StoragePrefixSetting)
+	storagePrefix := viper.GetString(conf.StoragePrefixSetting)
 	if storagePrefix != "" {
 		prefetchArgs = append(prefetchArgs, "--walg-storage-prefix", storagePrefix)
 	}

--- a/internal/databases/postgres/wal_push_handler.go
+++ b/internal/databases/postgres/wal_push_handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -47,10 +48,10 @@ func HandleWALPush(ctx context.Context, uploader *WalUploader, walFilePath strin
 		return err
 	}
 
-	totalBgUploadedLimit := viper.GetInt32(internal.TotalBgUploadedLimit)
+	totalBgUploadedLimit := viper.GetInt32(conf.TotalBgUploadedLimit)
 	// .history files must not be overwritten, see https://github.com/wal-g/wal-g/issues/420
-	preventWalOverwrite := viper.GetBool(internal.PreventWalOverwriteSetting) || strings.HasSuffix(walFilePath, ".history")
-	readyRename := viper.GetBool(internal.PgReadyRename)
+	preventWalOverwrite := viper.GetBool(conf.PreventWalOverwriteSetting) || strings.HasSuffix(walFilePath, ".history")
+	readyRename := viper.GetBool(conf.PgReadyRename)
 
 	bgUploader := NewBgUploader(ctx, walFilePath, int32(concurrency-1), totalBgUploadedLimit-1, uploader, preventWalOverwrite, readyRename)
 	// Look for new WALs while doing main upload

--- a/internal/databases/postgres/wal_push_handler.go
+++ b/internal/databases/postgres/wal_push_handler.go
@@ -43,7 +43,7 @@ func HandleWALPush(ctx context.Context, uploader *WalUploader, walFilePath strin
 		return uploadLocalWalMetadata(ctx, walFilePath, uploader)
 	}
 
-	concurrency, err := internal.GetMaxUploadConcurrency()
+	concurrency, err := conf.GetMaxUploadConcurrency()
 	if err != nil {
 		return err
 	}

--- a/internal/databases/postgres/wal_verify_handler_test.go
+++ b/internal/databases/postgres/wal_verify_handler_test.go
@@ -8,20 +8,20 @@ import (
 	"testing"
 	"time"
 
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/utility"
 )
 
 func init() {
 	// this setting affects the ProbablyUploading segments range size
-	viper.Set(internal.UploadConcurrencySetting, "4")
+	viper.Set(conf.UploadConcurrencySetting, "4")
 
 	// this setting controls the ProbablyDelayed segments range size
-	viper.Set(internal.MaxDelayedSegmentsCount, "3")
+	viper.Set(conf.MaxDelayedSegmentsCount, "3")
 }
 
 type WalVerifyTestSetup struct {

--- a/internal/databases/redis/redis.go
+++ b/internal/databases/redis/redis.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/go-redis/redis"
 	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 // DISCUSS: In some cases, we have default values, but we don't want to store it at global default settings.
 // Naming is far from best, if Go allowed overloads, name GetSettingWithDefault would be more appropriate
 func GetSettingWithLocalDefault(key string, defaultValue string) string {
-	value, ok := internal.GetSetting(key)
+	value, ok := conf.GetSetting(key)
 	if ok {
 		return value
 	}
@@ -22,8 +22,8 @@ func GetSettingWithLocalDefault(key string, defaultValue string) string {
 func _() *redis.Client {
 	redisAddr := GetSettingWithLocalDefault("WALG_REDIS_HOST", "localhost")
 	redisPort := GetSettingWithLocalDefault("WALG_REDIS_PORT", "6379")
-	redisPassword := GetSettingWithLocalDefault(internal.RedisPassword, "") // no password set
-	redisDBStr, ok := internal.GetSetting("WALG_REDIS_DB")
+	redisPassword := GetSettingWithLocalDefault(conf.RedisPassword, "") // no password set
+	redisDBStr, ok := conf.GetSetting("WALG_REDIS_DB")
 	redisDB := 0 // use default DB
 	if ok {
 		redisDBValue, err := strconv.Atoi(redisDBStr)

--- a/internal/databases/sqlserver/blob/server.go
+++ b/internal/databases/sqlserver/blob/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/wal-g/wal-g/utility"
 
 	"github.com/wal-g/wal-g/internal/compression"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/crypto"
 	"golang.org/x/xerrors"
 
@@ -61,24 +62,24 @@ func NewServer(folder storage.Folder) (*Server, error) {
 	var err error
 	bs := new(Server)
 	bs.folder = folder
-	bs.certFile, err = internal.GetRequiredSetting(internal.SQLServerBlobCertFile)
+	bs.certFile, err = conf.GetRequiredSetting(conf.SQLServerBlobCertFile)
 	if err != nil {
 		return nil, err
 	}
-	bs.keyFile, err = internal.GetRequiredSetting(internal.SQLServerBlobKeyFile)
+	bs.keyFile, err = conf.GetRequiredSetting(conf.SQLServerBlobKeyFile)
 	if err != nil {
 		return nil, err
 	}
-	hostname, err := internal.GetRequiredSetting(internal.SQLServerBlobHostname)
+	hostname, err := conf.GetRequiredSetting(conf.SQLServerBlobHostname)
 	if err != nil {
 		return nil, err
 	}
-	downloadConcurrency, err := internal.GetMaxDownloadConcurrency()
+	downloadConcurrency, err := conf.GetMaxDownloadConcurrency()
 	if err != nil {
 		downloadConcurrency = DefaultConcurrency
 	}
 	bs.downloadSem = make(chan struct{}, downloadConcurrency)
-	uploadConcurrency, err := internal.GetMaxUploadConcurrency()
+	uploadConcurrency, err := conf.GetMaxUploadConcurrency()
 	if err != nil {
 		uploadConcurrency = DefaultConcurrency
 	}
@@ -186,7 +187,7 @@ func (bs *Server) Shutdown() error {
 }
 
 func (bs *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if _, ok := internal.GetSetting(internal.SQLServerBlobKeyFile); ok {
+	if _, ok := conf.GetSetting(conf.SQLServerBlobKeyFile); ok {
 		if req.Header.Get(ReqIDHeader) == "" {
 			req.Header.Set(ReqIDHeader, uuid.New().String())
 		}
@@ -772,7 +773,7 @@ func (bs *Server) parseBytesRange(req *http.Request) (uint64, uint64, error) {
 }
 
 func (bs *Server) AcquireLock() (io.Closer, error) {
-	path, err := internal.GetRequiredSetting(internal.SQLServerBlobLockFile)
+	path, err := conf.GetRequiredSetting(conf.SQLServerBlobLockFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/sqlserver/blob/util.go
+++ b/internal/databases/sqlserver/blob/util.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 var ErrNoLease = errors.New("no lease")
@@ -69,6 +69,6 @@ func (r *SkipReader) Read(s []byte) (int, error) {
 const SQLServerCompressionMethod = "sqlserver"
 
 func UseBuiltinCompression() bool {
-	method, _ := internal.GetSetting(internal.CompressionMethodSetting)
+	method, _ := conf.GetSetting(conf.CompressionMethodSetting)
 	return strings.EqualFold(method, SQLServerCompressionMethod)
 }

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/sqlserver/blob"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
@@ -71,7 +71,7 @@ type DatabaseFile struct {
 }
 
 func getSQLServerConnection() (*sql.DB, error) {
-	connString, err := internal.GetRequiredSetting(internal.SQLServerConnectionString)
+	connString, err := conf.GetRequiredSetting(conf.SQLServerConnectionString)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func getDatabaseBackupPath(backupName, dbname string) string {
 }
 
 func getDatabaseBackupURL(backupName, dbname string) string {
-	hostname, err := internal.GetRequiredSetting(internal.SQLServerBlobHostname)
+	hostname, err := conf.GetRequiredSetting(conf.SQLServerBlobHostname)
 	if err != nil {
 		tracelog.ErrorLogger.FatalOnError(err)
 	}
@@ -325,7 +325,7 @@ func getLogBackupPath(logBackupName, dbname string) string {
 }
 
 func getLogBackupURL(logBackupName, dbname string) string {
-	hostname, err := internal.GetRequiredSetting(internal.SQLServerBlobHostname)
+	hostname, err := conf.GetRequiredSetting(conf.SQLServerBlobHostname)
 	if err != nil {
 		tracelog.ErrorLogger.FatalOnError(err)
 	}
@@ -430,7 +430,7 @@ func runParallel(f func(int) error, cnt int, concurrency int) error {
 }
 
 func getDBConcurrency() int {
-	concurrency, err := internal.GetMaxConcurrency(internal.SQLServerDBConcurrency)
+	concurrency, err := conf.GetMaxConcurrency(conf.SQLServerDBConcurrency)
 	if err != nil {
 		tracelog.WarningLogger.Printf("config error: %v", err)
 		tracelog.WarningLogger.Printf("using default db concurrency: %d", blob.DefaultConcurrency)
@@ -555,7 +555,7 @@ func RunOrReuseProxy(ctx context.Context, cancel context.CancelFunc, folder stor
 	if err != nil {
 		return nil, xerrors.Errorf("proxy create error: %v", err)
 	}
-	reuse, _, err := internal.GetBoolSetting(internal.SQLServerReuseProxy)
+	reuse, _, err := conf.GetBoolSetting(conf.SQLServerReuseProxy)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/extract.go
+++ b/internal/extract.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/compression"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/utility"
 	"golang.org/x/sync/semaphore"
@@ -150,11 +151,11 @@ func ExtractAllWithSleeper(tarInterpreter TarInterpreter, files []ReaderMaker, s
 	}
 
 	// Set maximum number of goroutines spun off by ExtractAll
-	downloadingConcurrency, err := GetMaxDownloadConcurrency()
+	downloadingConcurrency, err := conf.GetMaxDownloadConcurrency()
 	if err != nil {
 		return err
 	}
-	retries := GetFetchRetries()
+	retries := conf.GetFetchRetries()
 
 	for currentRun := files; len(currentRun) > 0; {
 		failed := tryExtractFiles(currentRun, tarInterpreter, downloadingConcurrency)

--- a/internal/extract_test.go
+++ b/internal/extract_test.go
@@ -180,7 +180,7 @@ func TestRetryExtractWithSleeper(t *testing.T) {
 }
 
 func TestExtractAll_multipleTars(t *testing.T) {
-	internal.GetMaxDownloadConcurrency()
+	conf.GetMaxDownloadConcurrency()
 	os.Setenv(conf.DownloadConcurrencySetting, "1")
 	defer os.Unsetenv(conf.DownloadConcurrencySetting)
 

--- a/internal/extract_test.go
+++ b/internal/extract_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/crypto/openpgp"
 	"github.com/wal-g/wal-g/testtools"
 	"github.com/wal-g/wal-g/utility"
@@ -115,8 +116,8 @@ func makeCorruptedTar(name string) (BufferReaderMaker, []byte) {
 }
 
 func TestExtractAll_simpleTar(t *testing.T) {
-	os.Setenv(internal.DownloadConcurrencySetting, "1")
-	defer os.Unsetenv(internal.DownloadConcurrencySetting)
+	os.Setenv(conf.DownloadConcurrencySetting, "1")
+	defer os.Unsetenv(conf.DownloadConcurrencySetting)
 
 	brm, b := makeTar("booba")
 
@@ -132,9 +133,9 @@ func TestExtractAll_simpleTar(t *testing.T) {
 }
 
 func TestRetryExtractWithSleeper(t *testing.T) {
-	os.Setenv(internal.DownloadConcurrencySetting, "1")
-	os.Setenv(internal.DownloadFileRetriesSetting, "7")
-	defer os.Unsetenv(internal.DownloadConcurrencySetting)
+	os.Setenv(conf.DownloadConcurrencySetting, "1")
+	os.Setenv(conf.DownloadFileRetriesSetting, "7")
+	defer os.Unsetenv(conf.DownloadConcurrencySetting)
 
 	brm, _ := makeCorruptedTar("corrupted")
 
@@ -180,8 +181,8 @@ func TestRetryExtractWithSleeper(t *testing.T) {
 
 func TestExtractAll_multipleTars(t *testing.T) {
 	internal.GetMaxDownloadConcurrency()
-	os.Setenv(internal.DownloadConcurrencySetting, "1")
-	defer os.Unsetenv(internal.DownloadConcurrencySetting)
+	os.Setenv(conf.DownloadConcurrencySetting, "1")
+	defer os.Unsetenv(conf.DownloadConcurrencySetting)
 
 	fileAmount := 3
 	bufs := [][]byte{}
@@ -206,8 +207,8 @@ func TestExtractAll_multipleTars(t *testing.T) {
 }
 
 func TestExtractAll_multipleConcurrentTars(t *testing.T) {
-	os.Setenv(internal.DownloadConcurrencySetting, "4")
-	defer os.Unsetenv(internal.DownloadConcurrencySetting)
+	os.Setenv(conf.DownloadConcurrencySetting, "4")
+	defer os.Unsetenv(conf.DownloadConcurrencySetting)
 
 	fileAmount := 24
 	bufs := [][]byte{}

--- a/internal/file_tar_interpreter.go
+++ b/internal/file_tar_interpreter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -20,7 +21,7 @@ type FileTarInterpreter struct {
 func NewFileTarInterpreter(directoryToSave string) TarInterpreter {
 	return &FileTarInterpreter{
 		DirectoryToSave: directoryToSave,
-		fsync:           !viper.GetBool(TarDisableFsyncSetting),
+		fsync:           !viper.GetBool(conf.TarDisableFsyncSetting),
 	}
 }
 

--- a/internal/profile.go
+++ b/internal/profile.go
@@ -4,6 +4,8 @@ import (
 	"math/rand"
 	"time"
 
+	conf "github.com/wal-g/wal-g/internal/config"
+
 	"github.com/pkg/profile"
 	"github.com/spf13/viper"
 )
@@ -13,11 +15,11 @@ type ProfileStopper interface {
 }
 
 func Profile() (ProfileStopper, error) {
-	if !viper.IsSet(ProfileSamplingRatio) {
+	if !viper.IsSet(conf.ProfileSamplingRatio) {
 		return nil, nil
 	}
 
-	samplingRatio := viper.GetFloat64(ProfileSamplingRatio)
+	samplingRatio := viper.GetFloat64(conf.ProfileSamplingRatio)
 
 	// sample profiling invoked commands
 	rand.Seed(time.Now().UnixNano())
@@ -27,7 +29,7 @@ func Profile() (ProfileStopper, error) {
 
 	var opts []func(*profile.Profile)
 
-	profileMode := viper.GetString(ProfileMode)
+	profileMode := viper.GetString(conf.ProfileMode)
 	switch profileMode {
 	case "cpu":
 		opts = append(opts, profile.CPUProfile)
@@ -45,7 +47,7 @@ func Profile() (ProfileStopper, error) {
 		opts = append(opts, profile.GoroutineProfile)
 	}
 
-	profilePath := viper.GetString(ProfilePath)
+	profilePath := viper.GetString(conf.ProfilePath)
 	if profilePath != "" {
 		opts = append(opts, profile.ProfilePath(profilePath))
 	}

--- a/internal/serializer.go
+++ b/internal/serializer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	streamJSON "github.com/wal-g/json"
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 type UnknownSerializerTypeError struct {
@@ -36,7 +37,7 @@ type DtoSerializer interface {
 }
 
 func NewDtoSerializer() (DtoSerializer, error) {
-	switch t := DtoSerializerType(viper.GetString(SerializerTypeSetting)); t {
+	switch t := DtoSerializerType(viper.GetString(conf.SerializerTypeSetting)); t {
 	case RegularJSONSerializer:
 		return RegularJSON{}, nil
 	case StreamedJSONSerializer:

--- a/internal/serializer_test.go
+++ b/internal/serializer_test.go
@@ -5,6 +5,8 @@ import (
 
 	"testing"
 
+	conf "github.com/wal-g/wal-g/internal/config"
+
 	"github.com/spf13/viper"
 	"github.com/wal-g/wal-g/internal"
 )
@@ -38,7 +40,7 @@ func TestDtoSerializer_NewDtoSerializer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			viper.Set(internal.SerializerTypeSetting, tt.serializerTypeSettingValue)
+			viper.Set(conf.SerializerTypeSetting, tt.serializerTypeSettingValue)
 
 			dto, err := internal.NewDtoSerializer()
 

--- a/internal/statistics/metrics.go
+++ b/internal/statistics/metrics.go
@@ -16,6 +16,10 @@ import (
 type metrics struct {
 	UploadedFilesTotal       prometheus.Counter
 	UploadedFilesFailedTotal prometheus.Counter
+
+	S3Code200 prometheus.Counter
+	S3Code400 prometheus.Counter
+	S3Code500 prometheus.Counter
 }
 
 var (
@@ -28,11 +32,28 @@ var (
 				Help: "Number of uploaded files.",
 			},
 		),
-
 		UploadedFilesFailedTotal: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Name: WalgMetricsPrefix + "uploader_uploaded_files_failed_total",
 				Help: "Number of file upload failures.",
+			},
+		),
+		S3Code200: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: WalgMetricsPrefix + "s3_answer_code_200",
+				Help: "Number of 200 status code answers from s3.",
+			},
+		),
+		S3Code400: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: WalgMetricsPrefix + "s3_answer_code_400",
+				Help: "Number of 200 status code answers from s3.",
+			},
+		),
+		S3Code500: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: WalgMetricsPrefix + "s3_answer_code_500",
+				Help: "Number of 200 status code answers from s3.",
 			},
 		),
 	}
@@ -63,7 +84,13 @@ func PushMetrics() {
 }
 
 func WriteStatusCodeMetric(code int) {
-	//TODO
+	if code >= 500 {
+		WalgMetrics.S3Code500.Inc()
+	} else if code >= 400 {
+		WalgMetrics.S3Code400.Inc()
+	} else {
+		WalgMetrics.S3Code200.Inc()
+	}
 }
 
 func pushMetrics(address string, extraTags map[string]string) error {

--- a/internal/statistics/metrics.go
+++ b/internal/statistics/metrics.go
@@ -19,6 +19,8 @@ type metrics struct {
 
 	S3Code200 prometheus.Counter
 	S3Code400 prometheus.Counter
+	S3Code404 prometheus.Counter
+	S3Code429 prometheus.Counter
 	S3Code500 prometheus.Counter
 }
 
@@ -47,13 +49,25 @@ var (
 		S3Code400: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Name: WalgMetricsPrefix + "s3_answer_code_400",
-				Help: "Number of 200 status code answers from s3.",
+				Help: "Number of 400 status code answers from s3.",
+			},
+		),
+		S3Code404: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: WalgMetricsPrefix + "s3_answer_code_404",
+				Help: "Number of 404 status code answers from s3.",
+			},
+		),
+		S3Code429: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: WalgMetricsPrefix + "s3_answer_code_429",
+				Help: "Number of 429 status code answers from s3.",
 			},
 		),
 		S3Code500: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Name: WalgMetricsPrefix + "s3_answer_code_500",
-				Help: "Number of 200 status code answers from s3.",
+				Help: "Number of 500 status code answers from s3.",
 			},
 		),
 	}
@@ -67,6 +81,12 @@ func init() {
 
 	prometheus.MustRegister(WalgMetrics.UploadedFilesTotal)
 	prometheus.MustRegister(WalgMetrics.UploadedFilesFailedTotal)
+
+	prometheus.MustRegister(WalgMetrics.S3Code200)
+	prometheus.MustRegister(WalgMetrics.S3Code400)
+	prometheus.MustRegister(WalgMetrics.S3Code404)
+	prometheus.MustRegister(WalgMetrics.S3Code429)
+	prometheus.MustRegister(WalgMetrics.S3Code500)
 }
 
 func PushMetrics() {
@@ -87,7 +107,13 @@ func WriteStatusCodeMetric(code int) {
 	if code >= 500 {
 		WalgMetrics.S3Code500.Inc()
 	} else if code >= 400 {
-		WalgMetrics.S3Code400.Inc()
+		if code == 404 {
+			WalgMetrics.S3Code404.Inc()
+		} else if code == 429 {
+			WalgMetrics.S3Code429.Inc()
+		} else {
+			WalgMetrics.S3Code400.Inc()
+		}
 	} else {
 		WalgMetrics.S3Code200.Inc()
 	}

--- a/internal/statistics/metrics.go
+++ b/internal/statistics/metrics.go
@@ -1,4 +1,4 @@
-package internal
+package statistics
 
 import (
 	"fmt"
@@ -10,25 +10,26 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 type metrics struct {
-	uploadedFilesTotal       prometheus.Counter
-	uploadedFilesFailedTotal prometheus.Counter
+	UploadedFilesTotal       prometheus.Counter
+	UploadedFilesFailedTotal prometheus.Counter
 }
 
 var (
 	WalgMetricsPrefix = "walg_"
 
 	WalgMetrics = metrics{
-		uploadedFilesTotal: prometheus.NewCounter(
+		UploadedFilesTotal: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Name: WalgMetricsPrefix + "uploader_uploaded_files_total",
 				Help: "Number of uploaded files.",
 			},
 		),
 
-		uploadedFilesFailedTotal: prometheus.NewCounter(
+		UploadedFilesFailedTotal: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Name: WalgMetricsPrefix + "uploader_uploaded_files_failed_total",
 				Help: "Number of file upload failures.",
@@ -43,22 +44,26 @@ func init() {
 	prometheus.Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	prometheus.Unregister(collectors.NewGoCollector())
 
-	prometheus.MustRegister(WalgMetrics.uploadedFilesTotal)
-	prometheus.MustRegister(WalgMetrics.uploadedFilesFailedTotal)
+	prometheus.MustRegister(WalgMetrics.UploadedFilesTotal)
+	prometheus.MustRegister(WalgMetrics.UploadedFilesFailedTotal)
 }
 
 func PushMetrics() {
-	address := viper.GetString(StatsdAddressSetting)
+	address := viper.GetString(conf.StatsdAddressSetting)
 	if address == "" {
 		return
 	}
 
-	extraTags := viper.GetStringMapString(StatsdExtraTagsSetting)
+	extraTags := viper.GetStringMapString(conf.StatsdExtraTagsSetting)
 
 	err := pushMetrics(address, extraTags)
 	if err != nil {
 		tracelog.WarningLogger.Printf("Pushing metrics failed: %v", err)
 	}
+}
+
+func WriteStatusCodeMetric(code int) {
+	//TODO
 }
 
 func pushMetrics(address string, extraTags map[string]string) error {

--- a/internal/storage_adapter.go
+++ b/internal/storage_adapter.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"github.com/spf13/viper"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/azure"
 	"github.com/wal-g/wal-g/pkg/storages/fs"
 	"github.com/wal-g/wal-g/pkg/storages/gcs"
@@ -38,9 +39,9 @@ func (adapter *StorageAdapter) loadSettings(config *viper.Viper) map[string]stri
 			continue
 		}
 
-		settingValue, ok := getWaleCompatibleSettingFrom(settingName, config)
+		settingValue, ok := conf.GetWaleCompatibleSettingFrom(settingName, config)
 		if !ok {
-			settingValue, ok = GetSetting(settingName)
+			settingValue, ok = conf.GetSetting(settingName)
 		}
 		if ok {
 			settings[settingName] = settingValue

--- a/internal/stream_fetch_helper.go
+++ b/internal/stream_fetch_helper.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"time"
 
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/ioextensions"
 	"github.com/wal-g/wal-g/internal/splitmerge"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func ParseTS(endTSEnvVar string) (endTS *time.Time, err error) {
-	endTSStr, ok := GetSetting(endTSEnvVar)
+	endTSStr, ok := conf.GetSetting(endTSEnvVar)
 	if ok {
 		t, err := time.Parse(time.RFC3339, endTSStr)
 		if err != nil {
@@ -28,9 +29,9 @@ func ParseTS(endTSEnvVar string) (endTS *time.Time, err error) {
 
 // GetLogsDstSettings reads from the environment variables fetch settings
 func GetLogsDstSettings(operationLogsDstEnvVariable string) (dstFolder string, err error) {
-	dstFolder, ok := GetSetting(operationLogsDstEnvVariable)
+	dstFolder, ok := conf.GetSetting(operationLogsDstEnvVariable)
 	if !ok {
-		return dstFolder, NewUnsetRequiredSettingError(operationLogsDstEnvVariable)
+		return dstFolder, conf.NewUnsetRequiredSettingError(operationLogsDstEnvVariable)
 	}
 	return dstFolder, nil
 }

--- a/internal/stream_fetch_helper_test.go
+++ b/internal/stream_fetch_helper_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 const (
@@ -67,7 +68,7 @@ func TestGetLogsDstSettings_shouldReturnNilOnNoDirectory(t *testing.T) {
 
 func resetToDefaults() {
 	viper.Reset()
-	ConfigureSettings(PG)
-	InitConfig()
-	Configure()
+	ConfigureSettings(conf.PG)
+	conf.InitConfig()
+	conf.Configure()
 }

--- a/internal/stream_metadata.go
+++ b/internal/stream_metadata.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
@@ -31,7 +32,7 @@ func GetBackupStreamFetcher(backup Backup) (StreamFetcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	maxDownloadRetry := viper.GetInt(MysqlBackupDownloadMaxRetry)
+	maxDownloadRetry := viper.GetInt(conf.MysqlBackupDownloadMaxRetry)
 
 	switch metadata.Type {
 	case SplitMergeStreamBackup:

--- a/internal/tar_ball_queue.go
+++ b/internal/tar_ball_queue.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/internal/abool"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 // TarBallQueue is used to process multiple tarballs concurrently
@@ -38,11 +39,11 @@ func (tarQueue *TarBallQueue) StartQueue() error {
 		panic("Trying to start already started Queue")
 	}
 	var err error
-	tarQueue.parallelTarballs, err = GetMaxUploadDiskConcurrency()
+	tarQueue.parallelTarballs, err = conf.GetMaxUploadDiskConcurrency()
 	if err != nil {
 		return err
 	}
-	tarQueue.maxUploadQueue, err = getMaxUploadQueue()
+	tarQueue.maxUploadQueue, err = conf.GetMaxUploadQueue()
 	if err != nil {
 		return err
 	}

--- a/internal/upload_test.go
+++ b/internal/upload_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 func TestConfigure(t *testing.T) {
@@ -43,8 +44,8 @@ func doConfigureWithBucketPath(t *testing.T, bucketPath string, expectedServer s
 	}
 	assert.Nil(t, uploader)
 	internal.ConfigureSettings("")
-	internal.InitConfig()
-	internal.Configure()
+	conf.InitConfig()
+	conf.Configure()
 	os.Setenv("AWS_ACCESS_KEY_ID", "aws_access_key_id")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key")
 	os.Setenv("AWS_SESSION_TOKEN", "aws_session_token")

--- a/internal/uploader.go
+++ b/internal/uploader.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/wal-g/wal-g/internal/abool"
+	"github.com/wal-g/wal-g/internal/statistics"
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/compression"
@@ -170,13 +171,13 @@ func (uploader *RegularUploader) Upload(ctx context.Context, path string, conten
 	uploader.waitGroup.Add(1)
 	defer uploader.waitGroup.Done()
 
-	WalgMetrics.uploadedFilesTotal.Inc()
+	statistics.WalgMetrics.UploadedFilesTotal.Inc()
 	if uploader.tarSize != nil {
 		content = utility.NewWithSizeReader(content, uploader.tarSize)
 	}
 	err := uploader.UploadingFolder.PutObjectWithContext(ctx, path, content)
 	if err != nil {
-		WalgMetrics.uploadedFilesFailedTotal.Inc()
+		statistics.WalgMetrics.UploadedFilesFailedTotal.Inc()
 		uploader.failed.Set()
 		tracelog.ErrorLogger.Printf(tracelog.GetErrorFormatter()+"\n", err)
 		return err

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -64,9 +64,8 @@ func (folder *Folder) Exists(objectRelativePath string) (bool, error) {
 			return false, nil
 		}
 		return false, errors.Wrapf(err, "failed to check s3 object '%s' existence", objectPath)
-	} else {
-		statistics.WriteStatusCodeMetric(200)
 	}
+	statistics.WriteStatusCodeMetric(200)
 	return true, nil
 }
 
@@ -94,9 +93,8 @@ func (folder *Folder) CopyObject(srcPath string, dstPath string) error {
 		if reqErr, ok := err.(awserr.RequestFailure); ok {
 			statistics.WriteStatusCodeMetric(reqErr.StatusCode())
 		}
-	} else {
-		statistics.WriteStatusCodeMetric(200)
 	}
+	statistics.WriteStatusCodeMetric(200)
 	return err
 }
 
@@ -116,9 +114,8 @@ func (folder *Folder) ReadObject(objectRelativePath string) (io.ReadCloser, erro
 			return nil, storage.NewObjectNotFoundError(objectPath)
 		}
 		return nil, errors.Wrapf(err, "failed to read object: '%s' from S3", objectPath)
-	} else {
-		statistics.WriteStatusCodeMetric(200)
 	}
+	statistics.WriteStatusCodeMetric(200)
 
 	reader := object.Body
 	if folder.config.RangeBatchEnabled {
@@ -229,9 +226,8 @@ func (folder *Folder) DeleteObjects(objectRelativePaths []string) error {
 				statistics.WriteStatusCodeMetric(reqErr.StatusCode())
 			}
 			return errors.Wrapf(err, "failed to delete s3 object: '%s'", part)
-		} else {
-			statistics.WriteStatusCodeMetric(200)
 		}
+		statistics.WriteStatusCodeMetric(200)
 	}
 	return nil
 }

--- a/pkg/storages/s3/uploader.go
+++ b/pkg/storages/s3/uploader.go
@@ -108,7 +108,7 @@ func CreateUploaderAPI(svc s3iface.S3API, partsize, concurrency int) s3managerif
 func partitionStrings(strings []string, blockSize int) [][]string {
 	// I've unsuccessfully tried this with interface{} but there was too much of casting
 	if blockSize <= 0 {
-		return [][]string{strings};
+		return [][]string{strings}
 	}
 	partition := make([][]string, 0)
 	for i := 0; i < len(strings); i += blockSize {

--- a/pkg/storages/s3/uploader.go
+++ b/pkg/storages/s3/uploader.go
@@ -8,11 +8,13 @@ import (
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal/statistics"
 )
 
 type UploaderConfig struct {
@@ -83,6 +85,13 @@ func (uploader *Uploader) createUploadInput(bucket, path string, content io.Read
 func (uploader *Uploader) upload(ctx context.Context, bucket, path string, content io.Reader) error {
 	input := uploader.createUploadInput(bucket, path, content)
 	_, err := uploader.uploaderAPI.UploadWithContext(ctx, input)
+	if err != nil {
+		if reqErr, ok := err.(awserr.RequestFailure); ok {
+			statistics.WriteStatusCodeMetric(reqErr.StatusCode())
+		}
+	} else {
+		statistics.WriteStatusCodeMetric(200)
+	}
 	return errors.Wrapf(err, "failed to upload '%s' to bucket '%s'", path, bucket)
 }
 

--- a/tests_func/helpers/walg.go
+++ b/tests_func/helpers/walg.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -121,7 +121,7 @@ func (w *WalgUtil) runCmd(run ...string) (ExecResult, error) {
 }
 
 func (w *WalgUtil) PushBackup() (string, error) {
-	PgDataSettingString, ok := internal.GetSetting(internal.PgDataSetting)
+	PgDataSettingString, ok := conf.GetSetting(conf.PgDataSetting)
 	if !ok {
 		tracelog.InfoLogger.Print("\nPGDATA is not set in the conf.\n")
 	}


### PR DESCRIPTION
### Database name
All databases

# Pull request description

1) Added s3 response code metrics (200, 400, 404, 429, 500)
2) Moved config to separate package to prevent cyclic dependencies. Many packages import whole "internal", when they actually need only some settings.