### PR TITLE
MySQL: add SpaceIDCollector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ PKG := github.com/wal-g/wal-g
 COVERAGE_FILE := coverage.out
 TEST := "pg_tests"
 MYSQL_TEST := "mysql_base_tests"
+MYSQL8_TEST := "mysql8_tests"
 MONGO_MAJOR ?= "5.0"
 MONGO_VERSION ?= "5.0.21"
 MONGO_PACKAGE ?= "mongodb-org"
@@ -145,8 +146,8 @@ mysql_integration_test: deps mysql_build unlink_brotli load_docker_common
 	docker compose up --force-recreate --exit-code-from $(MYSQL_TEST) $(MYSQL_TEST)
 
 mysql8_integration_test: go_deps unlink_brotli load_docker_common
-	docker compose build mysql8 && docker compose build $(MYSQL_TEST)
-	docker compose up --force-recreate --exit-code-from $(MYSQL_TEST) $(MYSQL_TEST)
+	docker compose build mysql8 && docker compose build $(MYSQL8_TEST)
+	docker compose up --force-recreate --exit-code-from $(MYSQL8_TEST) $(MYSQL8_TEST)
 
 mysql_clean:
 	(cd $(MAIN_MYSQL_PATH) && go clean)

--- a/internal/databases/mysql/innodb/.gitignore
+++ b/internal/databases/mysql/innodb/.gitignore
@@ -1,0 +1,1 @@
+test_data*

--- a/internal/databases/mysql/innodb/space_id_collector.go
+++ b/internal/databases/mysql/innodb/space_id_collector.go
@@ -1,0 +1,75 @@
+package innodb
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/wal-g/tracelog"
+)
+
+var ErrSpaceIDNotFound = errors.New("SpaceID not found")
+
+type SpaceIDCollector interface {
+	Collect() error
+	GetFileForSpaceID(spaceID SpaceID) (string, error)
+}
+
+type spaceIDCollectorImpl struct {
+	dataDir   string
+	collected map[SpaceID]string
+}
+
+var _ SpaceIDCollector = &spaceIDCollectorImpl{}
+
+func NewSpaceIDCollector(dataDir string) SpaceIDCollector {
+	return &spaceIDCollectorImpl{dataDir: dataDir}
+}
+
+func (c *spaceIDCollectorImpl) Collect() error {
+	c.collected = make(map[SpaceID]string)
+
+	err := filepath.WalkDir(c.dataDir, func(path string, info fs.DirEntry, walkErr error) error {
+		tracelog.ErrorLogger.FatalfOnError("Error encountered during datadir traverse", walkErr)
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".ibd") {
+			err := c.collect(path)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+func (c *spaceIDCollectorImpl) collect(filePath string) error {
+	// read first FPS page (always first page in the file)
+	file, err := os.OpenFile(filePath, os.O_RDONLY|syscall.O_NOFOLLOW, 0) // FIXME: test performance with O_SYNC
+	tracelog.ErrorLogger.FatalfOnError("Cannot open file: %v", err)
+
+	reader := NewPageReader(file)
+	if reader == nil {
+		return fmt.Errorf("canot read innodb file %v", filePath)
+	}
+	if !strings.HasPrefix(filePath, c.dataDir) {
+		tracelog.ErrorLogger.Fatalf("File %v is out of data dir %v", filePath, c.dataDir)
+	}
+	fileName := filePath[len(c.dataDir):]
+	c.collected[reader.SpaceID] = strings.TrimPrefix(fileName, "/")
+	return nil
+}
+
+func (c *spaceIDCollectorImpl) GetFileForSpaceID(spaceID SpaceID) (string, error) {
+	if c.collected == nil {
+		return "", fmt.Errorf("spaceIDCollectorImpl not initialized")
+	}
+	result, ok := c.collected[spaceID]
+	if ok {
+		return result, nil
+	}
+	return "", fmt.Errorf("file for SpaceID %v not found: %w", spaceID, ErrSpaceIDNotFound)
+}

--- a/internal/databases/mysql/innodb/space_id_collector_test.go
+++ b/internal/databases/mysql/innodb/space_id_collector_test.go
@@ -100,8 +100,7 @@ func TestSpaceIDCollector(t *testing.T) {
 	tempDir := generateData(t)
 	defer os.RemoveAll(tempDir)
 
-	collector := NewSpaceIDCollector(tempDir)
-	err := collector.Collect()
+	collector, err := NewSpaceIDCollector(tempDir)
 	assert.NoError(t, err)
 
 	raw := collector.(*spaceIDCollectorImpl).collected

--- a/internal/databases/mysql/innodb/space_id_collector_test.go
+++ b/internal/databases/mysql/innodb/space_id_collector_test.go
@@ -1,0 +1,117 @@
+package innodb
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wal-g/wal-g/internal/testutils"
+	"github.com/wal-g/wal-g/testtools"
+	"github.com/wal-g/wal-g/utility"
+)
+
+func generateData(t *testing.T) string {
+	cwd, err := filepath.Abs("./")
+	if err != nil {
+		t.Log(err)
+	}
+
+	// Create temp directory.
+	dir, err := os.MkdirTemp(cwd, "test_data")
+	if err != nil {
+		t.Log(err)
+	}
+
+	// Generates files with random data:
+	files := []string{
+		"orders.txt",
+		"orders",
+	}
+	for _, file := range files {
+		generateRandomFile(t, filepath.Join(dir, file))
+	}
+
+	// Generate innodb files with something like FSP-header:
+	ibdFiles := []string{
+		"main.ibd",
+		"test.ibd",
+		"orders.ibd",
+	}
+	for idx, file := range ibdFiles {
+		generateInnodbFile(t, filepath.Join(dir, file), SpaceID(idx+1))
+	}
+
+	// add nested dir & nested file:
+	err = os.MkdirAll(filepath.Join(dir, "nested"), 0777)
+	if err != nil {
+		t.Log(err)
+	}
+	generateInnodbFile(t, filepath.Join(dir, "nested", "database.ibd"), SpaceID(999))
+
+	return dir
+}
+
+func generateRandomFile(t *testing.T, path string) {
+	sb := testtools.NewStrideByteReader(10)
+	lr := &io.LimitedReader{
+		R: sb,
+		N: int64(100),
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Log(err)
+	}
+	io.Copy(f, lr)
+	defer utility.LoggedClose(f, "")
+}
+
+func generateInnodbFile(t *testing.T, path string, spaceId SpaceID) {
+	sb := testtools.NewStrideByteReader(10)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Log(err)
+	}
+
+	var hexFile = `
+		00000000  7c c3 d3 35 00 00 00 00  00 01 38 a3 00 00 00 01  ||..5......8.....|
+		00000010  00 00 00 00 58 ed a9 c1  00 08 00 00 00 00 00 00  |....X...........|
+		00000020  00 00 00 00 00 0b 00 00  00 0b 00 00 00 00 00 00  |................|
+		00000030  5a 00 00 00 57 c0 00 00  40 21 00 00 00 3a 00 00  |Z...W...@!...:..|`
+	pageBytes := testutils.HexToBytes(hexFile)
+	// set SpaceID:
+	binary.BigEndian.PutUint32(pageBytes[34:38], uint32(spaceId)) // FIL header
+	binary.BigEndian.PutUint32(pageBytes[38:42], uint32(spaceId)) // FSP header
+	io.Copy(f, bytes.NewReader(pageBytes))
+
+	lr := &io.LimitedReader{
+		R: sb,
+		N: int64(100),
+	}
+	io.Copy(f, lr)
+	defer utility.LoggedClose(f, "")
+}
+
+func TestSpaceIDCollector(t *testing.T) {
+	tempDir := generateData(t)
+	defer os.RemoveAll(tempDir)
+
+	collector := NewSpaceIDCollector(tempDir)
+	err := collector.Collect()
+	assert.NoError(t, err)
+
+	raw := collector.(*spaceIDCollectorImpl).collected
+	expected := map[SpaceID]string{
+		SpaceID(1):   "main.ibd",
+		SpaceID(2):   "test.ibd",
+		SpaceID(3):   "orders.ibd",
+		SpaceID(999): "nested/database.ibd",
+	}
+
+	assert.Equal(t, expected, raw)
+
+}


### PR DESCRIPTION
xtrabackup uses SpaceID to locate original files to which we should apply deltas (File names could change to reflect table renames).
SpaceIDCollector is a small helper that can collect SpaceID to Path mapping and return it to us.