### PR TITLE
Fix Postgres 12+/Cloudberry concurrent backups.

### DIFF
--- a/cmd/gp/backup_push_segment.go
+++ b/cmd/gp/backup_push_segment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 )
@@ -63,7 +64,9 @@ var (
 				permanent, verifyPageChecksums,
 				fullBackup, storeAllCorruptBlocks,
 				tarBallComposerType, greenplum.NewSegDeltaBackupConfigurator(deltaBaseSelector),
-				userData, viper.GetBool(conf.WithoutFilesMetadataSetting))
+				userData, viper.GetBool(conf.WithoutFilesMetadataSetting),
+				postgres.RegularPgFileFilter,
+			)
 
 			backupHandler, err := greenplum.NewSegBackupHandler(arguments)
 			tracelog.ErrorLogger.FatalOnError(err)

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 )
@@ -110,7 +111,9 @@ var (
 				permanent, verifyPageChecksums || viper.GetBool(conf.VerifyPageChecksumsSetting),
 				fullBackup, storeAllCorruptBlocks || viper.GetBool(conf.StoreAllCorruptBlocksSetting),
 				tarBallComposerType, postgres.NewRegularDeltaBackupConfigurator(deltaBaseSelector),
-				userData, withoutFilesMetadata)
+				userData, withoutFilesMetadata,
+				postgres.RegularPgFileFilter,
+			)
 
 			backupHandler, err := postgres.NewBackupHandler(arguments)
 			tracelog.ErrorLogger.FatalOnError(err)

--- a/docker/cloudberry_tests/scripts/tests/backup_after_failed_backup_test.sh
+++ b/docker/cloudberry_tests/scripts/tests/backup_after_failed_backup_test.sh
@@ -31,9 +31,7 @@ wal-g backup-list --config=${TMP_CONFIG}
 # show the storage objects (useful for debug)
 wal-g st ls -r --config=${TMP_CONFIG}
 
-# it looks like a bug in `tryExtractFiles` - it can override files when WALG_DOWNLOAD_CONCURRENCY != 1
-# https://github.com/wal-g/wal-g/blob/master/internal/extract.go#L201-L253
-WALG_DOWNLOAD_CONCURRENCY=1  wal-g backup-fetch LATEST --in-place --config=${TMP_CONFIG}
+wal-g backup-fetch LATEST --in-place --config=${TMP_CONFIG}
 prepare_cluster
 start_cluster
 cleanup

--- a/internal/bundle.go
+++ b/internal/bundle.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -31,20 +32,17 @@ type Bundle struct {
 
 	TarSizeThreshold int64
 
-	ExcludedFilenames map[string]utility.Empty
-
 	FilesFilter FilesFilter
 }
 
 func NewBundle(
 	directories []string, crypter crypto.Crypter,
-	tarSizeThreshold int64, excludedFilenames map[string]utility.Empty) *Bundle {
+	tarSizeThreshold int64, fileFilter FilesFilter) *Bundle {
 	return &Bundle{
-		Directories:       directories,
-		Crypter:           crypter,
-		TarSizeThreshold:  tarSizeThreshold,
-		ExcludedFilenames: excludedFilenames,
-		FilesFilter:       &CommonFilesFilter{},
+		Directories:      directories,
+		Crypter:          crypter,
+		TarSizeThreshold: tarSizeThreshold,
+		FilesFilter:      fileFilter,
 	}
 }
 
@@ -76,7 +74,7 @@ func (bundle *Bundle) AddToBundle(path string, info os.FileInfo, err error) erro
 	}
 
 	fileName := info.Name()
-	_, excluded := bundle.ExcludedFilenames[fileName]
+	excluded := !bundle.FilesFilter.ShouldUploadFile(fileName)
 	isDir := info.IsDir()
 
 	if excluded && !isDir {

--- a/internal/concurrent_uploader.go
+++ b/internal/concurrent_uploader.go
@@ -3,8 +3,8 @@ package internal
 import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+
 	conf "github.com/wal-g/wal-g/internal/config"
-	"github.com/wal-g/wal-g/utility"
 )
 
 type ConcurrentUploader struct {
@@ -18,7 +18,7 @@ type ConcurrentUploader struct {
 func CreateConcurrentUploader(uploader Uploader, backupName string, directories []string) (*ConcurrentUploader, error) {
 	crypter := ConfigureCrypter()
 	tarSizeThreshold := viper.GetInt64(conf.TarSizeThresholdSetting)
-	bundle := NewBundle(directories, crypter, tarSizeThreshold, map[string]utility.Empty{})
+	bundle := NewBundle(directories, crypter, tarSizeThreshold, NewCommonFilesFilter())
 
 	tracelog.InfoLogger.Println("Starting a new tar bundle")
 	tarBallMaker := NewStorageTarBallMaker(backupName, uploader)

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
+
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
@@ -23,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -160,9 +162,16 @@ func (bh *BackupHandler) createAndPushBackup(ctx context.Context) {
 
 	arguments := bh.Arguments
 	crypter := internal.ConfigureCrypter()
-	bh.Workers.Bundle = NewBundle(bh.PgInfo.PgDataDirectory, crypter, bh.prevBackupInfo.name,
-		bh.prevBackupInfo.sentinelDto.BackupStartLSN, bh.prevBackupInfo.filesMetadataDto.Files, arguments.forceIncremental,
-		viper.GetInt64(conf.TarSizeThresholdSetting))
+	bh.Workers.Bundle = NewBundle(
+		bh.PgInfo.PgDataDirectory,
+		crypter,
+		bh.prevBackupInfo.name,
+		bh.prevBackupInfo.sentinelDto.BackupStartLSN,
+		bh.prevBackupInfo.filesMetadataDto.Files,
+		arguments.forceIncremental,
+		viper.GetInt64(conf.TarSizeThresholdSetting),
+		NewPgFilesFilter(bh.PgInfo.PgVersion),
+	)
 	if orioledbEnabled && bh.prevBackupInfo.sentinelDto.BackupStartChkpNum != nil {
 		bh.Workers.Bundle.IncrementFromChkpNum = bh.prevBackupInfo.sentinelDto.BackupStartChkpNum
 	}

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -68,6 +68,7 @@ type BackupArguments struct {
 	withoutFilesMetadata     bool
 	composerInitFunc         func(handler *BackupHandler) error
 	preventConcurrentBackups bool
+	filesFilterType          PgFilesFilterType
 }
 
 // CurBackupInfo holds all information that is harvest during the backup process

--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -166,7 +166,7 @@ func (bundle *Bundle) StartBackup(queryRunner *PgQueryRunner,
 // and creates compressed tar members labeled as `part_00i.tar.*`, where '*' is compressor file extension.
 //
 // To see which files and directories are Skipped, please consult
-// ExcludedFilenames. Excluded directories will be created but their
+// FilesFilter. Excluded directories will be created but their
 // contents will not be included in the tar bundle.
 func (bundle *Bundle) HandleWalkedFSObject(path string, info os.FileInfo, err error) error {
 	if err != nil {
@@ -229,7 +229,7 @@ func (bundle *Bundle) HandleWalkedFSObject(path string, info os.FileInfo, err er
 
 // TODO : unit tests
 // addToBundle handles one given file.
-// Does not follow symlinks (it seems like it does). If file is in ExcludedFilenames, will not be included
+// Does not follow symlinks (it seems like it does). If file doesn't pass FilesFilter, will not be included
 // in the final tarball. EXCLUDED directories are created
 // but their contents are not written to local disk.
 func (bundle *Bundle) addToBundle(path string, info os.FileInfo) error {

--- a/internal/databases/postgres/bundle.go
+++ b/internal/databases/postgres/bundle.go
@@ -17,6 +17,7 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -49,6 +50,9 @@ func init() {
 		"pgsql_tmp", "postgresql.auto.conf.tmp", "postmaster.pid", "postmaster.opts", "recovery.conf", // Files
 		"pg_dynshmem", "pg_notify", "pg_replslot", "pg_serial", "pg_stat_tmp", "pg_snapshots", "pg_subtrans", // Directories
 		"standby.signal", // Signal files
+		// We don't rely on `backup_label` and `tablespace_map` from datadir because we create fictional files
+		// from `pg_stop_backup()`. Don't archive them - so we won't have data race during recovery.
+		BackupLabelFilename, TablespaceMapFilename,
 	}
 
 	for _, filename := range filesToExclude {

--- a/internal/databases/postgres/catchup_push_handler.go
+++ b/internal/databases/postgres/catchup_push_handler.go
@@ -28,7 +28,9 @@ func HandleCatchupPush(ctx context.Context, pgDataDirectory string, fromLSN LSN)
 		uploader, pgDataDirectory, utility.CatchupPath, false,
 		false, false, false,
 		RegularComposer, NewCatchupDeltaBackupConfigurator(fakePreviousBackupSentinelDto),
-		userData, false)
+		userData, false,
+		CatchupPgFilesFilter,
+	)
 	if orioledb.IsEnabled(pgDataDirectory) {
 		tracelog.InfoLogger.Printf("Catchup incremental backup is not implemented for orioledb. Full backup will be performed.")
 	}

--- a/internal/databases/postgres/catchup_push_handler.go
+++ b/internal/databases/postgres/catchup_push_handler.go
@@ -4,16 +4,11 @@ import (
 	"context"
 
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
 	"github.com/wal-g/wal-g/utility"
 )
-
-func extendExcludedFiles() {
-	for _, fname := range []string{"pg_hba.conf", "postgresql.conf", "postgresql.auto.conf"} {
-		ExcludedFilenames[fname] = utility.Empty{}
-	}
-}
 
 // HandleCatchupPush is invoked to perform a wal-g catchup-push
 func HandleCatchupPush(ctx context.Context, pgDataDirectory string, fromLSN LSN) {
@@ -25,8 +20,6 @@ func HandleCatchupPush(ctx context.Context, pgDataDirectory string, fromLSN LSN)
 	fakePreviousBackupSentinelDto := BackupSentinelDto{
 		BackupStartLSN: &fromLSN,
 	}
-
-	extendExcludedFiles()
 
 	userData, err := internal.GetSentinelUserData()
 	tracelog.ErrorLogger.FatalfOnError("Failed to unmarshal the provided UserData: %s", err)

--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -120,7 +120,12 @@ func chooseCompression() (compression.Compressor, compression.Decompressor) {
 	return c, d
 }
 
-func sendFileCommands(encoder *gob.Encoder, directory string, list internal.BackupFileList, checkpoint LSN, fileFilter internal.FilesFilter) {
+func sendFileCommands(encoder *gob.Encoder,
+	directory string,
+	list internal.BackupFileList,
+	checkpoint LSN,
+	fileFilter internal.FilesFilter,
+) {
 	seenFiles := make(map[string]bool)
 	err := filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
 		fullFileName := utility.GetSubdirectoryRelativePath(path, directory)

--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -21,7 +21,7 @@ import (
 )
 
 func HandleCatchupSend(pgDataDirectory string, destination string) {
-	fileFilter := NewPgCatchupFilesFilter()
+	fileFilter := NewCatchupPgFilesFilter()
 	pgDataDirectory = utility.ResolveSymlink(pgDataDirectory)
 	tracelog.InfoLogger.Printf("Sending %v to %v\n", pgDataDirectory, destination)
 	info, runner, err := GetPgServerInfo(true)
@@ -250,7 +250,7 @@ func sendOneFile(path string, info fs.FileInfo, wasInBase bool, checkpoint LSN,
 }
 
 func HandleCatchupReceive(pgDataDirectory string, port int) {
-	fileFilter := NewPgCatchupFilesFilter()
+	fileFilter := NewCatchupPgFilesFilter()
 	pgDataDirectory = utility.ResolveSymlink(pgDataDirectory)
 	tracelog.InfoLogger.Printf("Receiving %v on port %v\n", pgDataDirectory, port)
 	listen, err := net.Listen("tcp", fmt.Sprintf(":%v", port))

--- a/internal/databases/postgres/files_filter.go
+++ b/internal/databases/postgres/files_filter.go
@@ -1,0 +1,58 @@
+package postgres
+
+import (
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/utility"
+)
+
+var filesToExclude = []string{
+	"log", "pg_log", "pg_xlog", "pg_wal", // Directories
+	"pgsql_tmp", "postgresql.auto.conf.tmp", "postmaster.pid", "postmaster.opts", "recovery.conf", // Files
+	"pg_dynshmem", "pg_notify", "pg_replslot", "pg_serial", "pg_stat_tmp", "pg_snapshots", "pg_subtrans", // Directories
+	"standby.signal", // Signal files
+}
+
+type PgFilesFilter struct {
+	excludedFilenames map[string]utility.Empty
+}
+
+var _ internal.FilesFilter = &PgFilesFilter{}
+
+func NewPgFilesFilter(version int) internal.FilesFilter {
+	var excludedFilenames = make(map[string]utility.Empty)
+	for _, filename := range filesToExclude {
+		excludedFilenames[filename] = utility.Empty{}
+	}
+	// extend common file filters:
+	if version > 90600 {
+		// for Pg 9.6+ we don't rely on `backup_label` and `tablespace_map` from datadir because we create
+		// fictional files from `pg_stop_backup()`. Don't archive them - so we won't have data race during recovery.
+		excludedFilenames[BackupLabelFilename] = utility.Empty{}
+		excludedFilenames[TablespaceMapFilename] = utility.Empty{}
+	}
+
+	return &PgFilesFilter{
+		excludedFilenames: excludedFilenames,
+	}
+}
+
+func NewPgCatchupFilesFilter() internal.FilesFilter {
+	var excludedFilenames = make(map[string]utility.Empty)
+
+	for _, filename := range filesToExclude {
+		excludedFilenames[filename] = utility.Empty{}
+	}
+	// extend common file filters:
+	for _, fname := range []string{"pg_hba.conf", "postgresql.conf", "postgresql.auto.conf"} {
+		excludedFilenames[fname] = utility.Empty{}
+	}
+
+	return &PgFilesFilter{
+		excludedFilenames: excludedFilenames,
+	}
+}
+
+func (ff *PgFilesFilter) ShouldUploadFile(path string) bool {
+	_, ok := ff.excludedFilenames[path]
+	return !ok
+}

--- a/internal/databases/postgres/walk_test.go
+++ b/internal/databases/postgres/walk_test.go
@@ -229,7 +229,7 @@ func compare(t *testing.T, dir1, dir2 string, fileFilter internal.FilesFilter) b
 		mode := info1.Mode() == info2.Mode()
 		isDir := f1.IsDir() == f2.IsDir()
 
-		// If directory is in ExcludedFilenames list, make sure it exists but is empty.
+		// If directory doesn't pass FilesFilter, make sure it exists but is empty.
 		if f2.IsDir() {
 			if !fileFilter.ShouldUploadFile(f2.Name()) {
 				size = isEmpty(t, filepath.Join(dir2, f2.Name()))

--- a/internal/databases/postgres/walk_test.go
+++ b/internal/databases/postgres/walk_test.go
@@ -360,7 +360,7 @@ func testWalk(t *testing.T, composer postgres.TarBallComposerType, withoutFilesM
 	// Generate random data and write to tmp dir `data...`.
 	data := generateData(t)
 	tarSizeThreshold := int64(10)
-	fileFilter := postgres.NewPgFilesFilter(12000)
+	fileFilter := postgres.NewRegularPgFilesFilter(12000)
 	// Bundle and compress files to `compressed`.
 	bundle := postgres.NewBundle(data, nil, "", nil, nil, false, tarSizeThreshold, fileFilter)
 	compressed := filepath.Join(filepath.Dir(data), "compressed")

--- a/internal/directory_uploader.go
+++ b/internal/directory_uploader.go
@@ -5,8 +5,8 @@ import (
 	"sync/atomic"
 
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal/crypto"
-	"github.com/wal-g/wal-g/utility"
 )
 
 type DirectoryUploader interface {
@@ -20,29 +20,29 @@ type CommonDirectoryUploader struct {
 	tarBallComposerMaker TarBallComposerMaker
 	tarSizeThreshold     int64
 
-	excludedFiles map[string]utility.Empty
-	backupName    string
-	uploader      Uploader
+	fileFilter FilesFilter
+	backupName string
+	uploader   Uploader
 }
 
 func NewCommonDirectoryUploader(
 	crypter crypto.Crypter, packer TarBallFilePacker,
 	tarBallComposerMaker TarBallComposerMaker, tarSizeThreshold int64,
-	excludedFiles map[string]utility.Empty, backupName string,
+	fileFilter FilesFilter, backupName string,
 	uploader Uploader) *CommonDirectoryUploader {
 	return &CommonDirectoryUploader{
 		crypter:              crypter,
 		tarBallFilePacker:    packer,
 		tarBallComposerMaker: tarBallComposerMaker,
 		tarSizeThreshold:     tarSizeThreshold,
-		excludedFiles:        excludedFiles,
+		fileFilter:           fileFilter,
 		backupName:           backupName,
 		uploader:             uploader,
 	}
 }
 
 func (u *CommonDirectoryUploader) Upload(path string) TarFileSets {
-	bundle := NewBundle([]string{path}, u.crypter, u.tarSizeThreshold, u.excludedFiles)
+	bundle := NewBundle([]string{path}, u.crypter, u.tarSizeThreshold, u.fileFilter)
 
 	// Start a new tar bundle, walk the pgDataDirectory and upload everything there.
 	tracelog.InfoLogger.Println("Starting a new tar bundle")

--- a/internal/files_filter.go
+++ b/internal/files_filter.go
@@ -6,6 +6,10 @@ type FilesFilter interface {
 
 type CommonFilesFilter struct{}
 
+func NewCommonFilesFilter() FilesFilter {
+	return &CommonFilesFilter{}
+}
+
 func (*CommonFilesFilter) ShouldUploadFile(path string) bool {
 	return true
 }


### PR DESCRIPTION
### PostgreSQL / Cloudberry

PostgreSQL 12+ may run exclusive backup and several non-exclusive backups at the same time. We use non-exclusive backups. At the end of backup we call `pg_stop_backup` and save it in fictional `backup_label` file that we store in on of the `part_xxx.tar` files.
When `WALG_DOWNLOAD_CONCURRENCY` != 1, wal-g do the best to extract files as fast as possible. It is likely, that tiny `part_xxx.tar` with our `backup_label` will be fetched before huge main backup `part_000.tar`.
IFF main backup has `backup_label` - we will end up with wrong `backup_label` and restore will end with `requested recovery stop point is before consistent recovery point`

### Please provide steps to reproduce (if it's a bug)

```
  # imitate failed backup (label='abc', fast=true, exclusive=true)
  echo "SELECT pg_start_backup('abc', true, true);" | psql

  wal-g backup-push ${PGDATA}
```

**Solution:** don't backup 'backup_label' from disk when we create our own 'backup_label's (in Pg 9.6+)

### Please add config and wal-g stdout/stderr logs for debug purpose

<details><summary>logs</summary>

```
2024-10-15 15:06:44.801294 UTC,,,p4390,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","starting PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on aarch64-unknown-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit",,,,,,,0,,"postmaster.c",1370,
2024-10-15 15:06:44.801672 UTC,,,p4390,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","listening on IPv4 address ""0.0.0.0"", port 7000",,,,,,,0,,"pqcomm.c",623,
2024-10-15 15:06:44.801683 UTC,,,p4390,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","listening on IPv6 address ""::"", port 7000",,,,,,,0,,"pqcomm.c",623,
2024-10-15 15:06:44.804695 UTC,,,p4390,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","listening on Unix socket ""/tmp/.s.PGSQL.7000""",,,,,,,0,,"pqcomm.c",618,
2024-10-15 15:06:44.810222 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","database system was interrupted; last known up at 2024-10-15 15:06:10 UTC",,,,,,,0,,"xlog.c",6817,
2024-10-15 15:06:44.810255 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","creating missing WAL directory ""pg_wal/archive_status""",,,,,,,0,,"xlog.c",4382,
2024-10-15 15:06:44.925788 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","starting point-in-time recovery to ""backup_20241015T150608Z""",,,,,,,0,,"xlog.c",6916,
2024-10-15 15:06:45.876270 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","restored log file ""000000010000000000000003"" from archive",,,,,,,0,,"xlogarchive.c",219,
2024-10-15 15:06:45.980452 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","redo starts at 0/C000028",,,,,,,0,,"xlog.c",7675,
2024-10-15 15:06:46.868777 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","restored log file ""000000010000000000000004"" from archive",,,,,,,0,,"xlogarchive.c",219,
2024-10-15 15:06:47.052610 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","restored log file ""000000010000000000000005"" from archive",,,,,,,0,,"xlogarchive.c",219,
2024-10-15 15:06:47.152175 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"LOG","00000","recovery stopping at restore point ""backup_20241015T150608Z"", time 2024-10-15 15:06:28.640107+00",,,,,,,0,,"xlog.c",6053,
2024-10-15 15:06:47.162836 UTC,,,p4392,th-1770865664,,,,0,,,seg-1,,,,,"FATAL","XX000","requested recovery stop point is before consistent recovery point",,,,,,,0,,"xlog.c",7925,"Stack trace:
1    0xffff9aafd8c8 libpostgres.so errstart + 0x260
2    0xffff9a5a963c libpostgres.so StartupXLOG + 0x4f64
3    0xffff9a8d3c88 libpostgres.so StartupProcessMain + 0x108
4    0xffff9a5e87fc libpostgres.so AuxiliaryProcessMain + 0x6d4
5    0xffff9a8d33e8 libpostgres.so PostmasterMain + 0x11f0
6    0xaaaaddba1a08 postgres main + 0x4f8
7    0xffff99ed0e10 libc.so.6 __libc_start_main + 0xe8
8    0xaaaaddba1bb8 postgres <symbol not found> + 0xddba1bb8

```

</details>
