### PR TITLE
storages (s3): Add AWS_DUAL_STACK configuration

### DIFF
--- a/pkg/storages/s3/configure.go
+++ b/pkg/storages/s3/configure.go
@@ -22,6 +22,7 @@ const (
 	sessionTokenSetting             = "AWS_SESSION_TOKEN"
 	sessionNameSetting              = "AWS_ROLE_SESSION_NAME"
 	roleARNSetting                  = "AWS_ROLE_ARN"
+	dualStackSetting                = "AWS_DUAL_STACK"
 	skipValidationSetting           = "S3_SKIP_VALIDATION"
 	useYcSessionTokenSetting        = "S3_USE_YC_SESSION_TOKEN"
 	sseSetting                      = "S3_SSE"
@@ -60,6 +61,7 @@ var SettingList = []string{
 	sessionTokenSetting,
 	sessionNameSetting,
 	roleARNSetting,
+	dualStackSetting,
 	skipValidationSetting,
 	useYcSessionTokenSetting,
 	sseSetting,
@@ -84,6 +86,7 @@ var SettingList = []string{
 
 const (
 	defaultPort                    = "443"
+	defaultDualStack               = false
 	defaultSkipValidation          = true
 	defaultForcePathStyle          = false
 	defaultUseListObjectsV1        = false
@@ -114,6 +117,10 @@ func ConfigureStorage(
 	port := defaultPort
 	if p, ok := settings[endpointPortSetting]; ok {
 		port = p
+	}
+	dualStack, err := setting.BoolOptional(settings, dualStackSetting, defaultDualStack)
+	if err != nil {
+		return nil, err
 	}
 	skipValidation, err := setting.BoolOptional(settings, skipValidationSetting, defaultSkipValidation)
 	if err != nil {
@@ -181,6 +188,7 @@ func ConfigureStorage(
 		AccessKey:                strings.TrimSpace(setting.FirstDefined(settings, accessKeyIDSetting, accessKeySetting)),
 		SessionToken:             settings[sessionTokenSetting],
 		RoleARN:                  settings[roleARNSetting],
+		DualStack:                dualStack,
 		SessionName:              settings[sessionNameSetting],
 		CACertFile:               settings[caCertFileSetting],
 		SkipValidation:           skipValidation,

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -155,6 +156,9 @@ func configureSession(sess *session.Session, config *Config) error {
 		awsConfig = awsConfig.WithEndpoint(config.Endpoint)
 	}
 
+	if config.DualStack {
+		awsConfig.UseDualStackEndpoint = endpoints.DualStackEndpointStateEnabled
+	}
 	awsConfig.S3ForcePathStyle = &config.ForcePathStyle
 
 	if config.Region == "" {

--- a/pkg/storages/s3/storage.go
+++ b/pkg/storages/s3/storage.go
@@ -26,6 +26,7 @@ type Config struct {
 	AccessKey                string
 	SessionToken             string
 	RoleARN                  string
+	DualStack                bool
 	SessionName              string
 	CACertFile               string
 	SkipValidation           bool


### PR DESCRIPTION
This adds the capability to set AWS_DUAL_STACK=true to use IPv6 compatible endpoints for S3 storage.