### PR TITLE
Add makezero and asciicheck linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,8 @@ linters:
     - stylecheck
     - gosimple
     - whitespace
+    - makezero
+    - asciicheck
 
 run:
   go: "1.22"


### PR DESCRIPTION
Add more linters.


I was trying to revive https://github.com/wal-g/wal-g/pull/1726, however it seems that `prealloc ` linter is too agressive and enforces its own codestyle =/

Thanks to all people who participated in linter promotion:
@annetannet
@debebantur
@cuishuang
@haiderRizvii
@alingse