### PR TITLE
Add few unit test on azure ConfigureStorage

### DIFF
--- a/pkg/storages/azure/folder_test.go
+++ b/pkg/storages/azure/folder_test.go
@@ -16,6 +16,27 @@ func TestAzureFolder(t *testing.T) {
 	storage.RunFolderTest(st.RootFolder(), t)
 }
 
+func TestConfigureStorage_WithoutAccountNameSetting(t *testing.T) {
+	settings := map[string]string{}
+	prefix := "azure://test-container/test-folder/Sub0"
+
+	_, err := ConfigureStorage(prefix, settings)
+
+	assert.Error(t, err)
+}
+
+func TestConfigureStorage_WithValidInput(t *testing.T) {
+	settings := map[string]string{
+		"AZURE_STORAGE_ACCOUNT": "test-account",
+	}
+	prefix := "azure://test-container/test-folder/Sub0"
+
+	storage, err := ConfigureStorage(prefix, settings)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, storage)
+}
+
 var ConfigureAuthType = configureAuthType
 
 func TestConfigureAccessKeyAuthType(t *testing.T) {


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fix
Add unit test on ConfigureStorage func in pkg/storages/azure

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
