### PR TITLE
Fix link_libsodium.sh

### DIFF
--- a/link_libsodium.sh
+++ b/link_libsodium.sh
@@ -4,13 +4,13 @@ set -e
 
 readonly CWD=$PWD
 readonly OS=$(uname)
-readonly LIBSODIUM_VERSION="1.0.17"
+readonly LIBSODIUM_VERSION="1.0.18"
 
 test -d tmp/libsodium || mkdir -p tmp/libsodium
 
 cd tmp/libsodium
 
-curl --retry 5 --retry-delay 0 -sL https://github.com/jedisct1/libsodium/releases/download/$LIBSODIUM_VERSION/libsodium-$LIBSODIUM_VERSION.tar.gz -o libsodium-$LIBSODIUM_VERSION.tar.gz
+curl --retry 5 --retry-delay 0 -sL https://github.com/jedisct1/libsodium/releases/download/$LIBSODIUM_VERSION-RELEASE/libsodium-$LIBSODIUM_VERSION.tar.gz -o libsodium-$LIBSODIUM_VERSION.tar.gz
 tar xfz libsodium-$LIBSODIUM_VERSION.tar.gz --strip-components=1
 
 CONFIGURE_ARGS="--prefix ${PWD}"


### PR DESCRIPTION
Fix problem of build wal-g I experienced today. 
Found two problems
1 . There is no anymore libsodium version 1.0.17
2. Download url format changed


