### PR TITLE
fix data race on accessing bool var from different goroutines

### DIFF
--- a/internal/ioextensions/punch_hole_linux.go
+++ b/internal/ioextensions/punch_hole_linux.go
@@ -2,9 +2,12 @@
 
 package ioextensions
 
-import "os"
-import "syscall"
-import "golang.org/x/sys/unix"
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
 
 func PunchHole(f *os.File, offset int64, size int64) error {
 	return syscall.Fallocate(


### PR DESCRIPTION
### Database name
redis

# Pull request description
fix data race on accessing bool var from different goroutines

### Describe what this PR fix
fix data race on accessing bool var from different goroutines

### Please provide steps to reproduce (if it's a bug)
none

### Please add config and wal-g stdout/stderr logs for debug purpose

<details><summary>stacktrace</summary>
<p>


```
wal-g_redis_tests  | WARNING: DATA RACE
wal-g_redis_tests  | Read at 0x00c0001914f8 by goroutine 31:
wal-g_redis_tests  |   github.com/wal-g/wal-g/internal/diskwatcher.(*DiskWatcher).Start.func1()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/internal/diskwatcher/disk_watcher.go:38 +0x64
wal-g_redis_tests  | 
wal-g_redis_tests  | Previous write at 0x00c0001914f8 by main goroutine:
wal-g_redis_tests  |   github.com/wal-g/wal-g/internal/diskwatcher.(*DiskWatcher).Stop()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/internal/diskwatcher/disk_watcher.go:49 +0x5d
wal-g_redis_tests  |   github.com/wal-g/wal-g/internal/databases/redis/aof.(*BackupService).DoBackup.deferwrap2()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/internal/databases/redis/aof/backup.go:123 +0x17
wal-g_redis_tests  |   runtime.deferreturn()
wal-g_redis_tests  |       /usr/local/go/src/runtime/panic.go:602 +0x5d
wal-g_redis_tests  |   github.com/wal-g/wal-g/internal/databases/redis.HandleAOFBackupPush()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/internal/databases/redis/aof_backup_push_handler.go:43 +0x54f
wal-g_redis_tests  |   github.com/wal-g/wal-g/cmd/redis.init.func6()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/cmd/redis/aof_backup_push.go:50 +0x615
wal-g_redis_tests  |   github.com/spf13/cobra.(*Command).execute()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:860 +0xc28
wal-g_redis_tests  |   github.com/spf13/cobra.(*Command).ExecuteC()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:974 +0x617
wal-g_redis_tests  |   github.com/spf13/cobra.(*Command).Execute()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:902 +0x33
wal-g_redis_tests  |   github.com/wal-g/wal-g/cmd/redis.Execute()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/cmd/redis/redis.go:36 +0x1c
wal-g_redis_tests  |   main.main()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/main/redis/main.go:8 +0x1c
wal-g_redis_tests  | 
wal-g_redis_tests  | Goroutine 31 (running) created at:
wal-g_redis_tests  |   github.com/wal-g/wal-g/internal/diskwatcher.(*DiskWatcher).Start()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/internal/diskwatcher/disk_watcher.go:36 +0x8d
wal-g_redis_tests  |   github.com/wal-g/wal-g/internal/databases/redis/aof.(*BackupService).DoBackup()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/internal/databases/redis/aof/backup.go:122 +0x375
wal-g_redis_tests  |   github.com/wal-g/wal-g/internal/databases/redis.HandleAOFBackupPush()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/internal/databases/redis/aof_backup_push_handler.go:43 +0x54f
wal-g_redis_tests  |   github.com/wal-g/wal-g/cmd/redis.init.func6()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/cmd/redis/aof_backup_push.go:50 +0x615
wal-g_redis_tests  |   github.com/spf13/cobra.(*Command).execute()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:860 +0xc28
wal-g_redis_tests  |   github.com/spf13/cobra.(*Command).ExecuteC()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:974 +0x617
wal-g_redis_tests  |   github.com/spf13/cobra.(*Command).Execute()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:902 +0x33
wal-g_redis_tests  |   github.com/wal-g/wal-g/cmd/redis.Execute()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/cmd/redis/redis.go:36 +0x1c
wal-g_redis_tests  |   main.main()
wal-g_redis_tests  |       /go/src/github.com/wal-g/wal-g/main/redis/main.go:8 +0x1c
wal-g_redis_tests  | ==================
wal-g_redis_tests  | Found 1 data race(s)
```

</p>
</details>