### PR TITLE
Orioledb basic support

### DIFF
--- a/.github/workflows/dockertests-par.yml
+++ b/.github/workflows/dockertests-par.yml
@@ -89,5 +89,8 @@ jobs:
         "make gp_test",
         "make st_test",
         "make TEST=\"pg_pgbackrest_backup_fetch_test\" pg_integration_test",
-        "make etcd_test"
+        "make etcd_test",
+        "make TEST=\"orioledb_compatibility_test\" pg_integration_test",
+        "make TEST=\"orioledb_simple_test\" pg_integration_test",
+        "make TEST=\"orioledb_compressed_test\" pg_integration_test",
         ]

--- a/.github/workflows/dockertests-par.yml
+++ b/.github/workflows/dockertests-par.yml
@@ -90,7 +90,7 @@ jobs:
         "make st_test",
         "make TEST=\"pg_pgbackrest_backup_fetch_test\" pg_integration_test",
         "make etcd_test",
-        "make TEST=\"orioledb_compatibility_test\" pg_integration_test",
-        "make TEST=\"orioledb_simple_test\" pg_integration_test",
-        "make TEST=\"orioledb_compressed_test\" pg_integration_test",
+        "make TEST=\"orioledb_compatibility_test\" orioledb_integration_test",
+        "make TEST=\"orioledb_simple_test\" orioledb_integration_test",
+        "make TEST=\"orioledb_compressed_test\" orioledb_integration_test",
         ]

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ pg_integration_test: clean_compose
 	@if echo "$(TEST)" | grep -Fqe "pgbackrest"; then\
 		docker compose build pg_pgbackrest;\
 	fi
+	@if echo "$(TEST)" | grep -Fqe "orioledb"; then\
+		docker-compose build orioledb;\
+	fi
 	@if echo "$(TEST)" | grep -Fqe "pg_ssh_"; then\
 		docker compose build ssh;\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,6 @@ pg_integration_test: clean_compose
 	@if echo "$(TEST)" | grep -Fqe "pgbackrest"; then\
 		docker compose build pg_pgbackrest;\
 	fi
-	@if echo "$(TEST)" | grep -Fqe "orioledb"; then\
-		docker compose build orioledb;\
-	fi
 	@if echo "$(TEST)" | grep -Fqe "pg_ssh_"; then\
 		docker compose build ssh;\
 	fi
@@ -96,6 +93,11 @@ pg_integration_test: clean_compose
 		sleep 5 &&\
 		docker compose up --exit-code-from pg_wal_perftest_with_throttling pg_wal_perftest_with_throttling ;\
 	fi
+	make clean_compose
+
+orioledb_integration_test: install_and_build_pg clean_compose load_docker_common
+	docker compose build orioledb
+	docker compose up --exit-code-from $(TEST) $(TEST)
 	make clean_compose
 
 .PHONY: clean_compose

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ pg_integration_test: clean_compose
 		docker compose build pg_pgbackrest;\
 	fi
 	@if echo "$(TEST)" | grep -Fqe "orioledb"; then\
-		docker-compose build orioledb;\
+		docker compose build orioledb;\
 	fi
 	@if echo "$(TEST)" | grep -Fqe "pg_ssh_"; then\
 		docker compose build ssh;\
@@ -100,7 +100,7 @@ pg_integration_test: clean_compose
 
 .PHONY: clean_compose
 clean_compose:
-	services=$$(docker compose ps -a --format '{{.Name}} {{.Service}}' | grep wal-g_ | cut -w -f 2); \
+	services=$$(docker compose ps -a --format '{{.Name}} {{.Service}}' | grep wal-g_ | cut -d' ' -f 2); \
 		if [ "$$services" ]; then docker compose down $$services; fi
 
 all_unittests: deps unittest

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -28,7 +28,6 @@ const (
 	deltaFromNameFlag         = "delta-from-name"
 	addUserDataFlag           = "add-user-data"
 	withoutFilesMetadataFlag  = "without-files-metadata"
-	withOrioledb              = "with-orioledb"
 
 	permanentShorthand             = "p"
 	fullBackupShorthand            = "f"
@@ -107,8 +106,7 @@ var (
 			userData, err := internal.UnmarshalSentinelUserData(userDataRaw)
 			tracelog.ErrorLogger.FatalfOnError("Failed to unmarshal the provided UserData: %s", err)
 
-			var arguments postgres.BackupArguments
-			arguments = postgres.NewBackupArguments(uploader, dataDirectory, utility.BaseBackupPath,
+			arguments := postgres.NewBackupArguments(uploader, dataDirectory, utility.BaseBackupPath,
 				permanent, verifyPageChecksums || viper.GetBool(conf.VerifyPageChecksumsSetting),
 				fullBackup, storeAllCorruptBlocks || viper.GetBool(conf.StoreAllCorruptBlocksSetting),
 				tarBallComposerType, postgres.NewRegularDeltaBackupConfigurator(deltaBaseSelector),

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -108,19 +108,11 @@ var (
 			tracelog.ErrorLogger.FatalfOnError("Failed to unmarshal the provided UserData: %s", err)
 
 			var arguments postgres.BackupArguments
-			if orioledbEnabled {
-				arguments = postgres.OrioledbNewBackupArguments(uploader, dataDirectory, utility.BaseBackupPath,
-					permanent, verifyPageChecksums || viper.GetBool(conf.VerifyPageChecksumsSetting),
-					fullBackup, storeAllCorruptBlocks || viper.GetBool(conf.StoreAllCorruptBlocksSetting),
-					tarBallComposerType, postgres.NewRegularDeltaBackupConfigurator(deltaBaseSelector),
-					userData, withoutFilesMetadata, orioledbEnabled)
-			} else {
-				arguments = postgres.NewBackupArguments(uploader, dataDirectory, utility.BaseBackupPath,
-					permanent, verifyPageChecksums || viper.GetBool(conf.VerifyPageChecksumsSetting),
-					fullBackup, storeAllCorruptBlocks || viper.GetBool(conf.StoreAllCorruptBlocksSetting),
-					tarBallComposerType, postgres.NewRegularDeltaBackupConfigurator(deltaBaseSelector),
-					userData, withoutFilesMetadata)
-			}
+			arguments = postgres.NewBackupArguments(uploader, dataDirectory, utility.BaseBackupPath,
+				permanent, verifyPageChecksums || viper.GetBool(conf.VerifyPageChecksumsSetting),
+				fullBackup, storeAllCorruptBlocks || viper.GetBool(conf.StoreAllCorruptBlocksSetting),
+				tarBallComposerType, postgres.NewRegularDeltaBackupConfigurator(deltaBaseSelector),
+				userData, withoutFilesMetadata)
 
 			backupHandler, err := postgres.NewBackupHandler(arguments)
 			tracelog.ErrorLogger.FatalOnError(err)
@@ -138,7 +130,6 @@ var (
 	deltaFromUserData     = ""
 	userDataRaw           = ""
 	withoutFilesMetadata  = false
-	orioledbEnabled       = false
 )
 
 func chooseTarBallComposer() postgres.TarBallComposerType {
@@ -188,8 +179,6 @@ func init() {
 		"", "Write the provided user data to the backup sentinel and metadata files.")
 	backupPushCmd.Flags().BoolVar(&withoutFilesMetadata, withoutFilesMetadataFlag,
 		false, "Do not track files metadata, significantly reducing memory usage")
-	backupPushCmd.Flags().BoolVar(&orioledbEnabled, withOrioledb,
-		false, "Enable experimental orioledb delta backups support")
 	backupPushCmd.Flags().StringVar(&targetStorage, "target-storage", "",
 		targetStorageDescription)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,6 +177,9 @@ services:
       &&  mkdir -p /export/receivewalbucket
       &&  mkdir -p /export/severaldeltabackupsbucket
       &&  mkdir -p /export/walperftestbucket
+      &&  mkdir -p /export/orioledb_compatibility
+      &&  mkdir -p /export/orioledb_simple
+      &&  mkdir -p /export/orioledb_compressed
       &&  /usr/bin/minio server /export'
 
   s3-another:
@@ -476,6 +479,8 @@ services:
     <<: *pg_test_common
     container_name: wal-g_pg_delta_backup_fullscan_test
     command: /tmp/tests/delta_backup_fullscan_test.sh
+    env_file:
+      - docker/common/common_walg.env
 
   pg_several_delta_backups_test:
     <<: *pg_test_common
@@ -564,6 +569,33 @@ services:
     command: /tmp/tests/pgbackrest_backup_fetch_test.sh
     <<: *s3_common_depends
 
+  orioledb:
+    build:
+      dockerfile: docker/orioledb/Dockerfile
+      context: .
+    image: wal-g/orioledb
+
+  orioledb_compatibility_test:
+    image: wal-g/orioledb
+    user: postgres
+    container_name: wal-g_orioledb_compatibility_test
+    command: /tmp/tests/compatibility_test.sh
+    <<: *s3_common_depends
+
+  orioledb_simple_test:
+    image: wal-g/orioledb
+    user: postgres
+    container_name: wal-g_orioledb_simple_test
+    command: /tmp/tests/simple_test.sh
+    <<: *s3_common_depends
+
+  orioledb_compressed_test:
+    image: wal-g/orioledb
+    user: postgres
+    container_name: wal-g_orioledb_compressed_test
+    command: /tmp/tests/compressed_test.sh
+    <<: *s3_common_depends
+
   mysql:
     build:
       dockerfile: docker/mysql/Dockerfile
@@ -582,7 +614,7 @@ services:
     env_file:
       - docker/common/common_walg.env
     <<: *s3_common_depends
-  
+
   mysql_delete_tests:
     build:
       dockerfile: docker/mysql_tests/Dockerfile_delete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -479,8 +479,6 @@ services:
     <<: *pg_test_common
     container_name: wal-g_pg_delta_backup_fullscan_test
     command: /tmp/tests/delta_backup_fullscan_test.sh
-    env_file:
-      - docker/common/common_walg.env
 
   pg_several_delta_backups_test:
     <<: *pg_test_common

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -1,0 +1,161 @@
+FROM wal-g/golang:latest as build
+
+WORKDIR /go/src/github.com/wal-g/wal-g
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends --no-install-suggests \
+    liblzo2-dev
+
+COPY go.mod go.mod
+COPY vendor/ vendor/
+COPY internal/ internal/
+COPY pkg/ pkg/
+COPY cmd/ cmd/
+COPY main/ main/
+COPY utility/ utility/
+
+RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
+        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
+    sed -i 's|\(#cgo LDFLAGS:\) .*|\1 -Wl,-Bstatic -llzo2 -Wl,-Bdynamic|' \
+        vendor/github.com/cyberdelia/lzo/lzo.go
+RUN --mount=type=cache,target=/gocache cd main/pg && GOCACHE=/gocache \
+    go build -mod vendor -race -o wal-g -tags "brotli lzo" -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+RUN --mount=type=cache,target=/gocache cd cmd/daemonclient && GOCACHE=/gocache \
+    go build -mod vendor -o walg-daemon-client -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+
+RUN --mount=type=cache,target=/gocache cd pkg/storages/swift && GOCACHE=/gocache go test -v -c
+RUN --mount=type=cache,target=/gocache cd pkg/storages/sh && GOCACHE=/gocache go test -v -c
+
+
+FROM wal-g/ubuntu:20.04
+
+ENV PGDATA /var/lib/postgresql/16/main
+
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --no-install-suggests \
+		wget \
+		curl
+
+RUN mkdir -p /usr/src/postgresql/contrib/orioledb && chmod 777 /usr/src/postgresql/contrib/orioledb
+
+WORKDIR /usr/src/postgresql/contrib/orioledb
+RUN set -eux; \
+	git init; \
+	git remote add origin https://github.com/orioledb/orioledb.git; \
+	git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +69c83423532f995ef58d52ac8c614f6630c5dc2c:refs/remotes/origin/main; \
+	git checkout --progress --force -B main refs/remotes/origin/main;
+
+WORKDIR /
+RUN set -eux; \
+	\
+	# don't forget to change PGTAG below
+	PGTAG=$(grep "^16: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
+	\
+	curl -o postgresql.tar.gz \
+			--header "Accept: application/vnd.github.v3.raw" \
+			--remote-name \
+			--location https://github.com/orioledb/postgres/tarball/$PGTAG; \
+	mkdir -p /usr/src/postgresql; \
+	tar \
+		--extract \
+		--file postgresql.tar.gz \
+		--directory /usr/src/postgresql \
+		--strip-components 1 \
+	; \
+	rm postgresql.tar.gz;
+
+WORKDIR /usr/src/postgresql
+RUN set -eux; \
+	apt-get update; \
+	DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+		build-essential \
+		llvm-dev clang \
+		bison \
+		daemontools \
+		flex \
+		libcurl4-openssl-dev \
+		libicu-dev \
+		liblz4-1 \
+		liblz4-dev \
+		libz-dev \
+		libssl-dev \
+		libreadline-dev \
+		libuuid1 \
+		libzstd1 \
+		libzstd-dev \
+		make \
+		pkg-config \
+		uuid-dev \
+		wget
+
+RUN apt search zstd
+
+WORKDIR /usr/src/postgresql
+ENV PATH="$PATH:/usr/local/bin"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+RUN set -eux; \
+	\
+	# don't forget to change PGTAG above
+	PGTAG=$(grep "^16: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
+	ORIOLEDB_VERSION=$(grep "^#define ORIOLEDB_VERSION" /usr/src/postgresql/contrib/orioledb/include/orioledb.h | cut -d'"' -f2) ; \
+	ORIOLEDB_BUILDTIME=$(date -Iseconds) ; \
+	\
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	( CC=clang ./configure \
+		--build="$gnuArch" \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--disable-rpath \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		--with-openssl \
+		--with-icu \
+		--with-llvm \
+		--with-lz4 \
+		--with-zstd \
+		--with-extra-version=" ${ORIOLEDB_VERSION} PGTAG=${PGTAG} ubuntu:focal+clang build:${ORIOLEDB_BUILDTIME}" \
+	|| cat config.log ); \
+	echo "ORIOLEDB_PATCHSET_VERSION = `echo $PGTAG | cut -d'_' -f2`" >> src/Makefile.global; \
+	make -j "$(nproc)"; \
+	make -C contrib -j "$(nproc)"; \
+	make -C contrib/orioledb -j "$(nproc)"; \
+	make install; \
+	make -C contrib install; \
+	make -C contrib/orioledb install; \
+	postgres --version
+
+COPY docker/common/s3cfg /var/lib/postgresql/.s3cfg
+
+COPY docker/pg/walg.json /tmp/walg.json
+
+RUN rm -rf $PGDATA
+
+# explicitly set user/group IDs
+RUN set -eux; \
+	groupadd -r postgres --gid=999; \
+# https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
+	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+# also create the postgres user's home directory with appropriate permissions
+# see https://github.com/docker-library/postgres/issues/274
+	mkdir -p /var/lib/postgresql; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y netcat-openbsd && apt-get clean
+
+COPY --from=build /go/src/github.com/wal-g/wal-g/pkg/storages/swift/swift.test /tmp/test_bins/
+COPY --from=build /go/src/github.com/wal-g/wal-g/pkg/storages/sh/sh.test /tmp/test_bins/
+COPY --from=build /go/src/github.com/wal-g/wal-g/main/pg/wal-g /usr/bin
+COPY --from=build /go/src/github.com/wal-g/wal-g/cmd/daemonclient/walg-daemon-client /usr/bin
+
+COPY docker/pg_tests/scripts/scripts/ /tmp/scripts/
+COPY docker/pg_tests/scripts/configs/common_config.json /tmp/configs/
+COPY docker/orioledb/scripts/ /tmp
+
+RUN mkdir -p /tmp/logs/ && chmod 777 /tmp/configs/ && chmod 777 /tmp/logs/
+RUN mkdir -p /var/run/postgresql && chmod 777 /var/run/postgresql
+ENV PGHOST /var/run/postgresql

--- a/docker/orioledb/scripts/configs/compatibility_test_config.json
+++ b/docker/orioledb/scripts/configs/compatibility_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://orioledb_compatibility",
+"WALG_DELTA_MAX_STEPS": "6"

--- a/docker/orioledb/scripts/configs/compressed_test_config.json
+++ b/docker/orioledb/scripts/configs/compressed_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://orioledb_compressed",
+"WALG_DELTA_MAX_STEPS": "6"

--- a/docker/orioledb/scripts/configs/simple_test_config.json
+++ b/docker/orioledb/scripts/configs/simple_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://orioledb_simple",
+"WALG_DELTA_MAX_STEPS": "6"

--- a/docker/orioledb/scripts/scripts/compressed_prepare.sql
+++ b/docker/orioledb/scripts/scripts/compressed_prepare.sql
@@ -1,0 +1,32 @@
+CREATE EXTENSION IF NOT EXISTS orioledb;
+
+CREATE TABLE pgbench_accounts (
+	aid integer NOT NULL,
+	bid integer,
+	abalance integer,
+	filler character(84)
+) USING orioledb WITH (compress = 5);
+
+CREATE TABLE pgbench_branches (
+	bid integer NOT NULL,
+	bbalance integer,
+	filler character(88)
+) USING orioledb WITH (compress = 5);
+
+CREATE TABLE pgbench_tellers (
+	tid integer NOT NULL,
+	bid integer,
+	tbalance integer,
+	filler character(84)
+) USING orioledb WITH (compress = 5);
+
+CREATE TABLE pgbench_history
+(
+	tid integer NOT NULL,
+	bid integer NOT NULL,
+	aid integer NOT NULL,
+	delta integer NOT NULL,
+	mtime timestamp NOT NULL,
+	filler character(22),
+	PRIMARY KEY(bid, mtime, tid, aid, delta)
+) USING orioledb WITH (compress = 5);

--- a/docker/orioledb/scripts/scripts/orioledb_check.sql
+++ b/docker/orioledb/scripts/scripts/orioledb_check.sql
@@ -1,0 +1,11 @@
+CREATE FUNCTION check_table(reloid oid) RETURNS void AS $$
+BEGIN
+    IF NOT (SELECT orioledb_tbl_check(reloid)) THEN
+        RAISE EXCEPTION 'CHECK FAILED';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT c.relname, orioledb_tbl_check(reloid), check_table(reloid)
+    FROM orioledb_table ot
+    JOIN pg_class c ON c.oid = ot.reloid;

--- a/docker/orioledb/scripts/scripts/orioledb_compressed_check.sql
+++ b/docker/orioledb/scripts/scripts/orioledb_compressed_check.sql
@@ -1,0 +1,17 @@
+CREATE FUNCTION check_table_compression(reloid oid) RETURNS void AS $$
+BEGIN
+    IF NOT (WITH errors AS (
+                SELECT substring(errors_line, '%Errors #"%#",%', '#') errors_num
+                    FROM regexp_split_to_table(orioledb_tbl_compression_check(5, reloid),
+                                               '\n') AS errors_line
+                WHERE errors_line LIKE '%Errors%'
+            )
+            SELECT COUNT(*) = 0 FROM errors WHERE errors_num != '0') THEN
+        RAISE EXCEPTION 'CHECK FAILED';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT c.relname, check_table_compression(reloid)
+    FROM orioledb_table ot
+    JOIN pg_class c ON c.oid = ot.reloid;

--- a/docker/orioledb/scripts/scripts/simple_prepare.sql
+++ b/docker/orioledb/scripts/scripts/simple_prepare.sql
@@ -1,0 +1,32 @@
+CREATE EXTENSION IF NOT EXISTS orioledb;
+
+CREATE TABLE pgbench_accounts (
+	aid integer NOT NULL,
+	bid integer,
+	abalance integer,
+	filler character(84)
+) USING orioledb;
+
+CREATE TABLE pgbench_branches (
+	bid integer NOT NULL,
+	bbalance integer,
+	filler character(88)
+) USING orioledb;
+
+CREATE TABLE pgbench_tellers (
+	tid integer NOT NULL,
+	bid integer,
+	tbalance integer,
+	filler character(84)
+) USING orioledb;
+
+CREATE TABLE pgbench_history
+(
+	tid integer NOT NULL,
+	bid integer NOT NULL,
+	aid integer NOT NULL,
+	delta integer NOT NULL,
+	mtime timestamp NOT NULL,
+	filler character(22),
+	PRIMARY KEY(bid, mtime, tid, aid, delta)
+) USING orioledb;

--- a/docker/orioledb/scripts/scripts/wait_while_pg_not_ready.sh
+++ b/docker/orioledb/scripts/scripts/wait_while_pg_not_ready.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+STATUS=`pg_ctl status | egrep -o "server is running|no server running"`
+
+while [[ "${STATUS}" != "server is running" ]]
+do
+  echo "Wait a sec to start server"
+  sleep 1
+  pg_ctl status
+  STATUS=`pg_ctl status | egrep -o "server is running|no server running"`
+done
+
+echo "postgresql server is started"
+
+STATUS_READ_ONLY=`echo "show transaction_read_only;" | psql | egrep -o "off"`
+
+while [[ "${STATUS_READ_ONLY}" != "off" ]]
+do
+  echo "Wait a sec to not read-only mode"
+  sleep 1
+  echo "show transaction_read_only;" | psql postgres
+  STATUS_READ_ONLY=`echo "show transaction_read_only;" | psql | egrep -o "off"`
+done
+echo "postgresql read_only mode is off"

--- a/docker/orioledb/scripts/tests/compatibility_test.sh
+++ b/docker/orioledb/scripts/tests/compatibility_test.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e -x
+CONFIG_FILE="/tmp/configs/compatibility_test_config.json"
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/scripts/wrap_config_file.sh ${TMP_CONFIG}
+
+initdb ${PGDATA}
+
+echo "unix_socket_directories = '/var/run/postgresql'" >> ${PGDATA}/postgresql.conf
+echo "archive_mode = on" >> ${PGDATA}/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 /usr/bin/wal-g --config=${TMP_CONFIG} wal-push %p'" >> ${PGDATA}/postgresql.conf
+echo "archive_timeout = 600" >> ${PGDATA}/postgresql.conf
+echo "shared_preload_libraries = 'orioledb'" >> ${PGDATA}/postgresql.conf
+echo "orioledb.main_buffers = 512MB" >> ${PGDATA}/postgresql.conf
+echo "orioledb.undo_buffers = 256MB" >> ${PGDATA}/postgresql.conf
+echo "max_wal_size = 8GB" >> ${PGDATA}/postgresql.conf
+
+pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+psql -d postgres -c "CREATE EXTENSION orioledb;"
+psql -d postgres -c "CREATE TABLE o_test(a int) USING orioledb;"
+psql -d postgres -c "INSERT INTO o_test VALUES (1), (5), (2);"
+psql -d postgres -c "TABLE o_test;"
+psql -d postgres -c "DROP TABLE o_test;"
+psql -d postgres -c "DROP EXTENSION orioledb;"
+
+pgbench -i -s 4 postgres
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+
+pgbench -i -s 8 postgres
+pg_dumpall -f /tmp/dump1
+pgbench -c 2 -T 100000000 -S &
+sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+pg_ctl -D ${PGDATA} stop
+rm -rf $PGDATA
+
+wal-g --config=${TMP_CONFIG} backup-fetch ${PGDATA} LATEST
+
+touch ${PGDATA}/recovery.signal
+echo "restore_command = 'echo \"WAL file restoration: %f, %p\" && /usr/bin/wal-g --config=${TMP_CONFIG} wal-fetch \"%f\" \"%p\"'" >> ${PGDATA}/postgresql.conf
+
+pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+pg_dumpall -f /tmp/dump2
+
+diff /tmp/dump1 /tmp/dump2
+
+psql -f /tmp/scripts/amcheck.sql -v "ON_ERROR_STOP=1" postgres
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+rm ${TMP_CONFIG}
+/tmp/scripts/drop_pg.sh

--- a/docker/orioledb/scripts/tests/compressed_test.sh
+++ b/docker/orioledb/scripts/tests/compressed_test.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+set -e -x
+CONFIG_FILE="/tmp/configs/compressed_test_config.json"
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/scripts/wrap_config_file.sh ${TMP_CONFIG}
+
+initdb ${PGDATA}
+
+echo "unix_socket_directories = '/var/run/postgresql'" >> ${PGDATA}/postgresql.conf
+echo "archive_mode = on" >> ${PGDATA}/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 /usr/bin/wal-g --config=${TMP_CONFIG} wal-push %p'" >> ${PGDATA}/postgresql.conf
+echo "archive_timeout = 600" >> ${PGDATA}/postgresql.conf
+echo "shared_preload_libraries = 'orioledb'" >> ${PGDATA}/postgresql.conf
+echo "orioledb.main_buffers = 512MB" >> ${PGDATA}/postgresql.conf
+echo "orioledb.undo_buffers = 256MB" >> ${PGDATA}/postgresql.conf
+echo "max_wal_size = 8GB" >> ${PGDATA}/postgresql.conf
+
+pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+psql -d postgres -f /tmp/scripts/compressed_prepare.sql
+pgbench -Igvpf -i -s 4 postgres
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+pgbench -Id -i -s 4 postgres
+
+psql -d postgres -f /tmp/scripts/compressed_prepare.sql
+pgbench -Igvpf -i -s 8 postgres
+pg_dumpall -f /tmp/dump1
+pgbench -c 2 -T 100000000 -S &
+sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+pg_ctl -D ${PGDATA} stop
+rm -rf $PGDATA
+
+wal-g --config=${TMP_CONFIG} backup-fetch ${PGDATA} LATEST
+
+touch ${PGDATA}/recovery.signal
+echo "restore_command = 'echo \"WAL file restoration: %f, %p\" && /usr/bin/wal-g --config=${TMP_CONFIG} wal-fetch \"%f\" \"%p\"'" >> ${PGDATA}/postgresql.conf
+
+pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+pg_dumpall -f /tmp/dump2
+
+diff /tmp/dump1 /tmp/dump2
+
+psql -f /tmp/scripts/amcheck.sql -v "ON_ERROR_STOP=1" postgres
+psql -f /tmp/scripts/orioledb_check.sql -v "ON_ERROR_STOP=1" postgres
+psql -f /tmp/scripts/orioledb_compressed_check.sql -v "ON_ERROR_STOP=1" postgres
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+rm ${TMP_CONFIG}
+/tmp/scripts/drop_pg.sh

--- a/docker/orioledb/scripts/tests/simple_test.sh
+++ b/docker/orioledb/scripts/tests/simple_test.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -e -x
+CONFIG_FILE="/tmp/configs/simple_test_config.json"
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/scripts/wrap_config_file.sh ${TMP_CONFIG}
+
+initdb ${PGDATA}
+
+echo "unix_socket_directories = '/var/run/postgresql'" >> ${PGDATA}/postgresql.conf
+echo "archive_mode = on" >> ${PGDATA}/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 /usr/bin/wal-g --config=${TMP_CONFIG} wal-push %p'" >> ${PGDATA}/postgresql.conf
+echo "archive_timeout = 600" >> ${PGDATA}/postgresql.conf
+echo "shared_preload_libraries = 'orioledb'" >> ${PGDATA}/postgresql.conf
+echo "orioledb.main_buffers = 512MB" >> ${PGDATA}/postgresql.conf
+echo "orioledb.undo_buffers = 256MB" >> ${PGDATA}/postgresql.conf
+echo "max_wal_size = 8GB" >> ${PGDATA}/postgresql.conf
+
+pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+psql -d postgres -f /tmp/scripts/simple_prepare.sql
+pgbench -Igvpf -i -s 4 postgres
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+pgbench -Id -i -s 4 postgres
+
+psql -d postgres -f /tmp/scripts/simple_prepare.sql
+pgbench -Igvpf -i -s 8 postgres
+pg_dumpall -f /tmp/dump1
+pgbench -c 2 -T 100000000 -S &
+sleep 1
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+pg_ctl -D ${PGDATA} stop
+rm -rf $PGDATA
+
+wal-g --config=${TMP_CONFIG} backup-fetch ${PGDATA} LATEST
+
+touch ${PGDATA}/recovery.signal
+echo "restore_command = 'echo \"WAL file restoration: %f, %p\" && /usr/bin/wal-g --config=${TMP_CONFIG} wal-fetch \"%f\" \"%p\"'" >> ${PGDATA}/postgresql.conf
+
+pg_ctl -D ${PGDATA} -w start
+
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+pg_dumpall -f /tmp/dump2
+
+diff /tmp/dump1 /tmp/dump2
+
+psql -f /tmp/scripts/amcheck.sql -v "ON_ERROR_STOP=1" postgres
+psql -f /tmp/scripts/orioledb_check.sql -v "ON_ERROR_STOP=1" postgres
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+rm ${TMP_CONFIG}
+/tmp/scripts/drop_pg.sh

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -154,6 +154,9 @@ func (bh *BackupHandler) createAndPushBackup(ctx context.Context) {
 	bh.Arguments.Uploader.ChangeDirectory(bh.Arguments.backupsFolder)
 	tracelog.DebugLogger.Printf("Uploading folder: %s", bh.Arguments.Uploader.Folder())
 	orioledbEnabled := orioledb.IsEnabled(bh.PgInfo.PgDataDirectory)
+	if orioledbEnabled {
+		tracelog.InfoLogger.Printf("Orioledb support enabled")
+	}
 
 	arguments := bh.Arguments
 	crypter := internal.ConfigureCrypter()

--- a/internal/databases/postgres/backup_sentinel_dto.go
+++ b/internal/databases/postgres/backup_sentinel_dto.go
@@ -43,7 +43,7 @@ func NewBackupSentinelDto(bh *BackupHandler, tbsSpec *TablespaceSpec) BackupSent
 		IncrementFromLSN:     bh.prevBackupInfo.sentinelDto.BackupStartLSN,
 		PgVersion:            bh.PgInfo.PgVersion,
 		TablespaceSpec:       tbsSpec,
-		BackupStartChkpNum:   bh.CurBackupInfo.startChkpNum,
+		BackupStartChkpNum:   bh.CurBackupInfo.StartChkpNum,
 		IncrementFromChkpNum: bh.prevBackupInfo.sentinelDto.BackupStartChkpNum,
 	}
 	if bh.prevBackupInfo.sentinelDto.BackupStartLSN != nil {

--- a/internal/databases/postgres/backup_sentinel_dto.go
+++ b/internal/databases/postgres/backup_sentinel_dto.go
@@ -32,15 +32,19 @@ type BackupSentinelDto struct {
 
 	UserData interface{} `json:"UserData,omitempty"`
 
-	FilesMetadataDisabled bool `json:"FilesMetadataDisabled,omitempty"`
+	FilesMetadataDisabled bool    `json:"FilesMetadataDisabled,omitempty"`
+	BackupStartChkpNum    *uint32 `json:"ChkpNum"`
+	IncrementFromChkpNum  *uint32 `json:"DeltaChkpNum,omitempty"`
 }
 
 func NewBackupSentinelDto(bh *BackupHandler, tbsSpec *TablespaceSpec) BackupSentinelDto {
 	sentinel := BackupSentinelDto{
-		BackupStartLSN:   &bh.CurBackupInfo.startLSN,
-		IncrementFromLSN: bh.prevBackupInfo.sentinelDto.BackupStartLSN,
-		PgVersion:        bh.PgInfo.PgVersion,
-		TablespaceSpec:   tbsSpec,
+		BackupStartLSN:       &bh.CurBackupInfo.startLSN,
+		IncrementFromLSN:     bh.prevBackupInfo.sentinelDto.BackupStartLSN,
+		PgVersion:            bh.PgInfo.PgVersion,
+		TablespaceSpec:       tbsSpec,
+		BackupStartChkpNum:   bh.CurBackupInfo.startChkpNum,
+		IncrementFromChkpNum: bh.prevBackupInfo.sentinelDto.BackupStartChkpNum,
 	}
 	if bh.prevBackupInfo.sentinelDto.BackupStartLSN != nil {
 		sentinel.IncrementFrom = &bh.prevBackupInfo.name

--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/pkg/errors"
@@ -95,30 +96,6 @@ func NewBundle(
 		TablespaceSpec:     NewTablespaceSpec(directory),
 		forceIncremental:   forceIncremental,
 		DataCatalogSize:    new(int64),
-	}
-}
-
-// TODO: use DiskDataFolder
-func OrioledbNewBundle(
-	directory string, crypter crypto.Crypter,
-	incrementFromName string, incrementFromLsn *LSN, incrementFromFiles internal.BackupFileList,
-	forceIncremental bool, tarSizeThreshold int64,
-	incrementFromChkpNum *uint32,
-) *Bundle {
-	return &Bundle{
-		Bundle: internal.Bundle{
-			Directory:         directory,
-			Crypter:           crypter,
-			TarSizeThreshold:  tarSizeThreshold,
-			ExcludedFilenames: ExcludedFilenames,
-		},
-		IncrementFromLsn:     incrementFromLsn,
-		IncrementFromFiles:   incrementFromFiles,
-		IncrementFromName:    incrementFromName,
-		TablespaceSpec:       NewTablespaceSpec(directory),
-		forceIncremental:     forceIncremental,
-		DataCatalogSize:      new(int64),
-		IncrementFromChkpNum: incrementFromChkpNum,
 	}
 }
 
@@ -302,11 +279,8 @@ func (bundle *Bundle) addToBundle(path string, info os.FileInfo) error {
 			return nil
 		}
 		incrementBaseLsn := bundle.getIncrementBaseLsn()
-		isIncremented := incrementBaseLsn != nil && (wasInBase || bundle.forceIncremental) && (isPagedFile(info, path))
-
-		if !isIncremented && bundle.IncrementFromChkpNum != nil {
-			isIncremented = wasInBase && isOrioledbDataFile(info, path)
-		}
+		isIncremented := incrementBaseLsn != nil && (wasInBase || bundle.forceIncremental) && isPagedFile(info, path)
+		isIncremented = isIncremented || (bundle.IncrementFromChkpNum != nil && wasInBase && orioledb.IsOrioledbDataFile(info, path))
 		bundle.TarBallComposer.AddFile(internal.NewComposeFileInfo(path, info, wasInBase, isIncremented, fileInfoHeader))
 	} else {
 		err := bundle.TarBallComposer.AddHeader(fileInfoHeader, info)

--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -278,9 +279,7 @@ func (bundle *Bundle) addToBundle(path string, info os.FileInfo) error {
 			bundle.TarBallComposer.SkipFile(fileInfoHeader, info)
 			return nil
 		}
-		incrementBaseLsn := bundle.getIncrementBaseLsn()
-		isIncremented := incrementBaseLsn != nil && (wasInBase || bundle.forceIncremental) && isPagedFile(info, path)
-		isIncremented = isIncremented || (bundle.IncrementFromChkpNum != nil && wasInBase && orioledb.IsOrioledbDataFile(info, path))
+		isIncremented := bundle.isIncremented(path, wasInBase, info)
 		bundle.TarBallComposer.AddFile(internal.NewComposeFileInfo(path, info, wasInBase, isIncremented, fileInfoHeader))
 	} else {
 		err := bundle.TarBallComposer.AddHeader(fileInfoHeader, info)
@@ -293,6 +292,14 @@ func (bundle *Bundle) addToBundle(path string, info os.FileInfo) error {
 	}
 
 	return nil
+}
+
+// isPagedFile checks basic expectations for paged file
+func (bundle *Bundle) isIncremented(path string, wasInBase bool, info fs.FileInfo) bool {
+	incrementBaseLsn := bundle.getIncrementBaseLsn()
+	isIncremented := incrementBaseLsn != nil && (wasInBase || bundle.forceIncremental) && isPagedFile(info, path)
+	isIncremented = isIncremented || (bundle.IncrementFromChkpNum != nil && wasInBase && orioledb.IsOrioledbDataFile(info, path))
+	return isIncremented
 }
 
 // TODO : unit tests

--- a/internal/databases/postgres/catchup_push_handler.go
+++ b/internal/databases/postgres/catchup_push_handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -35,6 +36,9 @@ func HandleCatchupPush(ctx context.Context, pgDataDirectory string, fromLSN LSN)
 		false, false, false,
 		RegularComposer, NewCatchupDeltaBackupConfigurator(fakePreviousBackupSentinelDto),
 		userData, false)
+	if orioledb.IsEnabled(pgDataDirectory) {
+		tracelog.InfoLogger.Printf("Full backup of orioledb data will be performed, because catchup incremental backup is not implemented for now.")
+	}
 
 	backupConfig, err := NewBackupHandler(backupArguments)
 	tracelog.ErrorLogger.FatalOnError(err)

--- a/internal/databases/postgres/catchup_push_handler.go
+++ b/internal/databases/postgres/catchup_push_handler.go
@@ -37,7 +37,7 @@ func HandleCatchupPush(ctx context.Context, pgDataDirectory string, fromLSN LSN)
 		RegularComposer, NewCatchupDeltaBackupConfigurator(fakePreviousBackupSentinelDto),
 		userData, false)
 	if orioledb.IsEnabled(pgDataDirectory) {
-		tracelog.InfoLogger.Printf("Full backup of orioledb data will be performed, because catchup incremental backup is not implemented for now.")
+		tracelog.InfoLogger.Printf("Catchup incremental backup is not implemented for orioledb. Full backup will be performed.")
 	}
 
 	backupConfig, err := NewBackupHandler(backupArguments)

--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -3,11 +3,6 @@ package postgres
 import (
 	"encoding/gob"
 	"fmt"
-	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/internal"
-	"github.com/wal-g/wal-g/internal/compression"
-	"github.com/wal-g/wal-g/internal/ioextensions"
-	"github.com/wal-g/wal-g/utility"
 	"io"
 	"io/fs"
 	"net"
@@ -15,6 +10,13 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/compression"
+	"github.com/wal-g/wal-g/internal/databases/postgres/errors"
+	"github.com/wal-g/wal-g/internal/ioextensions"
+	"github.com/wal-g/wal-g/utility"
 )
 
 func HandleCatchupSend(pgDataDirectory string, destination string) {
@@ -204,7 +206,7 @@ func sendOneFile(path string, info fs.FileInfo, wasInBase bool, checkpoint LSN,
 	} else {
 		fd, size, err = ReadIncrementalFile(path, info.Size(), checkpoint, nil)
 
-		if _, ok := err.(*InvalidBlockError); ok {
+		if _, ok := err.(*errors.InvalidBlockError); ok {
 			fd, err = os.Open(path)
 			if os.IsNotExist(err) {
 				return

--- a/internal/databases/postgres/errors/errors.go
+++ b/internal/databases/postgres/errors/errors.go
@@ -1,0 +1,21 @@
+package errors
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/wal-g/tracelog"
+)
+
+// InvalidBlockError indicates that file contain invalid page and cannot be archived incrementally
+type InvalidBlockError struct {
+	error
+}
+
+func NewInvalidBlockError(blockNo uint32) InvalidBlockError {
+	return InvalidBlockError{errors.Errorf("block %d is invalid", blockNo)}
+}
+
+func (err InvalidBlockError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}

--- a/internal/databases/postgres/incremental_page_reader.go
+++ b/internal/databases/postgres/incremental_page_reader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/postgres/errors"
 	"github.com/wal-g/wal-g/internal/ioextensions"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -128,7 +129,7 @@ func (pageReader *IncrementalPageReader) FullScanInitialize() error {
 
 		valid := pageReader.SelectNewValidPage(pageBytes, currentBlockNumber) // TODO : torn page possibility
 		if !valid {
-			return newInvalidBlockError(currentBlockNumber)
+			return errors.NewInvalidBlockError(currentBlockNumber)
 		}
 	}
 }

--- a/internal/databases/postgres/orioledb/path.go
+++ b/internal/databases/postgres/orioledb/path.go
@@ -36,11 +36,7 @@ func IsOrioledbDataFile(info os.FileInfo, filePath string) bool {
 
 func IsEnabled(PgDataDirectory string) bool {
 	_, err := os.Stat(PgDataDirectory + "/orioledb_data")
-	if err == nil {
-		return true
-	} else {
-		return false
-	}
+	return err == nil
 }
 
 func GetChkpNum(PgDataDirectory string) (chkpNum uint32) {
@@ -63,9 +59,8 @@ func GetChkpNum(PgDataDirectory string) (chkpNum uint32) {
 		}
 		if info.IsDir() && filepath.Base(info.Name()) != "orioledb_data" {
 			return filepath.SkipDir
-		} else {
-			return nil
 		}
+		return nil
 	})
 	if err != nil {
 		tracelog.ErrorLogger.Fatalf("Cannot find any xid file")

--- a/internal/databases/postgres/orioledb/path.go
+++ b/internal/databases/postgres/orioledb/path.go
@@ -1,0 +1,74 @@
+package orioledb
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/wal-g/tracelog"
+)
+
+var pagedFilenameRegexp *regexp.Regexp
+
+func init() {
+	pagedFilenameRegexp = regexp.MustCompile(`^(\d+)([.]\d+)?$`)
+}
+
+func IsOrioledbDataPath(filePath string) bool {
+	if !strings.Contains(filePath, "orioledb_data") ||
+		!pagedFilenameRegexp.MatchString(path.Base(filePath)) {
+		return false
+	}
+	return true
+}
+
+func IsOrioledbDataFile(info os.FileInfo, filePath string) bool {
+	if info.IsDir() ||
+		info.Size() == 0 ||
+		!IsOrioledbDataPath(filePath) {
+		return false
+	}
+	return true
+}
+
+func IsEnabled(PgDataDirectory string) bool {
+	_, err := os.Stat(PgDataDirectory + "/orioledb_data")
+	if err == nil {
+		return true
+	} else {
+		return false
+	}
+}
+
+func GetChkpNum(PgDataDirectory string) (chkpNum uint32) {
+	OrioledbDataDirectory := PgDataDirectory + "/orioledb_data"
+	xidRegEx, err := regexp.Compile(`^.+\.(xid)$`)
+	if err != nil {
+		tracelog.ErrorLogger.Fatalf("Cannot compile xid regex")
+	}
+
+	chkpNum = uint32(0)
+	err = filepath.Walk(OrioledbDataDirectory, func(path string, info os.FileInfo, err error) error {
+		if err == nil && xidRegEx.MatchString(info.Name()) {
+			xid := strings.Split(info.Name(), ".")[0]
+			tempChkpNum, err := strconv.Atoi(xid)
+			if err != nil {
+				tracelog.ErrorLogger.Fatalf("Cannot parse chkpNum: %s", xid)
+			}
+			chkpNum = uint32(tempChkpNum)
+			return filepath.SkipAll
+		}
+		if info.IsDir() && filepath.Base(info.Name()) != "orioledb_data" {
+			return filepath.SkipDir
+		} else {
+			return nil
+		}
+	})
+	if err != nil {
+		tracelog.ErrorLogger.Fatalf("Cannot find any xid file")
+	}
+	return chkpNum
+}

--- a/internal/databases/postgres/orioledb_incremental_page_reader.go
+++ b/internal/databases/postgres/orioledb_incremental_page_reader.go
@@ -1,0 +1,324 @@
+package postgres
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/ioextensions"
+	"github.com/wal-g/wal-g/internal/limiters"
+	"github.com/wal-g/wal-g/internal/walparser/parsingutil"
+	"github.com/wal-g/wal-g/utility"
+)
+
+// IncrementFileHeader contains "wi" at the head which stands for "wal-g increment"
+// format version "1", signature magic number
+// var IncrementFileHeader = []byte{'w', 'i', '1', SignatureMagicNumber}
+
+// OrioledbIncrementalPageReader constructs difference map during initialization and than re-read file
+// Diff map may consist of 1Gb/PostgresBlockSize elements == 512Kb
+type OrioledbIncrementalPageReader struct {
+	PagedFile ioextensions.ReadSeekCloser
+	FileSize  int64
+	ChkpNum   uint32
+	Next      []byte
+	Blocks    []uint32
+}
+
+func (pageReader *OrioledbIncrementalPageReader) Read(p []byte) (n int, err error) {
+	for {
+		copied := copy(p, pageReader.Next)
+		p = p[copied:]
+		pageReader.Next = pageReader.Next[copied:]
+		n += copied
+		if len(p) == 0 {
+			return n, nil
+		}
+		moreData, err := pageReader.DrainMoreData()
+		if err != nil {
+			return n, err
+		}
+		if !moreData {
+			return n, io.EOF
+		}
+	}
+}
+
+func (pageReader *OrioledbIncrementalPageReader) DrainMoreData() (succeed bool, err error) {
+	if len(pageReader.Blocks) == 0 {
+		return false, nil
+	}
+	err = pageReader.AdvanceFileReader()
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (pageReader *OrioledbIncrementalPageReader) AdvanceFileReader() error {
+	pageBytes := make([]byte, DatabasePageSize)
+	blockNo := pageReader.Blocks[0]
+	pageReader.Blocks = pageReader.Blocks[1:]
+	offset := int64(blockNo) * DatabasePageSize
+	// TODO : possible race condition - page was deleted between blocks extraction and seek
+	_, err := pageReader.PagedFile.Seek(offset, io.SeekStart)
+	if err != nil {
+		return err
+	}
+	_, err = io.ReadFull(pageReader.PagedFile, pageBytes)
+	if err == nil {
+		pageReader.Next = pageBytes
+	}
+	return err
+}
+
+// Close OrioledbIncrementalPageReader
+func (pageReader *OrioledbIncrementalPageReader) Close() error {
+	return pageReader.PagedFile.Close()
+}
+
+// TODO : unit tests
+// TODO : "initialize" is rather meaningless name, maybe this func should be decomposed
+func (pageReader *OrioledbIncrementalPageReader) initialize(deltaBitmap *roaring.Bitmap) (size int64, err error) {
+	var headerBuffer bytes.Buffer
+	headerBuffer.Write(IncrementFileHeader)
+	fileSize := pageReader.FileSize
+	headerBuffer.Write(utility.ToBytes(uint64(fileSize)))
+	pageReader.Blocks = make([]uint32, 0, fileSize/DatabasePageSize)
+
+	if deltaBitmap == nil {
+		err := pageReader.FullScanInitialize()
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		pageReader.DeltaBitmapInitialize(deltaBitmap)
+	}
+
+	pageReader.WriteDiffMapToHeader(&headerBuffer)
+	pageReader.Next = headerBuffer.Bytes()
+	pageDataSize := int64(len(pageReader.Blocks)) * DatabasePageSize
+	size = int64(headerBuffer.Len()) + pageDataSize
+	return
+}
+
+func (pageReader *OrioledbIncrementalPageReader) DeltaBitmapInitialize(deltaBitmap *roaring.Bitmap) {
+	it := deltaBitmap.Iterator()
+	for it.HasNext() { // TODO : do something with file truncation during reading
+		blockNo := it.Next()
+		if pageReader.FileSize >= int64(blockNo+1)*DatabasePageSize { // whole block fits into file
+			pageReader.Blocks = append(pageReader.Blocks, blockNo)
+		} else {
+			break
+		}
+	}
+}
+
+func (pageReader *OrioledbIncrementalPageReader) FullScanInitialize() error {
+	pageBytes := make([]byte, DatabasePageSize)
+
+	for currentBlockNumber := uint32(0); ; currentBlockNumber++ {
+		_, err := io.ReadFull(pageReader.PagedFile, pageBytes)
+
+		if err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				return nil
+			}
+			return err
+		}
+
+		valid := pageReader.SelectNewValidPage(pageBytes, currentBlockNumber) // TODO : torn page possibility
+		if !valid {
+			tracelog.WarningLogger.Printf("NOT VALID!")
+			return newInvalidBlockError(currentBlockNumber)
+		}
+	}
+}
+
+// WriteDiffMapToHeader is currently used only with buffers, so we don't handle any writing errors
+func (pageReader *OrioledbIncrementalPageReader) WriteDiffMapToHeader(headerWriter io.Writer) {
+	diffBlockCount := len(pageReader.Blocks)
+	_, _ = headerWriter.Write(utility.ToBytes(uint32(diffBlockCount)))
+
+	for _, blockNo := range pageReader.Blocks {
+		_ = binary.Write(headerWriter, binary.LittleEndian, blockNo)
+	}
+}
+
+//  typedef struct
+//  {
+// 	 pg_atomic_uint32 state;
+// 	 pg_atomic_uint32 usageCount;
+// 	 uint32		pageChangeCount;
+//  } OrioleDBPageHeader;
+
+// typedef struct
+// {
+// 	OrioleDBPageHeader o_header;
+// 	uint32		flags:6,
+// 				field1:11,
+// 				field2:15;
+
+// 	UndoLocation undoLocation;
+// 	CommitSeqNo csn;
+
+// 	uint64		rightLink;
+// 	uint32		checkpointNum;
+// 	LocationIndex maxKeyLen;
+// 	OffsetNumber prevInsertOffset;
+// 	OffsetNumber chunksCount;
+// 	OffsetNumber itemsCount;
+// 	OffsetNumber hikeysEnd;
+// 	LocationIndex dataSize;
+// 	BTreePageChunkDesc chunkDesc[1];
+// } BTreePageHeader;
+
+// typedef struct
+// {
+// 	uint32		shortLocation:12,
+// 				offset:10,
+// 				hikeyShortLocation:8,
+// 				hikeyFlags:2;
+// } BTreePageChunkDesc;
+
+type OrioledbPageHeader struct {
+	state               uint32
+	usageCount          uint32
+	pageChangeCount     uint32
+	flags_field1_field2 uint32
+	undoLocation        uint64
+	csn                 uint64
+	rightLink           uint64
+	checkpointNum       uint32
+	maxKeyLen           uint16
+	prevInsertOffset    uint16
+	chunksCount         uint16
+	itemsCount          uint16
+	hikeysEnd           uint16
+	dataSize            uint16
+	// chunkDesc           []uint32
+}
+
+func (header *OrioledbPageHeader) isValid() bool {
+	// TODO: Add page validation
+	return true
+}
+
+// parseOrioledbPageHeader reads information from PostgreSQL page header. Exported for test reasons.
+func parseOrioledbPageHeader(reader io.Reader) (*OrioledbPageHeader, error) {
+	pageHeader := OrioledbPageHeader{}
+	fields := []parsingutil.FieldToParse{
+		{Field: &pageHeader.state, Name: "state"},
+		{Field: &pageHeader.usageCount, Name: "usageCount"},
+		{Field: &pageHeader.pageChangeCount, Name: "pageChangeCount"},
+
+		{Field: &pageHeader.flags_field1_field2, Name: "flags_field1_field2"},
+		{Field: &pageHeader.undoLocation, Name: "undoLocation"},
+		{Field: &pageHeader.csn, Name: "csn"},
+		{Field: &pageHeader.rightLink, Name: "rightLink"},
+		{Field: &pageHeader.checkpointNum, Name: "checkpointNum"},
+		{Field: &pageHeader.maxKeyLen, Name: "maxKeyLen"},
+		{Field: &pageHeader.prevInsertOffset, Name: "prevInsertOffset"},
+		{Field: &pageHeader.chunksCount, Name: "chunksCount"},
+		{Field: &pageHeader.itemsCount, Name: "itemsCount"},
+		{Field: &pageHeader.hikeysEnd, Name: "hikeysEnd"},
+		{Field: &pageHeader.dataSize, Name: "dataSize"},
+		// {Field: &pageHeader.chunkDesc, Name: "chunkDesc"},
+	}
+	err := parsingutil.ParseMultipleFieldsFromReader(fields, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pageHeader, nil
+}
+
+// SelectNewValidPage checks whether page is valid and if it so, then blockNo is appended to Blocks list
+func (pageReader *OrioledbIncrementalPageReader) SelectNewValidPage(pageBytes []byte, blockNo uint32) (valid bool) {
+	pageHeader, _ := parseOrioledbPageHeader(bytes.NewReader(pageBytes))
+	valid = pageHeader.isValid()
+
+	if !valid {
+		tracelog.DebugLogger.Println("Invalid page ", blockNo, " page header ", pageHeader)
+		return false
+	}
+
+	if pageHeader.checkpointNum >= pageReader.ChkpNum {
+		pageReader.Blocks = append(pageReader.Blocks, blockNo)
+	}
+	return
+}
+
+func isOrioledbDataFile(info os.FileInfo, filePath string) bool {
+	if info.IsDir() ||
+		!strings.Contains(filePath, "orioledb_data") ||
+		info.Size() == 0 ||
+		info.Size()%DatabasePageSize != 0 ||
+		!pagedFilenameRegexp.MatchString(path.Base(filePath)) {
+		return false
+	}
+	return true
+}
+
+func OrioledbReadIncrementalFile(filePath string,
+	fileSize int64,
+	chkpNum uint32,
+	deltaBitmap *roaring.Bitmap) (fileReader io.ReadCloser, size int64, err error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	fileReadSeekCloser := &ioextensions.ReadSeekCloserImpl{
+		Reader: limiters.NewDiskLimitReader(file),
+		Seeker: file,
+		Closer: file,
+	}
+
+	pageReader := &OrioledbIncrementalPageReader{fileReadSeekCloser, fileSize, chkpNum, nil, nil}
+	incrementSize, err := pageReader.initialize(deltaBitmap)
+	if err != nil {
+		utility.LoggedClose(file, "")
+		return nil, 0, err
+	}
+	return pageReader, incrementSize, nil
+}
+
+func OrioledbSetStartChkpNum(bh *BackupHandler) {
+	OrioledbDataDirectory := bh.PgInfo.PgDataDirectory + "/orioledb_data"
+	xidRegEx, err := regexp.Compile(`^.+\.(xid)$`)
+	if err != nil {
+		tracelog.ErrorLogger.Fatalf("Cannot compile xid regex")
+	}
+
+	chkpNum := uint32(0)
+	err = filepath.Walk(OrioledbDataDirectory, func(path string, info os.FileInfo, err error) error {
+		if err == nil && xidRegEx.MatchString(info.Name()) {
+			xid := strings.Split(info.Name(), ".")[0]
+			tempChkpNum, err := strconv.Atoi(xid)
+			if err != nil {
+				tracelog.ErrorLogger.Fatalf("Cannot parse chkpNum: %s", xid)
+			}
+			chkpNum = uint32(tempChkpNum)
+			return filepath.SkipAll
+		}
+		if info.IsDir() && filepath.Base(info.Name()) != "orioledb_data" {
+			return filepath.SkipDir
+		} else {
+			return nil
+		}
+	})
+	if err != nil {
+		tracelog.ErrorLogger.Fatalf("Cannot find any xid file")
+	}
+
+	bh.CurBackupInfo.startChkpNum = &chkpNum
+}

--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -165,15 +165,15 @@ func ApplyFileIncrement(fileName string, increment io.Reader, createNewIncrement
 	var fileSize uint64
 	var diffBlockCount uint32
 	pageSize := uint16(DatabasePageSize)
-	fields_to_parse := []parsingutil.FieldToParse{
+	fieldsToParse := []parsingutil.FieldToParse{
 		{Field: &fileSize, Name: "fileSize"},
 	}
 	if orioledb.IsOrioledbDataPath(fileName) {
-		fields_to_parse = append(fields_to_parse, parsingutil.FieldToParse{Field: &pageSize, Name: "pageSize"})
+		fieldsToParse = append(fieldsToParse, parsingutil.FieldToParse{Field: &pageSize, Name: "pageSize"})
 	}
-	fields_to_parse = append(fields_to_parse, parsingutil.FieldToParse{Field: &diffBlockCount, Name: "diffBlockCount"})
+	fieldsToParse = append(fieldsToParse, parsingutil.FieldToParse{Field: &diffBlockCount, Name: "diffBlockCount"})
 
-	err = parsingutil.ParseMultipleFieldsFromReader(fields_to_parse, increment)
+	err = parsingutil.ParseMultipleFieldsFromReader(fieldsToParse, increment)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -22,6 +22,7 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
 	"github.com/wal-g/wal-g/internal/ioextensions"
 	"github.com/wal-g/wal-g/internal/limiters"
 	"github.com/wal-g/wal-g/internal/walparser"
@@ -43,19 +44,6 @@ const (
 	GlobalTablespace     = "global"
 	NonDefaultTablespace = "pg_tblspc"
 )
-
-// InvalidBlockError indicates that file contain invalid page and cannot be archived incrementally
-type InvalidBlockError struct {
-	error
-}
-
-func newInvalidBlockError(blockNo uint32) InvalidBlockError {
-	return InvalidBlockError{errors.Errorf("block %d is invalid", blockNo)}
-}
-
-func (err InvalidBlockError) Error() string {
-	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
-}
 
 type InvalidIncrementFileHeaderError struct {
 	error
@@ -180,7 +168,7 @@ func ApplyFileIncrement(fileName string, increment io.Reader, createNewIncrement
 	fields_to_parse := []parsingutil.FieldToParse{
 		{Field: &fileSize, Name: "fileSize"},
 	}
-	if isOrioledbDataPath(fileName) {
+	if orioledb.IsOrioledbDataPath(fileName) {
 		fields_to_parse = append(fields_to_parse, parsingutil.FieldToParse{Field: &pageSize, Name: "pageSize"})
 	}
 	fields_to_parse = append(fields_to_parse, parsingutil.FieldToParse{Field: &diffBlockCount, Name: "diffBlockCount"})

--- a/internal/databases/postgres/prefetch.go
+++ b/internal/databases/postgres/prefetch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	conf "github.com/wal-g/wal-g/internal/config"
+	pg_errors "github.com/wal-g/wal-g/internal/databases/postgres/errors"
 	"github.com/wal-g/wal-g/internal/fsutil"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -171,7 +172,7 @@ func (bundle *Bundle) prefaultFile(path string, info os.FileInfo, fileInfoHeader
 			}
 			tracelog.InfoLogger.Println("Prefaulting ", path)
 			fileReader, fileInfoHeader.Size, err = ReadIncrementalFile(path, info.Size(), *incrementBaseLsn, bitmap)
-			if _, ok := err.(InvalidBlockError); ok {
+			if _, ok := err.(pg_errors.InvalidBlockError); ok {
 				return nil
 			} else if err != nil {
 				return errors.Wrapf(err, "packFileIntoTar: failed reading incremental file '%s'\n", path)

--- a/internal/databases/postgres/regular_tar_ball_composer.go
+++ b/internal/databases/postgres/regular_tar_ball_composer.go
@@ -59,14 +59,10 @@ func NewRegularTarBallComposerMaker(
 func (maker *RegularTarBallComposerMaker) Make(bundle *Bundle) (internal.TarBallComposer, error) {
 	bundleFiles := maker.files
 	tarFileSets := maker.tarFileSets
-	var tarBallFilePacker *TarBallFilePackerImpl
+	tarBallFilePacker := NewTarBallFilePacker(bundle.DeltaMap,
+		bundle.IncrementFromLsn, bundleFiles, maker.filePackerOptions)
 	if bundle.IncrementFromChkpNum != nil {
-		tarBallFilePacker = OrioledbNewTarBallFilePacker(bundle.DeltaMap,
-			bundle.IncrementFromLsn, bundleFiles, maker.filePackerOptions, bundle.IncrementFromChkpNum)
-	} else {
-
-		tarBallFilePacker = NewTarBallFilePacker(bundle.DeltaMap,
-			bundle.IncrementFromLsn, bundleFiles, maker.filePackerOptions)
+		tarBallFilePacker.IncrementFromChkpNum = bundle.IncrementFromChkpNum
 	}
 	return NewRegularTarBallComposer(bundle.TarBallQueue, tarBallFilePacker, bundleFiles, tarFileSets, bundle.Crypter), nil
 }

--- a/internal/databases/postgres/regular_tar_ball_composer.go
+++ b/internal/databases/postgres/regular_tar_ball_composer.go
@@ -59,8 +59,15 @@ func NewRegularTarBallComposerMaker(
 func (maker *RegularTarBallComposerMaker) Make(bundle *Bundle) (internal.TarBallComposer, error) {
 	bundleFiles := maker.files
 	tarFileSets := maker.tarFileSets
-	tarBallFilePacker := NewTarBallFilePacker(bundle.DeltaMap,
-		bundle.IncrementFromLsn, bundleFiles, maker.filePackerOptions)
+	var tarBallFilePacker *TarBallFilePackerImpl
+	if bundle.IncrementFromChkpNum != nil {
+		tarBallFilePacker = OrioledbNewTarBallFilePacker(bundle.DeltaMap,
+			bundle.IncrementFromLsn, bundleFiles, maker.filePackerOptions, bundle.IncrementFromChkpNum)
+	} else {
+
+		tarBallFilePacker = NewTarBallFilePacker(bundle.DeltaMap,
+			bundle.IncrementFromLsn, bundleFiles, maker.filePackerOptions)
+	}
 	return NewRegularTarBallComposer(bundle.TarBallQueue, tarBallFilePacker, bundleFiles, tarFileSets, bundle.Crypter), nil
 }
 

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -134,7 +134,8 @@ func (p *TarBallFilePackerImpl) createFileReadCloser(cfi *internal.ComposeFileIn
 			return nil, errors.Wrapf(err, "PackFileIntoTar: failed to find corresponding bitmap '%s'\n", cfi.Path)
 		}
 		if p.IncrementFromChkpNum != nil && orioledb.IsOrioledbDataFile(cfi.FileInfo, cfi.Path) {
-			fileReadCloser, cfi.Header.Size, err = orioledb.OrioledbReadIncrementalFile(cfi.Path, cfi.FileInfo.Size(), *p.IncrementFromChkpNum, bitmap)
+			fileReadCloser, cfi.Header.Size, err =
+				orioledb.ReadIncrementalFile(cfi.Path, cfi.FileInfo.Size(), *p.IncrementFromChkpNum, bitmap)
 		} else {
 			fileReadCloser, cfi.Header.Size, err = ReadIncrementalFile(cfi.Path, cfi.FileInfo.Size(), *p.incrementFromLsn, bitmap)
 		}


### PR DESCRIPTION
I added some basic support of [orioledb](https://github.com/orioledb/orioledb) by wal-g
I tested that with these small modifications these features work:
- backup-push
- backup-fetch
- wal-push
- wal-fetch

Adding Dockerfile, scripts, and log of running this test to prove that it works
Sorry, that I'm not added it to pg_tests yet. Was not sure.

For now I added code to postgres wal-g version with option to enable it

Orioledb implemented as postgres extension with own table access method, and so it basically works alongside regular postgres, but uses own file format to store table pages
Without modification wal-g performs a full backup (with WALG_DELTA_MAX_STEPS=6)

wal-push and wal-fetch works because we implemented custom wal records, so no additional code required for this

I duplicated some functions with Orioledb* prefixed versions just to not affect any non-postgres related code for now

But I wan't to discuss before going any further what will be the better way to implement this
I see three variants:
1. Implement orioledb as a separate wal-g version, but it will duplicate many of postgres-es code
2. Adding some kind of generic interface for processing data of postgres extensions
3. Leave just orioledb as option but implement it in a different, better way

What do you think?

Files:
[ubuntu_check.log](https://github.com/wal-g/wal-g/files/15126355/ubuntu_check.log)
[wal-g-orioledb-test.zip](https://github.com/wal-g/wal-g/files/15126356/wal-g-orioledb-test.zip)
