### PR TITLE
Fix WALG_STATSD_EXTRA_TAGS

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -549,7 +549,8 @@ var (
 	}
 
 	complexSettings = map[string]bool{
-		PgFailoverStorages: true,
+		PgFailoverStorages:     true,
+		StatsdExtraTagsSetting: true,
 	}
 )
 


### PR DESCRIPTION
### Database name

Postgres (but affects all via statsd)

# Pull request description

### Describe what this PR fix

We recently ( https://github.com/wal-g/wal-g/pull/1649 ) introduced `WALG_STATSD_EXTRA_TAGS` to allow statsd metrics to be annotated with, e.g., the database name. Unfortunately, the implementation (shipped in 3.0.0) is broken because the config key isn't marked as "complex", leading to it being squashed down to a string representation like `map[foo:bar]` - and the viper `GetStringMapString()` returns an empty map as a result.

### Please provide steps to reproduce (if it's a bug)

Set `WALG_STATSD_EXTRA_TAGS` in config file; observe outputted metrics lack said tags.

### Please add config and wal-g stdout/stderr logs for debug purpose

Adding some printf-based debugging...

<details><summary>A run without the fix</summary>
<p>

```bash
...
	WALG_SKIP_REDUNDANT_TARS=false
	WALG_STATSD_ADDRESS=127.0.0.1:8190
	WALG_STATSD_EXTRA_TAGS=map[process_name:patroni_poc]
	WALG_STORE_ALL_CORRUPT_BLOCKS=false
...
isSet: true
etw: "map[process_name:patroni_poc]" (string)
DEBUG: 2024/04/02 17:23:29.075054 Sending metrics to statsd
extraTags: map[string]string{}
tags: []statsd.Tag{}
DEBUG: 2024/04/02 17:23:29.076075 writing metric: gauge:<value:0 > 
```

</p>
</details>


<details><summary>And with the fix</summary>
<p>

```bash
...
	WALG_SKIP_REDUNDANT_TARS=false
	WALG_STATSD_ADDRESS=127.0.0.1:8190
	WALG_STORE_ALL_CORRUPT_BLOCKS=false
...
isSet: true
etw: map[string]interface {}{"process_name":"patroni_poc"} (map[string]interface {})
DEBUG: 2024/04/02 17:24:27.245197 Sending metrics to statsd
extraTags: map[string]string{"process_name":"patroni_poc"}
tags: []statsd.Tag{statsd.Tag{"process_name", "patroni_poc"}}
DEBUG: 2024/04/02 17:24:27.245418 writing metric: gauge:<value:0 > 
...
```

</p>
</details>

cc @debebantur 