### PR TITLE
MySQL: Fix regression - broken backup considered as good one

### DIFF
--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -202,14 +202,14 @@ func handleXtrabackupBackup(
 	backupName, err = uploader.PushStream(context.Background(), limiters.NewDiskLimitReader(stdout))
 	tracelog.ErrorLogger.FatalfOnError("failed to push backup: %v", err)
 
-	err = backupCmd.Wait()
-	if err != nil {
+	cmdErr := backupCmd.Wait()
+	if cmdErr != nil {
 		tracelog.ErrorLogger.Printf("Backup command output:\n%s", stderr.String())
 	}
 
-	backupInfo, extraErr := readXtrabackupInfo(xtrabackupExtraDirectory)
-	if extraErr != nil {
-		tracelog.WarningLogger.Printf("failed to read and parse `xtrabackup_checkpoints`: %v", extraErr)
+	backupInfo, err := readXtrabackupInfo(xtrabackupExtraDirectory)
+	if err != nil {
+		tracelog.WarningLogger.Printf("failed to read and parse `xtrabackup_checkpoints`: %v", err)
 	}
 	backupExtInfo = XtrabackupExtInfo{
 		XtrabackupInfo: backupInfo,
@@ -218,10 +218,10 @@ func handleXtrabackupBackup(
 		ServerArch: runtime.GOARCH,
 	}
 
-	extraErr = removeTemporaryDirectory(xtrabackupExtraDirectory)
-	if extraErr != nil {
-		tracelog.ErrorLogger.Printf("failed to remove tmp directory from diff-backup: %v", extraErr)
+	err = removeTemporaryDirectory(xtrabackupExtraDirectory)
+	if err != nil {
+		tracelog.ErrorLogger.Printf("failed to remove tmp directory from diff-backup: %v", err)
 	}
 
-	return backupName, backupExtInfo, err
+	return backupName, backupExtInfo, cmdErr
 }

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -207,9 +207,9 @@ func handleXtrabackupBackup(
 		tracelog.ErrorLogger.Printf("Backup command output:\n%s", stderr.String())
 	}
 
-	backupInfo, err := readXtrabackupInfo(xtrabackupExtraDirectory)
-	if err != nil {
-		tracelog.WarningLogger.Printf("failed to read and parse `xtrabackup_checkpoints`: %v", err)
+	backupInfo, extraErr := readXtrabackupInfo(xtrabackupExtraDirectory)
+	if extraErr != nil {
+		tracelog.WarningLogger.Printf("failed to read and parse `xtrabackup_checkpoints`: %v", extraErr)
 	}
 	backupExtInfo = XtrabackupExtInfo{
 		XtrabackupInfo: backupInfo,
@@ -218,10 +218,9 @@ func handleXtrabackupBackup(
 		ServerArch: runtime.GOARCH,
 	}
 
-	err = removeTemporaryDirectory(xtrabackupExtraDirectory)
-	if err != nil {
-		tracelog.ErrorLogger.Printf("failed to remove tmp directory from diff-backup: %v", err)
-		err = nil // don't crash an app
+	extraErr = removeTemporaryDirectory(xtrabackupExtraDirectory)
+	if extraErr != nil {
+		tracelog.ErrorLogger.Printf("failed to remove tmp directory from diff-backup: %v", extraErr)
 	}
 
 	return backupName, backupExtInfo, err


### PR DESCRIPTION
### MySQL

There is a regression that leads to broken backups to be considered as good one.
Fix error handling in `handleXtrabackupBackup()`

Example:

```
2024-12-03T00:36:25.353680-00:00 4 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./test/test.ibd
2024-12-03T00:36:25.371292-00:00 4 [Note] [MY-011825] [Xtrabackup] Streaming ./test/test2#p#p40.ibd
2024-12-03T00:36:43.209941-00:00 1 [Note] [MY-011825] [Xtrabackup] >> log scanned up to (25526356185088)
2024-12-03T00:43:36.377008-00:00 1 [Note] [MY-011825] [Xtrabackup] >> log scanned up to (25528235218944)
2024-12-03T00:44:26.654449-00:00 1 [Note] [MY-012894] [InnoDB] Unable to open './#innodb_redo/#ib_redo32319' (error: 1504).
2024-12-03T00:44:26.654477-00:00 1 [ERROR] [MY-011825] [Xtrabackup] read_logfile() failed.
2024-12-03T00:44:27.080408-00:00 0 [ERROR] [MY-011825] [Xtrabackup] log copying failed.
/bin/sh: line 2: --extra-lsndir=/tmp/wal-g2860127194: No such file or directory
WARNING: 2024/12/03 00:44:43.768730 failed to read and parse `xtrabackup_checkpoints`: open /tmp/wal-g2860127194/xtrabackup_checkpoints: no such file or directory
INFO: 2024/12/03 00:44:49.290766 Backup sentinel: {"Tool":"WALG_XTRABACKUP_TOOL","BinLogStart":"<...>","BinLogEnd":"<...>","StartLocalTime":"2024-12-03T00:19:05.657437Z","StopLocalTime":"2024-12-03T00:44:49.29065
3Z","UncompressedSize":187033517316,"CompressedSize":51126297204,"Hostname":"<...>","ServerUUID":"<UUID>","ServerVersion":"<...>","ServerArch":"amd64","ServerOS":"linux","IsPermanent":false,"IsIncremental":false,"UserData":<JSON>,"LSN":null,"DeltaCount":0}
2024-12-03 00:44:49,574 [INFO]: setting slave_parallel_workers to 32
2024-12-03 00:44:51,338 [INFO]: Backup done
```