### PR TITLE
Exclude standby.signal 

### DIFF
--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -46,6 +46,7 @@ func init() {
 		"log", "pg_log", "pg_xlog", "pg_wal", // Directories
 		"pgsql_tmp", "postgresql.auto.conf.tmp", "postmaster.pid", "postmaster.opts", "recovery.conf", // Files
 		"pg_dynshmem", "pg_notify", "pg_replslot", "pg_serial", "pg_stat_tmp", "pg_snapshots", "pg_subtrans", // Directories
+		"standby.signal", // Signal files
 	}
 
 	for _, filename := range filesToExclude {


### PR DESCRIPTION
To prevent an endless wait during recovery from standby

### Database name
PostgreSQL

# Pull request description

### Describe what this PR fix
Restore from replica of PG12+ to latest point in time

### Please provide steps to reproduce (if it's a bug)
Create backup on standby
Stop cluster
Restore backup without target time or target lsn
Start new database without manual deleting standby.signal
