### PR TITLE
Skip archive_command check on standby

### DIFF
--- a/internal/databases/postgres/connect.go
+++ b/internal/databases/postgres/connect.go
@@ -41,7 +41,7 @@ func Connect(configOptions ...func(config *pgx.ConnConfig) error) (*pgx.Conn, er
 		}
 	}
 
-	err = checkArchiveCommand(err, conn)
+	err = checkArchiveCommand(conn)
 	if err != nil {
 		return nil, err
 	}
@@ -49,12 +49,12 @@ func Connect(configOptions ...func(config *pgx.ConnConfig) error) (*pgx.Conn, er
 	return conn, nil
 }
 
-func checkArchiveCommand(err error, conn *pgx.Conn) error {
+func checkArchiveCommand(conn *pgx.Conn) error {
 	// TODO: Move this logic to queryRunner
 
 	var standby bool
 
-	err = conn.QueryRow("select pg_is_in_recovery()").Scan(&standby)
+	err := conn.QueryRow("select pg_is_in_recovery()").Scan(&standby)
 	if err != nil {
 		return errors.Wrap(err, "Connect: postgres standby test failed")
 	}

--- a/internal/databases/postgres/connect.go
+++ b/internal/databases/postgres/connect.go
@@ -41,18 +41,27 @@ func Connect(configOptions ...func(config *pgx.ConnConfig) error) (*pgx.Conn, er
 		}
 	}
 
+	err = checkArchiveCommand(err, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func checkArchiveCommand(err error, conn *pgx.Conn) error {
 	// TODO: Move this logic to queryRunner
 
 	var standby bool
 
 	err = conn.QueryRow("select pg_is_in_recovery()").Scan(&standby)
 	if err != nil {
-		return nil, errors.Wrap(err, "Connect: postgres standby test failed")
+		return errors.Wrap(err, "Connect: postgres standby test failed")
 	}
 
 	if standby {
 		// archive_mode may be configured on primary
-		return conn, nil
+		return nil
 	}
 
 	var archiveMode string
@@ -60,7 +69,7 @@ func Connect(configOptions ...func(config *pgx.ConnConfig) error) (*pgx.Conn, er
 	err = conn.QueryRow("show archive_mode").Scan(&archiveMode)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "Connect: postgres archive_mode test failed")
+		return errors.Wrap(err, "Connect: postgres archive_mode test failed")
 	}
 
 	if archiveMode != "on" && archiveMode != "always" {
@@ -73,7 +82,7 @@ func Connect(configOptions ...func(config *pgx.ConnConfig) error) (*pgx.Conn, er
 		err = conn.QueryRow("show archive_command").Scan(&archiveCommand)
 
 		if err != nil {
-			return nil, errors.Wrap(err, "Connect: postgres archive_mode test failed")
+			return errors.Wrap(err, "Connect: postgres archive_mode test failed")
 		}
 
 		if len(archiveCommand) == 0 || archiveCommand == "(disabled)" {
@@ -82,8 +91,7 @@ func Connect(configOptions ...func(config *pgx.ConnConfig) error) (*pgx.Conn, er
 					" Please consider configuring WAL archiving.")
 		}
 	}
-
-	return conn, nil
+	return nil
 }
 
 // nolint:gocritic


### PR DESCRIPTION
### Database name
Postgres

# Pull request description
WAL archival may be configured on primary. This PR skips false warnings about lack of archive_command configuration.
