### PR TITLE
MongoDB: don't skip error if file was deleted while make backup

### DIFF
--- a/internal/concurrent_uploader.go
+++ b/internal/concurrent_uploader.go
@@ -15,7 +15,12 @@ type ConcurrentUploader struct {
 	CompressedSize   int64
 }
 
-func CreateConcurrentUploader(uploader Uploader, backupName string, directories []string) (*ConcurrentUploader, error) {
+func CreateConcurrentUploader(
+	uploader Uploader,
+	backupName string,
+	directories []string,
+	skipFileNotExists bool,
+) (*ConcurrentUploader, error) {
 	crypter := ConfigureCrypter()
 	tarSizeThreshold := viper.GetInt64(conf.TarSizeThresholdSetting)
 	bundle := NewBundle(directories, crypter, tarSizeThreshold, map[string]utility.Empty{})
@@ -27,7 +32,7 @@ func CreateConcurrentUploader(uploader Uploader, backupName string, directories 
 		return nil, err
 	}
 
-	tarBallComposerMaker := NewRegularTarBallComposerMaker(&RegularBundleFiles{}, NewRegularTarFileSets())
+	tarBallComposerMaker := NewRegularTarBallComposerMaker(&RegularBundleFiles{}, NewRegularTarFileSets(), skipFileNotExists)
 	err = bundle.SetupComposer(tarBallComposerMaker)
 	if err != nil {
 		return nil, err

--- a/internal/databases/mongo/binary/backup.go
+++ b/internal/databases/mongo/binary/backup.go
@@ -53,7 +53,7 @@ func (backupService *BackupService) DoBackup(backupName string, permanent bool) 
 	backupCursor.StartKeepAlive()
 
 	mongodDBPath := backupCursor.BackupCursorMeta.DBPath
-	concurrentUploader, err := internal.CreateConcurrentUploader(backupService.Uploader, backupName, []string{mongodDBPath})
+	concurrentUploader, err := internal.CreateConcurrentUploader(backupService.Uploader, backupName, []string{mongodDBPath}, false)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/redis/aof_backup_push_handler.go
+++ b/internal/databases/redis/aof_backup_push_handler.go
@@ -19,7 +19,7 @@ func HandleAOFBackupPush(ctx context.Context, permanent bool, uploader internal.
 	aofFolder, _ := conf.GetSetting(conf.RedisAppendonlyFolder)
 	aofPath := filepath.Join(dataFolder, aofFolder)
 	tmpPath, _ := conf.GetSetting(conf.RedisAppendonlyTmpFolder)
-	concurrentUploader, err := internal.CreateConcurrentUploader(uploader, backupName, []string{aofPath, tmpPath})
+	concurrentUploader, err := internal.CreateConcurrentUploader(uploader, backupName, []string{aofPath, tmpPath}, true)
 	if err != nil {
 		return err
 	}

--- a/internal/regular_tar_ball_composer.go
+++ b/internal/regular_tar_ball_composer.go
@@ -41,19 +41,22 @@ func NewRegularTarBallComposer(
 type RegularTarBallComposerMaker struct {
 	files       BundleFiles
 	tarFileSets TarFileSets
+
+	skipFileNotExists bool
 }
 
-func NewRegularTarBallComposerMaker(files BundleFiles, tarFileSets TarFileSets) *RegularTarBallComposerMaker {
+func NewRegularTarBallComposerMaker(files BundleFiles, tarFileSets TarFileSets, skipFileNotExists bool) *RegularTarBallComposerMaker {
 	return &RegularTarBallComposerMaker{
-		files:       files,
-		tarFileSets: tarFileSets,
+		files:             files,
+		tarFileSets:       tarFileSets,
+		skipFileNotExists: skipFileNotExists,
 	}
 }
 
 func (maker *RegularTarBallComposerMaker) Make(bundle *Bundle) (TarBallComposer, error) {
 	bundleFiles := maker.files
 	tarFileSets := maker.tarFileSets
-	packer := NewRegularTarBallFilePacker(bundleFiles)
+	packer := NewRegularTarBallFilePacker(bundleFiles, maker.skipFileNotExists)
 	return NewRegularTarBallComposer(bundle.TarBallQueue, packer, bundleFiles, tarFileSets, bundle.Crypter), nil
 }
 

--- a/internal/tar_ball_file_packer.go
+++ b/internal/tar_ball_file_packer.go
@@ -31,18 +31,24 @@ type TarBallFilePacker interface {
 }
 
 type RegularTarBallFilePacker struct {
-	files BundleFiles
+	files             BundleFiles
+	skipFileNotExists bool
 }
 
-func NewRegularTarBallFilePacker(files BundleFiles) *RegularTarBallFilePacker {
+func NewRegularTarBallFilePacker(files BundleFiles, skipFileNotExists bool) *RegularTarBallFilePacker {
 	return &RegularTarBallFilePacker{
-		files: files,
+		files:             files,
+		skipFileNotExists: skipFileNotExists,
 	}
 }
 
 func (p *RegularTarBallFilePacker) PackFileIntoTar(cfi *ComposeFileInfo, tarBall TarBall) error {
 	fileReadCloser, err := StartReadingFile(cfi.Header, cfi.FileInfo, cfi.Path)
 	if err != nil {
+		if !p.skipFileNotExists {
+			return err
+		}
+
 		switch err.(type) {
 		case FileNotExistError:
 			// File was deleted before opening.


### PR DESCRIPTION
### Database name
MongoDB

# Pull request description


### Describe what this PR fix
while creating backup if file was deleted, it will be ignored& But for mongodb this is wrong behaviour 



### Please add config and wal-g stdout/stderr logs for debug purpose
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/bc5b40cd-460f-4ad0-95c8-a672842ea219">
