### PR TITLE
fix(PostgreSQL): exclude transaction state files from page file detec…

### DIFF
--- a/internal/databases/postgres/pagefile_test.go
+++ b/internal/databases/postgres/pagefile_test.go
@@ -68,6 +68,16 @@ func TestIsPagedFile(t *testing.T) {
 		{"name starts with dot", "../../../test/testdata/pagefiles/base/.123", false},
 		{"name contains digits only", "../../../test/testdata/pagefiles/base/123", true},
 		{"name contains digits separated by dot", "../../../test/testdata/pagefiles/base/123.123", true},
+
+		// For the following special file types:
+		// - pg_xact: transaction status files
+		// - pg_multixact/members: multitransaction member files
+		// - pg_multixact/offsets: multitransaction offset files
+		// We determine they are not page files purely based on their path patterns,
+		// without actually reading the files
+		{"pg_xact file", "~/DemoDb/pg_xact/0000", false},
+		{"pg_multixact members file", "~/DemoDb/pg_multixact/members/0000", false},
+		{"pg_multixact offsets file", "~/DemoDb/pg_multixact/offsets/0000", false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Exclude transaction state files from page file detection.

Previously, transaction state related files (pg_xact, pg_multixact) were incorrectly identified as page files, causing errors(please refer to the stack trace below for details of the error) during delta backup process.

This fix adds specific checks to exclude these files from page file detection.

The issue occurred because:
- Transaction state files were wrongly treated as page files during delta backup
- This led to incorrect IsIncremented flag setting in internal.ComposeFileInfo
- Resulted in errors when TarBallFilePackerImpl tried to process these files

Changes:
- Add constants for transaction state directories
- Implement isTransactionStatePath() to identify these special files
- Update isPagedFile() to exclude transaction state files
- Add corresponding test cases

```
ERROR: 2024/12/16 08:50:05.594331 strconv.Atoi: parsing "pg_xact": invalid syntax
GetRelFileNodeFrom: can't get dbNode from: '/home/robertmu/database/pg_xact/0000'
github.com/wal-g/wal-g/internal/databases/postgres.GetRelFileNodeFrom
        /home/robertmu/Projects/wal-g/internal/databases/postgres/paged_file_delta_map.go:124
github.com/wal-g/wal-g/internal/databases/postgres.(*PagedFileDeltaMap).GetDeltaBitmapFor
        /home/robertmu/Projects/wal-g/internal/databases/postgres/paged_file_delta_map.go:74
github.com/wal-g/wal-g/internal/databases/postgres.(*TarBallFilePackerImpl).getDeltaBitmapFor
        /home/robertmu/Projects/wal-g/internal/databases/postgres/tar_ball_file_packer.go:68
github.com/wal-g/wal-g/internal/databases/postgres.(*TarBallFilePackerImpl).createFileReadCloser
        /home/robertmu/Projects/wal-g/internal/databases/postgres/tar_ball_file_packer.go:130
github.com/wal-g/wal-g/internal/databases/postgres.(*TarBallFilePackerImpl).PackFileIntoTar
        /home/robertmu/Projects/wal-g/internal/databases/postgres/tar_ball_file_packer.go:77
github.com/wal-g/wal-g/internal/databases/postgres.(*RegularTarBallComposer).AddFile.func1
        /home/robertmu/Projects/wal-g/internal/databases/postgres/regular_tar_ball_composer.go:78
golang.org/x/sync/errgroup.(*Group).Go.func1
        /home/robertmu/Projects/wal-g/vendor/golang.org/x/sync/errgroup/errgroup.go:78
runtime.goexit
        /usr/lib/go-1.23/src/runtime/asm_amd64.s:1700
PackFileIntoTar: failed to find corresponding bitmap '/home/robertmu/database/pg_xact/0000'

github.com/wal-g/wal-g/internal/databases/postgres.(*TarBallFilePackerImpl).createFileReadCloser
        /home/robertmu/Projects/wal-g/internal/databases/postgres/tar_ball_file_packer.go:134
github.com/wal-g/wal-g/internal/databases/postgres.(*TarBallFilePackerImpl).PackFileIntoTar
        /home/robertmu/Projects/wal-g/internal/databases/postgres/tar_ball_file_packer.go:77
github.com/wal-g/wal-g/internal/databases/postgres.(*RegularTarBallComposer).AddFile.func1
        /home/robertmu/Projects/wal-g/internal/databases/postgres/regular_tar_ball_composer.go:78
golang.org/x/sync/errgroup.(*Group).Go.func1
        /home/robertmu/Projects/wal-g/vendor/golang.org/x/sync/errgroup/errgroup.go:78
runtime.goexit
        /usr/lib/go-1.23/src/runtime/asm_amd64.s:1700
```
