### PR TITLE
Fix release link in link_libsodium.sh

### DIFF
--- a/link_libsodium.sh
+++ b/link_libsodium.sh
@@ -4,13 +4,13 @@ set -e
 
 readonly CWD=$PWD
 readonly OS=$(uname)
-readonly LIBSODIUM_VERSION="1.0.17"
+readonly LIBSODIUM_VERSION="1.0.18"
 
 test -d tmp/libsodium || mkdir -p tmp/libsodium
 
 cd tmp/libsodium
 
-curl --retry 5 --retry-delay 0 -sL https://github.com/jedisct1/libsodium/releases/download/$LIBSODIUM_VERSION/libsodium-$LIBSODIUM_VERSION.tar.gz -o libsodium-$LIBSODIUM_VERSION.tar.gz
+curl --retry 5 --retry-delay 0 -sL https://github.com/jedisct1/libsodium/releases/download/$LIBSODIUM_VERSION-RELEASE/libsodium-$LIBSODIUM_VERSION.tar.gz -o libsodium-$LIBSODIUM_VERSION.tar.gz
 tar xfz libsodium-$LIBSODIUM_VERSION.tar.gz --strip-components=1
 
 CONFIGURE_ARGS="--prefix ${PWD}"


### PR DESCRIPTION
### Database name
Postgres

# Pull request description

### Describe what this PR fix
Libsodium release link is updated as older one is no longer valid.

### Please provide steps to reproduce (if it's a bug)
bash link_libsodium.sh

### Logs
```
98.94 + bash link_libsodium.sh
99.22 
99.22 gzip: stdin: not in gzip format
99.22 tar: Child returned status 1
99.22 tar: Error is not recoverable: exiting now
```
