### PR TITLE
Implement lockFile for windows

### DIFF
--- a/internal/multistorage/stats/cache/file.go
+++ b/internal/multistorage/stats/cache/file.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"os"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 type SharedFile struct {
@@ -86,18 +84,3 @@ func (sf *SharedFile) write(content storageStatuses) error {
 	return nil
 }
 
-func lockFile(file *os.File, exclusive bool) (err error) {
-	how := unix.LOCK_SH
-	if exclusive {
-		how = unix.LOCK_EX
-	}
-
-	for {
-		err = unix.Flock(int(file.Fd()), how)
-		// When calling syscalls directly, we need to retry EINTR errors. They mean the call was interrupted by a signal.
-		if err != unix.EINTR {
-			break
-		}
-	}
-	return err
-}

--- a/internal/multistorage/stats/cache/flock_unix.go
+++ b/internal/multistorage/stats/cache/flock_unix.go
@@ -1,0 +1,25 @@
+// +build !windows
+
+package cache
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFile(file *os.File, exclusive bool) (err error) {
+	how := unix.LOCK_SH
+	if exclusive {
+		how = unix.LOCK_EX
+	}
+
+	for {
+		err = unix.Flock(int(file.Fd()), how)
+		// When calling syscalls directly, we need to retry EINTR errors. They mean the call was interrupted by a signal.
+		if err != unix.EINTR {
+			break
+		}
+	}
+	return err
+}

--- a/internal/multistorage/stats/cache/flock_windows.go
+++ b/internal/multistorage/stats/cache/flock_windows.go
@@ -1,0 +1,44 @@
+// +build windows
+
+package cache
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32, _         = syscall.LoadLibrary("kernel32.dll")
+	procLockFileEx, _   = syscall.GetProcAddress(kernel32, "LockFileEx")
+)
+
+const (
+	winLockfileExclusiveLock   = 0x00000003
+	winLockfileSharedLock      = 0x00000001
+)
+
+func lockFile(file *os.File, exclusive bool) (err error) {
+	how := winLockfileSharedLock
+	if exclusive {
+		how = winLockfileExclusiveLock
+	}
+
+	_, _, errno := syscall.Syscall6(
+		uintptr(procLockFileEx),
+		6,
+		uintptr(syscall.Handle(file.Fd())),
+		uintptr(how),
+		uintptr(0), // reserved
+		uintptr(1), // lock length (low bytes)  |
+		uintptr(0), // lock length (high bytes) |=> entire file
+		uintptr(unsafe.Pointer(&syscall.Overlapped{}))) // offset = 0
+
+	err = nil
+	if errno != 0 {
+		err = errno
+	}
+
+	return err
+}
+


### PR DESCRIPTION
Fixes #1668

Implements the `lockFile` function for Windows using [LockFileEx](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex) API.