### PR TITLE
fix: correct LSN format string in delta backup logging

### DIFF
--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -251,7 +251,7 @@ func (bh *BackupHandler) startBackup() error {
 func (bh *BackupHandler) handleDeltaBackup(folder storage.Folder) {
 	if len(bh.prevBackupInfo.name) > 0 && bh.prevBackupInfo.sentinelDto.BackupStartLSN != nil {
 		tracelog.InfoLogger.Println("Delta backup enabled")
-		tracelog.DebugLogger.Printf("Previous backup: %s\nBackup start LSN: %d", bh.prevBackupInfo.name,
+		tracelog.DebugLogger.Printf("Previous backup: %s\nBackup start LSN: %s", bh.prevBackupInfo.name,
 			bh.prevBackupInfo.sentinelDto.BackupStartLSN)
 		if *bh.prevBackupInfo.sentinelDto.BackupFinishLSN > bh.CurBackupInfo.startLSN {
 			tracelog.ErrorLogger.FatalOnError(newBackupFromFuture(bh.prevBackupInfo.name))


### PR DESCRIPTION
Change the format specifier from %d to %s when logging backup start LSN in handleDeltaBackup. maintaining consistency with other LSN logging in the codebase.

Before:
DEBUG: Previous backup: base_*23_D_*1E
Backup start LSN: 824644527024

After:
DEBUG: Previous backup: base_*27_D_*23
Backup start LSN: 0/27000028