### PR TITLE
Fix "backup-push Connection cancelled by remote host" error on Windows

### DIFF
--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -582,10 +582,7 @@ func GetPgServerInfo(keepRunner bool) (pgInfo BackupPgInfo, runner *PgQueryRunne
 	tracelog.DebugLogger.Printf("Timeline: %d", pgInfo.Timeline)
 
 	if !keepRunner {
-		err = tmpConn.Close()
-		if err != nil {
-			return pgInfo, nil, err
-		}
+		utility.LoggedClose(tmpConn, "")
 		return pgInfo, nil, err
 	}
 


### PR DESCRIPTION
As in https://github.com/wal-g/wal-g/issues/1028#issuecomment-2197864705, we're trying to upstream the patch for #1028.

This PR simply logs the error emitted on closing the connection to Postgres rather than failing on it, allowing the command to proceed. This seems to be more common behaviour across the codebase.

This does mean that on Windows users are likely to see the `wsarecv: An existing connection was forcibly closed by the remote host` error message every time. Integrating the fix from https://github.com/jackc/pgx/issues/637 avoids this cluttering. However, it requires upgrading the dependency `pgx` from v3 to v4.2[^1].

[^1]: The fix commit mentioned in the `pgx` issue thread was for `pgconn` v1.2.0, which `pgx` v4.2.0 depends on. Note that `wal-g`’s dependency on `pgconn` is unrelated since the the error we’re experiencing is coming from `pgx`, and `pgx` v3 doesn’t use `pgconn`.