### PR TITLE
Fixing [issue](https://github.com/wal-g/wal-g/issues/1809)

### DIFF
--- a/internal/multistorage/stats/cache/cache_test.go
+++ b/internal/multistorage/stats/cache/cache_test.go
@@ -182,8 +182,26 @@ func Test_cache_ApplyExplicitCheckResult(t *testing.T) {
 		assert.Equal(t, checkRes, fileStatuses.aliveMap(c.emaParams))
 	})
 
+	t.Run("applies check result to file if file does not exist", func(t *testing.T) {
+		c := newTestCache(t, 2, true)
+		WithCustomFlushTimeout(time.Hour)(c)
+		checkRes := AliveMap{
+			"def": true,
+			"fo1": false,
+			"fo2": true,
+		}
+		_, err := c.ApplyExplicitCheckResult(checkRes, time.Now())
+		require.NoError(t, err)
+
+		fileStatuses, err := c.shFile.read()
+		require.NoError(t, err)
+
+		assert.Equal(t, checkRes, fileStatuses.aliveMap(c.emaParams))
+	})
+
 	t.Run("does not apply check result to file if flush timeout did not exceed", func(t *testing.T) {
 		c := newTestCache(t, 2, true)
+		c.shFile.Updated = time.Now()
 		WithCustomFlushTimeout(time.Hour)(c)
 
 		err := c.shFile.write(nil)
@@ -280,6 +298,19 @@ func Test_cache_ApplyOperationResult(t *testing.T) {
 	t.Run("applies operation result to file if flush timeout exceeded", func(t *testing.T) {
 		c := newTestCache(t, 1, true)
 		WithCustomFlushTimeout(0)(c)
+
+		c.ApplyOperationResult("fo1", true, 100)
+
+		fileStatuses, err := c.shFile.read()
+		require.NoError(t, err)
+
+		assert.True(t, fileStatuses[key("fo1")].alive(c.emaParams))
+	})
+
+    t.Run("apply operation result to file if file does not exist", func(t *testing.T) {
+		c := newTestCache(t, 1, true)
+		c.shFile.Updated = time.Now()
+		WithCustomFlushTimeout(time.Hour)(c)
 
 		c.ApplyOperationResult("fo1", true, 100)
 

--- a/internal/multistorage/stats/cache/cache_test.go
+++ b/internal/multistorage/stats/cache/cache_test.go
@@ -309,7 +309,6 @@ func Test_cache_ApplyOperationResult(t *testing.T) {
 
     t.Run("apply operation result to file if file does not exist", func(t *testing.T) {
 		c := newTestCache(t, 1, true)
-		c.shFile.Updated = time.Now()
 		WithCustomFlushTimeout(time.Hour)(c)
 
 		c.ApplyOperationResult("fo1", true, 100)
@@ -322,6 +321,7 @@ func Test_cache_ApplyOperationResult(t *testing.T) {
 
 	t.Run("does not apply operation result to file if flush timeout did not exceed", func(t *testing.T) {
 		c := newTestCache(t, 1, true)
+        c.shFile.Updated = time.Now()
 		WithCustomFlushTimeout(time.Hour)(c)
 		err := c.shFile.write(nil)
 		require.NoError(t, err)

--- a/internal/multistorage/stats/cache/cache_test.go
+++ b/internal/multistorage/stats/cache/cache_test.go
@@ -307,7 +307,7 @@ func Test_cache_ApplyOperationResult(t *testing.T) {
 		assert.True(t, fileStatuses[key("fo1")].alive(c.emaParams))
 	})
 
-    t.Run("apply operation result to file if file does not exist", func(t *testing.T) {
+	t.Run("apply operation result to file if file does not exist", func(t *testing.T) {
 		c := newTestCache(t, 1, true)
 		WithCustomFlushTimeout(time.Hour)(c)
 
@@ -321,7 +321,7 @@ func Test_cache_ApplyOperationResult(t *testing.T) {
 
 	t.Run("does not apply operation result to file if flush timeout did not exceed", func(t *testing.T) {
 		c := newTestCache(t, 1, true)
-        c.shFile.Updated = time.Now()
+		c.shFile.Updated = time.Now()
 		WithCustomFlushTimeout(time.Hour)(c)
 		err := c.shFile.write(nil)
 		require.NoError(t, err)

--- a/internal/multistorage/stats/cache/file.go
+++ b/internal/multistorage/stats/cache/file.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"syscall"
 	"time"
 )
 
@@ -18,8 +17,7 @@ func NewSharedFile(path string) *SharedFile {
 	info, err := os.Stat(path)
 	var updated time.Time
 	if err == nil {
-		atime := info.Sys().(*syscall.Stat_t).Atim
-		updated = time.Unix(atime.Sec, atime.Nsec)
+		updated = info.ModTime()
 	} else {
 		// File does not exist or is not available
 		// Set very low time, so any comparison with timeout will return True

--- a/internal/multistorage/stats/cache/file.go
+++ b/internal/multistorage/stats/cache/file.go
@@ -14,9 +14,19 @@ type SharedFile struct {
 }
 
 func NewSharedFile(path string) *SharedFile {
+	info, err := os.Stat(path)
+	var updated time.Time
+	if err == nil {
+		atime := info.Sys().(*syscall.Stat_t).Atim
+		updated = time.Unix(atime.Sec, atime.Nsec)
+	} else {
+		// File does not exist or is not available
+		// Set very low time, so any comparison with timeout will return True
+		updated = time.Time{}
+	}
 	return &SharedFile{
 		Path:    path,
-		Updated: time.Now(),
+		Updated: updated,
 	}
 }
 

--- a/internal/multistorage/stats/cache/file.go
+++ b/internal/multistorage/stats/cache/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 	"time"
 )
 

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -24,7 +24,6 @@ import (
 
 func createSession(config *Config) (*session.Session, error) {
 	sessOpts := session.Options{}
-	tracelog.DebugLogger.Printf("Creating S3 session")
 	if config.CACertFile != "" {
 		file, err := os.Open(config.CACertFile)
 		if err != nil {

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -24,6 +24,7 @@ import (
 
 func createSession(config *Config) (*session.Session, error) {
 	sessOpts := session.Options{}
+	tracelog.DebugLogger.Printf("Creating S3 session")
 	if config.CACertFile != "" {
 		file, err := os.Open(config.CACertFile)
 		if err != nil {


### PR DESCRIPTION
### Database name
Postgres

# Pull request description
When failover storages are enabled and wal-g is used without daemond it don't ever cache storage state in shared file while doing walg-push. This PR fixes it.

### Describe what this PR fix
Fixing [issue](https://github.com/wal-g/wal-g/issues/1809)

### Please provide steps to reproduce (if it's a bug)
Described in the issue above.

