### PR TITLE
clean all redis data before aof backup, not only aof folder

### DIFF
--- a/internal/databases/redis/aof/restore.go
+++ b/internal/databases/redis/aof/restore.go
@@ -58,7 +58,7 @@ func (restoreService *RestoreService) DoRestore(args RestoreArgs) error {
 	}
 
 	if !args.SkipBackupDownload {
-		err = restoreService.Folder.Clean()
+		err = restoreService.Folder.CleanParent()
 		if err != nil {
 			return err
 		}

--- a/internal/databases/redis/archive/fs.go
+++ b/internal/databases/redis/archive/fs.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"io/fs"
 	"os"
+	"path/filepath"
 )
 
 type FolderInfo struct {
@@ -17,8 +18,9 @@ func CreateFolderInfo(path string, fileMode fs.FileMode) *FolderInfo {
 	}
 }
 
-func (f *FolderInfo) Clean() error {
-	err := os.RemoveAll(f.Path)
+func (f *FolderInfo) CleanParent() error {
+	parent := filepath.Dir(f.Path)
+	err := os.RemoveAll(parent)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Database name
redis

# Pull request description

### Describe what this PR fix
there might be some data in redis path somehow - need to clean it all

### Please provide steps to reproduce (if it's a bug)
1. some data in /var/lib/redis (e.g. rdb.dump or tmp files).
2. making aof backup into /var/lib/redis/appendonly
3. ???

### Please add config and wal-g stdout/stderr logs for debug purpose
none
