### PR TITLE
up golang version to 1.21

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -18,7 +18,7 @@ env:
   IMAGE_UBUNTU_20_04: wal-g/ubuntu:20.04
   IMAGE_GOLANG: wal-g/golang
   IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
-  GO_VERSION: "1.21.12"
+  GO_VERSION: "1.22.5"
 
 jobs:
   buildimages:

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -18,7 +18,7 @@ env:
   IMAGE_UBUNTU_20_04: wal-g/ubuntu:20.04
   IMAGE_GOLANG: wal-g/golang
   IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
-  GO_VERSION: "1.20.5" # until this will be resolved https://github.com/golang/go/issues/61431
+  GO_VERSION: "1.21.12"
 
 jobs:
   buildimages:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 
 jobs:
   golangci:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.21"
 
 jobs:
   golangci:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*' # Push events to matching v*, i.e. v0.2.19, v0.2.14a
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.21"
   USE_BROTLI: 1
   USE_LIBSODIUM: 1
   USE_LZO: 1
@@ -100,8 +100,8 @@ jobs:
             apt-get update
             apt-get install -y build-essential curl git cmake liblzo2-dev brotli libsodium-dev
             
-            curl -LO https://go.dev/dl/go1.20.5.linux-arm64.tar.gz
-            tar -C /usr/local -xzf go1.20.5.linux-arm64.tar.gz
+            curl -LO https://go.dev/dl/go1.21.12.linux-arm64.tar.gz
+            tar -C /usr/local -xzf go1.21.12.linux-arm64.tar.gz
             export GOROOT=/usr/local/go
             export GOPATH=$HOME/go          
             export PATH=$GOPATH/bin:$GOROOT/bin:$PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*' # Push events to matching v*, i.e. v0.2.19, v0.2.14a
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
   USE_BROTLI: 1
   USE_LIBSODIUM: 1
   USE_LZO: 1
@@ -100,8 +100,8 @@ jobs:
             apt-get update
             apt-get install -y build-essential curl git cmake liblzo2-dev brotli libsodium-dev
             
-            curl -LO https://go.dev/dl/go1.21.12.linux-arm64.tar.gz
-            tar -C /usr/local -xzf go1.21.12.linux-arm64.tar.gz
+            curl -LO https://go.dev/dl/go1.22.5.linux-arm64.tar.gz
+            tar -C /usr/local -xzf go1.22.5.linux-arm64.tar.gz
             export GOROOT=/usr/local/go
             export GOPATH=$HOME/go          
             export PATH=$GOPATH/bin:$GOROOT/bin:$PATH

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
   USE_BROTLI: 1
 
 jobs:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: "1.21"
   USE_BROTLI: 1
 
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,7 @@ linters:
     - whitespace
 
 run:
-  go: "1.20"
+  go: "1.21"
   timeout: 5m
   modules-download-mode: readonly
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,7 @@ linters:
     - whitespace
 
 run:
-  go: "1.21"
+  go: "1.22"
   timeout: 5m
   modules-download-mode: readonly
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wal-g/wal-g
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/storage v1.10.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaegertracing/jaeger-clickhouse/internal/tools
 
-go 1.21
+go 1.22
 
 require (
 	github.com/golangci/golangci-lint v1.41.1

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaegertracing/jaeger-clickhouse/internal/tools
 
-go 1.20
+go 1.21
 
 require (
 	github.com/golangci/golangci-lint v1.41.1

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -768,6 +768,7 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/tests_func/images/base/Dockerfile
+++ b/tests_func/images/base/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM golang:1.20.5-bullseye
+FROM golang:1.21.12-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/tests_func/images/base/Dockerfile
+++ b/tests_func/images/base/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM golang:1.21.12-bullseye
+FROM golang:1.22.5-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
### Database name
all

# Pull request description
up golang version to 1.21 over the repo

### Describe what this PR fix
version is partially uped already here, need some consistency: https://github.com/wal-g/wal-g/commit/cf53d7416b227b6cb13ce48e021d658d20a48874

### Please provide steps to reproduce (if it's a bug)
none

### Please add config and wal-g stdout/stderr logs for debug purpose
none