### PR TITLE
fix LoadCustomCABundleError when setting WALG_S3_CA_CERT_FILE

### DIFF
--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -23,24 +23,24 @@ import (
 )
 
 func createSession(config *Config) (*session.Session, error) {
-	sess, err := session.NewSession()
-	if err != nil {
-		return nil, fmt.Errorf("init new default session: %w", err)
-	}
-
-	err = configureSession(sess, config)
-	if err != nil {
-		return nil, fmt.Errorf("configure session: %w", err)
-	}
-
+	sessOpts := session.Options{}
 	if config.CACertFile != "" {
 		file, err := os.Open(config.CACertFile)
 		if err != nil {
 			return nil, err
 		}
 		defer utility.LoggedClose(file, "S3 CA cert file")
-		sess, err = session.NewSessionWithOptions(session.Options{Config: *sess.Config, CustomCABundle: file})
-		return sess, err
+		sessOpts.CustomCABundle = file
+	}
+
+	sess, err := session.NewSessionWithOptions(sessOpts)
+	if err != nil {
+		return nil, fmt.Errorf("init new session: %w", err)
+	}
+
+	err = configureSession(sess, config)
+	if err != nil {
+		return nil, fmt.Errorf("configure session: %w", err)
 	}
 
 	if config.UseYCSessionToken != "" {


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description

Passes the custom CA bundle to the AWS sdk before configuring the session to avoid LoadCustomCABundleError.

Also fixes an issue where if you had set `WALG_S3_CA_CERT_FILE`, some other config would be ignored due to the early function return (UseYCSessionToken, EndpointSource, and RequestAdditionalHeaders).

### Describe what this PR fixes

In wal-g 3.0.1 and 3.0.2, using S3 storage and setting the environment variable `WALG_S3_CA_CERT_FILE` would result in
```
LoadCustomCABundleError: unable to load custom CA bundle, HTTPClient's transport unsupported type
caused by: unsupported transport, *s3.loggingTransport
```

Fixes #1762

### Please provide steps to reproduce (if it's a bug)

See description in #1762
