### PR TITLE
fix(postgres): resolve race condition in pg_wal_restore_test

### DIFF
--- a/docker/pg_tests/scripts/tests/wal_restore_test.sh
+++ b/docker/pg_tests/scripts/tests/wal_restore_test.sh
@@ -9,6 +9,37 @@ PGDATA_BETA="${PGDATA}_beta"
 ALPHA_PORT=5432
 BETA_PORT=5433
 
+check_archiving_status() {
+    local port=$1
+    local expected_count=$2
+    local timeout_minutes=${3:-10}
+    local max_wait=`expr $timeout_minutes \* 60`
+    local interval=5
+
+    echo "Starting archive check, waiting for $expected_count files, timeout in $timeout_minutes minutes"
+
+    i=0
+    while [ $i -lt $max_wait ]; do
+        local archived_count=`psql -h 127.0.0.1 -p $port -t -c "
+            SELECT archived_count
+            FROM pg_stat_archiver;" | tr -d ' '`
+
+        if [ "$archived_count" -ge "$expected_count" ]; then
+            echo "Archiving completed: $archived_count files archived"
+            return 0
+        fi
+
+        local remaining_minutes=`expr \( $max_wait - $i \) / 60`
+        local remaining_seconds=`expr \( $max_wait - $i \) % 60`
+        echo "Waiting for archiving to complete... ($archived_count/$expected_count) - Remaining time: ${remaining_minutes}m ${remaining_seconds}s"
+        sleep $interval
+        i=`expr $i + $interval`
+    done
+
+    echo "Warning: Archiving did not complete after $timeout_minutes minutes"
+    return 1
+}
+
 # init config
 CONFIG_FILE="/tmp/configs/wal_restore_test_config.json"
 COMMON_CONFIG="/tmp/configs/common_config.json"
@@ -71,36 +102,67 @@ EOF
 /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA_BETA} -w start
 
 # fill database postgres
-pgbench -i -s 10   -h 127.0.0.1 -p ${ALPHA_PORT} postgres
+pgbench -i -s 4 -h 127.0.0.1 -p ${ALPHA_PORT} postgres
+
+# Wait for WAL files to be archived. Not strictly required, but better to do(see below notes):
+#
+# The expected count (6) of WAL files is tightly
+# coupled with pgbench -s parameter. If you modify the pgbench scale factor (-s 4),
+# you MUST adjust this expected_count accordingly. Current correlation: -s 4 => 6
+# WAL files.
+if ! check_archiving_status ${ALPHA_PORT} 6 10; then
+    echo "Failed to wait for archiving completion on alpha instance"
+    exit 1
+fi
 
 #                                               db       table            conn_port    row_count
-/tmp/scripts/wait_while_replication_complete.sh postgres pgbench_accounts ${ALPHA_PORT} 1000000 # 10 * 100000, 10 is value of -s in pgbench
-# script above waits only one table, so just in case sleep
-sleep 3
+/tmp/scripts/wait_while_replication_complete.sh postgres pgbench_accounts ${BETA_PORT} 400000 # 4 * 100000, 4 is value of -s in pgbench
 
 /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA_ALPHA} -m fast -w stop
-sleep 7
 
 /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA_BETA} -w promote
 
-pgbench -i -s 20 -h 127.0.0.1 -p ${BETA_PORT} postgres
+pgbench -i -s 4 -h 127.0.0.1 -p ${BETA_PORT} postgres
+
+# NOTES: Must wait for archiving completion before stopping the database for two reasons:
+#
+# 1. Prevent pg_rewind failure:
+#    - When using "pg_ctl -m fast stop", some PostgreSQL processes will exit early,
+#      but postmaster and archiver remain running
+#    - The archiver process continues to call wal-g wal-push to upload WAL files
+#    - During archiving, .ready files are created and deleted(renamed)
+#    - This will cause subsequent pg_rewind(archiver is still running) to fail with error:
+#      "could not open source file .../archive_status/XXX.ready: No such file or directory"
+#
+# 2. Ensure complete testing of wal-g wal-restore:
+#    - Without waiting, WAL files might not be uploaded to S3 at all
+#    - This would cause wal-g wal-restore to exit early with "No WAL files to restore",
+#      preventing thorough testing of the wal-restore functionality
+if ! check_archiving_status ${BETA_PORT} 8 10; then
+    echo "Failed to wait for archiving completion on beta instance"
+    exit 1
+fi
 
 /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA_BETA} -m fast -W stop
-sleep 10
 
 /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA_ALPHA} -w start
 PGDATA=${PGDATA_ALPHA} /tmp/scripts/wait_while_pg_not_ready.sh
 
-pgbench -i -s 5 -h 127.0.0.1 -p ${ALPHA_PORT} postgres
+
+pgbench -i -s 4 -h 127.0.0.1 -p ${ALPHA_PORT} postgres
+
+# Wait for WAL files to be archived. Not strictly required, but better to do(see above notes):
+if ! check_archiving_status ${ALPHA_PORT} 8 10; then
+    echo "Failed to wait for archiving completion on alpha instance"
+    exit 1
+fi
 
 /usr/lib/postgresql/10/bin/pg_ctl -D ${PGDATA_ALPHA} -m fast -W stop
-sleep 10
 
 # for more info to log
 ls "${PGDATA_BETA}/pg_wal"
 
 timeout 30 wal-g --config=${TMP_CONFIG} wal-restore ${PGDATA_ALPHA} ${PGDATA_BETA}
-sleep 10
 
 /usr/lib/postgresql/10/bin/pg_rewind -D ${PGDATA_ALPHA} --source-pgdata=${PGDATA_BETA}
 


### PR DESCRIPTION
#1867 Root Cause Analysis

There are two distinct issues in this test:

### 1. Archive Status File Race Condition
When using `pg_ctl -m fast stop`, there's a race condition between PostgreSQL's archiver process and pg_rewind:

1. While most PostgreSQL processes exit immediately after fast stop:
   - The postmaster and archiver processes continue running
   - The archiver process continues calling `wal-g wal-push` to upload WAL files
   - During archiving, `.ready` files in `archive_status` directory are created and then deleted|renamed

2. When pg_rewind runs while archiving is still in progress, it fails with:
   ```
   could not open source file ".../archive_status/XXX.ready: No such file or directory"
   ```
   This happens because pg_rewind tries to access `.ready` files that are being actively managed by the still-running archiver.

### 2. Incomplete Testing of wal-g wal-restore
The second issue is not a race condition, but rather a test coverage limitation:

1. When `wal-g wal-restore` runs before any WAL files are archived to S3, it correctly exits with:
   ```
   INFO: No WAL files to restore
   ```

2. While this behavior is correct, it means:
   - The test isn't fully exercising the WAL restore functionality
   - We're missing verification of actual WAL file restoration
   - The test passes without testing the core WAL restore features

### Impact on Test Quality
- The race condition makes the test unreliable and flaky
- The premature wal-restore execution reduces test coverage
- Both issues can be addressed by ensuring WAL archiving completes at appropriate points in the test flow

The key improvements needed are:
1. Properly handling the archiver race condition for test stability
2. Ensuring WAL files are archived before testing restoration for better coverage