### PR TITLE
Disable storage validation by default

### DIFF
--- a/pkg/storages/s3/configure.go
+++ b/pkg/storages/s3/configure.go
@@ -2,8 +2,8 @@ package s3
 
 import (
 	"fmt"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/pkg/storages/storage/setting"
@@ -82,7 +82,7 @@ var SettingList = []string{
 
 const (
 	defaultPort                    = "443"
-	defaultSkipValidation          = false
+	defaultSkipValidation          = true
 	defaultForcePathStyle          = false
 	defaultUseListObjectsV1        = false
 	defaultMaxRetries              = 15


### PR DESCRIPTION
We need to redesign our storage validation policy: either cache validation result or provide separate command for validation. Or, perhaps, both. Currently validation does extra S3 call on every single operation which might be too expensive.

cc @Themplarer
fix #1736