### PR TITLE
Remove unexpected '\r\n' sequence at the end of multiline commands in the config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -639,7 +639,9 @@ func isAllowedSetting(setting string, AllowedSettings map[string]bool) (exists b
 // GetSetting extract setting by key if key is set, return empty string otherwise
 func GetSetting(key string) (value string, ok bool) {
 	if viper.IsSet(key) {
-		return viper.GetString(key), true
+		value := viper.GetString(key)
+		value = strings.TrimRight(value, "\r\n")
+		return value, true
 	}
 	return "", false
 }


### PR DESCRIPTION
### Database name

All DBMS that use `GetSetting`. Particularly, MySQL, because I locate this bug there.

# Pull request description

When we get a string using Viper in a simple key-value format, there are no problems.
```
Key: value
```
But Viper adds '\r\n' at the end of the command when we move value to the next line:
```
Key: >
    value
```
It is not a problem in many cases, but it is a subtle thing that crushes the logic of `enrichBackupArgs` (mysql): https://github.com/wal-g/wal-g/blob/1448594c0880239b8388ede5b8f875355c703627/internal/databases/mysql/xtrabackup.go#L100 because it just adds an argument to the end of the command.

### Describe what this PR fix

It removes the '\r\n' sequence at the end of a command.

### Please provide steps to reproduce (if it's a bug)

For MySQL write down to the config file the next lines
```
WALG_STREAM_CREATE_COMMAND: >
    xtrabackup --backup --stream=xbstream --lock-ddl --parallel=1 --datadir=/var/lib/mysql
```
and try to do backup. It will be finished, but:
```
INFO: 2024/10/25 08:20:26.598216 Command to execute: /bin/bash -c xtrabackup --backup --stream=xbstream --lock-ddl --lock-ddl-timeout=3600 --parallel=1 --datadir=/var/lib/mysql
--extra-lsndir=/tmp/wal-g3366112092
...
241025 08:20:55 [00] Streaming <STDOUT>
241025 08:20:55 [00]        ...done
241025 08:20:55 [00] Streaming <STDOUT>
241025 08:20:55 [00]        ...done
xtrabackup: Transaction log of lsn (16845089) to (52904811) was copied.
241025 08:20:55 completed OK!
/bin/bash: line 2: --extra-lsndir=/tmp/wal-g3366112092: No such file or directory
WARNING: 2024/10/25 08:20:55.912024 failed to read and parse `xtrabackup_checkpoints`: open /tmp/wal-g3366112092/xtrabackup_checkpoints: no such file or directory
```
Due to this LSN in MySQL, sentinels are always null.
```
INFO: 2024/10/25 08:20:55.919823 Backup sentinel: {"Tool":"WALG_XTRABACKUP_TOOL","BinLogStart":"<BINLOG-START>","BinLogEnd":"<BINLOG-END>","StartLocalTime":"2024-10-25T08:20:26.598148Z","StopLocalTime":"2024-10-25T08:20:55.919676Z","UncompressedSize":154699929,"CompressedSize":8617513,"Hostname":"<HOSTNAME>","ServerUUID":"<UID>","ServerVersion":"5.7.44-51","ServerArch":"amd64","ServerOS":"linux","IsPermanent":false,"IsIncremental":false,"LSN":null,"DeltaCount":0}
```