### PR TITLE
Fix Mongodb commitIndexBuild panic in olpog-replay

### DIFF
--- a/internal/databases/mongo/oplog/applier.go
+++ b/internal/databases/mongo/oplog/applier.go
@@ -254,8 +254,8 @@ func indexSpecFromCommitIndexBuilds(op db.Oplog) (string, []client.IndexDocument
 				if !ok {
 					return "", nil, NewTypeAssertionError("bson.D", fmt.Sprintf("indexes[%d]", i), elemE.Value)
 				}
-				for i := range elements {
-					elemE = elements[i]
+				for j := range elements {
+					elemE = elements[j]
 					if elemE.Key == "key" {
 						if indexSpecs[i].Key, ok = elemE.Value.(bson.D); !ok {
 							return "", nil, NewTypeAssertionError("bson.D", "key", elemE.Value)

--- a/internal/databases/mongo/oplog/applier.go
+++ b/internal/databases/mongo/oplog/applier.go
@@ -254,8 +254,7 @@ func indexSpecFromCommitIndexBuilds(op db.Oplog) (string, []client.IndexDocument
 				if !ok {
 					return "", nil, NewTypeAssertionError("bson.D", fmt.Sprintf("indexes[%d]", i), elemE.Value)
 				}
-				for j := range elements {
-					elemE = elements[j]
+				for _, elemE := range elements {
 					if elemE.Key == "key" {
 						if indexSpecs[i].Key, ok = elemE.Value.(bson.D); !ok {
 							return "", nil, NewTypeAssertionError("bson.D", "key", elemE.Value)


### PR DESCRIPTION
### Database name
Mongodb

### Describe what this PR fix
For `oplog-replay`, any oplog with commitIndexBuild command, in indexSpecFromCommitIndexBuilds func, its getting panic due to for loop's variables misposition in [indexSpecs slice](https://github.com/wal-g/wal-g/blob/master/internal/databases/mongo/oplog/applier.go#L259C1-L265C7)

### Please provide steps to reproduce (if it's a bug)
multiple index commit in oplog-replay
