### PR TITLE
sqlserver: special url for proxy health-checks

### DIFF
--- a/internal/databases/sqlserver/blob/server.go
+++ b/internal/databases/sqlserver/blob/server.go
@@ -38,6 +38,8 @@ const BlockReadCacheSize = 16
 
 const MaxCacheBlockSize = 16 * 1024 * 1024 // 16M
 
+const InternalPingURL = "/__walg_g_ping__"
+
 type Server struct {
 	folder       storage.Folder
 	certFile     string
@@ -150,7 +152,7 @@ func (bs *Server) RunBackground(ctx context.Context, cancel context.CancelFunc) 
 func (bs *Server) WaitReady(ctx context.Context, timeout time.Duration) error {
 	sctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	url := fmt.Sprintf("https://%s/", bs.endpoint)
+	url := fmt.Sprintf("https://%s%s", bs.endpoint, InternalPingURL)
 	c := http.Client{Timeout: 100 * time.Millisecond}
 	t := time.NewTicker(200 * time.Millisecond)
 	for {
@@ -207,6 +209,10 @@ func (bs *Server) ServeHTTP2(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}()
+	if req.URL.Path == InternalPingURL {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 	// default headers
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Length", "0")


### PR DESCRIPTION
Special URL added for SQLServer proxy health checks.
Proxy health-checks should not hit storage.