### PR TITLE
clean data on rdb restore also

### DIFF
--- a/cmd/redis/rdb_backup_fetch.go
+++ b/cmd/redis/rdb_backup_fetch.go
@@ -14,7 +14,15 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-const backupFetchShortDescription = "Fetches desired rdb backup from storage"
+const (
+	backupFetchShortDescription = "Fetches desired rdb backup from storage"
+	SkipCleanFlag               = "skip-clean"
+	SkipCleanShorthand          = "s"
+)
+
+var (
+	skipClean bool
+)
 
 var backupFetchCmd = &cobra.Command{
 	Use:   "backup-fetch backup-name",
@@ -48,7 +56,7 @@ var backupFetchCmd = &cobra.Command{
 		restoreCmd.Stdout = os.Stdout
 		restoreCmd.Stderr = os.Stderr
 
-		err = redis.HandleBackupFetch(ctx, storage.RootFolder(), args[0], restoreCmd)
+		err = redis.HandleBackupFetch(ctx, storage.RootFolder(), args[0], restoreCmd, skipClean)
 		tracelog.ErrorLogger.FatalOnError(err)
 	},
 }
@@ -62,5 +70,6 @@ func init() {
 		Args:  backupFetchCmd.Args,
 		Run:   backupFetchCmd.Run,
 	}
+	rdbBackupFetchCmd.Flags().BoolVarP(&skipClean, SkipCleanFlag, SkipCleanShorthand, false, "Skip data folder clean check")
 	cmd.AddCommand(rdbBackupFetchCmd)
 }

--- a/docker/redis_tests/scripts/tests/redis_aof_full_backup_test.sh
+++ b/docker/redis_tests/scripts/tests/redis_aof_full_backup_test.sh
@@ -20,7 +20,15 @@ ensure aof $(wal-g backup-info --tag BackupType LATEST)
 
 test_cleanup; sleep $REDIS_TIMEOUT
 
+touch /var/lib/redis/fake.aof
+touch /var/lib/redis/fake.rdb
+mkdir /var/lib/redis/appendonlydir
+touch /var/lib/redis/appendonlydir/fake.tmp
 wal-g aof-backup-fetch LATEST 7.2.5
+ensure no $(test -e /var/lib/redis/fake.aof && echo "yes" || echo "no")
+ensure no $(test -e /var/lib/redis/fake.rdb && echo "yes" || echo "no")
+ensure no $(test -e /var/lib/redis/appendonlydir/fake.tmp && echo "yes" || echo "no")
+
 redis-server --save "" --appendonly "yes" --dir "/var/lib/redis" &
 sleep $REDIS_TIMEOUT
 

--- a/docker/redis_tests/scripts/tests/redis_rdb_full_backup_test.sh
+++ b/docker/redis_tests/scripts/tests/redis_rdb_full_backup_test.sh
@@ -20,7 +20,15 @@ ensure rdb $(wal-g backup-info --tag BackupType LATEST)
 
 test_cleanup; sleep $REDIS_TIMEOUT
 
+touch /var/lib/redis/fake.aof
+touch /var/lib/redis/fake.rdb
+mkdir /var/lib/redis/appendonlydir
+touch /var/lib/redis/appendonlydir/fake.tmp
 wal-g rdb-backup-fetch LATEST
+ensure no $(test -e /var/lib/redis/fake.aof && echo "yes" || echo "no")
+ensure no $(test -e /var/lib/redis/fake.rdb && echo "yes" || echo "no")
+ensure no $(test -e /var/lib/redis/appendonlydir/fake.tmp && echo "yes" || echo "no")
+
 redis-server --save "900 0" --appendonly "no" --dir "/var/lib/redis" &
 sleep $REDIS_TIMEOUT
 
@@ -41,7 +49,12 @@ wal-g backup-info LATEST
 
 test_cleanup; sleep $REDIS_TIMEOUT
 
+touch /var/lib/redis/fake.aof
+touch /var/lib/redis/fake.rdb
 wal-g backup-fetch LATEST
+ensure no $(test -e /var/lib/redis/fake.aof && echo "yes" || echo "no")
+ensure no $(test -e /var/lib/redis/fake.rdb && echo "yes" || echo "no")
+
 redis-server --save "900 0" --appendonly "no" --dir "/var/lib/redis" &
 sleep $REDIS_TIMEOUT
 

--- a/internal/databases/redis/aof/restore.go
+++ b/internal/databases/redis/aof/restore.go
@@ -61,7 +61,7 @@ func (r *RestoreService) DoRestore(args RestoreArgs) error {
 	}
 
 	if !args.SkipBackupDownload {
-		err = r.TargetDiskFolder.CleanData()
+		err = r.TargetDiskFolder.CleanPathAndParent()
 		if err != nil {
 			return err
 		}

--- a/internal/databases/redis/archive/fs.go
+++ b/internal/databases/redis/archive/fs.go
@@ -16,7 +16,7 @@ func CreateAofFolderInfo(path string) *AofFolderInfo {
 	}
 }
 
-func (f *AofFolderInfo) CleanData() error {
+func (f *AofFolderInfo) CleanPathAndParent() error {
 	path := filepath.Clean(f.Path)
 	err := os.RemoveAll(path)
 	if err != nil {
@@ -24,16 +24,24 @@ func (f *AofFolderInfo) CleanData() error {
 	}
 
 	parent := filepath.Dir(path)
+
 	starred := filepath.Join(parent, "*.rdb")
 	contents, err := filepath.Glob(starred)
 	if err != nil {
 		return fmt.Errorf("failed to create glob for rdb files: %v", err)
 	}
 
+	starred = filepath.Join(parent, "*.aof")
+	aofContents, err := filepath.Glob(starred)
+	if err != nil {
+		return fmt.Errorf("failed to create glob for aof files: %v", err)
+	}
+
+	contents = append(contents, aofContents...)
 	for _, item := range contents {
 		err = os.RemoveAll(item)
 		if err != nil {
-			return fmt.Errorf("failed to remove rdb file: %v", err)
+			return fmt.Errorf("failed to remove %s path: %v", item, err)
 		}
 	}
 

--- a/internal/databases/redis/rdb_backup_fetch_handler.go
+++ b/internal/databases/redis/rdb_backup_fetch_handler.go
@@ -3,16 +3,30 @@ package redis
 import (
 	"context"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/redis/archive"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
-func HandleBackupFetch(ctx context.Context, folder storage.Folder, backupName string, restoreCmd *exec.Cmd) error {
+func HandleBackupFetch(ctx context.Context, folder storage.Folder, backupName string, restoreCmd *exec.Cmd, skipClean bool) error {
 	backup, err := archive.SentinelWithExistenceCheck(folder, backupName)
 	if err != nil {
 		return err
+	}
+
+	if !skipClean {
+		dataFolder, _ := conf.GetSetting(conf.RedisDataPath)
+		aofFolder, _ := conf.GetSetting(conf.RedisAppendonlyFolder)
+		aofPath := filepath.Join(dataFolder, aofFolder)
+		aofFolderInfo := archive.CreateAofFolderInfo(aofPath)
+
+		err = aofFolderInfo.CleanPathAndParent()
+		if err != nil {
+			return err
+		}
 	}
 
 	return internal.StreamBackupToCommandStdin(restoreCmd, backup.ToInternal(folder))


### PR DESCRIPTION
### Database name
redis

# Pull request description
clean all known data folders and files during rdb and aof restore

### Describe what this PR fix
we clean data on aof restore - let's do it for rdb also

### Please provide steps to reproduce (if it's a bug)
none

### Please add config and wal-g stdout/stderr logs for debug purpose
none
