### PR TITLE
Fix for GP incremental backups

### DIFF
--- a/internal/databases/greenplum/ao_storage_uploader.go
+++ b/internal/databases/greenplum/ao_storage_uploader.go
@@ -63,7 +63,7 @@ func (u *AoStorageUploader) AddFile(cfi *internal.ComposeFileInfo, aoMeta AoRelF
 	return err
 }
 
-func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error { //here
+func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error {
 	remoteFile, ok := u.baseAoFiles[cfi.Header.Name]
 	if !ok {
 		tracelog.DebugLogger.Printf("%s: no base file in storage, will perform a regular upload", cfi.Header.Name)
@@ -77,8 +77,8 @@ func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelF
 	}
 
 	if !u.isIncremental && remoteFile.IsIncremented {
-		tracelog.DebugLogger.Printf("%s: isIncremental: %t, will perform a regular upload",
-			cfi.Header.Name, u.isIncremental)
+		tracelog.DebugLogger.Printf("%s: backup isIncremental: %t, remote file isIncremented: %t, will perform a regular upload",
+			cfi.Header.Name, u.isIncremental, remoteFile.IsIncremented)
 		return u.regularAoUpload(cfi, aoMeta, location)
 	}
 

--- a/internal/databases/greenplum/ao_storage_uploader.go
+++ b/internal/databases/greenplum/ao_storage_uploader.go
@@ -63,7 +63,7 @@ func (u *AoStorageUploader) AddFile(cfi *internal.ComposeFileInfo, aoMeta AoRelF
 	return err
 }
 
-func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error {
+func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error { //here
 	remoteFile, ok := u.baseAoFiles[cfi.Header.Name]
 	if !ok {
 		tracelog.DebugLogger.Printf("%s: no base file in storage, will perform a regular upload", cfi.Header.Name)
@@ -73,6 +73,12 @@ func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelF
 	if remoteFile.InitialUploadTS.Before(u.deduplicationMinAge) {
 		tracelog.DebugLogger.Printf("%s: deduplication age limit passed (initial upload time: %s), will perform a regular upload",
 			cfi.Header.Name, remoteFile.InitialUploadTS)
+		return u.regularAoUpload(cfi, aoMeta, location)
+	}
+
+	if !u.isIncremental && remoteFile.IsIncremented {
+		tracelog.DebugLogger.Printf("%s: isIncremental: %t, will perform a regular upload",
+			cfi.Header.Name, u.isIncremental)
 		return u.regularAoUpload(cfi, aoMeta, location)
 	}
 


### PR DESCRIPTION
### Database name
Greenplum

# Problem
0) create gp cluster with ao/aocs tables and turn on deduplication for wal-g
1) create full backup
2) generate some changes
3) create incremental backup
4) do not perform any changes
5) create full backup
While creating backup wal-g finds unchanged delta files in storage and skips it, however it is supposed to reupload it in full mode
# Pull request description
When uploading full backup and finding delta file with no changes, upload it in full mode, because while fetching wal-g will unpack only files in last full backup