### PR TITLE
Correction for checksum verification PostgreSQL

### DIFF
--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -668,6 +668,9 @@ func (bh *BackupHandler) checkDataChecksums() error {
 			tracelog.WarningLogger.Println(
 				"data_checksum is disabled in the database. " +
 					"Skipping checksum validation, which may result in undetected data corruption.")
+
+			// Set verifyPageChecksums to false if dataChecksums is not enable on DB
+			bh.Arguments.verifyPageChecksums = false
 		} else {
 			tracelog.InfoLogger.Println("data_checksums is enabled in DB.")
 		}

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -665,12 +665,16 @@ func (bh *BackupHandler) checkDataChecksums() error {
 		}
 
 		if dataChecksums != "on" {
-			tracelog.WarningLogger.Println("data_checksum is disabled in the database. Skipping checksum validation, which may result in undetected data corruption.")
+			tracelog.WarningLogger.Println(
+				"data_checksum is disabled in the database. " +
+					"Skipping checksum validation, which may result in undetected data corruption.")
 		} else {
 			tracelog.InfoLogger.Println("data_checksums is enabled in DB.")
 		}
 	} else {
-		tracelog.DebugLogger.Println("checkDataChecksums: Checking if data_checksums is enabled in DB is skipped because the --verify parameter is not set.")
+		tracelog.DebugLogger.Println(
+			"checkDataChecksums: Checking if data_checksums is enabled in DB is skipped " +
+				"because the --verify parameter is not set.")
 	}
 	return nil
 }

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -169,6 +169,9 @@ func (bh *BackupHandler) createAndPushBackup(ctx context.Context) {
 
 	err = bh.startBackup()
 	tracelog.ErrorLogger.FatalOnError(err)
+	err = bh.checkDataChecksums()
+	tracelog.ErrorLogger.FatalOnError(err)
+
 	if orioledbEnabled {
 		chkpNum := orioledb.GetChkpNum(bh.PgInfo.PgDataDirectory)
 		bh.CurBackupInfo.StartChkpNum = &chkpNum
@@ -650,6 +653,26 @@ func (bh *BackupHandler) initBackupTerminator() {
 		terminator.TerminateBackup()
 		tracelog.ErrorLogger.Fatal("Finished backup termination, will now exit")
 	}()
+}
+
+func (bh *BackupHandler) checkDataChecksums() error {
+	if bh.Arguments.verifyPageChecksums {
+		tracelog.DebugLogger.Println("checkDataChecksums: Checking data_checksums setting.")
+
+		dataChecksums, err := bh.Workers.QueryRunner.GetDataChecksums()
+		if err != nil {
+			return err
+		}
+
+		if dataChecksums != "on" {
+			tracelog.WarningLogger.Println("data_checksum is disabled in the database. Skipping checksum validation, which may result in undetected data corruption.")
+		} else {
+			tracelog.InfoLogger.Println("data_checksums is enabled in DB.")
+		}
+	} else {
+		tracelog.DebugLogger.Println("checkDataChecksums: Checking if data_checksums is enabled in DB is skipped because the --verify parameter is not set.")
+	}
+	return nil
 }
 
 func addSignalListener(errCh chan error) {

--- a/internal/databases/postgres/paged_file_verifier.go
+++ b/internal/databases/postgres/paged_file_verifier.go
@@ -192,7 +192,7 @@ func VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Re
 // VerifyPagedFileBase verifies pages of a standard paged file
 func VerifyPagedFileBase(path string, fileInfo os.FileInfo, pagedFile io.Reader) ([]uint32, error) {
 	size := fileInfo.Size()
-	filePageCount := uint32(size / DatabasePageSize)
+	filePageCount := uint32((size + DatabasePageSize - 1) / DatabasePageSize)
 	blockNumbers := make([]uint32, 0, filePageCount)
 	for i := uint32(0); i < filePageCount; i++ {
 		blockNumbers = append(blockNumbers, i)

--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -98,6 +98,16 @@ func isPagedFile(info os.FileInfo, filePath string) bool {
 		pagedFilenameRegexp.MatchString(path.Base(filePath))
 }
 
+// isChecksumValidatableFile checks if the file meets the expectations for checksum validation.
+func isChecksumValidatableFile(info os.FileInfo, filePath string) bool {
+	// For details on which file is paged see
+	//nolint:lll    // https://www.postgresql.org/message-id/flat/F0627DEB-7D0D-429B-97A9-D321450365B4%40yandex-team.ru#F0627DEB-7D0D-429B-97A9-D321450365B4@yandex-team.ru
+	return !info.IsDir() &&
+		(strings.Contains(filePath, DefaultTablespace) || strings.Contains(filePath, NonDefaultTablespace)) &&
+		info.Size() > 0 &&
+		pagedFilenameRegexp.MatchString(path.Base(filePath))
+}
+
 func ReadIncrementalFile(filePath string,
 	fileSize int64,
 	lsn LSN,

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -599,3 +599,18 @@ func (queryRunner *PgQueryRunner) getTables() (map[string]uint32, error) {
 
 	return tables, nil
 }
+
+// GetDataChecksums checks if data checksums are enabled
+func (queryRunner *PgQueryRunner) GetDataChecksums() (string, error) {
+	queryRunner.Mu.Lock()
+	defer queryRunner.Mu.Unlock()
+
+	var dataChecksums string
+	conn := queryRunner.Connection
+	err := conn.QueryRow("SHOW data_checksums").Scan(&dataChecksums)
+	if err != nil {
+		return "", errors.Wrap(err, "GetDataChecksums: failed to check data_checksums")
+	}
+
+	return dataChecksums, nil
+}

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -173,7 +173,10 @@ func (p *TarBallFilePackerImpl) createFileReadCloser(cfi *internal.ComposeFileIn
 
 func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool) ([]uint32, error) {
 	if !isChecksumValidatableFile(fileInfo, path) {
-		tracelog.DebugLogger.Printf("verifyFile: %s does not meet the criteria for checksum validation. File will be copied without checksum verification.\n", path)
+		tracelog.DebugLogger.Printf(
+			"verifyFile: %s does not meet the criteria for checksum validation. "+
+				"File will be copied without checksum verification.\n",
+			path)
 		_, err := io.Copy(io.Discard, fileReader)
 		return nil, err
 	}
@@ -181,7 +184,10 @@ func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncre
 	// if files don’t meet the size standard. The standard is that the file size divided by the block size should be an integer
 	// then skip the block check and copy the file directly with a warning message
 	if fileInfo.Size()%DatabasePageSize != 0 {
-		tracelog.WarningLogger.Printf("verifyFile: %s invalid file size %d. File copied without validation. The file may be corrupted.\n", path, fileInfo.Size())
+		tracelog.WarningLogger.Printf(
+			"verifyFile: %s invalid file size %d. File copied without validation. "+
+				"The file may be corrupted.\n",
+			path, fileInfo.Size())
 		_, err := io.Copy(io.Discard, fileReader)
 		return nil, err
 	}


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description
Hi everyone,

This is a new attempt to address issue #1140. The previous Pull Request related to this issue was made three years ago, and I’m now submitting a fresh update for the upcoming year, 2024. The old PR has been closed, and you can find the link to it here: [Previous closed PR #1143].

1. The function checkDataChecksums() executes the SQL query SHOW data_checksums, which has been supported since version 9.3. Therefore, we do not check the PostgreSQL version before executing it. At the start of the backup, if the user has used the -v (verify) flag, we check if data_checksums are enabled in the database. If they are not enabled, we warn the user about this.
```
   _INFO: 2024/09/06 11:41:44.787458 data_checksums is enabled in DB.
   or
   WARNING: 2024/09/07 13:27:08.224138 data_checksum is disabled in the database. Skipping checksum validation, which may result in undetected data corruption.
```

2. We have two options when database files don’t meet the size standard. The standard is that the file size divided by the block size should be an integer **(24576/8192=3)**. If not, the file size might be wrong or corrupted **(24596/8192=3,002)**.
- Option 1: Still check every block**
        •	Pros: The number and IDs of corrupted blocks will be recorded in the files_metadata.json.
        •	Cons: Extra work for checking a file that is already damaged, and if the damage is near the start of the file, more blocks will be marked as corrupted.
```
        #For instance: stdout with 1 option
        WARNING: 2024/09/06 11:10:34.775197 invalid page header encountered: blockNo 1633, path /var/lib/postgresql/16/main/base/16390/16568
        WARNING: 2024/09/06 11:10:34.775206 invalid page header encountered: blockNo 1634, path /var/lib/postgresql/16/main/base/16390/16568
        WARNING: 2024/09/06 11:10:34.775213 invalid page header encountered: blockNo 1635, path /var/lib/postgresql/16/main/base/16390/16568
        ... thousend of errors
        WARNING: 2024/09/06 11:10:34.775258 invalid page header encountered: blockNo 16039, path /var/lib/postgresql/16/main/base/16390/16568
        WARNING: 2024/09/06 11:10:34.775282 verifyPageBlocks: /var/lib/postgresql/16/main/base/16390/16568 invalid file size 13434892
```
- Option 2: Skip the block check and copy the file directly during func verifyFile() with a warning message:
    tracelog.WarningLogger.Printf("%s invalid file size %d. File copied without validation. The file may be corrupted.\n", path, fileInfo.Size())
        •	Pros: We avoid unnecessary checks and don’t flood stdout with thousands of records.
        •	Cons: The issue is only reported as a warning in stdout (no records of corrupted blocks in the files_metadata.json).
```
        #For instance: stdout with 2 option
        WARNING: 2024/09/06 11:41:44.825738 /var/lib/postgresql/16/main/base/16390/16551 invalid file size 8216. File copied without validation. The file may be corrupted.
        WARNING: 2024/09/06 11:41:44.825989 /var/lib/postgresql/16/main/base/16390/16568 invalid file size 13434892. File copied without validation. The file may be corrupted.
```
**Which option is better?”** (in my opinion the second)


3. I’m testing everything in a Vagrant environment. If it’s useful, I can create a separate PR with Vagrant tips and add a section in docs/README.md under Development/Installing that explains how to use it. Would this be of interest to the community, or would it be unnecessary?

### Please provide steps to reproduce (if it's a bug)
```
# Deleting old backups, keeping only one full backup
sudo -u postgres wal-g delete retain FULL 1 --confirm 

# Initializing data in database 
sudo -u postgres pgbench -i -s 1 -d maratos_db
sudo -u postgres psql -d maratos_db -c "DROP TABLE IF EXISTS public.test_table;"
sudo -u postgres psql -d maratos_db -c "CREATE TABLE public.test_table (id INT4 NOT NULL,name VARCHAR) WITH (fillfactor = 100);"
sudo -u postgres psql -d maratos_db -c "INSERT INTO public.test_table (id, name) VALUES (1, 'MARAT'); INSERT INTO public.test_table (id, name) VALUES (2, 'OLGA'); INSERT INTO public.test_table (id, name) VALUES (3, 'MISHA');"

# Getting the file path of 'pgbench_accounts' in the database
PG_FILE_PATH=$(sudo -u postgres psql -d maratos_db -Atc "select format('%s/%s', current_setting('data_directory'), pg_relation_filepath('pgbench_accounts'))")
PG_FILE_PATH2=$(sudo -u postgres psql -d maratos_db -Atc "select format('%s/%s', current_setting('data_directory'), pg_relation_filepath('test_table'))")
echo $PG_FILE_PATH
echo $PG_FILE_PATH2

# Executing the checkpoint command
sudo -u postgres psql -d maratos_db -c "checkpoint"

# Working with the file and replacing part of it with random data
rm tempfile
dd if=$PG_FILE_PATH of=tempfile bs=121900 count=1
dd if=/dev/urandom bs=123 count=1 >> tempfile
dd if=$PG_FILE_PATH bs=121900 skip=1 oflag=seek_bytes >> tempfile
mv tempfile $PG_FILE_PATH
chown postgres:postgres $PG_FILE_PATH
echo -n "Hello1" | dd conv=notrunc oflag=seek_bytes seek=8190 bs=67 count=1 of=$PG_FILE_PATH2

# Restarting PostgreSQL
systemctl restart postgresql

# Creating a new full backup or incremental 
sudo -u postgres wal-g backup-push -f -v -s /var/lib/postgresql/16/main

# Removing all files from the test directory for restoration
sudo -u postgres rm -rf /var/lib/postgresql/16_test/main/*

# Restoring the latest backup
LATEST_BACKUP=$(sudo -u postgres wal-g backup-list | tail -n 1 | awk '{print $1}')
echo $LATEST_BACKUP
sudo -u postgres wal-g backup-fetch /var/lib/postgresql/16_test/main $LATEST_BACKUP

# Getting the corresponding file path in the test directory for comparison
PG_TEST_FILE_PATH=$(echo $PG_FILE_PATH | sed 's/\/var\/lib\/postgresql\/16\/main/\/var\/lib\/postgresql\/16_test\/main/')
PG_TEST_FILE_PATH2=$(echo $PG_FILE_PATH2 | sed 's/\/var\/lib\/postgresql\/16\/main/\/var\/lib\/postgresql\/16_test\/main/')

# Comparing the restored file with the original
cmp $PG_TEST_FILE_PATH $PG_FILE_PATH
ls -l $PG_TEST_FILE_PATH $PG_FILE_PATH

cmp $PG_TEST_FILE_PATH2 $PG_FILE_PATH2
ls -l $PG_TEST_FILE_PATH2 $PG_FILE_PATH2

# metadata inspection
#LATEST_BACKUP_DIR="/var/lib/postgresql/wal-g/basebackups_005/$LATEST_BACKUP"
#jq . $LATEST_BACKUP_DIR/metadata.json
#jq '.Files | to_entries | map(select(.value.IsIncremented == false))' $LATEST_BACKUP_DIR/files_metadata.json
#hexdump -C /var/lib/postgresql/16_test/main/base/16390/16909
```

[WAL-G-Checksum_Validation.pdf](https://github.com/user-attachments/files/16919075/WAL-G-Checksum_Validation.pdf)

