### PR TITLE
Fix `unsupported transport, *s3.loggingTransport` error if create S3 session multiple time

### DIFF
--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -33,6 +33,10 @@ func createSession(config *Config) (*session.Session, error) {
 		sessOpts.CustomCABundle = file
 	}
 
+	if http.DefaultClient.Transport != nil {
+		http.DefaultClient.Transport = nil
+	}
+
 	sess, err := session.NewSessionWithOptions(sessOpts)
 	if err != nil {
 		return nil, fmt.Errorf("init new session: %w", err)


### PR DESCRIPTION
### Database name
MongoDB

# Pull request description

### Describe what this PR fix
For mongodb `olpog-push`, walg configure storage twice [oplog_push.go#L58](https://github.com/wal-g/wal-g/blob/master/cmd/mongo/oplog_push.go#L58) and [oplog_push.go#L88](https://github.com/wal-g/wal-g/blob/master/cmd/mongo/oplog_push.go#L88). In storage configuration, everytime after creating a session, that session is configured [here](https://github.com/wal-g/wal-g/blob/master/pkg/storages/s3/session.go#L36C1-L44C3). while configuring session walg is making `http.DefaultClient.Transport` to `*s3.loggingTransport` type. This is making problem while again creating session in aws-sdk-go [here](https://github.com/aws/aws-sdk-go/blob/main/aws/session/session.go#L625C1-L629C3) if we use `WALG_S3_CA_CERT_FILE`, because aws-sdk-go use default http client ([session.go#L457](https://github.com/aws/aws-sdk-go/blob/main/aws/session/session.go#L457) -> [defaults.go#L60](https://github.com/aws/aws-sdk-go/blob/main/aws/defaults/defaults.go#L60)). 

So if we make `http.DefaultClient.Transport` to nil before creating s3 session, I hope this issue will fix.

### Please provide steps to reproduce (if it's a bug)
- Set the WALG_S3_CA_CERT_FILE environment variable to point to a custom CA bundle file.
- Upgrade wal-g to version v3.0.1.
- Run any wal-g command (for example wal-g oplog-push).

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
DEBUG: 2024/10/02 16:33:57.110342 starting oplog archiving with arguments: {archiveAfterSize:16777216 archiveTimeout:60000000000 mongodbURL:mongodb://root:VY36tlrlMvxUG8bU@localhost:27018/?authSource=admin&connect=direct primaryWait:true primaryWaitTimeout:30000000000 lwUpdate:3000000000}
DEBUG: 2024/10/02 16:33:57.125115 starting archiving stats with arguments: {enabled:false updateInterval:0 logInterval:0 exposeHTTP:false httpPrefix:}
INFO: 2024/10/02 16:33:57.126075 Removing sigmask. Shutting down
ERROR: 2024/10/02 16:33:57.126115 configure storage with prefix "s3://stash/sayed/demo/sample-mongodb/oplog-backup": create S3 storage: create new AWS session: init new session: LoadCustomCABundleError: unable to load custom CA bundle, HTTPClient's transport unsupported type
caused by: unsupported transport, *s3.loggingTransport
```
</p>
</details>
