### PR TITLE
fix: fix slice init length

### DIFF
--- a/internal/multistorage/storage.go
+++ b/internal/multistorage/storage.go
@@ -109,7 +109,7 @@ func (ce *CloseError) Add(err error) {
 }
 
 func (ce *CloseError) Error() string {
-	errMsgs := make([]string, len(ce.specificStorageErrs))
+	errMsgs := make([]string, 0, len(ce.specificStorageErrs))
 	for _, e := range ce.specificStorageErrs {
 		errMsgs = append(errMsgs, e.Error())
 	}


### PR DESCRIPTION
### Describe what this PR fix


The intention here should be to initialize a slice with a capacity of  len(ce.specificStorageErrs)   rather than initializing the length of this slice. 

The only demo: https://go.dev/play/p/q1BcVCmvidW