### PR TITLE
Greenplum 7 support

### DIFF
--- a/docker/cloudberry/Dockerfile
+++ b/docker/cloudberry/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get install --yes --no-install-recommends --no-install-suggests \
     openssl \
     python3-dev \
     python3-pip \
+    python3-psycopg2 \
     python3-psutil \
     python3-yaml \
     python3-pygresql \
@@ -67,6 +68,12 @@ RUN apt-get install --yes --no-install-recommends --no-install-suggests \
 ADD docker/cloudberry/run_greenplum.sh /home/gpadmin/run_greenplum.sh
 
 WORKDIR /usr/local
+
+# You can run these tests with Greenplum 7.
+# open-gpdb/gpdb doesn't have 7 branch... so, we can use adb-7:
+#RUN git clone https://github.com/arenadata/gpdb.git gpdb_src --single-branch --branch adb-7.2.0 --depth 1 \
+# && ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+
 RUN git clone https://github.com/cloudberrydb/cloudberrydb.git gpdb_src --single-branch --branch main --depth 1 \
  && ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 

--- a/docker/cloudberry_tests/scripts/tests/test_functions/util.sh
+++ b/docker/cloudberry_tests/scripts/tests/test_functions/util.sh
@@ -65,7 +65,7 @@ prepare_cluster() {
   # start Coordinator only... it will fail
   /usr/local/gpdb_src/bin/gpstart -c -a -t 180 || true
   # then wait until coordinator recovery finished & it will start accepting connections:
-  for i in {1..180}; do psql -p 7000 -d postgres -c " select 1;" && break || sleep 1; done
+  for i in {1..180}; do PGOPTIONS='-c gp_role=utility' psql -p 7000 -d postgres -c " select 1;" && break || sleep 1; done
   # here we can do all we need to fix cluster configuration
   # e.g. update gp_segment_configuration... however we don't need to do it in this tests
   # stop cluster...

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -433,6 +433,8 @@ func (queryRunner *GpQueryRunner) buildAORelPgClassQuery() (string, error) {
 	case Greenplum:
 		{
 			switch {
+			case queryRunner.Version >= 120000:
+				return cbAoRelationPgClassQuery, nil
 			case queryRunner.Version >= 90000:
 				return gpAoRelationPgClassQuery, nil
 			case queryRunner.Version == 0:


### PR DESCRIPTION
### Greenplum

Use new queries (from Cloudberry) for Greenplum v7. Fixes #1719

### Please add config and wal-g stdout/stderr logs for debug purpose

<details><summary>Logs</summary>

```
WARNING: 2024/05/24 14:25:02.025294 failed to fetch storage types: postgres                                                                                                                                        
'pg_class query failed: ERROR: column c.relstorage does not exist (SQLSTATE 42703)'                                                                                                                                
INFO: 2024/05/24 14:25:02.053679 Querying pg_class for template1                                                                                                                                                   
WARNING: 2024/05/24 14:25:02.054175 failed to fetch storage types: template1                                                                                                                                       
'pg_class query failed: ERROR: column c.relstorage does not exist (SQLSTATE 42703)'                                                                                                                                
INFO: 2024/05/24 14:25:02.084703 Querying pg_class for aip_dwh                                                                                                                                                     
WARNING: 2024/05/24 14:25:02.085212 failed to fetch storage types: aip_dwh                                                                                                                                         
'pg_class query failed: ERROR: column c.relstorage does not exist (SQLSTATE 42703)'                                                                                                                                
INFO: 2024/05/24 14:25:02.119218 Querying pg_class for test                                                                                                                                                        
WARNING: 2024/05/24 14:25:02.119936 failed to fetch storage types: test                                                                                                                                            
'pg_class query failed: ERROR: column c.relstorage does not exist (SQLSTATE 42703)'                      
```

</details>
