### PR TITLE
fix: don't ignore libsodiumKeyPath

### DIFF
--- a/internal/configure.go
+++ b/internal/configure.go
@@ -292,7 +292,7 @@ func ConfigureCrypterForSpecificConfig(config *viper.Viper) (crypto.Crypter, err
 	envelopePgpKeyPath := config.IsSet(conf.PgpEnvelopeKeySetting)
 
 	libsodiumKey := config.IsSet(conf.LibsodiumKeySetting)
-	libsodiumKeyPath := config.IsSet(conf.LibsodiumKeySetting)
+	libsodiumKeyPath := config.IsSet(conf.LibsodiumKeyPathSetting)
 
 	isPgpKey := pgpKey || pgpKeyPath || legacyGpg
 	isEnvelopePgpKey := envelopePgpKey || envelopePgpKeyPath


### PR DESCRIPTION
### Database name
Postgres, but should not be database specific.

# Pull request description
Change `libsodiumKeyPath` to be derived from the correct setting.

### Describe what this PR fix
There was a typo introduced in #1547 which lead to the `LibsodiumKeyPathSetting` not being read in `ConfigureCrypterForSpecificConfig`. As such `isLibsodium` would not be set if only the key's path was given, no Crypter would be set and no encryption/decryption being used.


### Please provide steps to reproduce (if it's a bug)
This occurred after upgrading from wal-g 2.0.1 installation with `WALG_LIBSODIUM_KEY_PATH` to wal-g 3.0.3 and lead to lz4 errors because the files had incorrect file magic (because decryption was not performed)
New instances in this environment would not encrypt the backups at all.
