### PR TITLE
Add option to disable 100 continue in s3

### DIFF
--- a/pkg/storages/s3/configure.go
+++ b/pkg/storages/s3/configure.go
@@ -44,6 +44,7 @@ const (
 	maxRetriesSetting              = "S3_MAX_RETRIES"
 	minThrottlingRetryDelaySetting = "S3_MIN_THROTTLING_RETRY_DELAY"
 	maxThrottlingRetryDelaySetting = "S3_MAX_THROTTLING_RETRY_DELAY"
+	disable100ContinueSetting      = "S3_DISABLE_100_CONTINUE"
 )
 
 var SettingList = []string{
@@ -78,6 +79,7 @@ var SettingList = []string{
 	maxThrottlingRetryDelaySetting,
 	retentionPeriodSetting,
 	retentionModeSetting,
+	disable100ContinueSetting,
 }
 
 const (
@@ -93,6 +95,7 @@ const (
 	defaultRangeBatchEnabled       = false
 	defaultRangeMaxRetries         = 10
 	defaultDisabledRetentionPeriod = -1
+	defaultDisable100Continue      = false
 )
 
 // TODO: Unit tests
@@ -160,6 +163,10 @@ func ConfigureStorage(
 	if err != nil {
 		return nil, err
 	}
+	disable100Continue, err := setting.BoolOptional(settings, disable100ContinueSetting, defaultDisable100Continue)
+	if err != nil {
+		return nil, err
+	}
 
 	config := &Config{
 		Secrets: &Secrets{
@@ -197,6 +204,7 @@ func ConfigureStorage(
 		RangeMaxRetries:         rangeMaxRetries,
 		MinThrottlingRetryDelay: time.Duration(minThrottlingRetryDelay) * time.Millisecond,
 		MaxThrottlingRetryDelay: time.Duration(maxThrottlingRetryDelay) * time.Millisecond,
+		Disable100Continue:      disable100Continue,
 	}
 
 	st, err := NewStorage(config, rootWraps...)

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -166,6 +166,8 @@ func configureSession(sess *session.Session, config *Config) error {
 	} else {
 		awsConfig = awsConfig.WithRegion(config.Region)
 	}
+	tracelog.DebugLogger.Printf("disable 100 continue %t", config.Disable100Continue)
+	awsConfig.S3Disable100Continue = aws.Bool(config.Disable100Continue)
 
 	sess.Config = awsConfig
 	return nil

--- a/pkg/storages/s3/storage.go
+++ b/pkg/storages/s3/storage.go
@@ -40,6 +40,7 @@ type Config struct {
 	RangeMaxRetries          int
 	MinThrottlingRetryDelay  time.Duration
 	MaxThrottlingRetryDelay  time.Duration
+	Disable100Continue       bool
 }
 
 type Secrets struct {


### PR DESCRIPTION
### Database name
Not related to specific Database

# Pull request description

### Describe what this PR fix
We ran into an issue where our S3 compatible block storage provider corrupted files when http 100 continue messages were used. Since awsConfig allows disabling this behavior we added a flag to add this to the awsConfig to mitigate this issue.