### PR TITLE
Reduce log clutter from storages

### DIFF
--- a/internal/storage_folder_reader.go
+++ b/internal/storage_folder_reader.go
@@ -34,7 +34,7 @@ func PrepareMultiStorageFolderReader(folder storage.Folder, targetStorage string
 	} else {
 		folder, err = multistorage.UseSpecificStorage(targetStorage, folder)
 	}
-	tracelog.InfoLogger.Printf("Files will be read from storages: %v", multistorage.UsedStorages(folder))
+	tracelog.DebugLogger.Printf("Files will be read from storages: %v", multistorage.UsedStorages(folder))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
"INFO: 2024/07/20 18:53:16.817627 Files will be read from storages: [default]" for every single call is just too much