### PR TITLE
Save isIncremented attribute

### DIFF
--- a/internal/databases/greenplum/ao_storage_uploader.go
+++ b/internal/databases/greenplum/ao_storage_uploader.go
@@ -120,7 +120,7 @@ func (u *AoStorageUploader) addFile(cfi *internal.ComposeFileInfo, aoMeta AoRelF
 	tracelog.DebugLogger.Printf(
 		"%s: ModCount %d, EOF %d matches the remote file %s, will skip this file",
 		cfi.Header.Name, remoteFile.ModCount, remoteFile.EOF, remoteFile.StoragePath)
-	return u.skipAoUpload(cfi, aoMeta, remoteFile.StoragePath, remoteFile.InitialUploadTS)
+	return u.skipAoUpload(cfi, aoMeta, remoteFile.StoragePath, remoteFile.InitialUploadTS, remoteFile.IsIncremented)
 }
 
 func (u *AoStorageUploader) addAoFileMetadata(
@@ -137,8 +137,8 @@ func (u *AoStorageUploader) GetFiles() *AOFilesMetadataDTO {
 }
 
 func (u *AoStorageUploader) skipAoUpload(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, storageKey string,
-	initialUploadTS time.Time) error {
-	u.addAoFileMetadata(cfi, storageKey, aoMeta, true, false, initialUploadTS)
+	initialUploadTS time.Time, isIncremented bool) error {
+	u.addAoFileMetadata(cfi, storageKey, aoMeta, true, isIncremented, initialUploadTS)
 	u.bundleFiles.AddSkippedFile(cfi.Header, cfi.FileInfo)
 	tracelog.DebugLogger.Printf("Skipping %s AO relfile (already exists in storage as %s)", cfi.Path, storageKey)
 	return nil


### PR DESCRIPTION
### Database name
Greenplum

# Pull request description

### Describe what this PR fix
When we reuse file between backups, we mark it as non-incremented by default. Fixed that by passing isIncremented from previous metadata

