### PR TITLE
Sort backups by the creation time in generic backup-list command

### DIFF
--- a/cmd/fdb/backup_list.go
+++ b/cmd/fdb/backup_list.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/fdb"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -17,7 +18,7 @@ var backupListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		storage, err := internal.ConfigureStorage()
 		tracelog.ErrorLogger.FatalOnError(err)
-		internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), false, false)
+		internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), fdb.NewGenericMetaInteractor(), false, false)
 	},
 }
 

--- a/cmd/gp/backup_list.go
+++ b/cmd/gp/backup_list.go
@@ -27,7 +27,7 @@ var (
 			if detail {
 				greenplum.HandleDetailedBackupList(storage.RootFolder(), pretty, jsonOutput)
 			} else {
-				internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), pretty, jsonOutput)
+				internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), greenplum.NewGenericMetaInteractor(), pretty, jsonOutput)
 			}
 		},
 	}

--- a/cmd/gp/restore_point_list.go
+++ b/cmd/gp/restore_point_list.go
@@ -21,7 +21,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			storage, err := internal.ConfigureStorage()
 			tracelog.ErrorLogger.FatalOnError(err)
-			greenplum.HandleRestorePointList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), pretty, jsonOutput)
+			greenplum.HandleRestorePointList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), greenplum.NewGenericMetaInteractor(), pretty, jsonOutput)
 		},
 	}
 )

--- a/cmd/mongo/backup_list.go
+++ b/cmd/mongo/backup_list.go
@@ -36,7 +36,7 @@ var backupListCmd = &cobra.Command{
 			err := mongo.HandleDetailedBackupList(backupFolder, os.Stdout, prettyPrint, jsonFormat)
 			tracelog.ErrorLogger.FatalOnError(err)
 		} else {
-			internal.HandleDefaultBackupList(backupFolder, prettyPrint, jsonFormat)
+			internal.HandleDefaultBackupList(backupFolder, mongo.NewGenericMetaInteractor(), prettyPrint, jsonFormat)
 		}
 	},
 }

--- a/cmd/mysql/backup_list.go
+++ b/cmd/mysql/backup_list.go
@@ -27,7 +27,7 @@ var (
 			if detail {
 				mysql.HandleDetailedBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), pretty, json)
 			} else {
-				internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), pretty, json)
+				internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), mysql.NewGenericMetaInteractor(), pretty, json)
 			}
 		},
 	}

--- a/cmd/pg/backup_list.go
+++ b/cmd/pg/backup_list.go
@@ -40,7 +40,7 @@ var (
 			if detail {
 				postgres.HandleDetailedBackupList(backupsFolder, pretty, json)
 			} else {
-				internal.HandleDefaultBackupList(backupsFolder, pretty, json)
+				internal.HandleDefaultBackupList(backupsFolder, postgres.NewGenericMetaInteractor(), pretty, json)
 			}
 		},
 	}

--- a/cmd/pg/catchup_list.go
+++ b/cmd/pg/catchup_list.go
@@ -24,7 +24,7 @@ var (
 			if detail {
 				postgres.HandleDetailedBackupList(storage.RootFolder().GetSubFolder(utility.CatchupPath), pretty, json)
 			} else {
-				internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.CatchupPath), pretty, json)
+				internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.CatchupPath), postgres.NewGenericMetaInteractor(), pretty, json)
 			}
 		},
 	}

--- a/cmd/pg/pgbackrest_backup_list.go
+++ b/cmd/pg/pgbackrest_backup_list.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/internal/databases/postgres/pgbackrest"
 )
 
@@ -12,7 +13,7 @@ var pgbackrestBackupListCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		folder, stanza := configurePgbackrestSettings()
-		err := pgbackrest.HandleBackupList(folder, stanza, detail, pretty, json)
+		err := pgbackrest.HandleBackupList(folder, postgres.NewGenericMetaInteractor(), stanza, detail, pretty, json)
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
 }

--- a/cmd/redis/backup_list.go
+++ b/cmd/redis/backup_list.go
@@ -27,7 +27,7 @@ var (
 			if detail {
 				redis.HandleDetailedBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), pretty, json)
 			} else {
-				internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), pretty, json)
+				internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), redis.NewGenericMetaInteractor(), pretty, json)
 			}
 		},
 	}

--- a/cmd/sqlserver/backup_list.go
+++ b/cmd/sqlserver/backup_list.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/sqlserver"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -18,7 +19,7 @@ var backupListCmd = &cobra.Command{
 		storage, err := internal.ConfigureStorage()
 		tracelog.ErrorLogger.FatalOnError(err)
 		// todo: implement pretty and json logic
-		internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), false, false)
+		internal.HandleDefaultBackupList(storage.RootFolder().GetSubFolder(utility.BaseBackupPath), sqlserver.NewGenericMetaInteractor(), false, false)
 	},
 }
 

--- a/internal/backup_list_handler.go
+++ b/internal/backup_list_handler.go
@@ -8,8 +8,8 @@ import (
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
-func HandleDefaultBackupList(folder storage.Folder, pretty, json bool) {
-	backupTimes, err := GetBackups(folder)
+func HandleDefaultBackupList(folder storage.Folder, metaFetcher GenericMetaFetcher, pretty, json bool) {
+	backupTimesWithMeta, err := GetBackupsWithMetadata(folder, metaFetcher)
 	_, noBackupsErr := err.(NoBackupsFoundError)
 	if noBackupsErr {
 		tracelog.InfoLogger.Println("No backups found")
@@ -17,11 +17,11 @@ func HandleDefaultBackupList(folder storage.Folder, pretty, json bool) {
 	}
 	tracelog.ErrorLogger.FatalfOnError("Get backups from folder: %v", err)
 
-	SortBackupTimeSlices(backupTimes)
+	SortBackupTimeWithMetadataSlices(backupTimesWithMeta)
 
-	printableEntities := make([]printlist.Entity, len(backupTimes))
-	for i := range backupTimes {
-		printableEntities[i] = backupTimes[i]
+	printableEntities := make([]printlist.Entity, len(backupTimesWithMeta))
+	for i := range backupTimesWithMeta {
+		printableEntities[i] = backupTimesWithMeta[i]
 	}
 	err = printlist.List(printableEntities, os.Stdout, pretty, json)
 	tracelog.ErrorLogger.FatalfOnError("Print backups: %v", err)

--- a/internal/backup_time_with_metadata.go
+++ b/internal/backup_time_with_metadata.go
@@ -1,0 +1,40 @@
+package internal
+
+import (
+	"encoding/json"
+
+	"github.com/wal-g/wal-g/internal/printlist"
+)
+
+// BackupTimeWithMetadata is used to sort backups by
+// latest modified time or creation time.
+type BackupTimeWithMetadata struct {
+	BackupTime
+	GenericMetadata
+}
+
+func (b BackupTimeWithMetadata) PrintableFields() []printlist.TableField {
+	prettyCreatedTime := PrettyFormatTime(b.StartTime)
+	return []printlist.TableField{
+		{
+			Name:       "name",
+			PrettyName: "Name",
+			Value:      b.BackupTime.BackupName,
+		},
+		{
+			Name:        "created",
+			PrettyName:  "Created",
+			Value:       FormatTime(b.GenericMetadata.StartTime),
+			PrettyValue: &prettyCreatedTime,
+		},
+		{
+			Name:       "wal_segment_backup_start",
+			PrettyName: "WAL segment backup start",
+			Value:      b.BackupTime.WalFileName,
+		},
+	}
+}
+
+func (b BackupTimeWithMetadata) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.BackupTime)
+}

--- a/internal/backup_time_with_metadata_test.go
+++ b/internal/backup_time_with_metadata_test.go
@@ -1,0 +1,75 @@
+package internal
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal/printlist"
+)
+
+func TestBackupTimeWithMetadata_PrintableFields(t *testing.T) {
+	btm := BackupTimeWithMetadata{
+		BackupTime: BackupTime{
+			BackupName:  "my first backup",
+			Time:        time.Unix(1692883732, 0).UTC(),
+			WalFileName: "my/wal/file/name",
+			StorageName: "my failover ssh storage",
+		},
+		GenericMetadata: GenericMetadata{
+			StartTime: time.Unix(1692883722, 0).UTC(),
+		},
+	}
+	got := btm.PrintableFields()
+	prettyTime := "Thursday, 24-Aug-23 13:28:42 UTC"
+	want := []printlist.TableField{
+		{
+			Name:        "name",
+			PrettyName:  "Name",
+			Value:       "my first backup",
+			PrettyValue: nil,
+		},
+		{
+			Name:        "created",
+			PrettyName:  "Created",
+			Value:       "2023-08-24T13:28:42Z",
+			PrettyValue: &prettyTime,
+		},
+		{
+			Name:        "wal_segment_backup_start",
+			PrettyName:  "WAL segment backup start",
+			Value:       "my/wal/file/name",
+			PrettyValue: nil,
+		},
+	}
+
+	assert.Equal(t, want, got)
+}
+
+func TestBackupTimeWithMetadata_MarshalJSON(t *testing.T) {
+	btm := BackupTimeWithMetadata{
+		BackupTime: BackupTime{
+			BackupName:  "my first backup",
+			Time:        time.Unix(1692883732, 0).UTC(),
+			WalFileName: "my/wal/file/name",
+			StorageName: "my failover ssh storage",
+		},
+		GenericMetadata: GenericMetadata{
+			StartTime: time.Unix(1692883722, 0).UTC(),
+		},
+	}
+
+	got, err := json.Marshal(btm)
+	require.NoError(t, err)
+
+	wantJSON := `{
+	"backup_name": "my first backup",
+	"time": "2023-08-24T13:28:52Z",
+	"wal_file_name": "my/wal/file/name",
+	"storage_name": "my failover ssh storage"
+}`
+	assert.JSONEq(t, wantJSON, string(got))
+}

--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -108,6 +108,26 @@ func GetBackups(folder storage.Folder) (backups []BackupTime, err error) {
 	return
 }
 
+// GetBackupsWithMetadata receives backup descriptions with meta information
+func GetBackupsWithMetadata(folder storage.Folder, metaFetcher GenericMetaFetcher) (backupsWithMeta []BackupTimeWithMetadata, err error) {
+	backups, err := GetBackups(folder)
+
+	if err != nil {
+		return nil, err
+	}
+
+	backupsWithMeta = make([]BackupTimeWithMetadata, len(backups))
+	for i, backup := range backups {
+		meta, err := metaFetcher.Fetch(backup.BackupName, folder)
+		if err != nil {
+			return nil, err
+		}
+
+		backupsWithMeta[i] = BackupTimeWithMetadata{backup, meta}
+	}
+	return
+}
+
 func GetBackupsAndGarbage(folder storage.Folder) (backups []BackupTime, garbage []string, err error) {
 	backupObjects, subFolders, err := folder.ListFolder()
 	if err != nil {
@@ -138,6 +158,12 @@ func GetBackupTimeSlices(backupObjects []storage.Object) []BackupTime {
 func SortBackupTimeSlices(backupTimes []BackupTime) {
 	sort.Slice(backupTimes, func(i, j int) bool {
 		return backupTimes[i].Time.Before(backupTimes[j].Time)
+	})
+}
+
+func SortBackupTimeWithMetadataSlices(backupTimes []BackupTimeWithMetadata) {
+	sort.Slice(backupTimes, func(i, j int) bool {
+		return backupTimes[i].StartTime.Before(backupTimes[j].StartTime)
 	})
 }
 

--- a/internal/databases/fdb/backup_push_handler.go
+++ b/internal/databases/fdb/backup_push_handler.go
@@ -11,8 +11,10 @@ import (
 )
 
 // TODO: add more metadata
-type streamSentinelDto struct {
+type StreamSentinelDto struct {
 	StartLocalTime time.Time
+	IsPermanent    bool
+	UserData       any
 }
 
 func HandleBackupPush(uploader internal.Uploader, backupCmd *exec.Cmd) {
@@ -30,7 +32,7 @@ func HandleBackupPush(uploader internal.Uploader, backupCmd *exec.Cmd) {
 		tracelog.ErrorLogger.Fatalf("backup create command failed: %v", err)
 	}
 
-	sentinel := streamSentinelDto{StartLocalTime: timeStart}
+	sentinel := StreamSentinelDto{StartLocalTime: timeStart}
 
 	err = internal.UploadSentinel(uploader, &sentinel, fileName)
 	tracelog.ErrorLogger.FatalOnError(err)

--- a/internal/databases/fdb/generic_meta_interactor.go
+++ b/internal/databases/fdb/generic_meta_interactor.go
@@ -1,0 +1,83 @@
+package fdb
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaInteractor struct {
+	GenericMetaFetcher
+	GenericMetaSetter
+}
+
+func NewGenericMetaInteractor() GenericMetaInteractor {
+	return GenericMetaInteractor{
+		GenericMetaFetcher: NewGenericMetaFetcher(),
+		GenericMetaSetter:  NewGenericMetaSetter(),
+	}
+}
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	var sentinel StreamSentinelDto
+	if err = backup.FetchSentinel(&sentinel); err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:       backupName,
+		StartTime:        sentinel.StartLocalTime,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         sentinel.UserData,
+		IsPermanent:      sentinel.IsPermanent,
+	}, nil
+}
+
+type GenericMetaSetter struct{}
+
+func NewGenericMetaSetter() GenericMetaSetter {
+	return GenericMetaSetter{}
+}
+
+func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData any) error {
+	modifier := func(dto StreamSentinelDto) StreamSentinelDto {
+		dto.UserData = userData
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	modifier := func(dto StreamSentinelDto) StreamSentinelDto {
+		dto.IsPermanent = isPermanent
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func modifyBackupSentinel(backupName string, backupFolder storage.Folder, modifier func(StreamSentinelDto) StreamSentinelDto) error {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return err
+	}
+	var sentinel StreamSentinelDto
+	if err = backup.FetchSentinel(&sentinel); err != nil {
+		return errors.Wrap(err, "failed to fetch the existing backup metadata for modifying")
+	}
+	sentinel = modifier(sentinel)
+	if err = backup.UploadSentinel(sentinel); err != nil {
+		return errors.Wrap(err, "failed to upload the modified metadata to the storage")
+	}
+	return nil
+}

--- a/internal/databases/fdb/generic_meta_interactor_test.go
+++ b/internal/databases/fdb/generic_meta_interactor_test.go
@@ -1,0 +1,116 @@
+package fdb_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/fdb"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	conf.InitConfig()
+	conf.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	data := "Data"
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := fdb.StreamSentinelDto{
+		UserData:       data,
+		StartLocalTime: date,
+		IsPermanent:    isPermanent,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		StartTime:        date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	actualResult, err := fdb.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := fdb.StreamSentinelDto{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = fdb.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	require.NoError(t, err)
+	backup, err := fdb.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := fdb.StreamSentinelDto{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = fdb.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+	require.NoError(t, err)
+
+	backup, err := fdb.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/mongo/generic_meta_interactor.go
+++ b/internal/databases/mongo/generic_meta_interactor.go
@@ -1,0 +1,89 @@
+package mongo
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"github.com/wal-g/wal-g/internal/databases/redis/archive"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaInteractor struct {
+	GenericMetaFetcher
+	GenericMetaSetter
+}
+
+func NewGenericMetaInteractor() GenericMetaInteractor {
+	return GenericMetaInteractor{
+		GenericMetaFetcher: NewGenericMetaFetcher(),
+		GenericMetaSetter:  NewGenericMetaSetter(),
+	}
+}
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+	var sentinel models.Backup
+	if err = backup.FetchSentinel(&sentinel); err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: sentinel.UncompressedSize,
+		CompressedSize:   sentinel.CompressedSize,
+		Hostname:         sentinel.Hostname,
+		StartTime:        sentinel.StartLocalTime,
+		FinishTime:       sentinel.FinishLocalTime,
+		IsPermanent:      sentinel.Permanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         sentinel.UserData,
+	}, nil
+}
+
+type GenericMetaSetter struct{}
+
+func NewGenericMetaSetter() GenericMetaSetter {
+	return GenericMetaSetter{}
+}
+
+func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData any) error {
+	modifier := func(dto archive.Backup) archive.Backup {
+		dto.UserData = userData
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	modifier := func(dto archive.Backup) archive.Backup {
+		dto.Permanent = isPermanent
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func modifyBackupSentinel(backupName string, backupFolder storage.Folder, modifier func(archive.Backup) archive.Backup) error {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return err
+	}
+
+	var sentinel archive.Backup
+	if err = backup.FetchSentinel(&sentinel); err != nil {
+		return errors.Wrap(err, "failed to fetch the existing backup metadata for modifying")
+	}
+	sentinel = modifier(sentinel)
+	if err = backup.UploadSentinel(sentinel); err != nil {
+		return errors.Wrap(err, "failed to upload the modified metadata to the storage")
+	}
+	return nil
+}

--- a/internal/databases/mongo/generic_meta_interactor_test.go
+++ b/internal/databases/mongo/generic_meta_interactor_test.go
@@ -1,0 +1,133 @@
+package mongo_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/mongo"
+	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	conf.InitConfig()
+	conf.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	backupType := "type"
+	hostname := "hostname"
+	data := "Data"
+	uncompressedSize := rand.Int63()
+	compressedSize := rand.Int63()
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := models.Backup{
+		BackupName:       backupName,
+		BackupType:       backupType,
+		Hostname:         hostname,
+		StartLocalTime:   date,
+		FinishLocalTime:  date,
+		UserData:         data,
+		MongoMeta:        models.MongoMeta{},
+		Permanent:        isPermanent,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   compressedSize,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   compressedSize,
+		Hostname:         hostname,
+		StartTime:        date,
+		FinishTime:       date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+	actualResult, err := mongo.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := models.Backup{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		Permanent:      false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = mongo.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	require.NoError(t, err)
+	backup, err := mongo.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := models.Backup{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		Permanent:      false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = mongo.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+	require.NoError(t, err)
+
+	backup, err := mongo.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/mysql/generic_meta_interactor.go
+++ b/internal/databases/mysql/generic_meta_interactor.go
@@ -24,7 +24,6 @@ func NewGenericMetaFetcher() GenericMetaFetcher {
 	return GenericMetaFetcher{}
 }
 
-// TODO: Unit tests
 func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
 	backup, err := internal.NewBackup(backupFolder, backupName)
 	if err != nil {
@@ -55,7 +54,6 @@ func NewGenericMetaSetter() GenericMetaSetter {
 	return GenericMetaSetter{}
 }
 
-// TODO: Unit tests
 func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData interface{}) error {
 	modifier := func(dto StreamSentinelDto) StreamSentinelDto {
 		dto.UserData = userData
@@ -64,7 +62,6 @@ func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.
 	return modifyBackupSentinel(backupName, backupFolder, modifier)
 }
 
-// TODO: Unit tests
 func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
 	modifier := func(dto StreamSentinelDto) StreamSentinelDto {
 		dto.IsPermanent = isPermanent

--- a/internal/databases/mysql/generic_meta_interactor_test.go
+++ b/internal/databases/mysql/generic_meta_interactor_test.go
@@ -1,0 +1,135 @@
+package mysql_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/mysql"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	conf.InitConfig()
+	conf.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	data := "Data"
+	hostname := "hostname"
+	uncompressedSize := rand.Int63()
+	compressedSize := rand.Int63()
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := mysql.StreamSentinelDto{
+		StartLocalTime:   date,
+		StopLocalTime:    date,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   compressedSize,
+		Hostname:         hostname,
+		IsPermanent:      isPermanent,
+		UserData:         data,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: uncompressedSize,
+		CompressedSize:   compressedSize,
+		Hostname:         hostname,
+		StartTime:        date,
+		FinishTime:       date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: mysql.NewIncrementDetailsFetcher(&mysql.StreamSentinelDto{
+			StartLocalTime:   date,
+			StopLocalTime:    date,
+			UncompressedSize: uncompressedSize,
+			CompressedSize:   compressedSize,
+			Hostname:         hostname,
+			UserData:         data,
+		}),
+		UserData: data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+	actualResult, err := mysql.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := mysql.StreamSentinelDto{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = mysql.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	require.NoError(t, err)
+	backup, err := mysql.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := mysql.StreamSentinelDto{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = mysql.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+	require.NoError(t, err)
+
+	backup, err := mysql.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/postgres/pgbackrest/backup_list_handler.go
+++ b/internal/databases/postgres/pgbackrest/backup_list_handler.go
@@ -11,30 +11,29 @@ import (
 )
 
 // TODO: unit tests
-func HandleBackupList(folder storage.Folder, stanza string, detailed bool, pretty bool, json bool) error {
-	backupTimes, err := GetBackupList(folder, stanza)
-
-	if len(backupTimes) == 0 {
-		tracelog.InfoLogger.Println("No backups found")
-		return nil
-	}
-
+func HandleBackupList(folder storage.Folder, metaFetcher internal.GenericMetaFetcher, stanza string, detailed bool, pretty bool, json bool) error {
+	backupTimesWithMeta, err := GetBackupListWithMetadata(folder, metaFetcher, stanza)
 	if err != nil {
 		return err
 	}
 
-	internal.SortBackupTimeSlices(backupTimes)
+	if len(backupTimesWithMeta) == 0 {
+		tracelog.InfoLogger.Println("No backups found")
+		return nil
+	}
 
-	printableEntities := make([]printlist.Entity, len(backupTimes))
-	for i := range backupTimes {
+	internal.SortBackupTimeWithMetadataSlices(backupTimesWithMeta)
+
+	printableEntities := make([]printlist.Entity, len(backupTimesWithMeta))
+	for i := range backupTimesWithMeta {
 		if detailed {
-			details, err := GetBackupDetails(folder, stanza, backupTimes[i].BackupName)
+			details, err := GetBackupDetails(folder, stanza, backupTimesWithMeta[i].BackupTime.BackupName)
 			if err != nil {
 				return fmt.Errorf("get backup details: %w", err)
 			}
 			printableEntities[i] = details
 		} else {
-			printableEntities[i] = backupTimes[i]
+			printableEntities[i] = backupTimesWithMeta[i]
 		}
 	}
 

--- a/internal/databases/postgres/pgbackrest/pgbackrest_importer.go
+++ b/internal/databases/postgres/pgbackrest/pgbackrest_importer.go
@@ -101,6 +101,31 @@ func GetBackupList(backupsFolder storage.Folder, stanza string) ([]internal.Back
 	return backupTimes, nil
 }
 
+func GetBackupListWithMetadata(backupsFolder storage.Folder, metaFetcher internal.GenericMetaFetcher,
+	stanza string) ([]internal.BackupTimeWithMetadata, error) {
+	backupsSettings, err := LoadBackupsSettings(backupsFolder, stanza)
+	if err != nil {
+		return nil, err
+	}
+
+	var backupTimes []internal.BackupTimeWithMetadata
+	for i := range backupsSettings {
+		metadata, err := metaFetcher.Fetch(backupsSettings[i].Name, backupsFolder)
+		if err != nil {
+			return nil, err
+		}
+		backupTimes = append(backupTimes, internal.BackupTimeWithMetadata{
+			BackupTime: internal.BackupTime{
+				BackupName:  backupsSettings[i].Name,
+				Time:        getTime(backupsSettings[i].BackupTimestampStop),
+				WalFileName: backupsSettings[i].BackupArchiveStart,
+			},
+			GenericMetadata: metadata,
+		})
+	}
+	return backupTimes, nil
+}
+
 func GetBackupDetails(backupsFolder storage.Folder, stanza string, backupName string) (*BackupDetails, error) {
 	manifest, err := LoadManifest(backupsFolder, stanza, backupName)
 	if err != nil {

--- a/internal/databases/redis/generic_meta_interactor.go
+++ b/internal/databases/redis/generic_meta_interactor.go
@@ -1,0 +1,87 @@
+package redis
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/redis/archive"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaInteractor struct {
+	GenericMetaFetcher
+	GenericMetaSetter
+}
+
+func NewGenericMetaInteractor() GenericMetaInteractor {
+	return GenericMetaInteractor{
+		GenericMetaFetcher: NewGenericMetaFetcher(),
+		GenericMetaSetter:  NewGenericMetaSetter(),
+	}
+}
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+	var sentinel archive.Backup
+	if err = backup.FetchSentinel(&sentinel); err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: sentinel.DataSize,
+		CompressedSize:   sentinel.BackupSize,
+		StartTime:        sentinel.StartLocalTime,
+		FinishTime:       sentinel.FinishLocalTime,
+		IsPermanent:      sentinel.Permanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         sentinel.UserData,
+	}, nil
+}
+
+type GenericMetaSetter struct{}
+
+func NewGenericMetaSetter() GenericMetaSetter {
+	return GenericMetaSetter{}
+}
+
+func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData any) error {
+	modifier := func(dto archive.Backup) archive.Backup {
+		dto.UserData = userData
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	modifier := func(dto archive.Backup) archive.Backup {
+		dto.Permanent = isPermanent
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func modifyBackupSentinel(backupName string, backupFolder storage.Folder, modifier func(archive.Backup) archive.Backup) error {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return err
+	}
+
+	var sentinel archive.Backup
+	if err = backup.FetchSentinel(&sentinel); err != nil {
+		return errors.Wrap(err, "failed to fetch the existing backup metadata for modifying")
+	}
+	sentinel = modifier(sentinel)
+	if err = backup.UploadSentinel(sentinel); err != nil {
+		return errors.Wrap(err, "failed to upload the modified metadata to the storage")
+	}
+	return nil
+}

--- a/internal/databases/redis/generic_meta_interactor_test.go
+++ b/internal/databases/redis/generic_meta_interactor_test.go
@@ -1,0 +1,125 @@
+package redis_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/redis"
+	"github.com/wal-g/wal-g/internal/databases/redis/archive"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	conf.InitConfig()
+	conf.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	data := "Data"
+	dataSize := rand.Int63()
+	backupSize := rand.Int63()
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := archive.Backup{
+		StartLocalTime:  date,
+		FinishLocalTime: date,
+		DataSize:        dataSize,
+		BackupSize:      backupSize,
+		BackupName:      backupName,
+		UserData:        data,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		UncompressedSize: dataSize,
+		CompressedSize:   backupSize,
+		StartTime:        date,
+		FinishTime:       date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+	actualResult, err := redis.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := archive.Backup{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		Permanent:      false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = redis.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	require.NoError(t, err)
+	backup, err := redis.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := archive.Backup{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		Permanent:      false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = redis.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+	require.NoError(t, err)
+
+	backup, err := redis.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/sqlserver/generic_meta_interactor.go
+++ b/internal/databases/sqlserver/generic_meta_interactor.go
@@ -1,0 +1,83 @@
+package sqlserver
+
+import (
+	"github.com/pkg/errors"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaInteractor struct {
+	GenericMetaFetcher
+	GenericMetaSetter
+}
+
+func NewGenericMetaInteractor() GenericMetaInteractor {
+	return GenericMetaInteractor{
+		GenericMetaFetcher: NewGenericMetaFetcher(),
+		GenericMetaSetter:  NewGenericMetaSetter(),
+	}
+}
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+	var sentinel SentinelDto
+	if err = backup.FetchSentinel(&sentinel); err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:       backupName,
+		StartTime:        sentinel.StartLocalTime,
+		FinishTime:       sentinel.StopLocalTime,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		IsPermanent:      sentinel.IsPermanent,
+		UserData:         sentinel.UserData,
+	}, nil
+}
+
+type GenericMetaSetter struct{}
+
+func NewGenericMetaSetter() GenericMetaSetter {
+	return GenericMetaSetter{}
+}
+
+func (ms GenericMetaSetter) SetUserData(backupName string, backupFolder storage.Folder, userData any) error {
+	modifier := func(dto SentinelDto) SentinelDto {
+		dto.UserData = userData
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func (ms GenericMetaSetter) SetIsPermanent(backupName string, backupFolder storage.Folder, isPermanent bool) error {
+	modifier := func(dto SentinelDto) SentinelDto {
+		dto.IsPermanent = isPermanent
+		return dto
+	}
+	return modifyBackupSentinel(backupName, backupFolder, modifier)
+}
+
+func modifyBackupSentinel(backupName string, backupFolder storage.Folder, modifier func(SentinelDto) SentinelDto) error {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return err
+	}
+	var sentinel SentinelDto
+	if err = backup.FetchSentinel(&sentinel); err != nil {
+		return errors.Wrap(err, "failed to fetch the existing backup metadata for modifying")
+	}
+	sentinel = modifier(sentinel)
+	if err = backup.UploadSentinel(sentinel); err != nil {
+		return errors.Wrap(err, "failed to upload the modified metadata to the storage")
+	}
+	return nil
+}

--- a/internal/databases/sqlserver/generic_meta_interactor_test.go
+++ b/internal/databases/sqlserver/generic_meta_interactor_test.go
@@ -1,0 +1,117 @@
+package sqlserver_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/sqlserver"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	conf.InitConfig()
+	conf.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	backupName := "test"
+	data := "Data"
+
+	date := time.Date(2022, 3, 21, 0, 0, 0, 0, time.UTC)
+	isPermanent := false
+
+	testObject := sqlserver.SentinelDto{
+		StartLocalTime: date,
+		StopLocalTime:  date,
+		UserData:       data,
+	}
+
+	expectedResult := internal.GenericMetadata{
+		BackupName:       backupName,
+		StartTime:        date,
+		FinishTime:       date,
+		IsPermanent:      isPermanent,
+		IncrementDetails: &internal.NopIncrementDetailsFetcher{},
+		UserData:         data,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+	actualResult, err := sqlserver.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	//check equality of time separately
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	isEqualTimeFinish := expectedResult.FinishTime.Equal(actualResult.FinishTime)
+	assert.True(t, isEqualTimeFinish)
+
+	// since assert.Equal doesn't compare time properly, just assign the actual to the expected time
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.Equal(t, expectedResult, actualResult)
+}
+
+func TestSetIsPermanent(t *testing.T) {
+	backupName := "test"
+	testObject := sqlserver.SentinelDto{
+		UserData:       nil,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = sqlserver.NewGenericMetaSetter().SetIsPermanent(backupName, folder, true)
+	require.NoError(t, err)
+	backup, err := sqlserver.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.True(t, backup.IsPermanent)
+}
+
+func TestSetUserData(t *testing.T) {
+	backupName := "test"
+	updatedData := "Updated Data"
+	oldData := "Old Data"
+	testObject := sqlserver.SentinelDto{
+		UserData:       oldData,
+		StartLocalTime: time.Now(),
+		IsPermanent:    false,
+	}
+
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	marshaller, err := internal.NewDtoSerializer()
+	require.NoError(t, err)
+	file, err := marshaller.Marshal(testObject)
+	require.NoError(t, err)
+	err = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+	require.NoError(t, err)
+
+	err = sqlserver.NewGenericMetaSetter().SetUserData(backupName, folder, updatedData)
+	require.NoError(t, err)
+
+	backup, err := sqlserver.NewGenericMetaFetcher().Fetch(backupName, folder)
+	require.NoError(t, err)
+
+	assert.Equal(t, updatedData, backup.UserData)
+}

--- a/internal/databases/sqlserver/sqlserver.go
+++ b/internal/databases/sqlserver/sqlserver.go
@@ -51,8 +51,10 @@ var SystemDbnames = []string{
 type SentinelDto struct {
 	Server         string
 	Databases      []string
+	IsPermanent    bool
 	StartLocalTime time.Time `json:"StartLocalTime,omitempty"`
 	StopLocalTime  time.Time `json:"StopLocalTime,omitempty"`
+	UserData       any
 }
 
 func (s *SentinelDto) String() string {

--- a/testtools/mock_generic_metadata_interactor.go
+++ b/testtools/mock_generic_metadata_interactor.go
@@ -1,0 +1,14 @@
+package testtools
+
+import (
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type MockGenericMetaFetcher struct {
+	MockMeta map[string]internal.GenericMetadata
+}
+
+func (m *MockGenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	return m.MockMeta[backupName], nil
+}


### PR DESCRIPTION
[Issue] (https://github.com/wal-g/wal-g/issues/1108)
Added GenericMetaInteractors for:

- Mongo
- Redis
- Fdb
- SqlServers

Interactors are used for fetching backup StartTime to sort backups by creation time.
Added sorting by creation time in DefaultHandleBackupList when --detailed flag is not specified