### PR TITLE
Clarified dev installing instruction on Ubuntu for go 1.16+

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -304,6 +304,7 @@ sudo apt install libbrotli-dev liblzo2-dev libsodium-dev curl cmake
 # Go 1.15 and below
 go get github.com/wal-g/wal-g
 # Go 1.16+ - just clone repository to $GOPATH
+# if you want to save space add --depth=1 or --single-branch
 git clone https://github.com/wal-g/wal-g $(go env GOPATH)/src/github.com/wal-g/wal-g
 
 cd $(go env GOPATH)/src/github.com/wal-g/wal-g
@@ -339,6 +340,7 @@ brew install cmake
 # Go 1.15 and below
 go get github.com/wal-g/wal-g
 # Go 1.16+ - just clone repository to $GOPATH
+# if you want to save space add --depth=1 or --single-branch
 git clone https://github.com/wal-g/wal-g $(go env GOPATH)/src/github.com/wal-g/wal-g
 
 cd $(go env GOPATH)/src/github.com/wal-g/wal-g

--- a/docs/README.md
+++ b/docs/README.md
@@ -334,11 +334,23 @@ GOBIN=/usr/local/bin make pg_install
 ```sh
 # brew command is Homebrew for Mac OS
 brew install cmake
+
+# Fetch project and build
+# Go 1.15 and below
+go get github.com/wal-g/wal-g
+# Go 1.16+ - just clone repository to $GOPATH
+git clone https://github.com/wal-g/wal-g $(go env GOPATH)/src/github.com/wal-g/wal-g
+
+cd $(go env GOPATH)/src/github.com/wal-g/wal-g
+
 export USE_BROTLI=1
 export USE_LIBSODIUM="true" # since we're linking libsodium later
 ./link_brotli.sh
 ./link_libsodium.sh
 make install_and_build_pg
+
+# if you need to install
+GOBIN=/usr/local/bin make pg_install
 ```
 
 To build on ARM64, set the corresponding `GOOS`/`GOARCH` environment variables:

--- a/docs/README.md
+++ b/docs/README.md
@@ -293,7 +293,7 @@ Optional:
 
 ```sh
 # Install latest Go compiler
-sudo add-apt-repository ppa:longsleep/golang-backports 
+sudo add-apt-repository ppa:longsleep/golang-backports
 sudo apt update
 sudo apt install golang-go
 
@@ -301,8 +301,18 @@ sudo apt install golang-go
 sudo apt install libbrotli-dev liblzo2-dev libsodium-dev curl cmake
 
 # Fetch project and build
+# Go 1.15 and below
 go get github.com/wal-g/wal-g
-cd ~/go/src/github.com/wal-g/wal-g
+# Go 1.16+ - just clone repository to $GOPATH
+git clone https://github.com/wal-g/wal-g $(go env GOPATH)/src/github.com/wal-g/wal-g
+
+cd $(go env GOPATH)/src/github.com/wal-g/wal-g
+
+# optional exports (see above)
+export USE_BROTLI=1
+export USE_LIBSODIUM=1
+export USE_LZO=1
+
 make deps
 make pg_build
 main/pg/wal-g --version


### PR DESCRIPTION
Fixes #1632
Maybe `git clone` should be with `--single-branch --depth=1` but this looks uglier and probably developers need whole repo

Installing like this will be more convenient
```
go install github.com/wal-g/wal-g/main/pg@latest
```
but wrong in this case, for developing, espesially when additional lib support needed