### PR TITLE
Add JournalSize to backup sentinels

### DIFF
--- a/cmd/mysql/backup_push.go
+++ b/cmd/mysql/backup_push.go
@@ -13,6 +13,7 @@ import (
 const (
 	backupPushShortDescription = "Creates new backup and pushes it to storage"
 	permanentFlag              = "permanent"
+	countJournalsFlag          = "count-journals"
 	addUserDataFlag            = "add-user-data"
 
 	permanentShorthand = "p"
@@ -48,14 +49,16 @@ var (
 				uploader,
 				backupCmd,
 				permanent,
+				countJournals,
 				true,
 				userData,
 				mysql.NewNoDeltaBackupConfigurator(),
 			)
 		},
 	}
-	permanent = false
-	userData  = ""
+	permanent     = false
+	countJournals = false
+	userData      = ""
 )
 
 func init() {
@@ -67,4 +70,6 @@ func init() {
 		false, "Pushes permanent backup")
 	backupPushCmd.Flags().StringVar(&userData, addUserDataFlag,
 		"", "Write the provided user data to the backup sentinel and metadata files.")
+	backupPushCmd.Flags().BoolVar(&countJournals, countJournalsFlag,
+		false, "Create 'backups.json' file in the bucket and maintain the binlog sizes required to get from one backup to the next one")
 }

--- a/cmd/mysql/xtrabackup_push.go
+++ b/cmd/mysql/xtrabackup_push.go
@@ -62,6 +62,7 @@ var (
 				uploader,
 				backupCmd,
 				permanent,
+				countJournals,
 				fullBackup,
 				userData,
 				mysql.NewRegularDeltaBackupConfigurator(folder, deltaBaseSelector),
@@ -88,4 +89,6 @@ func init() {
 		"", "Select the backup specified by UserData as the target for the delta backup")
 	xtrabackupPushCmd.Flags().StringVar(&userData, addUserDataFlag,
 		"", "Write the provided user data to the backup sentinel and metadata files.")
+	xtrabackupPushCmd.Flags().BoolVar(&countJournals, countJournalsFlag,
+		false, "Create 'backups.json' file in the bucket and maintain the binlog sizes required to get from one backup to the next one")
 }

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -76,7 +76,14 @@ func HandleBackupPush(
 	tracelog.ErrorLogger.FatalfOnError("failed to get last uploaded binlog (after): %v", err)
 	timeStop := utility.TimeNowCrossPlatformLocal()
 
-	err = internal.AddJournalSizeToPreviousBackup(folder, BinlogPath, utility.BaseBackupPath, lastSentinel.GetName(), lastSentinel.GetLastModified(), timeStop)
+	err = internal.AddJournalSizeToPreviousBackup(
+		folder,
+		BinlogPath,
+		utility.BaseBackupPath,
+		lastSentinel.GetName(),
+		lastSentinel.GetLastModified(),
+		timeStop,
+	)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("Failed to push journal size to the previous backup: %v", err)
 	}

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -81,8 +81,15 @@ func HandleBackupPush(
 			BinlogPath,
 			utility.BaseBackupPath,
 			lastSentinel.GetName(),
-			lastSentinel.GetLastModified(),
-			timeStop,
+			func(sentinel map[string]interface{}) (firstBackupJournal string, lastBackupJournal string) {
+				firstBackupJournal = sentinel["BinLogEnd"].(string)
+				lastBackupJournal = binlogEnd
+				tracelog.InfoLogger.Printf("We take in account binlogs in the semi interval (%s;%s]", firstBackupJournal, lastBackupJournal)
+				return firstBackupJournal, lastBackupJournal
+			},
+			func(a, b string) bool {
+				return a < b
+			},
 		)
 		if err != nil {
 			tracelog.ErrorLogger.Printf("Failed to push journal size to the previous backup: %v", err)

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -76,16 +76,18 @@ func HandleBackupPush(
 	tracelog.ErrorLogger.FatalfOnError("failed to get last uploaded binlog (after): %v", err)
 	timeStop := utility.TimeNowCrossPlatformLocal()
 
-	err = internal.AddJournalSizeToPreviousBackup(
-		folder,
-		BinlogPath,
-		utility.BaseBackupPath,
-		lastSentinel.GetName(),
-		lastSentinel.GetLastModified(),
-		timeStop,
-	)
-	if err != nil {
-		tracelog.ErrorLogger.Printf("Failed to push journal size to the previous backup: %v", err)
+	if lastSentinel != nil {
+		err = internal.AddJournalSizeToPreviousBackup(
+			folder,
+			BinlogPath,
+			utility.BaseBackupPath,
+			lastSentinel.GetName(),
+			lastSentinel.GetLastModified(),
+			timeStop,
+		)
+		if err != nil {
+			tracelog.ErrorLogger.Printf("Failed to push journal size to the previous backup: %v", err)
+		}
 	}
 
 	uploadedSize, err := uploader.UploadedDataSize()

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -22,6 +22,7 @@ func HandleBackupPush(
 	uploader internal.Uploader,
 	backupCmd *exec.Cmd,
 	isPermanent bool,
+	countJournals bool,
 	isFullBackup bool,
 	userDataRaw string,
 	deltaBackupConfigurator DeltaBackupConfigurator,
@@ -120,36 +121,43 @@ func HandleBackupPush(
 	err = internal.UploadSentinel(uploader, &sentinel, backupName)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	lastSentinelName, lastSentinel, err := internal.GetLastNotPermanentBackupInfo(folder)
+	if !countJournals {
+		tracelog.InfoLogger.Printf("binlog counting mode is disabled: option is disabled")
+		return
+	}
+
+	// permanent backups can live longer than binlogs; they should not take part in binlog counting
+	if isPermanent {
+		tracelog.InfoLogger.Printf("binlog counting mode is disabled: the backup is permanent")
+		return
+	}
+
+	lastSentinelName, lastSentinel, err := internal.GetLastBackupInfo(folder)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("failed to find the last backup: %v", err)
 	} else {
 		tracelog.InfoLogger.Printf("last sentinel is %+v", lastSentinelName)
 	}
 
-	newBackupInfo := internal.BackupInfo{
-		JournalStart:     lastSentinel.JournalEnd,
-		JournalEnd:       binlogEnd,
-		JournalSize:      0,
-		CompressedSize:   uploadedSize,
-		UncompressedSize: rawSize,
-		IsPermanent:      isPermanent,
-		StopLocalTime:    timeStop,
+	newBackupInfo := internal.JournalInfo{
+		JournalStart: lastSentinel.JournalEnd,
+		JournalEnd:   binlogEnd,
+		JournalSize:  0,
 	}
 
-	// permanent backups can live longer than binlogs; they should not take part in binlog counting
-	if !isPermanent && err == nil {
-		err = internal.UpdatePreviousBackupInfoJournal(folder, BinlogPath, newBackupInfo.JournalEnd)
-		if err != nil {
-			tracelog.ErrorLogger.Printf("unable to update previous backup info for %s: %s", backupName, err)
-		} else {
-			tracelog.InfoLogger.Printf("updated backup info for %s", backupName)
-		}
+	err = internal.UpdatePreviousBackupInfo(
+		folder,
+		BinlogPath,
+		func(a, b string) bool { return a < b },
+		newBackupInfo.JournalEnd,
+	)
+	if err != nil {
+		tracelog.ErrorLogger.Printf("unable to update previous backup info for %s: %s", backupName, err)
 	} else {
-		tracelog.InfoLogger.Printf("skipping update of last backup's journal, due to either the new backup being permanent or an error: %s", err)
+		tracelog.InfoLogger.Printf("updated backup info for %s", backupName)
 	}
 
-	err = internal.UploadBackupInfo(folder, backupName+utility.SentinelSuffix, newBackupInfo)
+	err = internal.UploadBackupInfo(folder, backupName, newBackupInfo)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("failed to upload backup info for %s: %s", backupName, err)
 		return

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -35,7 +35,6 @@ func HandleBackupPush(
 	lastSentinel, err := getLastUploadedBackupSentinel(folder)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("failed to find the last backup: %v", err)
-		return
 	}
 
 	db, err := getMySQLConnection()

--- a/internal/databases/mysql/mysql.go
+++ b/internal/databases/mysql/mysql.go
@@ -146,13 +146,13 @@ func getLastUploadedBackupSentinel(folder storage.Folder) (storage.Object, error
 		tracelog.InfoLogger.Printf("can not find backup sentinels")
 		return nil, nil
 	}
-	oldest := logFiles[0]
+	latestSentinel := logFiles[0]
 	for i := 1; i < len(logFiles); i++ {
-		if logFiles[i].GetLastModified().After(oldest.GetLastModified()) {
-			oldest = logFiles[i]
+		if logFiles[i].GetLastModified().After(latestSentinel.GetLastModified()) {
+			latestSentinel = logFiles[i]
 		}
 	}
-	return oldest, nil
+	return latestSentinel, nil
 }
 
 func getLastUploadedBinlogBeforeGTID(folder storage.Folder, gtid gomysql.GTIDSet, flavor string) (string, error) {

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -16,7 +16,14 @@ const (
 	JournalSize = "JournalSize"
 )
 
-func AddJournalSizeToPreviousBackup(root storage.Folder, journalPath string, sentinelPath string, sentinelName string, oldBackupTime, newBackupTime time.Time) error {
+func AddJournalSizeToPreviousBackup(
+	root storage.Folder,
+	journalPath string,
+	sentinelPath string,
+	sentinelName string,
+	oldBackupTime time.Time,
+	newBackupTime time.Time,
+) error {
 	if len(sentinelName) == 0 {
 		return fmt.Errorf("sentinel name is empty")
 	}
@@ -44,12 +51,12 @@ func AddJournalSizeToPreviousBackup(root storage.Folder, journalPath string, sen
 	}
 
 	sentinel[JournalSize] = journalSize
-	sentinelJson, err := json.Marshal(sentinel)
+	sentinelJSON, err := json.Marshal(sentinel)
 	if err != nil {
 		return err
 	}
 
-	r := bytes.NewReader(sentinelJson)
+	r := bytes.NewReader(sentinelJSON)
 	err = folder.PutObject(sentinelName, r)
 	if err != nil {
 		return err

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -1,0 +1,82 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/wal-g/tracelog"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+const (
+	JournalSize = "JournalSize"
+)
+
+func AddJournalSizeToPreviousBackup(root storage.Folder, journalPath string, sentinelPath string, sentinelName string, oldBackupTime, newBackupTime time.Time) error {
+	if len(sentinelName) == 0 {
+		return fmt.Errorf("sentinel name is empty")
+	}
+
+	folder := root.GetSubFolder(sentinelPath)
+	sentinelReader, err := folder.ReadObject(sentinelName)
+	if err != nil {
+		return err
+	}
+
+	rawSentinel, err := io.ReadAll(sentinelReader)
+	if err != nil {
+		return err
+	}
+
+	var sentinel map[string]interface{}
+	err = json.Unmarshal(rawSentinel, &sentinel)
+	if err != nil {
+		return err
+	}
+
+	journalSize, err := GetJournalSizeInSemiInterval(root, journalPath, oldBackupTime, newBackupTime)
+	if err != nil {
+		return err
+	}
+
+	sentinel[JournalSize] = journalSize
+	sentinelJson, err := json.Marshal(sentinel)
+	if err != nil {
+		return err
+	}
+
+	r := bytes.NewReader(sentinelJson)
+	err = folder.PutObject(sentinelName, r)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// (start;end]
+func GetJournalSizeInSemiInterval(folder storage.Folder, journalPath string, start, end time.Time) (int64, error) {
+	folder = folder.GetSubFolder(journalPath)
+	journalFiles, _, err := folder.ListFolder()
+	if err != nil {
+		return 0, err
+	}
+	if len(journalFiles) == 0 {
+		return 0, nil
+	}
+
+	sum := int64(0)
+	for i := 0; i < len(journalFiles); i++ {
+		jt := journalFiles[i].GetLastModified()
+		if start.Before(jt) && (end.After(jt) || end.Equal(jt)) {
+			sum += journalFiles[i].GetSize()
+		}
+	}
+	tracelog.InfoLogger.Printf("Journal Sum: %d\n", sum)
+
+	return sum, nil
+}

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -1,0 +1,219 @@
+package internal_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/ioextensions"
+	"github.com/wal-g/wal-g/pkg/storages/memory"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/testtools"
+	"github.com/wal-g/wal-g/utility"
+)
+
+var (
+	ZeroDate         = time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
+	FutureDate       = time.Now().Add(time.Hour * 8760)
+	SentinelFilePath = "sentinel"
+)
+
+func GenerateS3SetAndTest(t *testing.T, recordCount, recordSize int, beginTimeFunc, endTimeFunc func([]storage.Object) time.Time, expected int) {
+	root, mockUploader := initTestS3()
+
+	generateAndUploadData(mockUploader, recordCount, recordSize)
+
+	start, end := getTimeIntervalByData(t, root, beginTimeFunc, endTimeFunc)
+
+	journalSize, err := internal.GetJournalSizeInSemiInterval(root, utility.WalPath, start, end)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(expected), journalSize)
+}
+
+func GenerateS3SetAndAddJournalToOldBackup(t *testing.T, recordCount, recordSize int, beginTimeFunc, endTimeFunc func([]storage.Object) time.Time, expected int) {
+	root, mockUploader := initTestS3()
+
+	generateAndUploadData(mockUploader, recordCount, recordSize)
+
+	start, end := getTimeIntervalByData(t, root, beginTimeFunc, endTimeFunc)
+
+	createEmptySentinel(t, root)
+
+	err := internal.AddJournalSizeToPreviousBackup(root, utility.WalPath, "", SentinelFilePath, start, end)
+	assert.NoError(t, err)
+
+	journalSize := readJournalSizeFromSentinel(t, root)
+	assert.Equal(t, int64(expected), journalSize)
+}
+
+func initTestS3() (*memory.Folder, internal.Uploader) {
+	storage := memory.NewKVS()
+	root := memory.NewFolder("", storage)
+	mockUploader := internal.NewRegularUploader(
+		&testtools.MockCompressor{},
+		root.GetSubFolder(utility.WalPath),
+	)
+	return root, mockUploader
+}
+
+func generateAndUploadData(mockUploader internal.Uploader, recordCount, recordSize int) {
+	record := strings.Repeat("a", recordSize)
+	for i := 0; i < recordCount; i++ {
+		journalName := fmt.Sprintf("%d", i)
+
+		r := bytes.NewReader([]byte(record))
+		mockUploader.UploadFile(context.Background(), ioextensions.NewNamedReaderImpl(r, journalName))
+	}
+}
+
+func createEmptySentinel(t *testing.T, root storage.Folder) {
+	err := root.PutObject(SentinelFilePath, bytes.NewReader([]byte("{}")))
+	assert.NoError(t, err)
+}
+
+func readJournalSizeFromSentinel(t *testing.T, root storage.Folder) int64 {
+	var sentinel map[string]json.RawMessage
+	sentinelReader, err := root.ReadObject(SentinelFilePath)
+	assert.NoError(t, err)
+
+	rawSentinel, err := io.ReadAll(sentinelReader)
+	assert.NoError(t, err)
+
+	err = json.Unmarshal(rawSentinel, &sentinel)
+	assert.NoError(t, err)
+
+	journalSize, err := strconv.ParseInt(string(sentinel[internal.JournalSize]), 10, 64)
+	assert.NoError(t, err)
+
+	return journalSize
+}
+
+func getTimeIntervalByData(t *testing.T, root *memory.Folder, beginTimeFunc, endTimeFunc func([]storage.Object) time.Time) (time.Time, time.Time) {
+	jfiles, _, err := root.GetSubFolder(utility.WalPath).ListFolder()
+	assert.NoError(t, err)
+
+	sort.Slice(jfiles, func(i, j int) bool {
+		return jfiles[i].GetLastModified().Before(jfiles[j].GetLastModified())
+	})
+
+	return beginTimeFunc(jfiles), endTimeFunc(jfiles)
+}
+
+func TestEmptyFolder(t *testing.T) {
+	recordCount := 0
+	recordSize := 0
+	begin := func([]storage.Object) time.Time { return ZeroDate }
+	end := func([]storage.Object) time.Time { return FutureDate }
+	expectedSize := 0
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestOneJournal(t *testing.T) {
+	recordCount := 1
+	recordSize := 8
+	begin := func([]storage.Object) time.Time { return ZeroDate }
+	end := func([]storage.Object) time.Time { return FutureDate }
+	expectedSize := 8
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestManyJournals(t *testing.T) {
+	recordCount := 100
+	recordSize := 8
+	begin := func([]storage.Object) time.Time { return ZeroDate }
+	end := func([]storage.Object) time.Time { return FutureDate }
+	expectedSize := 800
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestSimpleFrom(t *testing.T) {
+	recordCount := 3
+	recordSize := 8
+	begin := func(jfiles []storage.Object) time.Time { return jfiles[1].GetLastModified() }
+	end := func([]storage.Object) time.Time { return FutureDate }
+	expectedSize := 8
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestSimpleTo(t *testing.T) {
+	recordCount := 3
+	recordSize := 8
+	begin := func([]storage.Object) time.Time { return ZeroDate }
+	end := func(jfiles []storage.Object) time.Time { return jfiles[1].GetLastModified() }
+	expectedSize := 16
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestHalfFrom(t *testing.T) {
+	recordCount := 100
+	recordSize := 8
+	begin := func(jfiles []storage.Object) time.Time { return jfiles[49].GetLastModified() }
+	end := func([]storage.Object) time.Time { return FutureDate }
+	expectedSize := 400
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestHalfTo(t *testing.T) {
+	recordCount := 100
+	recordSize := 8
+	begin := func([]storage.Object) time.Time { return ZeroDate }
+	end := func(jfiles []storage.Object) time.Time { return jfiles[49].GetLastModified() }
+	expectedSize := 400
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestEmptySetOnTheRightSide(t *testing.T) {
+	recordCount := 100
+	recordSize := 8
+	begin := func(jfiles []storage.Object) time.Time { return jfiles[99].GetLastModified() }
+	end := func([]storage.Object) time.Time { return FutureDate }
+	expectedSize := 0
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestEmptySetOnTheLeftSide(t *testing.T) {
+	recordCount := 100
+	recordSize := 8
+	begin := func([]storage.Object) time.Time { return ZeroDate }
+	end := func(jfiles []storage.Object) time.Time { return jfiles[0].GetLastModified().Add(-time.Microsecond) }
+	expectedSize := 0
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}
+
+func TestOnlyFirstRecord(t *testing.T) {
+	recordCount := 100
+	recordSize := 8
+	begin := func([]storage.Object) time.Time { return ZeroDate }
+	end := func(jfiles []storage.Object) time.Time { return jfiles[0].GetLastModified() }
+	expectedSize := 8
+
+	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	GenerateS3SetAndAddJournalToOldBackup(t, recordCount, recordSize, begin, end, expectedSize)
+}

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -6,11 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
@@ -22,37 +20,53 @@ import (
 )
 
 var (
-	ZeroDate         = time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
-	FutureDate       = time.Now().Add(time.Hour * 8760)
-	SentinelFilePath = "sentinel"
+	JournalFmt           = "%09d"
+	SentinelFilePath     = "sentinel"
+	MinimalJournalNumber = "000000000"
+	MaximalJournalNumber = "999999999"
 )
 
-func GenerateS3SetAndTest(t *testing.T, recordCount, recordSize int, beginTimeFunc, endTimeFunc func([]storage.Object) time.Time, expected int) {
+func GenerateS3SetAndTest(t *testing.T, recordCount, recordSize int, beginJournalID, endJournalID string, expectedSum int) {
 	root, mockUploader := initTestS3()
 
 	generateAndUploadData(mockUploader, recordCount, recordSize)
 
-	start, end := getTimeIntervalByData(t, root, beginTimeFunc, endTimeFunc)
-
-	journalSize, err := internal.GetJournalSizeInSemiInterval(root, utility.WalPath, start, end)
+	journalSize, err := internal.GetJournalSizeInSemiInterval(
+		root,
+		utility.WalPath,
+		func(a, b string) bool {
+			return a < b
+		},
+		beginJournalID,
+		endJournalID,
+	)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(expected), journalSize)
+	assert.Equal(t, int64(expectedSum), journalSize)
 }
 
-func GenerateS3SetAndAddJournalToOldBackup(t *testing.T, recordCount, recordSize int, beginTimeFunc, endTimeFunc func([]storage.Object) time.Time, expected int) {
+func GenerateS3SetAndAddJournalToOldBackup(t *testing.T, recordCount, recordSize int, beginJournalID, endJournalID string, expectedSum int) {
 	root, mockUploader := initTestS3()
 
 	generateAndUploadData(mockUploader, recordCount, recordSize)
-
-	start, end := getTimeIntervalByData(t, root, beginTimeFunc, endTimeFunc)
 
 	createEmptySentinel(t, root)
 
-	err := internal.AddJournalSizeToPreviousBackup(root, utility.WalPath, "", SentinelFilePath, start, end)
+	err := internal.AddJournalSizeToPreviousBackup(
+		root,
+		utility.WalPath,
+		"",
+		SentinelFilePath,
+		func(sentinel map[string]interface{}) (firstBackupJournal string, lastBackupJournal string) {
+			return beginJournalID, endJournalID
+		},
+		func(a, b string) bool {
+			return a < b
+		},
+	)
 	assert.NoError(t, err)
 
 	journalSize := readJournalSizeFromSentinel(t, root)
-	assert.Equal(t, int64(expected), journalSize)
+	assert.Equal(t, int64(expectedSum), journalSize)
 }
 
 func initTestS3() (*memory.Folder, internal.Uploader) {
@@ -65,10 +79,15 @@ func initTestS3() (*memory.Folder, internal.Uploader) {
 	return root, mockUploader
 }
 
+func toJournalNumber(index int) string {
+	return fmt.Sprintf(JournalFmt, index)
+}
+
 func generateAndUploadData(mockUploader internal.Uploader, recordCount, recordSize int) {
 	record := strings.Repeat("a", recordSize)
-	for i := 0; i < recordCount; i++ {
-		journalName := fmt.Sprintf("%d", i)
+	// numerate journal names from 1 to make "MinimalJournalNumber" the minimal journal
+	for i := 1; i <= recordCount; i++ {
+		journalName := fmt.Sprintf(JournalFmt, i)
 
 		r := bytes.NewReader([]byte(record))
 		mockUploader.UploadFile(context.Background(), ioextensions.NewNamedReaderImpl(r, journalName))
@@ -97,22 +116,11 @@ func readJournalSizeFromSentinel(t *testing.T, root storage.Folder) int64 {
 	return journalSize
 }
 
-func getTimeIntervalByData(t *testing.T, root *memory.Folder, beginTimeFunc, endTimeFunc func([]storage.Object) time.Time) (time.Time, time.Time) {
-	jfiles, _, err := root.GetSubFolder(utility.WalPath).ListFolder()
-	assert.NoError(t, err)
-
-	sort.Slice(jfiles, func(i, j int) bool {
-		return jfiles[i].GetLastModified().Before(jfiles[j].GetLastModified())
-	})
-
-	return beginTimeFunc(jfiles), endTimeFunc(jfiles)
-}
-
 func TestEmptyFolder(t *testing.T) {
 	recordCount := 0
 	recordSize := 0
-	begin := func([]storage.Object) time.Time { return ZeroDate }
-	end := func([]storage.Object) time.Time { return FutureDate }
+	begin := MinimalJournalNumber
+	end := MaximalJournalNumber
 	expectedSize := 0
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -122,8 +130,8 @@ func TestEmptyFolder(t *testing.T) {
 func TestOneJournal(t *testing.T) {
 	recordCount := 1
 	recordSize := 8
-	begin := func([]storage.Object) time.Time { return ZeroDate }
-	end := func([]storage.Object) time.Time { return FutureDate }
+	begin := MinimalJournalNumber
+	end := MaximalJournalNumber
 	expectedSize := 8
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -133,8 +141,8 @@ func TestOneJournal(t *testing.T) {
 func TestManyJournals(t *testing.T) {
 	recordCount := 100
 	recordSize := 8
-	begin := func([]storage.Object) time.Time { return ZeroDate }
-	end := func([]storage.Object) time.Time { return FutureDate }
+	begin := MinimalJournalNumber
+	end := MaximalJournalNumber
 	expectedSize := 800
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -144,8 +152,8 @@ func TestManyJournals(t *testing.T) {
 func TestSimpleFrom(t *testing.T) {
 	recordCount := 3
 	recordSize := 8
-	begin := func(jfiles []storage.Object) time.Time { return jfiles[1].GetLastModified() }
-	end := func([]storage.Object) time.Time { return FutureDate }
+	begin := toJournalNumber(2)
+	end := MaximalJournalNumber
 	expectedSize := 8
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -155,8 +163,8 @@ func TestSimpleFrom(t *testing.T) {
 func TestSimpleTo(t *testing.T) {
 	recordCount := 3
 	recordSize := 8
-	begin := func([]storage.Object) time.Time { return ZeroDate }
-	end := func(jfiles []storage.Object) time.Time { return jfiles[1].GetLastModified() }
+	begin := MinimalJournalNumber
+	end := toJournalNumber(2)
 	expectedSize := 16
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -166,8 +174,8 @@ func TestSimpleTo(t *testing.T) {
 func TestHalfFrom(t *testing.T) {
 	recordCount := 100
 	recordSize := 8
-	begin := func(jfiles []storage.Object) time.Time { return jfiles[49].GetLastModified() }
-	end := func([]storage.Object) time.Time { return FutureDate }
+	begin := toJournalNumber(50)
+	end := MaximalJournalNumber
 	expectedSize := 400
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -177,8 +185,8 @@ func TestHalfFrom(t *testing.T) {
 func TestHalfTo(t *testing.T) {
 	recordCount := 100
 	recordSize := 8
-	begin := func([]storage.Object) time.Time { return ZeroDate }
-	end := func(jfiles []storage.Object) time.Time { return jfiles[49].GetLastModified() }
+	begin := MinimalJournalNumber
+	end := toJournalNumber(50)
 	expectedSize := 400
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -188,8 +196,8 @@ func TestHalfTo(t *testing.T) {
 func TestEmptySetOnTheRightSide(t *testing.T) {
 	recordCount := 100
 	recordSize := 8
-	begin := func(jfiles []storage.Object) time.Time { return jfiles[99].GetLastModified() }
-	end := func([]storage.Object) time.Time { return FutureDate }
+	begin := toJournalNumber(100)
+	end := MaximalJournalNumber
 	expectedSize := 0
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -199,8 +207,8 @@ func TestEmptySetOnTheRightSide(t *testing.T) {
 func TestEmptySetOnTheLeftSide(t *testing.T) {
 	recordCount := 100
 	recordSize := 8
-	begin := func([]storage.Object) time.Time { return ZeroDate }
-	end := func(jfiles []storage.Object) time.Time { return jfiles[0].GetLastModified().Add(-time.Microsecond) }
+	begin := MinimalJournalNumber
+	end := MinimalJournalNumber
 	expectedSize := 0
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)
@@ -210,8 +218,8 @@ func TestEmptySetOnTheLeftSide(t *testing.T) {
 func TestOnlyFirstRecord(t *testing.T) {
 	recordCount := 100
 	recordSize := 8
-	begin := func([]storage.Object) time.Time { return ZeroDate }
-	end := func(jfiles []storage.Object) time.Time { return jfiles[0].GetLastModified() }
+	begin := MinimalJournalNumber
+	end := toJournalNumber(1)
 	expectedSize := 8
 
 	GenerateS3SetAndTest(t, recordCount, recordSize, begin, end, expectedSize)

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -30,13 +30,13 @@ func GenerateDataAndTest(
 	beginJournalID, endJournalID string,
 	expectedSum int64,
 ) {
-	GenerateS3SetAndTest(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
+	GenerateS3SetAndCheckJournalSizes(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
 	GenerateS3SetAndUpdateBackupsInfo(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
 	GenerateS3SetAndUpdateBackupsInfoManyTimes(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
 	GenerateS3AndUpdateLastBackup(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
 }
 
-func GenerateS3SetAndTest(
+func GenerateS3SetAndCheckJournalSizes(
 	t *testing.T,
 	recordCount, recordSize int,
 	beginJournalID, endJournalID string,


### PR DESCRIPTION
### Database name
MySQL

# Pull request description
It can be useful to know journal size from one backup to another to estimate recovery time or bill user.

### Describe what this PR fix
Add JournalSize in sentinels and evaluate the sum of binlog size in the semi interval (time of the previous backup; time of new the backup]. If a backup falls within the specified interval, it will be taken into account. Binlog size sum is written to the previous backup sentinel.
