### PR TITLE
greenplum: separate restore points fetch & find operations - so we can reuse fetched metadata.

### DIFF
--- a/cmd/gp/backup_fetch.go
+++ b/cmd/gp/backup_fetch.go
@@ -59,7 +59,9 @@ var backupFetchCmd = &cobra.Command{
 		}
 
 		if restorePointTS != "" {
-			restorePoint, err = greenplum.FindRestorePointBeforeTS(restorePointTS, storage.RootFolder())
+			restorePoints, err := greenplum.FetchAllRestorePoints(storage.RootFolder())
+			tracelog.ErrorLogger.FatalOnError(err)
+			restorePoint, err = greenplum.FindRestorePointBeforeTS(restorePointTS, restorePoints)
 			tracelog.ErrorLogger.FatalOnError(err)
 		}
 

--- a/internal/databases/greenplum/segment_delete_handler.go
+++ b/internal/databases/greenplum/segment_delete_handler.go
@@ -140,7 +140,13 @@ func GetPermanentBackupsAndWals(rootFolder storage.Folder, contentID int) (map[p
 	folder := rootFolder.GetSubFolder(FormatSegmentStoragePrefix(contentID))
 	backupTimes, err := internal.GetBackups(folder.GetSubFolder(utility.BaseBackupPath))
 	if err != nil {
-		tracelog.WarningLogger.Println("Error while time")
+		tracelog.WarningLogger.Println("Error while fetching backups")
+		return map[postgres.PermanentObject]bool{}, map[postgres.PermanentObject]bool{}
+	}
+
+	restorePointMetas, err := FetchAllRestorePoints(rootFolder)
+	if err != nil {
+		tracelog.WarningLogger.Println("Error while fetching restore points")
 		return map[postgres.PermanentObject]bool{}, map[postgres.PermanentObject]bool{}
 	}
 
@@ -161,7 +167,7 @@ func GetPermanentBackupsAndWals(rootFolder storage.Folder, contentID int) (map[p
 			continue
 		}
 
-		restorePoint, err := FindRestorePointWithTS(meta.StartTime.Format(time.RFC3339), rootFolder)
+		restorePoint, err := FindRestorePointWithTS(meta.StartTime.Format(time.RFC3339), restorePointMetas)
 		if err != nil {
 			internal.FatalOnUnrecoverableMetadataError(backupTime, err)
 			continue


### PR DESCRIPTION
We have observed slow `wal-g-gp delete garbage` on some hosts.

Got stacktraces:
```
curl http://127.0.0.1:9876/debug/pprof/goroutine?debug=2 | less
```
Almost all of them were sitting in fetching RestorePointsMetadata:
```
NewSegDeleteHandler()
    GetPermanentBackupsAndWals()
        FindRestorePointWithTS()
            FetchRestorePointMetadata()
                FetchDto()
```

We figured out that we have ~10000 restore points in cluster.

Also, in code we can see that we execute: restore_points_cnt * backups_cnt calls to S3 for each segment.

This PR moves restore points fetching out of the loop, so time complexity will be: restore_points_cnt + backups_cnt.

Expected result: faster garbage deletion