### PR TITLE
aof datadir clean fix

### DIFF
--- a/cmd/redis/rdb_backup_fetch.go
+++ b/cmd/redis/rdb_backup_fetch.go
@@ -50,7 +50,7 @@ var backupFetchCmd = &cobra.Command{
 		restoreCmd.Stderr = os.Stderr
 
 		dataPath, _ := conf.GetSetting(conf.RedisDataPath)
-		dataDir := archive.CreateFolderInfo(dataPath, os.FileMode(0750))
+		dataDir := archive.CreateFolderInfo(dataPath)
 		err = redis.HandleBackupFetch(ctx, storage.RootFolder(), args[0], restoreCmd, dataDir)
 		tracelog.ErrorLogger.FatalOnError(err)
 	},

--- a/internal/databases/redis/aof_backup_fetch_handler.go
+++ b/internal/databases/redis/aof_backup_fetch_handler.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 
 	"github.com/wal-g/wal-g/internal"
@@ -20,7 +19,7 @@ func HandleAofFetchPush(
 	dataFolder, _ := conf.GetSetting(conf.RedisDataPath)
 	aofFolder, _ := conf.GetSetting(conf.RedisAppendonlyFolder)
 	aofPath := filepath.Join(dataFolder, aofFolder)
-	folder := archive.CreateFolderInfo(aofPath, os.FileMode(0750))
+	folder := archive.CreateFolderInfo(aofPath)
 
 	uploader, err := internal.ConfigureUploader()
 	if err != nil {

--- a/internal/databases/redis/archive/fs.go
+++ b/internal/databases/redis/archive/fs.go
@@ -1,29 +1,33 @@
 package archive
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 )
 
 type FolderInfo struct {
-	Path     string
-	fileMode fs.FileMode
+	Path string
 }
 
-func CreateFolderInfo(path string, fileMode fs.FileMode) *FolderInfo {
+func CreateFolderInfo(path string) *FolderInfo {
 	return &FolderInfo{
-		Path:     path,
-		fileMode: fileMode,
+		Path: path,
 	}
 }
 
-func (f *FolderInfo) CleanParent() error {
+func (f *FolderInfo) CleanParent() (err error) {
 	parent := filepath.Dir(f.Path)
-	err := os.RemoveAll(parent)
+	starred := filepath.Join(parent, "*")
+	contents, err := filepath.Glob(starred)
 	if err != nil {
-		return err
+		return
 	}
 
-	return os.MkdirAll(f.Path, f.fileMode)
+	for _, item := range contents {
+		err = os.RemoveAll(item)
+		if err != nil {
+			return
+		}
+	}
+	return
 }


### PR DESCRIPTION
### Database name
redis

# Pull request description
cleaning parent data folder in aof backup fetch instead of deleting it
### Describe what this PR fix
folder cleaning by deleting is poor option in some cases

### Please provide steps to reproduce (if it's a bug)
none

### Please add config and wal-g stdout/stderr logs for debug purpose
none
