### PR TITLE
pg_checksum_verification_fix

### DIFF
--- a/internal/databases/postgres/paged_file_verifier.go
+++ b/internal/databases/postgres/paged_file_verifier.go
@@ -135,7 +135,7 @@ func isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage) (bool, e
 	if !valid {
 		// If the pageHeader is not valid, there is no sense in proceeding with the page checking.
 		tracelog.WarningLogger.Printf("Invalid page header encountered: blockNo %d, path %s", blockNo, path)
-		return true, nil
+		return false, nil
 	}
 
 	// We only calculate the checksum for properly-initialized pages


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.
PostgreSQL

# Pull request description

### Describe what this PR fix
A fix triggered by objects from certain extensions, like RUM: the pageHeader check may fail validation, which is expected in this case. This fix prevents false positives by simply not marking the page as “corrupted” when the pageHeader is invalid.


