### PR TITLE
Fix Postgres 12+/Cloudberry concurrent backups.

### DIFF
--- a/docker/cloudberry_tests/scripts/tests/backup_after_failed_backup_test.sh
+++ b/docker/cloudberry_tests/scripts/tests/backup_after_failed_backup_test.sh
@@ -31,9 +31,7 @@ wal-g backup-list --config=${TMP_CONFIG}
 # show the storage objects (useful for debug)
 wal-g st ls -r --config=${TMP_CONFIG}
 
-# it looks like a bug in `tryExtractFiles` - it can override files when WALG_DOWNLOAD_CONCURRENCY != 1
-# https://github.com/wal-g/wal-g/blob/master/internal/extract.go#L201-L253
-WALG_DOWNLOAD_CONCURRENCY=1  wal-g backup-fetch LATEST --in-place --config=${TMP_CONFIG}
+wal-g backup-fetch LATEST --in-place --config=${TMP_CONFIG}
 prepare_cluster
 start_cluster
 cleanup

--- a/internal/databases/greenplum/extract_provider.go
+++ b/internal/databases/greenplum/extract_provider.go
@@ -15,16 +15,16 @@ func (t ExtractProviderImpl) Get(
 	skipRedundantTars bool,
 	dbDataDir string,
 	createNewIncrementalFiles bool,
-) (postgres.IncrementalTarInterpreter, []internal.ReaderMaker, string, error) {
+) (postgres.IncrementalTarInterpreter, []internal.ReaderMaker, []internal.ReaderMaker, error) {
 	segBackup := ToGpSegBackup(backup)
 
 	interpreter, err := t.getTarInterpreter(dbDataDir, segBackup, filesToUnwrap, createNewIncrementalFiles)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, nil, err
 	}
 
-	tarsToExtract, pgControlKey, err := t.FilesToExtractProviderImpl.Get(segBackup, filesToUnwrap, skipRedundantTars)
-	return interpreter, tarsToExtract, pgControlKey, err
+	concurrentTarsToExtract, sequentialTarsToExtract, err := t.FilesToExtractProviderImpl.Get(segBackup, filesToUnwrap, skipRedundantTars)
+	return interpreter, concurrentTarsToExtract, sequentialTarsToExtract, err
 }
 
 func (t ExtractProviderImpl) getTarInterpreter(dbDataDir string, backup SegBackup,

--- a/internal/databases/greenplum/extract_provider_with_spec.go
+++ b/internal/databases/greenplum/extract_provider_with_spec.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
@@ -52,7 +53,7 @@ func (p ExtractProviderDBSpec) Get(
 	skipRedundantTars bool,
 	dbDataDir string,
 	createNewIncrementalFiles bool,
-) (postgres.IncrementalTarInterpreter, []internal.ReaderMaker, string, error) {
+) (postgres.IncrementalTarInterpreter, []internal.ReaderMaker, []internal.ReaderMaker, error) {
 	_, filesMeta, err := backup.GetSentinelAndFilesMetadata()
 	tracelog.ErrorLogger.FatalOnError(err)
 

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -348,7 +348,9 @@ func (bh *BackupHandler) uploadBackup() internal.TarFileSets {
 
 	// Stops backup and write/upload postgres `backup_label` and `tablespace_map` Files
 	tracelog.DebugLogger.Println("Stop backup and upload backup_label and tablespace_map")
-	labelFilesTarBallName, labelFilesList, finishLsn, err := bundle.uploadLabelFiles(bh.Workers.QueryRunner, bh.Arguments.Uploader.Compression().FileExtension())
+	labelFilesTarBallName, labelFilesList, finishLsn, err := bundle.uploadLabelFiles(
+		bh.Workers.QueryRunner,
+		bh.Arguments.Uploader.Compression().FileExtension())
 	tracelog.ErrorLogger.FatalOnError(err)
 	bh.CurBackupInfo.endLSN = finishLsn
 	bh.CurBackupInfo.uncompressedSize = atomic.LoadInt64(bundle.TarBallQueue.AllTarballsSize)

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
+
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
@@ -23,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -346,7 +348,7 @@ func (bh *BackupHandler) uploadBackup() internal.TarFileSets {
 
 	// Stops backup and write/upload postgres `backup_label` and `tablespace_map` Files
 	tracelog.DebugLogger.Println("Stop backup and upload backup_label and tablespace_map")
-	labelFilesTarBallName, labelFilesList, finishLsn, err := bundle.uploadLabelFiles(bh.Workers.QueryRunner)
+	labelFilesTarBallName, labelFilesList, finishLsn, err := bundle.uploadLabelFiles(bh.Workers.QueryRunner, bh.Arguments.Uploader.Compression().FileExtension())
 	tracelog.ErrorLogger.FatalOnError(err)
 	bh.CurBackupInfo.endLSN = finishLsn
 	bh.CurBackupInfo.uncompressedSize = atomic.LoadInt64(bundle.TarBallQueue.AllTarballsSize)

--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -17,6 +17,7 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -354,7 +355,7 @@ func (bundle *Bundle) UploadPgControl(compressorFileExtension string) error {
 // TODO : unit tests
 // UploadLabelFiles creates the `backup_label` and `tablespace_map` files by stopping the backup
 // and uploads them to S3.
-func (bundle *Bundle) uploadLabelFiles(queryRunner *PgQueryRunner) (string, []string, LSN, error) {
+func (bundle *Bundle) uploadLabelFiles(queryRunner *PgQueryRunner, compressorFileExtension string) (string, []string, LSN, error) {
 	label, offsetMap, lsnStr, err := queryRunner.StopBackup()
 	if err != nil {
 		return "", nil, 0, errors.Wrap(err, "UploadLabelFiles: failed to stop backup")
@@ -370,7 +371,7 @@ func (bundle *Bundle) uploadLabelFiles(queryRunner *PgQueryRunner) (string, []st
 	}
 
 	tarBall := bundle.NewTarBall(false)
-	tarBall.SetUp(bundle.Crypter)
+	tarBall.SetUp(bundle.Crypter, "backup_label.tar."+compressorFileExtension)
 
 	labelHeader := &tar.Header{
 		Name:     BackupLabelFilename,

--- a/internal/databases/postgres/extract_provider.go
+++ b/internal/databases/postgres/extract_provider.go
@@ -6,7 +6,10 @@ import (
 
 type ExtractProvider interface {
 	Get(backup Backup, filesToUnwrap map[string]bool, skipRedundantTars bool, dbDataDir string, createNewIncrementalFiles bool) (
-		interpreter IncrementalTarInterpreter, tarsToExtract []internal.ReaderMaker, pgControlKey string, err error)
+		interpreter IncrementalTarInterpreter,
+		concurrentTarsToExtract []internal.ReaderMaker,
+		sequentialTarsToExtract []internal.ReaderMaker,
+		err error)
 }
 
 type ExtractProviderImpl struct {
@@ -19,10 +22,10 @@ func (t ExtractProviderImpl) Get(
 	skipRedundantTars bool,
 	dbDataDir string,
 	createNewIncrementalFiles bool,
-) (IncrementalTarInterpreter, []internal.ReaderMaker, string, error) {
+) (IncrementalTarInterpreter, []internal.ReaderMaker, []internal.ReaderMaker, error) {
 	interpreter := t.getTarInterpreter(dbDataDir, backup, filesToUnwrap, createNewIncrementalFiles)
-	tarsToExtract, pgControlKey, err := t.FilesToExtractProviderImpl.Get(backup, filesToUnwrap, skipRedundantTars)
-	return interpreter, tarsToExtract, pgControlKey, err
+	concurrentTarsToExtract, sequentialTarsToExtract, err := t.FilesToExtractProviderImpl.Get(backup, filesToUnwrap, skipRedundantTars)
+	return interpreter, concurrentTarsToExtract, sequentialTarsToExtract, err
 }
 
 func (t ExtractProviderImpl) getTarInterpreter(dbDataDir string, backup Backup,

--- a/internal/databases/postgres/extract_provider_with_spec.go
+++ b/internal/databases/postgres/extract_provider_with_spec.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 )
 
@@ -130,7 +131,7 @@ func (p ExtractProviderDBSpec) Get(
 	skipRedundantTars bool,
 	dbDataDir string,
 	createNewIncrementalFiles bool,
-) (IncrementalTarInterpreter, []internal.ReaderMaker, string, error) {
+) (IncrementalTarInterpreter, []internal.ReaderMaker, []internal.ReaderMaker, error) {
 	_, filesMeta, err := backup.GetSentinelAndFilesMetadata()
 	tracelog.ErrorLogger.FatalOnError(err)
 


### PR DESCRIPTION
### PostgreSQL / Cloudberry

PostgreSQL 12+ may run exclusive backup and several non-exclusive backups at the same time. We use non-exclusive backups. At the end of backup we call `pg_stop_backup` and save it in fictional `backup_label` file that we store in on of the `part_xxx.tar` files.
When `WALG_DOWNLOAD_CONCURRENCY` != 1, wal-g do the best to extract files as fast as possible. It is likely, that tiny `part_xxx.tar` with our `backup_label` will be fetched before huge main backup `part_000.tar`.
IFF main backup has `backup_label` - we will end up with wrong `backup_label` and restore will end with `requested recovery stop point is before consistent recovery point`

### Please provide steps to reproduce (if it's a bug)

```
  # imitate failed backup (label='abc', fast=true, exclusive=true)
  echo "SELECT pg_start_backup('abc', true, true);" | psql

  wal-g backup-push ${PGDATA}
```

### Please add config and wal-g stdout/stderr logs for debug purpose

<details><summary>logs</summary>

```
2024-10-15 15:06:44.801294 UTC,,,p4390,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","starting PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on aarch64-unknown-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit",,,,,,,0,,"postmaster.c",1370,
2024-10-15 15:06:44.801672 UTC,,,p4390,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","listening on IPv4 address ""0.0.0.0"", port 7000",,,,,,,0,,"pqcomm.c",623,
2024-10-15 15:06:44.801683 UTC,,,p4390,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","listening on IPv6 address ""::"", port 7000",,,,,,,0,,"pqcomm.c",623,
2024-10-15 15:06:44.804695 UTC,,,p4390,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","listening on Unix socket ""/tmp/.s.PGSQL.7000""",,,,,,,0,,"pqcomm.c",618,
2024-10-15 15:06:44.810222 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","database system was interrupted; last known up at 2024-10-15 15:06:10 UTC",,,,,,,0,,"xlog.c",6817,
2024-10-15 15:06:44.810255 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","creating missing WAL directory ""pg_wal/archive_status""",,,,,,,0,,"xlog.c",4382,
2024-10-15 15:06:44.925788 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","starting point-in-time recovery to ""backup_20241015T150608Z""",,,,,,,0,,"xlog.c",6916,
2024-10-15 15:06:45.876270 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","restored log file ""000000010000000000000003"" from archive",,,,,,,0,,"xlogarchive.c",219,
2024-10-15 15:06:45.980452 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","redo starts at 0/C000028",,,,,,,0,,"xlog.c",7675,
2024-10-15 15:06:46.868777 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","restored log file ""000000010000000000000004"" from archive",,,,,,,0,,"xlogarchive.c",219,
2024-10-15 15:06:47.052610 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","restored log file ""000000010000000000000005"" from archive",,,,,,,0,,"xlogarchive.c",219,
2024-10-15 15:06:47.152175 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","recovery stopping at restore point ""backup_20241015T150608Z"", time 2024-10-15 15:06:28.640107+00",,,,,,,0,,"xlog.c",6053,
2024-10-15 15:06:47.162836 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"FATAL","XX000","requested recovery stop point is before consistent recovery point",,,,,,,0,,"xlog.c",7925,"Stack trace:
1    0xffff9aafd8c8 libpostgres.so errstart + 0x260
2    0xffff9a5a963c libpostgres.so StartupXLOG + 0x4f64
3    0xffff9a8d3c88 libpostgres.so StartupProcessMain + 0x108
4    0xffff9a5e87fc libpostgres.so AuxiliaryProcessMain + 0x6d4
5    0xffff9a8d33e8 libpostgres.so PostmasterMain + 0x11f0
6    0xaaaaddba1a08 postgres main + 0x4f8
7    0xffff99ed0e10 libc.so.6 __libc_start_main + 0xe8
8    0xaaaaddba1bb8 postgres <symbol not found> + 0xddba1bb8

```

</details>
