### PR TITLE
feat(file): add sync mutex to TarFileSet

### DIFF
--- a/internal/tar_file_sets.go
+++ b/internal/tar_file_sets.go
@@ -1,27 +1,52 @@
 package internal
 
+import (
+	"sync"
+)
+
 type TarFileSets interface {
 	AddFile(name string, file string)
 	AddFiles(name string, files []string)
 	Get() map[string][]string
 }
 
-type RegularTarFileSets map[string][]string
+type RegularTarFileSets struct {
+	data  map[string][]string
+	mutex sync.RWMutex
+}
 
 func NewRegularTarFileSets() *RegularTarFileSets {
-	return &RegularTarFileSets{}
+	return &RegularTarFileSets{
+		data: make(map[string][]string),
+	}
 }
 
 func (tarFileSets *RegularTarFileSets) AddFile(name string, file string) {
-	(*tarFileSets)[name] = append((*tarFileSets)[name], file)
+	tarFileSets.mutex.Lock()
+	defer tarFileSets.mutex.Unlock()
+
+	tarFileSets.data[name] = append(tarFileSets.data[name], file)
 }
 
 func (tarFileSets *RegularTarFileSets) AddFiles(name string, files []string) {
-	(*tarFileSets)[name] = append((*tarFileSets)[name], files...)
+	tarFileSets.mutex.Lock()
+	defer tarFileSets.mutex.Unlock()
+
+	tarFileSets.data[name] = append(tarFileSets.data[name], files...)
 }
 
 func (tarFileSets *RegularTarFileSets) Get() map[string][]string {
-	return *tarFileSets
+	tarFileSets.mutex.RLock()
+	defer tarFileSets.mutex.RUnlock()
+
+	// Create a copy to ensure thread safety
+	result := make(map[string][]string, len(tarFileSets.data))
+	for k, v := range tarFileSets.data {
+		newSlice := make([]string, len(v))
+		copy(newSlice, v)
+		result[k] = newSlice
+	}
+	return result
 }
 
 type NopTarFileSets struct {


### PR DESCRIPTION
### Database name
Using Postgres but I think this will be useful for any database engine as this is in the core internal package.

# Pull request description
Add mutex support for TarFileSet to prevent concurrent map write panics during backup operations.
Linked to this issue : https://github.com/wal-g/wal-g/issues/1839

### Describe what this PR fix
The problem is concurrent map writes in TarFileSets during backup operations, particularly when multiple goroutines try to access and modify the underlying map simultaneously. This causes panics with the error "fatal error: concurrent map writes".

The fix:
1. Adds sync.RWMutex to protect map operations
2. Encapsulates the map in a struct with proper locking
3. Ensures thread-safe copy operations in Get()
4. Maintains backward compatibility with the existing interface

### Steps to reproduce
1. Configure WAL-G with high concurrency settings:
```bash
WALG_UPLOAD_CONCURRENCY=16
WALG_UPLOAD_DISK_CONCURRENCY=4
```

2. Run a full backup on a large database:
```bash
wal-g backup-push /path/to/pgdata
```

3. The backup fails with:
```
fatal error: concurrent map writes
    at: github.com/wal-g/wal-g/internal.(*RegularTarFileSets).AddFile
```

### Debug logs
<details><summary>Error logs</summary>
<p>

```bash
INFO: 2024/11/20 15:59:02.965820 Backup will be pushed to storage: default
INFO: 2024/11/20 15:59:03.001134 Calling pg_start_backup()
INFO: 2024/11/20 15:59:03.967540 Initializing the PG alive checker (interval=1m0s)...
INFO: 2024/11/20 15:59:03.967596 Starting a new tar bundle
INFO: 2024/11/20 15:59:03.967619 Walking ...
INFO: 2024/11/20 15:59:03.967943 Starting part 1 ...
[...]
fatal error: concurrent map writes

goroutine 146 [running]:
github.com/wal-g/wal-g/internal.(*RegularTarFileSets).AddFile(0xc0005745a0?, {0xc0004bd5a0?, 0x25df9d0?}, {0xc00779f800, 0x12})
        /home/runner/work/wal-g/wal-g/internal/tar_file_sets.go:16 +0x45
```
</p>
</details>

### Testing Done
1. Manual testing with high concurrency settings
2. Verified thread safety with Go race detector
3. Tested backward compatibility
4. Verified no performance degradation with normal workloads

The changes are minimal and maintain the existing interface while adding thread safety.