### PR TITLE
Add SSH jump server support

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -182,7 +182,9 @@ To store backups via ssh, WAL-G requires that these variables be set:
 * `SSH_USERNAME` connect with username
 * `SSH_PASSWORD` connect with password
 * `SSH_PRIVATE_KEY_PATH` or connect with a SSH KEY by specifying its full path
-
+* `SSH_JUMP_HOST` use ssh jump server host (optional)
+* `SSH_JUMP_PORT` port for the ssh jump server (optional)
+  
 Examples
 -----------
 ***Example: Using Minio.io S3-compatible storage***

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,9 +83,9 @@ const (
 	PgPassfileSetting                      = "PGPASSFILE"
 	PgDatabaseSetting                      = "PGDATABASE"
 	PgSslModeSetting                       = "PGSSLMODE"
-	PgSslKey = "PGSSLKEY"
-	PgSslCert = "PGSSLCERT"
-	PgSslRootCert = "PGSSLROOTCERT"
+	PgSslKey                               = "PGSSLKEY"
+	PgSslCert                              = "PGSSLCERT"
+	PgSslRootCert                          = "PGSSLROOTCERT"
 	PgSlotName                             = "WALG_SLOTNAME"
 	PgWalSize                              = "WALG_PG_WAL_SIZE"
 	TotalBgUploadedLimit                   = "TOTAL_BG_UPLOADED_LIMIT"
@@ -213,6 +213,8 @@ const (
 	SSHPassword       = "SSH_PASSWORD"
 	SSHUsername       = "SSH_USERNAME"
 	SSHPrivateKeyPath = "SSH_PRIVATE_KEY_PATH"
+	SSHJumpHost       = "SSH_JUMP_HOST"
+	SSHJumpPort       = "SSH_JUMP_PORT"
 
 	SystemdNotifySocket = "NOTIFY_SOCKET"
 )
@@ -416,6 +418,8 @@ var (
 		SSHPassword:       true,
 		SSHUsername:       true,
 		SSHPrivateKeyPath: true,
+		SSHJumpHost:       true,
+		SSHJumpPort:       true,
 
 		//File
 		"WALG_FILE_PREFIX": true,
@@ -439,9 +443,9 @@ var (
 		PgPassfileSetting:                      true,
 		PgDatabaseSetting:                      true,
 		PgSslModeSetting:                       true,
-		PgSslCert: true,
-		PgSslKey: true,
-		PgSslRootCert: true,
+		PgSslCert:                              true,
+		PgSslKey:                               true,
+		PgSslRootCert:                          true,
 		PgSlotName:                             true,
 		PgWalSize:                              true,
 		PrefetchDir:                            true,

--- a/pkg/storages/sh/configure.go
+++ b/pkg/storages/sh/configure.go
@@ -13,6 +13,8 @@ const (
 	passwordSetting       = "SSH_PASSWORD"
 	usernameSetting       = "SSH_USERNAME"
 	privateKeyPathSetting = "SSH_PRIVATE_KEY_PATH"
+	jumpHostSetting       = "SSH_JUMP_HOST"
+	jumpPortSetting       = "SSH_JUMP_PORT"
 )
 
 var SettingList = []string{
@@ -20,6 +22,8 @@ var SettingList = []string{
 	passwordSetting,
 	usernameSetting,
 	privateKeyPathSetting,
+	jumpHostSetting,
+	jumpPortSetting,
 }
 
 const defaultPort = "22"
@@ -49,6 +53,8 @@ func ConfigureStorage(
 		RootPath:       folderPath,
 		User:           settings[usernameSetting],
 		PrivateKeyPath: settings[privateKeyPathSetting],
+		JumpHost:       settings[jumpHostSetting],
+		JumpPort:       settings[jumpPortSetting],
 	}
 
 	st, err := NewStorage(config, rootWraps...)

--- a/pkg/storages/sh/storage.go
+++ b/pkg/storages/sh/storage.go
@@ -24,6 +24,8 @@ type Config struct {
 	RootPath       string
 	User           string
 	PrivateKeyPath string
+	JumpHost       string
+	JumpPort       string
 }
 
 type Secrets struct {
@@ -57,7 +59,12 @@ func NewStorage(config *Config, rootWraps ...storage.WrapRootFolder) (*Storage, 
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	address := fmt.Sprint(config.Host, ":", config.Port)
-	client := NewSFTPLazy(address, sshConfig)
+	jump := ""
+	if config.JumpHost != "" {
+		jump = fmt.Sprint(config.JumpHost, ":", config.JumpPort)
+	}
+
+	client := NewSFTPLazy(address, jump, sshConfig)
 
 	path := storage.AddDelimiterToPath(config.RootPath)
 	var folder storage.Folder = NewFolder(client, path)


### PR DESCRIPTION
### Database name
I'm using PostgreSQL database only.

# Pull request description

### Describe what this PR fix
Fix adds support of SSH jump servers for SSH storage. 
This is useful in some cases where the database servers do not have direct access to the Internet.
We successfully use this fix on our production database.