### PR TITLE
Added retention period for s3

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -82,6 +82,14 @@ Overrides the default minimum time between retries when throttled in millisecond
 
 Overrides the default minimum time between retries when throttled in milliseconds. Default is 300000ms.
 
+* `S3_RETENTION_PERIOD`
+
+Sets retention period in seconds to files, uploaded to s3. Default is disabled with value -1.
+
+* `S3_RETENTION_MODE`
+
+Sets mode of retention (GOVERNANCE/COMPLIANCE). Default is GOVERNANCE, which means, that files can still be deleted if user has special permissions.
+
 GCS
 -----------
 To store backups in Google Cloud Storage, WAL-G requires that this variable be set:

--- a/pkg/storages/s3/configure.go
+++ b/pkg/storages/s3/configure.go
@@ -95,6 +95,8 @@ const (
 )
 
 // TODO: Unit tests
+//
+//nolint:funlen,gocyclo
 func ConfigureStorage(
 	prefix string,
 	settings map[string]string,

--- a/pkg/storages/s3/configure.go
+++ b/pkg/storages/s3/configure.go
@@ -37,6 +37,8 @@ const (
 	rangeBatchEnabledSetting        = "S3_RANGE_BATCH_ENABLED"
 	rangeQueriesMaxRetriesSetting   = "S3_RANGE_MAX_RETRIES"
 	requestAdditionalHeadersSetting = "S3_REQUEST_ADDITIONAL_HEADERS"
+	retentionPeriodSetting          = "S3_RETENTION_PERIOD"
+	retentionModeSetting            = "S3_RETENTION_MODE"
 	// limiters for retry policy during interaction with S3
 	maxRetriesSetting              = "S3_MAX_RETRIES"
 	minThrottlingRetryDelaySetting = "S3_MIN_THROTTLING_RETRY_DELAY"
@@ -73,6 +75,8 @@ var SettingList = []string{
 	requestAdditionalHeadersSetting,
 	minThrottlingRetryDelaySetting,
 	maxThrottlingRetryDelaySetting,
+	retentionPeriodSetting,
+	retentionModeSetting,
 }
 
 const (
@@ -87,6 +91,7 @@ const (
 	defaultStorageClass            = "STANDARD"
 	defaultRangeBatchEnabled       = false
 	defaultRangeMaxRetries         = 10
+	defaultDisabledRetentionPeriod = -1
 )
 
 // TODO: Unit tests
@@ -148,6 +153,10 @@ func ConfigureStorage(
 	if err != nil {
 		return nil, err
 	}
+	retentionPeriod, err := setting.IntOptional(settings, retentionPeriodSetting, defaultDisabledRetentionPeriod)
+	if err != nil {
+		return nil, err
+	}
 
 	config := &Config{
 		Secrets: &Secrets{
@@ -178,6 +187,8 @@ func ConfigureStorage(
 			ServerSideEncryption:         settings[sseSetting],
 			ServerSideEncryptionCustomer: settings[sseCSetting],
 			ServerSideEncryptionKMSID:    settings[sseKmsIDSetting],
+			RetentionPeriod:              retentionPeriod,
+			RetentionMode:                settings[retentionModeSetting],
 		},
 		RangeBatchEnabled:       rangeBatchEnabled,
 		RangeMaxRetries:         rangeMaxRetries,

--- a/pkg/storages/s3/uploader.go
+++ b/pkg/storages/s3/uploader.go
@@ -54,11 +54,18 @@ type Uploader struct {
 	RetentionPeriod      time.Duration
 }
 
-func NewUploader(uploaderAPI s3manageriface.UploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyID, storageClass, retentionMode string, retentionPeriod int) *Uploader {
+func NewUploader(uploaderAPI s3manageriface.UploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyID, storageClass,
+	retentionMode string, retentionPeriod int) *Uploader {
 	if retentionMode == "" {
 		retentionMode = "GOVERNANCE"
 	}
-	return &Uploader{uploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyID, storageClass, retentionMode, time.Duration(retentionPeriod)}
+	return &Uploader{uploaderAPI,
+		serverSideEncryption,
+		sseCustomerKey,
+		sseKmsKeyID,
+		storageClass,
+		retentionMode,
+		time.Duration(retentionPeriod)}
 }
 
 func (uploader *Uploader) createUploadInput(bucket, path string, content io.Reader) *s3manager.UploadInput {

--- a/pkg/storages/s3/uploader.go
+++ b/pkg/storages/s3/uploader.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -22,6 +23,8 @@ type UploaderConfig struct {
 	ServerSideEncryption         string
 	ServerSideEncryptionCustomer string
 	ServerSideEncryptionKMSID    string
+	RetentionPeriod              int
+	RetentionMode                string
 }
 
 func createUploader(s3Client *s3.S3, config *UploaderConfig) (*Uploader, error) {
@@ -36,6 +39,8 @@ func createUploader(s3Client *s3.S3, config *UploaderConfig) (*Uploader, error) 
 		config.ServerSideEncryptionCustomer,
 		config.ServerSideEncryptionKMSID,
 		config.StorageClass,
+		config.RetentionMode,
+		config.RetentionPeriod,
 	), nil
 }
 
@@ -45,10 +50,15 @@ type Uploader struct {
 	SSECustomerKey       string
 	SSEKMSKeyID          string
 	StorageClass         string
+	RetentionMode        string
+	RetentionPeriod      time.Duration
 }
 
-func NewUploader(uploaderAPI s3manageriface.UploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyID, storageClass string) *Uploader {
-	return &Uploader{uploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyID, storageClass}
+func NewUploader(uploaderAPI s3manageriface.UploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyID, storageClass, retentionMode string, retentionPeriod int) *Uploader {
+	if retentionMode == "" {
+		retentionMode = "GOVERNANCE"
+	}
+	return &Uploader{uploaderAPI, serverSideEncryption, sseCustomerKey, sseKmsKeyID, storageClass, retentionMode, time.Duration(retentionPeriod)}
 }
 
 func (uploader *Uploader) createUploadInput(bucket, path string, content io.Reader) *s3manager.UploadInput {
@@ -57,6 +67,11 @@ func (uploader *Uploader) createUploadInput(bucket, path string, content io.Read
 		Key:          aws.String(path),
 		Body:         content,
 		StorageClass: aws.String(uploader.StorageClass),
+	}
+	if uploader.RetentionPeriod != defaultDisabledRetentionPeriod {
+		mytime := time.Now().Add(time.Second * uploader.RetentionPeriod)
+		uploadInput.ObjectLockMode = &uploader.RetentionMode
+		uploadInput.ObjectLockRetainUntilDate = &mytime
 	}
 
 	if uploader.serverSideEncryption != "" {

--- a/testtools/util.go
+++ b/testtools/util.go
@@ -42,7 +42,7 @@ func MakeDefaultInMemoryStorageFolder() *memory.Folder {
 }
 
 func MakeDefaultUploader(uploaderAPI s3manageriface.UploaderAPI) *s3.Uploader {
-	return s3.NewUploader(uploaderAPI, "", "", "", "STANDARD")
+	return s3.NewUploader(uploaderAPI, "", "", "", "STANDARD", "", -1)
 }
 
 func NewMockUploader(apiMultiErr, apiErr bool) internal.Uploader {


### PR DESCRIPTION
Added retention period support for s3.
To prevent files from deletion for some time, added support for:
S3_RETENTION_PERIOD - time in seconds to store file version
S3_RETENTION_MODE - mode of retention (GOVERNANCE/COMPLIANCE)
Warning: bucket object lock configuration needs to be set before using these options
