### PR TITLE
Add charset converter to convert non `utf-8` char

### DIFF
--- a/internal/databases/sqlserver/blob/xml.go
+++ b/internal/databases/sqlserver/blob/xml.go
@@ -2,14 +2,12 @@ package blob
 
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/xml"
 	"fmt"
+	"golang.org/x/net/html/charset"
 	"io"
 
 	"strings"
-	"unicode/utf16"
-	"unicode/utf8"
 )
 
 const (
@@ -121,9 +119,11 @@ func (bl *XBlockListIn) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 
 func ParseBlocklistXML(data []byte) (*XBlockListIn, error) {
 	bl := &XBlockListIn{}
-	data = utf16utf8(data, binary.LittleEndian)
 	d := xml.NewDecoder(bytes.NewBuffer(data))
 	d.CharsetReader = func(s string, r io.Reader) (io.Reader, error) {
+		if s == "utf-16" {
+			return charset.NewReader(r, "charset=utf-16")
+		}
 		return r, nil
 	}
 	err := d.Decode(bl)
@@ -131,18 +131,6 @@ func ParseBlocklistXML(data []byte) (*XBlockListIn, error) {
 		return nil, err
 	}
 	return bl, nil
-}
-
-// 21century, we can't convert charset in golang. nice
-func utf16utf8(b []byte, o binary.ByteOrder) []byte {
-	utf := make([]uint16, (len(b)+(2-1))/2)
-	for i := 0; i+(2-1) < len(b); i += 2 {
-		utf[i/2] = o.Uint16(b[i:])
-	}
-	if len(b)/2 < len(utf) {
-		utf[len(utf)-1] = utf8.RuneError
-	}
-	return []byte(string(utf16.Decode(utf)))
 }
 
 type XBlockListOut struct {


### PR DESCRIPTION
### Database name

MS SQL-Server
# Pull request description

### Linux OS:
```bash
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.04
DISTRIB_DESCRIPTION="Ubuntu 22.04.4 LTS"
VERSION="22.04.4 LTS (Jammy Jellyfish)"
```
### SQL Server Version: `2022-CU12-ubuntu-22.04`

### Error:
```bash
> ERROR: 2024/05/10 16:11:34.598412 proxy: failed to read blocklist xml: EOF
```

During the backup process, SQL Server always provides data encoded in `UTF-8`(Tested for Linux: `2022-CU12-ubuntu-22.04` and Windows: `SQL Server 2022`).
However, inside the wal-g codebase, we always assume that the data is encoded in `UTF-16`. As a result, during the decoding process, we encounter an `EOF` error.
So, I added a `decoder` which convert any non `UTF-16` character to `UTF-8`.

### Please provide steps to reproduce (if it's a bug)
> Just try to back up  SQL-Server Latest by using Wal-g 

### Please add config and wal-g stdout/stderr logs for debug purpose

```bash
2024/05/10 16:11:34 WARN: You specified both instance name and port in the connection string, port will be used and instance name will be ignored
INFO: 2024/05/10 16:11:34.190430 running proxy at backup.local:443
INFO: 2024/05/10 16:11:34.436030 database [demo] size is 6478336, required blob count 1
INFO: 2024/05/10 16:11:34.436046 starting backup database [demo] to URL = 'https://backup.local/basebackups_005/base_20240510T101134Z/demo/blob_000'
ERROR: 2024/05/10 16:11:34.598412 proxy: failed to read blocklist xml: EOF
ERROR: 2024/05/10 16:11:34.598761 proxy: failed to read blocklist xml: EOF
ERROR: 2024/05/10 16:11:34.599061 proxy: failed to read blocklist xml: EOF
ERROR: 2024/05/10 16:11:34.599358 proxy: failed to read blocklist xml: EOF
ERROR: 2024/05/10 16:11:36.497753 proxy: failed to read blocklist xml: EOF
ERROR: 2024/05/10 16:11:38.498794 proxy: failed to read blocklist xml: EOF
^X^CINFO: 2024/05/10 16:11:40.777150 Received interrupt signal. Shutting down
INFO: 2024/05/10 16:11:40.777175 stopping proxy
^C^Zfish: Job 1, 'sudo wal-g backup-push --config…' has stopped
```