### PR TITLE
CI: drop ubuntu-18.04 from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release-ubuntu:
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04 ]
         db: [ pg, mysql, sqlserver, redis, mongo, fdb, gp ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -41,10 +41,6 @@ jobs:
           fi
       - name: Make deps
         run: make deps
-
-      - name: Fix LZO (ubuntu-18.04)
-        if: matrix.os == 'ubuntu-18.04'
-        run: echo "CGO_LDFLAGS=-no-pie" >> $GITHUB_ENV
 
       - name: Build WAL-G
         run: make ${{ matrix.db }}_build


### PR DESCRIPTION
ubuntu-18.04 image is deprecated in GitHub actions