### PR TITLE
Add JournalInfo deletion logic

### DIFF
--- a/cmd/mysql/delete.go
+++ b/cmd/mysql/delete.go
@@ -80,12 +80,16 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 		mysql.BinlogPath,
 		internal.DefaultLessCmp,
 	)
-	tracelog.ErrorLogger.FatalOnError(err)
-	tracelog.InfoLogger.Printf("Deleted journal info: %+v", journalInfo)
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can't find the journal info: %s", err.Error())
+	} else {
+		tracelog.InfoLogger.Printf("Deleted journal info: %+v", journalInfo)
+	}
 
 	deleteHandler.HandleDeleteTarget(backupSelector, confirmed, findFullBackup)
 
-	if confirmed {
+	// Backup could be created without journal
+	if confirmed && err == nil {
 		err := journalInfo.Delete(storage.RootFolder())
 		tracelog.ErrorLogger.PrintOnError(err)
 	}

--- a/cmd/mysql/delete.go
+++ b/cmd/mysql/delete.go
@@ -80,7 +80,6 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 		backupName,
 		storage.RootFolder(),
 		mysql.BinlogPath,
-		mysql.BinlogFilenameComparator,
 	)
 	// Backup could be created without journal
 	if err != nil {

--- a/cmd/mysql/delete.go
+++ b/cmd/mysql/delete.go
@@ -80,7 +80,7 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 		backupName,
 		storage.RootFolder(),
 		mysql.BinlogPath,
-		internal.DefaultLessCmp,
+		mysql.BinlogFilenameComparator,
 	)
 	// Backup could be created without journal
 	if err != nil {

--- a/cmd/mysql/delete.go
+++ b/cmd/mysql/delete.go
@@ -74,7 +74,21 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 	backupSelector, err := internal.NewBackupNameSelector(backupName, true) //todo: add selection by userdata
 	tracelog.ErrorLogger.PrintOnError(err)
 
+	journalInfo, err := internal.NewJournalInfo(
+		backupName,
+		storage.RootFolder(),
+		mysql.BinlogPath,
+		internal.DefaultLessCmp,
+	)
+	tracelog.ErrorLogger.FatalOnError(err)
+	tracelog.InfoLogger.Printf("Deleted journal info: %+v", journalInfo)
+
 	deleteHandler.HandleDeleteTarget(backupSelector, confirmed, findFullBackup)
+
+	if confirmed {
+		err := journalInfo.Delete(storage.RootFolder())
+		tracelog.ErrorLogger.PrintOnError(err)
+	}
 }
 
 func runDeleteBefore(cmd *cobra.Command, args []string) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
       &&  mkdir -p /export/mysqlpitrmysqldumpbucket
       &&  mkdir -p /export/mysqllivereplay
       &&  mkdir -p /export/mysqlpermanentbackupbucket
+      &&  mkdir -p /export/mysql_journal_test_bucket
       &&  mkdir -p /export/mysql8_xbtool_extract_bucket
       &&  mkdir -p /export/mysql8_full_xtrabackup_xbtool_bucket
       &&  mkdir -p /export/mysql8_full_xtrabackup_xbtool_incremental_bucket

--- a/docker/mysql_tests/scripts/base_tests/journals.sh
+++ b/docker/mysql_tests/scripts/base_tests/journals.sh
@@ -3,7 +3,7 @@ set -e -x
 
 . /usr/local/export_common.sh
 
-export WALE_S3_PREFIX=s3://mysqlfullxtrabackupbucket
+export WALE_S3_PREFIX=s3://mysql_journal_test_bucket
 
 get_journal_count() {
     wal-g st ls basebackups_005/ 2>&1 | grep journal_ | awk '{ printf $7 "\n" }' | wc -l
@@ -23,10 +23,7 @@ get_journal_size() {
     wal-g st cat basebackups_005/$JOURNAL_NAME | jq '.JournalSize'
 }
 
-# Clear S3 storage
-wal-g delete everything FORCE --confirm
 mysqld --initialize --init-file=/etc/mysql/init.sql
-
 service mysql start
 sysbench --table-size=10 prepare
 
@@ -92,6 +89,3 @@ test "0" -eq $(get_journal_size 1)
 # We can sucessfully delete the single backup
 wal-g delete target $(get_backup_name 1) --confirm
 test "0" -eq $(get_journal_count)
-
-# Clear S3 storage
-wal-g delete everything FORCE --confirm

--- a/docker/mysql_tests/scripts/base_tests/journals.sh
+++ b/docker/mysql_tests/scripts/base_tests/journals.sh
@@ -20,7 +20,7 @@ get_backup_name() {
 
 get_journal_size() {
     JOURNAL_NAME=$(get_journal_name $1)
-    wal-g st cat basebackups_005/$JOURNAL_NAME | jq '.JournalSize'
+    wal-g st cat basebackups_005/$JOURNAL_NAME | jq '.SizeToNextBackup'
 }
 
 mysqld --initialize --init-file=/etc/mysql/init.sql

--- a/docker/mysql_tests/scripts/base_tests/journals.sh
+++ b/docker/mysql_tests/scripts/base_tests/journals.sh
@@ -28,7 +28,7 @@ service mysql start
 sysbench --table-size=10 prepare
 
 # Create backup #1 with journals
-sysbench --time=5 run
+sysbench --time=1 run
 mysql -e 'FLUSH LOGS'
 wal-g binlog-push
 wal-g backup-push --count-journals
@@ -39,7 +39,7 @@ test "1" -eq $(get_journal_count)
 test "0" -eq $(get_journal_size 1)
 
 # Create backup #2 with journals
-sysbench --time=5 run
+sysbench --time=1 run
 mysql -e 'FLUSH LOGS'
 wal-g binlog-push
 wal-g backup-push --count-journals
@@ -51,7 +51,7 @@ test "0" -ne $(get_journal_size 1)
 test "0" -eq $(get_journal_size 2)
 
 # Create backup #3 with journals
-sysbench --time=5 run
+sysbench --time=1 run
 mysql -e 'FLUSH LOGS'
 wal-g binlog-push
 wal-g backup-push --count-journals

--- a/docker/mysql_tests/scripts/base_tests/journals.sh
+++ b/docker/mysql_tests/scripts/base_tests/journals.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -e -x
+
+. /usr/local/export_common.sh
+
+export WALE_S3_PREFIX=s3://mysqlfullxtrabackupbucket
+
+get_journal_count() {
+    wal-g st ls basebackups_005/ 2>&1 | grep journal_ | awk '{ printf $7 "\n" }' | wc -l
+}
+
+get_journal_name() {
+    wal-g st ls basebackups_005/ 2>&1 | grep journal_ | awk '{ printf $7 "\n"}' | sort | awk "FNR == $1 {print}"
+}
+
+get_backup_name() {
+    JOURNAL_NAME=$(get_journal_name $1)
+    echo ${JOURNAL_NAME#"journal_"}
+}
+
+get_journal_size() {
+    JOURNAL_NAME=$(get_journal_name $1)
+    wal-g st cat basebackups_005/$JOURNAL_NAME | jq '.JournalSize'
+}
+
+# Clear S3 storage
+wal-g delete everything FORCE --confirm
+mysqld --initialize --init-file=/etc/mysql/init.sql
+
+service mysql start
+sysbench --table-size=10 prepare
+
+# Create backup #1 with journals
+sysbench --time=5 run
+mysql -e 'FLUSH LOGS'
+wal-g binlog-push
+wal-g backup-push --count-journals
+sleep 1
+
+# Check count of backups and content of them
+test "1" -eq $(get_journal_count)
+test "0" -eq $(get_journal_size 1)
+
+# Create backup #2 with journals
+sysbench --time=5 run
+mysql -e 'FLUSH LOGS'
+wal-g binlog-push
+wal-g backup-push --count-journals
+sleep 1
+
+# Check count of backups and content of them
+test "2" -eq $(get_journal_count)
+test "0" -ne $(get_journal_size 1)
+test "0" -eq $(get_journal_size 2)
+
+# Create backup #3 with journals
+sysbench --time=5 run
+mysql -e 'FLUSH LOGS'
+wal-g binlog-push
+wal-g backup-push --count-journals
+sleep 1
+
+# Check count of backups and content of them
+test "3" -eq $(get_journal_count)
+
+FIRST_BACKUP_SIZE=$(get_journal_size 1)
+test "0" -ne $FIRST_BACKUP_SIZE
+
+SECOND_BACKUP_SIZE=$(get_journal_size 2)
+test "0" -ne $SECOND_BACKUP_SIZE
+
+THIRD_BACKUP_SIZE=$(get_journal_size 3)
+test "0" -eq $THIRD_BACKUP_SIZE
+
+# We can sucessfully delete backup in the middle
+wal-g delete target $(get_backup_name 2) --confirm
+test "2" -eq $(get_journal_count)
+
+NEW_FIRST_BACKUP_SIZE=$(get_journal_size 1)
+test "0" -ne $FIRST_BACKUP_SIZE
+
+NEW_THIRD_BACKUP_SIZE=$(get_journal_size 2)
+test "0" -eq $NEW_THIRD_BACKUP_SIZE
+
+test $NEW_FIRST_BACKUP_SIZE -eq $(($SECOND_BACKUP_SIZE + $FIRST_BACKUP_SIZE))
+
+# We can sucessfully delete the last backup
+wal-g delete target $(get_backup_name 2) --confirm
+test "1" -eq $(get_journal_count)
+test "0" -eq $(get_journal_size 1)
+
+# We can sucessfully delete the single backup
+wal-g delete target $(get_backup_name 1) --confirm
+test "0" -eq $(get_journal_count)
+
+# Clear S3 storage
+wal-g delete everything FORCE --confirm

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -135,7 +135,6 @@ func HandleBackupPush(
 	previousJournalInfo, err := internal.GetLastJournalInfo(
 		folder,
 		BinlogPath,
-		BinlogFilenameComparator,
 	)
 	if err != nil {
 		// there can be no backups on S3
@@ -144,9 +143,8 @@ func HandleBackupPush(
 
 	journalInfo := internal.NewEmptyJournalInfo(
 		backupName,
-		previousJournalInfo.CurrentBackupEnd, binlogEnd,
+		previousJournalInfo.CurrentBackupEnd, timeStop,
 		BinlogPath,
-		BinlogFilenameComparator,
 	)
 
 	err = journalInfo.Upload(folder)

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -155,7 +155,7 @@ func HandleBackupPush(
 		return
 	}
 
-	err = journalInfo.Calculate(folder)
+	err = journalInfo.UpdateIntervalSize(folder)
 	if err != nil {
 		tracelog.WarningLogger.Printf("can not calculate journal size: %s", err.Error())
 		return

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -135,7 +135,7 @@ func HandleBackupPush(
 	previousJournalInfo, err := internal.GetLastJournalInfo(
 		folder,
 		BinlogPath,
-		internal.DefaultLessCmp,
+		BinlogFilenameComparator,
 	)
 	if err != nil {
 		// there can be no backups on S3
@@ -146,7 +146,7 @@ func HandleBackupPush(
 		backupName,
 		previousJournalInfo.CurrentBackupEnd, binlogEnd,
 		BinlogPath,
-		internal.DefaultLessCmp,
+		BinlogFilenameComparator,
 	)
 
 	err = journalInfo.Upload(folder)

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -144,7 +144,7 @@ func HandleBackupPush(
 
 	journalInfo := internal.NewEmptyJournalInfo(
 		backupName,
-		previousJournalInfo.JournalEnd, binlogEnd,
+		previousJournalInfo.CurrentBackupEnd, binlogEnd,
 		BinlogPath,
 		internal.DefaultLessCmp,
 	)

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -132,7 +132,7 @@ func HandleBackupPush(
 		return
 	}
 
-	previousJournalInfo, err := internal.GetLastJournalInfo(
+	mostRecentJournalInfo, err := internal.GetMostRecentJournalInfo(
 		folder,
 		BinlogPath,
 	)
@@ -143,7 +143,7 @@ func HandleBackupPush(
 
 	journalInfo := internal.NewEmptyJournalInfo(
 		backupName,
-		previousJournalInfo.CurrentBackupEnd, timeStop,
+		mostRecentJournalInfo.CurrentBackupEnd, timeStop,
 		BinlogPath,
 	)
 

--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -191,14 +191,3 @@ func BinlogPrefix(filename string) string {
 	}
 	return filename[:p]
 }
-
-func BinlogFilenameComparator(a, b string) bool {
-	aInt, bInt := 0, 0
-	if a != "" {
-		aInt = BinlogNum(a)
-	}
-	if b != "" {
-		bInt = BinlogNum(b)
-	}
-	return aInt < bInt
-}

--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -193,12 +193,12 @@ func BinlogPrefix(filename string) string {
 }
 
 func BinlogFilenameComparator(a, b string) bool {
-	a_int, b_int := 0, 0
+	aInt, bInt := 0, 0
 	if a != "" {
-		a_int = BinlogNum(a)
+		aInt = BinlogNum(a)
 	}
 	if b != "" {
-		b_int = BinlogNum(b)
+		bInt = BinlogNum(b)
 	}
-	return a_int < b_int
+	return aInt < bInt
 }

--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -191,3 +191,14 @@ func BinlogPrefix(filename string) string {
 	}
 	return filename[:p]
 }
+
+func BinlogFilenameComparator(a, b string) bool {
+	a_int, b_int := 0, 0
+	if a != "" {
+		a_int = BinlogNum(a)
+	}
+	if b != "" {
+		b_int = BinlogNum(b)
+	}
+	return a_int < b_int
+}

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -256,8 +256,8 @@ func GetLastJournalInfo(
 	return backupInfo, nil
 }
 
-// Calculate calculates the size of the JournalInfo in the semi-interval (JournalStart; JournalEnd] using journal files on JournalDirectoryName
-// and save it for the previous JournalInfo
+// Calculate calculates the size of the JournalInfo in the semi-interval (JournalStart; JournalEnd]
+// using journal files on JournalDirectoryName and save it for the previous JournalInfo
 func (ji *JournalInfo) Calculate(folder storage.Folder) error {
 	journalFiles, _, err := folder.GetSubFolder(ji.JournalDirectoryName).ListFolder()
 	if err != nil {

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -145,7 +145,6 @@ func (ji *JournalInfo) GetNext(folder storage.Folder, direction direction) (Jour
 		return JournalInfo{}, err
 	}
 	return newerJournalInfo, err
-
 }
 
 // Delete deletes the current JournalInfo from S3,

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -8,30 +8,84 @@ import (
 	"strings"
 
 	"github.com/wal-g/tracelog"
+	"golang.org/x/xerrors"
 
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
 
 const (
-	JournalSize   = "JournalSize"
-	JournalPrefix = "journal_"
+	JournalSize     = "JournalSize"
+	JournalPrefix   = "journal_"
+	cantFindJournal = "can not find appropriate journal on S3"
 )
 
+var (
+	DefaultLessCmp = func(a, b string) bool { return a < b }
+)
+
+// JournalInfo is a projection of the S3 journal info object.
+// When a JournalInfo instance was changed, it should be synced with S3 using the upload/read method.
 type JournalInfo struct {
-	JournalStart string `json:"JournalStart"`
-	JournalEnd   string `json:"JournalEnd"`
-	JournalSize  int64  `json:"JournalSize"`
+	JournalDirectoryName      string                 `json:"-"`
+	JournalNameLessComparator func(a, b string) bool `json:"-"`
+	JournalName               string                 `json:"-"`
+	JournalStart              string                 `json:"JournalStart"`
+	JournalEnd                string                 `json:"JournalEnd"`
+	JournalSize               int64                  `json:"JournalSize"`
 }
 
-func UploadBackupInfo(folder storage.Folder, metaName string, info JournalInfo) error {
+// NewEmptyJournalInfo creates instance of JournalInfo without sync with S3
+func NewEmptyJournalInfo(
+	backupName string,
+	start, end string,
+	journalDir string,
+	journalLessComparator func(a, b string) bool,
+) JournalInfo {
+	return JournalInfo{
+		JournalName:               fmt.Sprintf("%s%s", JournalPrefix, backupName),
+		JournalNameLessComparator: journalLessComparator,
+		JournalDirectoryName:      journalDir,
+		JournalStart:              start,
+		JournalEnd:                end,
+		JournalSize:               0,
+	}
+}
+
+func NewJournalInfo(
+	backupName string,
+	folder storage.Folder,
+	journalDir string,
+	journalLessComparator func(a, b string) bool,
+) (JournalInfo, error) {
+	ji := JournalInfo{
+		JournalName:               fmt.Sprintf("%s%s", JournalPrefix, backupName),
+		JournalDirectoryName:      journalDir,
+		JournalNameLessComparator: journalLessComparator,
+	}
+
+	err := ji.Read(folder)
+	if err != nil {
+		return JournalInfo{}, err
+	}
+
+	return ji, nil
+}
+
+// Read syncs JournalInfo by reading the file on S3
+func (ji *JournalInfo) Read(folder storage.Folder) error {
 	folder = folder.GetSubFolder(utility.BaseBackupPath)
-	rawBackupsInfo, err := json.Marshal(info)
+	backupInfoReader, err := folder.ReadObject(ji.JournalName)
 	if err != nil {
 		return err
 	}
 
-	err = folder.PutObject(fmt.Sprintf("%s%s", JournalPrefix, metaName), bytes.NewBuffer(rawBackupsInfo))
+	backupInfoRaw, err := io.ReadAll(backupInfoReader)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(backupInfoRaw, ji)
 	if err != nil {
 		return err
 	}
@@ -39,45 +93,162 @@ func UploadBackupInfo(folder storage.Folder, metaName string, info JournalInfo) 
 	return nil
 }
 
-func GetLastBackupInfo(folder storage.Folder) (string, JournalInfo, error) {
-	objs, _, err := folder.GetSubFolder(utility.BaseBackupPath).ListFolder()
+// Upload syncs Journalinfo by uploading the structure as a file on S3
+func (ji *JournalInfo) Upload(folder storage.Folder) error {
+	folder = folder.GetSubFolder(utility.BaseBackupPath)
+
+	rawBackupsInfo, err := json.Marshal(ji)
 	if err != nil {
-		return "", JournalInfo{}, nil
+		return err
 	}
 
-	var lastBackupInfo storage.Object
-	lastBackupName := ""
+	err = folder.PutObject(ji.JournalName, bytes.NewBuffer(rawBackupsInfo))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetPrevious gets the previous JournalInfo on S3 using JournalNameLessComparator
+func (ji *JournalInfo) GetPrevious(folder storage.Folder) (JournalInfo, error) {
+	objs, _, err := folder.GetSubFolder(utility.BaseBackupPath).ListFolder()
+	if err != nil {
+		return JournalInfo{}, err
+	}
+
+	var previousJournalObject storage.Object
+	less := ji.JournalNameLessComparator
 	for _, v := range objs {
-		if strings.HasPrefix(v.GetName(), JournalPrefix) {
-			if lastBackupInfo == nil || v.GetLastModified().After(lastBackupInfo.GetLastModified()) {
-				lastBackupName = v.GetName()
-				lastBackupInfo = v
-			}
+		if strings.HasPrefix(v.GetName(), JournalPrefix) && less(v.GetName(), ji.JournalName) &&
+			(previousJournalObject == nil || less(previousJournalObject.GetName(), v.GetName())) {
+			previousJournalObject = v
 		}
 	}
 
-	backupInfo, err := GetBackupInfo(folder, lastBackupName)
-	if err != nil {
-		return "", JournalInfo{}, nil
+	if previousJournalObject == nil {
+		return JournalInfo{}, xerrors.New(cantFindJournal)
 	}
 
-	return lastBackupName, backupInfo, nil
+	previousJournalInfo, err := NewJournalInfo(
+		strings.TrimPrefix(
+			previousJournalObject.GetName(),
+			JournalPrefix,
+		),
+		folder,
+		ji.JournalDirectoryName,
+		ji.JournalNameLessComparator,
+	)
+	if err != nil {
+		return JournalInfo{}, err
+	}
+
+	return previousJournalInfo, err
 }
 
-func GetBackupInfo(folder storage.Folder, metaName string) (JournalInfo, error) {
-	folder = folder.GetSubFolder(utility.BaseBackupPath)
-	backupInfoReader, err := folder.ReadObject(metaName)
+// GetNext gets the next JournalInfo on S3 using JournalNameLessComparator
+func (ji *JournalInfo) GetNext(folder storage.Folder) (JournalInfo, error) {
+	objs, _, err := folder.GetSubFolder(utility.BaseBackupPath).ListFolder()
 	if err != nil {
 		return JournalInfo{}, err
 	}
 
-	backupInfoRaw, err := io.ReadAll(backupInfoReader)
+	var nextJournalObject storage.Object
+	less := ji.JournalNameLessComparator
+	for _, v := range objs {
+		if strings.HasPrefix(v.GetName(), JournalPrefix) && less(ji.JournalName, v.GetName()) &&
+			(nextJournalObject == nil || less(v.GetName(), nextJournalObject.GetName())) {
+			nextJournalObject = v
+		}
+	}
+
+	if nextJournalObject == nil {
+		return JournalInfo{}, xerrors.New(cantFindJournal)
+	}
+
+	previousJournalInfo, err := NewJournalInfo(
+		strings.TrimPrefix(
+			nextJournalObject.GetName(),
+			JournalPrefix,
+		),
+		folder,
+		ji.JournalDirectoryName,
+		ji.JournalNameLessComparator,
+	)
 	if err != nil {
 		return JournalInfo{}, err
 	}
 
-	backupInfo := JournalInfo{}
-	err = json.Unmarshal(backupInfoRaw, &backupInfo)
+	return previousJournalInfo, err
+}
+
+// Delete deletes the current JournalInfo from S3 and updates the previous one with the journal size of the deleted one
+func (ji *JournalInfo) Delete(folder storage.Folder) error {
+	err := folder.
+		GetSubFolder(utility.BaseBackupPath).
+		DeleteObjects([]string{ji.JournalName})
+	if err != nil {
+		return err
+	}
+
+	nextJi, err := ji.GetNext(folder)
+	if err != nil {
+		// We could delete last backup or there could be just one backups on S3
+		if err.Error() == cantFindJournal {
+			return nil
+		}
+		return err
+	}
+	tracelog.InfoLogger.Printf("found the next journal %+v", nextJi)
+
+	nextJi.JournalStart = ji.JournalStart
+	err = nextJi.Upload(folder)
+	if err != nil {
+		return err
+	}
+	tracelog.InfoLogger.Printf("the next journal updated %+v", nextJi)
+
+	err = nextJi.Calculate(folder)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetLastJournalInfo receives the most recently created JournalInfo on S3
+func GetLastJournalInfo(
+	folder storage.Folder,
+	journalDir string,
+	journalLessComparator func(a, b string) bool,
+) (JournalInfo, error) {
+	objs, _, err := folder.GetSubFolder(utility.BaseBackupPath).ListFolder()
+	if err != nil {
+		return JournalInfo{}, err
+	}
+	if len(objs) == 0 {
+		return JournalInfo{}, nil
+	}
+
+	var lastJournalInfo storage.Object
+	for _, v := range objs {
+		if strings.HasPrefix(v.GetName(), JournalPrefix) &&
+			(lastJournalInfo == nil || journalLessComparator(lastJournalInfo.GetName(), v.GetName())) {
+			lastJournalInfo = v
+		}
+	}
+
+	if lastJournalInfo == nil {
+		return JournalInfo{}, xerrors.New("there are no journals on the S3")
+	}
+
+	lastBackupName := strings.TrimPrefix(lastJournalInfo.GetName(), JournalPrefix)
+	backupInfo, err := NewJournalInfo(
+		lastBackupName,
+		folder,
+		journalDir,
+		journalLessComparator,
+	)
 	if err != nil {
 		return JournalInfo{}, err
 	}
@@ -85,86 +256,46 @@ func GetBackupInfo(folder storage.Folder, metaName string) (JournalInfo, error) 
 	return backupInfo, nil
 }
 
-func UpdatePreviousBackupInfo(
-	folder storage.Folder,
-	journalPath string,
-	journalCmpLess func(a, b string) bool,
-	newJournalEnd string,
-) error {
-	lastSentinelName, lastSentinel, err := GetLastBackupInfo(folder)
+// Calculate calculates the size of the JournalInfo in the semi-interval (JournalStart; JournalEnd] using journal files on JournalDirectoryName
+// and save it for the previous JournalInfo
+func (ji *JournalInfo) Calculate(folder storage.Folder) error {
+	journalFiles, _, err := folder.GetSubFolder(ji.JournalDirectoryName).ListFolder()
 	if err != nil {
 		return err
 	}
-	lastSentinelName = strings.ReplaceAll(lastSentinelName, JournalPrefix, "")
-
-	if len(lastSentinelName) == 0 {
-		tracelog.WarningLogger.Printf("last sentinel was not found, we can not evaluate journal size")
+	if len(journalFiles) == 0 {
 		return nil
 	}
 
-	journalSize, err := GetJournalSizeInSemiInterval(
-		folder,
-		journalPath,
-		journalCmpLess,
-		lastSentinel.JournalEnd,
-		newJournalEnd,
-	)
-	if err != nil {
-		tracelog.ErrorLogger.Printf("can not evaluate journal sum for %s: %s", lastSentinelName, err)
-		return err
-	}
-	tracelog.InfoLogger.Printf(
-		"journal size for %s in the semi interval (%s; %s] is equal to %d",
-		lastSentinelName,
-		lastSentinel.JournalEnd,
-		newJournalEnd,
-		journalSize,
-	)
-
-	err = UploadBackupInfo(folder, lastSentinelName, JournalInfo{
-		JournalStart: lastSentinel.JournalStart,
-		JournalEnd:   lastSentinel.JournalEnd,
-		JournalSize:  journalSize,
-	})
-	if err != nil {
-		tracelog.ErrorLogger.Printf("can not update journal info for %s: %s", lastSentinelName, err)
-		return err
-	}
-
-	tracelog.InfoLogger.Printf("journal info has been updated for %s", lastSentinelName)
-	return nil
-}
-
-// (start;end]
-func GetJournalSizeInSemiInterval(
-	folder storage.Folder,
-	journalPath string,
-	journalCmpLess func(a, b string) bool,
-	start, end string,
-) (int64, error) {
-	folder = folder.GetSubFolder(journalPath)
-	journalFiles, _, err := folder.ListFolder()
-	if err != nil {
-		return 0, err
-	}
-	if len(journalFiles) == 0 {
-		return 0, nil
-	}
-
 	sum := int64(0)
+	cmp := ji.JournalNameLessComparator
 	for i := 0; i < len(journalFiles); i++ {
-		jt := utility.TrimFileExtension(journalFiles[i].GetName())
+		jf := utility.TrimFileExtension(journalFiles[i].GetName())
 
-		isEqual := !journalCmpLess(jt, end) && !journalCmpLess(end, jt)
+		isEqual := !cmp(jf, ji.JournalEnd) && !cmp(ji.JournalEnd, jf)
 
-		if journalCmpLess(start, jt) && (journalCmpLess(jt, end) || isEqual) {
-			tracelog.InfoLogger.Printf("Found in range: %+v\n", jt)
+		if cmp(ji.JournalStart, jf) && (cmp(jf, ji.JournalEnd) || isEqual) {
+			tracelog.DebugLogger.Printf("Taking into accoutn: %s\n", jf)
 			sum += journalFiles[i].GetSize()
-		} else {
-			tracelog.InfoLogger.Printf("Not in range: %+v\n", jt)
 		}
 	}
-	tracelog.InfoLogger.Printf("Journal Sum: %d\n", sum)
+	tracelog.InfoLogger.Printf("Journal Sum of %s: %d\n", ji.JournalName, sum)
 
-	return sum, nil
+	prevJi, err := ji.GetPrevious(folder)
+	if err != nil {
+		// We could delete the oldest backup or there could be just one backups on S3
+		if err.Error() == cantFindJournal {
+			return nil
+		}
+		return err
+	}
+
+	prevJi.JournalSize = sum
+
+	err = prevJi.Upload(folder)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -193,12 +193,11 @@ func (ji *JournalInfo) Delete(folder storage.Folder) error {
 
 	nextJi, err := ji.GetNext(folder)
 	if err != nil {
-		// We could delete last backup or there could be just one backups on S3
 		if err.Error() != cantFindJournal {
 			return err
 		}
 
-		// We should update previous journal to zero value if there is no journals after that
+		// We should update previous JournalInfo to zero value if there are no JournalInfo after that
 		prevJi, err := ji.GetPrevious(folder)
 		if err != nil {
 			if err.Error() != cantFindJournal {
@@ -294,7 +293,7 @@ func (ji *JournalInfo) Calculate(folder storage.Folder) error {
 
 	prevJi, err := ji.GetPrevious(folder)
 	if err != nil {
-		// We could delete the oldest backup or there could be just one backups on S3
+		// There can only be one backup on S3 or we can delete the oldest one
 		if err.Error() == cantFindJournal {
 			return nil
 		}

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	JournalSize             = "JournalSize"
 	JournalPrefix           = "journal_"
 	JournalTimeLayout       = "20060102T150405Z"
 	cantFindJournal         = "can not find appropriate journal on S3"

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -192,8 +192,8 @@ func (ji *JournalInfo) Delete(folder storage.Folder) error {
 	return nil
 }
 
-// GetLastJournalInfo receives the most recently created JournalInfo on S3
-func GetLastJournalInfo(
+// GetMostRecentJournalInfo receives the most recently created JournalInfo on S3
+func GetMostRecentJournalInfo(
 	folder storage.Folder,
 	journalDir string,
 ) (JournalInfo, error) {
@@ -207,18 +207,14 @@ func GetLastJournalInfo(
 
 	objs = filterJournalsInfoFiles(objs)
 	objs = sortJournalsInfo(objs)
-	for _, obj := range objs {
-		tracelog.InfoLogger.Println(obj.GetName(), obj.GetLastModified())
-	}
-
 	if len(objs) == 0 {
 		return JournalInfo{}, xerrors.New("there are no journals on the S3")
 	}
 
-	lastJournalInfo := objs[len(objs)-1]
-	lastBackupName := strings.TrimPrefix(lastJournalInfo.GetName(), JournalPrefix)
+	theMostRecentJournalObject := objs[len(objs)-1]
+	theMostRecentBackupName := strings.TrimPrefix(theMostRecentJournalObject.GetName(), JournalPrefix)
 	backupInfo, err := NewJournalInfo(
-		lastBackupName,
+		theMostRecentBackupName,
 		folder,
 		journalDir,
 	)

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -30,9 +30,9 @@ type JournalInfo struct {
 	JournalDirectoryName      string                 `json:"-"`
 	JournalNameLessComparator func(a, b string) bool `json:"-"`
 	JournalName               string                 `json:"-"`
-	PriorBackupEnd            string                 `json:"JournalStart"`
-	CurrentBackupEnd          string                 `json:"JournalEnd"`
-	SizeToNextBackup          int64                  `json:"JournalSize"`
+	PriorBackupEnd            string                 `json:"PriorBackupEnd"`
+	CurrentBackupEnd          string                 `json:"CurrentBackupEnd"`
+	SizeToNextBackup          int64                  `json:"SizeToNextBackup"`
 }
 
 // NewEmptyJournalInfo creates instance of JournalInfo without sync with S3
@@ -154,7 +154,7 @@ func (ji *JournalInfo) GetNextNewer(folder storage.Folder) (JournalInfo, error) 
 	}
 
 	var newerJournalInfoObject storage.Object
-	less := ji.JournalNameLessComparator
+	less := DefaultLessCmp
 	for _, obj := range objs {
 		isJournal := strings.HasPrefix(obj.GetName(), JournalPrefix)
 		isOlderThenCurrentJournal := less(obj.GetName(), ji.JournalName)
@@ -255,7 +255,7 @@ func GetLastJournalInfo(
 	var lastJournalInfo storage.Object
 	for _, v := range objs {
 		if strings.HasPrefix(v.GetName(), JournalPrefix) &&
-			(lastJournalInfo == nil || journalLessComparator(lastJournalInfo.GetName(), v.GetName())) {
+			(lastJournalInfo == nil || DefaultLessCmp(lastJournalInfo.GetName(), v.GetName())) {
 			lastJournalInfo = v
 		}
 	}

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -19,9 +19,7 @@ import (
 var (
 	JournalFmt              = "%09d"
 	BackupName              = "stream"
-	SentinelName            = "sentinel"
 	MinimalJournalNumber    = time.Now()
-	MaximalJournalNumber    = time.Now().Add(time.Hour * 24 * 365)
 	DefaultJournalDirectory = "journals_005"
 	journalTimestamps       = map[int]time.Time{}
 )

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -147,7 +147,7 @@ func TestDeleteJournalInEnd(t *testing.T) {
 	assert.NoError(t, ji1.Read(folder))
 	assert.NoError(t, ji2.Read(folder))
 	assert.Equal(t, int64(33), ji1.JournalSize)
-	assert.Equal(t, int64(33), ji2.JournalSize)
+	assert.Equal(t, int64(0), ji2.JournalSize)
 }
 
 func TestSafetyOfRepeatingMethodCalls(t *testing.T) {

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -9,173 +9,27 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
-	"github.com/wal-g/wal-g/internal/ioextensions"
 	"github.com/wal-g/wal-g/pkg/storages/memory"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/testtools"
-	"github.com/wal-g/wal-g/utility"
 )
 
 var (
-	JournalFmt           = "%09d"
-	SentinelName         = "sentinel"
-	SentinelS3Name       = internal.JournalPrefix + "sentinel"
-	MinimalJournalNumber = "000000000"
-	MaximalJournalNumber = "999999999"
+	JournalFmt              = "%09d"
+	BackupName              = "stream"
+	SentinelName            = "sentinel"
+	MinimalJournalNumber    = "000000000"
+	MaximalJournalNumber    = "999999999"
+	DefaultJournalDirectory = "journals_005"
 )
 
-func GenerateDataAndTest(
-	t *testing.T,
-	recordCount, recordSize int,
-	beginJournalID, endJournalID string,
-	expectedSum int64,
-) {
-	GenerateS3SetAndCheckJournalSizes(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
-	GenerateS3SetAndUpdateBackupsInfo(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
-	GenerateS3SetAndUpdateBackupsInfoManyTimes(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
-	GenerateS3AndUpdateLastBackup(t, recordCount, recordSize, beginJournalID, endJournalID, expectedSum)
-}
-
-func GenerateS3SetAndCheckJournalSizes(
-	t *testing.T,
-	recordCount, recordSize int,
-	beginJournalID, endJournalID string,
-	expectedSum int64,
-) {
-	root, mockUploader := initTestS3()
-
-	generateAndUploadData(mockUploader, recordCount, recordSize)
-
-	journalSize, err := internal.GetJournalSizeInSemiInterval(
-		root,
-		utility.WalPath,
-		func(a, b string) bool {
-			return a < b
-		},
-		beginJournalID,
-		endJournalID,
-	)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedSum, journalSize)
-}
-
-func GenerateS3SetAndUpdateBackupsInfo(
-	t *testing.T,
-	recordCount, recordSize int,
-	beginJournalID, endJournalID string,
-	expectedSum int64,
-) {
-	root, mockUploader := initTestS3()
-
-	generateAndUploadData(mockUploader, recordCount, recordSize)
-
-	backupInfo, err := internal.GetBackupInfo(root, SentinelS3Name)
-	assert.Error(t, err)
-	assert.Equal(t, backupInfo, internal.JournalInfo{})
-
-	createEmptySentinel(t, root)
-
-	backupInfo, err = internal.GetBackupInfo(root, SentinelS3Name)
-	assert.NoError(t, err)
-	assert.Equal(t, backupInfo, internal.JournalInfo{})
-
-	backupInfo.JournalSize, err = internal.GetJournalSizeInSemiInterval(
-		root,
-		utility.WalPath,
-		func(a, b string) bool {
-			return a < b
-		},
-		beginJournalID,
-		endJournalID,
-	)
-	assert.Equal(t, backupInfo, internal.JournalInfo{
-		JournalSize: expectedSum,
-	})
-	assert.NoError(t, err)
-
-	err = internal.UploadBackupInfo(root, SentinelName, backupInfo)
-	assert.NoError(t, err)
-
-	backupInfo, err = internal.GetBackupInfo(root, SentinelS3Name)
-	assert.NoError(t, err)
-	assert.Equal(t, backupInfo, internal.JournalInfo{
-		JournalSize: expectedSum,
-	})
-}
-
-func GenerateS3AndUpdateLastBackup(
-	t *testing.T,
-	recordCount, recordSize int,
-	beginJournalID, endJournalID string,
-	expectedSum int64,
-) {
-	root, mockUploader := initTestS3()
-
-	generateAndUploadData(mockUploader, recordCount, recordSize)
-
-	createEmptySentinel(t, root)
-
-	backupInfo, err := internal.GetBackupInfo(root, SentinelS3Name)
-	assert.NoError(t, err)
-	assert.Equal(t, backupInfo, internal.JournalInfo{})
-
-	err = internal.UploadBackupInfo(root, SentinelName, internal.JournalInfo{
-		JournalStart: beginJournalID,
-		JournalEnd:   beginJournalID,
-		JournalSize:  0,
-	})
-	assert.NoError(t, err)
-
-	err = internal.UpdatePreviousBackupInfo(
-		root,
-		utility.WalPath,
-		func(a, b string) bool { return a < b },
-		endJournalID,
-	)
-	assert.NoError(t, err)
-
-	backupInfo, err = internal.GetBackupInfo(root, SentinelS3Name)
-	assert.NoError(t, err)
-
-	assert.Equal(t, backupInfo.JournalSize, expectedSum)
-}
-
-func GenerateS3SetAndUpdateBackupsInfoManyTimes(
-	t *testing.T,
-	recordCount, recordSize int,
-	beginJournalID, endJournalID string,
-	expectedSum int64,
-) {
-	times := 10
-	root, mockUploader := initTestS3()
-
-	generateAndUploadData(mockUploader, recordCount, recordSize)
-
-	for i := 0; i < times; i++ {
-		var backupInfo internal.JournalInfo
-		var err error
-
-		backupInfo.JournalSize, err = internal.GetJournalSizeInSemiInterval(
-			root,
-			utility.WalPath,
-			func(a, b string) bool {
-				return a < b
-			},
-			beginJournalID,
-			endJournalID,
-		)
-		assert.NoError(t, err)
-
-		sentinel := fmt.Sprintf("%s%d", SentinelName, i)
-		err = internal.UploadBackupInfo(root, sentinel, backupInfo)
-		assert.NoError(t, err)
-
-		sentinel = fmt.Sprintf("%s%d", SentinelS3Name, i)
-		backupInfo, err = internal.GetBackupInfo(root, sentinel)
-		assert.NoError(t, err)
-		assert.Equal(t, backupInfo, internal.JournalInfo{
-			JournalSize: expectedSum,
-		})
+func NewEmptyTestJournal(
+	JournalName string,
+	start, end string,
+) internal.JournalInfo {
+	return internal.JournalInfo{
+		JournalNameLessComparator: internal.DefaultLessCmp,
+		JournalDirectoryName:      DefaultJournalDirectory,
 	}
 }
 
@@ -183,127 +37,139 @@ func initTestS3() (storage.Folder, internal.Uploader) {
 	root := memory.NewFolder("", memory.NewKVS())
 	mockUploader := internal.NewRegularUploader(
 		&testtools.MockCompressor{},
-		root.GetSubFolder(utility.WalPath),
+		root,
 	)
 	return root, mockUploader
 }
 
-func toJournalNumber(index int) string {
-	return fmt.Sprintf(JournalFmt, index)
+func numberToJournalName(num int) string {
+	return fmt.Sprintf(JournalFmt, num)
 }
 
-func generateAndUploadData(mockUploader internal.Uploader, recordCount, recordSize int) {
+func generateAndUploadData(t *testing.T, mockUploader internal.Uploader) {
+	recordCount := 100
+	recordSize := 1
+
 	record := strings.Repeat("a", recordSize)
 	// numerate journal names from 1 to make "MinimalJournalNumber" the minimal journal
 	for i := 1; i <= recordCount; i++ {
-		journalName := fmt.Sprintf(JournalFmt, i)
+		journalPath := fmt.Sprintf("%s/"+JournalFmt, DefaultJournalDirectory, i)
 
 		r := bytes.NewReader([]byte(record))
-		mockUploader.UploadFile(context.Background(), ioextensions.NewNamedReaderImpl(r, journalName))
+		err := mockUploader.Upload(context.Background(), journalPath, r)
+		assert.NoError(t, err)
 	}
 }
 
-func createEmptySentinel(t *testing.T, root storage.Folder) {
-	err := internal.UploadBackupInfo(root, SentinelName, internal.JournalInfo{})
-	assert.NoError(t, err)
+func CreateThreeJournals(
+	t *testing.T,
+	folder storage.Folder,
+) (internal.JournalInfo, internal.JournalInfo, internal.JournalInfo) {
+	ji1 := internal.NewEmptyJournalInfo(
+		BackupName+"0",
+		MinimalJournalNumber, MinimalJournalNumber,
+		DefaultJournalDirectory,
+		internal.DefaultLessCmp,
+	)
+
+	assert.NoError(t, ji1.Upload(folder))
+
+	ji2 := internal.NewEmptyJournalInfo(
+		BackupName+"1",
+		MinimalJournalNumber, numberToJournalName(33),
+		DefaultJournalDirectory,
+		internal.DefaultLessCmp,
+	)
+
+	assert.NoError(t, ji2.Upload(folder))
+	assert.NoError(t, ji2.Calculate(folder))
+	assert.NoError(t, ji1.Read(folder))
+
+	ji3 := internal.NewEmptyJournalInfo(
+		BackupName+"2",
+		numberToJournalName(33), numberToJournalName(66),
+		DefaultJournalDirectory,
+		internal.DefaultLessCmp,
+	)
+
+	assert.NoError(t, ji3.Upload(folder))
+	assert.NoError(t, ji3.Calculate(folder))
+	assert.NoError(t, ji2.Read(folder))
+	assert.NoError(t, ji1.Read(folder))
+
+	assert.Equal(t, int64(33), ji1.JournalSize)
+	assert.Equal(t, int64(33), ji2.JournalSize)
+	assert.Equal(t, int64(0), ji3.JournalSize)
+
+	return ji1, ji2, ji3
 }
 
-func TestEmptyFolder(t *testing.T) {
-	recordCount := 0
-	recordSize := 0
-	begin := MinimalJournalNumber
-	end := MaximalJournalNumber
-	expectedSize := int64(0)
+func TestCreateThreeJournals(t *testing.T) {
+	folder, uploader := initTestS3()
+	generateAndUploadData(t, uploader)
 
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	CreateThreeJournals(t, folder)
 }
 
-func TestOneJournal(t *testing.T) {
-	recordCount := 1
-	recordSize := 8
-	begin := MinimalJournalNumber
-	end := MaximalJournalNumber
-	expectedSize := int64(8)
+func TestDeleteJournalInMiddle(t *testing.T) {
+	folder, uploader := initTestS3()
+	generateAndUploadData(t, uploader)
 
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	ji1, ji2, ji3 := CreateThreeJournals(t, folder)
+
+	assert.NoError(t, ji2.Delete(folder))
+	assert.NoError(t, ji1.Read(folder))
+	assert.NoError(t, ji3.Read(folder))
+	assert.Equal(t, int64(66), ji1.JournalSize)
+	assert.Equal(t, int64(0), ji3.JournalSize)
 }
 
-func TestManyJournals(t *testing.T) {
-	recordCount := 100
-	recordSize := 8
-	begin := MinimalJournalNumber
-	end := MaximalJournalNumber
-	expectedSize := int64(800)
+func TestDeleteJournalInBegin(t *testing.T) {
+	folder, uploader := initTestS3()
+	generateAndUploadData(t, uploader)
 
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	ji1, ji2, ji3 := CreateThreeJournals(t, folder)
+
+	assert.NoError(t, ji1.Delete(folder))
+	assert.NoError(t, ji2.Read(folder))
+	assert.NoError(t, ji3.Read(folder))
+	assert.Equal(t, int64(33), ji2.JournalSize)
+	assert.Equal(t, int64(0), ji3.JournalSize)
 }
 
-func TestSimpleFrom(t *testing.T) {
-	recordCount := 3
-	recordSize := 8
-	begin := toJournalNumber(2)
-	end := MaximalJournalNumber
-	expectedSize := int64(8)
+func TestDeleteJournalInEnd(t *testing.T) {
+	folder, uploader := initTestS3()
+	generateAndUploadData(t, uploader)
 
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	ji1, ji2, ji3 := CreateThreeJournals(t, folder)
+
+	assert.NoError(t, ji3.Delete(folder))
+	assert.NoError(t, ji1.Read(folder))
+	assert.NoError(t, ji2.Read(folder))
+	assert.Equal(t, int64(33), ji1.JournalSize)
+	assert.Equal(t, int64(33), ji2.JournalSize)
 }
 
-func TestSimpleTo(t *testing.T) {
-	recordCount := 3
-	recordSize := 8
-	begin := MinimalJournalNumber
-	end := toJournalNumber(2)
-	expectedSize := int64(16)
+func TestSafetyOfRepeatingMethodCalls(t *testing.T) {
+	folder, uploader := initTestS3()
+	generateAndUploadData(t, uploader)
 
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
-}
+	ji1, ji2, ji3 := CreateThreeJournals(t, folder)
 
-func TestHalfFrom(t *testing.T) {
-	recordCount := 100
-	recordSize := 8
-	begin := toJournalNumber(50)
-	end := MaximalJournalNumber
-	expectedSize := int64(400)
+	// There are random method calls
+	for i := 0; i < 10; i++ {
+		assert.NoError(t, ji1.Calculate(folder))
+		assert.NoError(t, ji1.Upload(folder))
+		assert.NoError(t, ji3.Read(folder))
+		assert.NoError(t, ji2.Upload(folder))
+		assert.NoError(t, ji2.Calculate(folder))
+		assert.NoError(t, ji3.Upload(folder))
+		assert.NoError(t, ji3.Calculate(folder))
+		assert.NoError(t, ji2.Read(folder))
+		assert.NoError(t, ji1.Read(folder))
+	}
 
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
-}
-
-func TestHalfTo(t *testing.T) {
-	recordCount := 100
-	recordSize := 8
-	begin := MinimalJournalNumber
-	end := toJournalNumber(50)
-	expectedSize := int64(400)
-
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
-}
-
-func TestEmptySetOnTheRightSide(t *testing.T) {
-	recordCount := 100
-	recordSize := 8
-	begin := toJournalNumber(100)
-	end := MaximalJournalNumber
-	expectedSize := int64(0)
-
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
-}
-
-func TestEmptySetOnTheLeftSide(t *testing.T) {
-	recordCount := 100
-	recordSize := 8
-	begin := MinimalJournalNumber
-	end := MinimalJournalNumber
-	expectedSize := int64(0)
-
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
-}
-
-func TestOnlyFirstRecord(t *testing.T) {
-	recordCount := 100
-	recordSize := 8
-	begin := MinimalJournalNumber
-	end := toJournalNumber(1)
-	expectedSize := int64(8)
-
-	GenerateDataAndTest(t, recordCount, recordSize, begin, end, expectedSize)
+	assert.Equal(t, int64(33), ji1.JournalSize)
+	assert.Equal(t, int64(33), ji2.JournalSize)
+	assert.Equal(t, int64(0), ji3.JournalSize)
 }

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -81,7 +81,7 @@ func CreateThreeJournals(
 	)
 
 	assert.NoError(t, ji2.Upload(folder))
-	assert.NoError(t, ji2.Calculate(folder))
+	assert.NoError(t, ji2.UpdateIntervalSize(folder))
 	assert.NoError(t, ji1.Read(folder))
 
 	ji3 := internal.NewEmptyJournalInfo(
@@ -92,7 +92,7 @@ func CreateThreeJournals(
 	)
 
 	assert.NoError(t, ji3.Upload(folder))
-	assert.NoError(t, ji3.Calculate(folder))
+	assert.NoError(t, ji3.UpdateIntervalSize(folder))
 	assert.NoError(t, ji2.Read(folder))
 	assert.NoError(t, ji1.Read(folder))
 
@@ -157,13 +157,13 @@ func TestSafetyOfRepeatingMethodCalls(t *testing.T) {
 
 	// There are random method calls
 	for i := 0; i < 10; i++ {
-		assert.NoError(t, ji1.Calculate(folder))
+		assert.NoError(t, ji1.UpdateIntervalSize(folder))
 		assert.NoError(t, ji1.Upload(folder))
 		assert.NoError(t, ji3.Read(folder))
 		assert.NoError(t, ji2.Upload(folder))
-		assert.NoError(t, ji2.Calculate(folder))
+		assert.NoError(t, ji2.UpdateIntervalSize(folder))
 		assert.NoError(t, ji3.Upload(folder))
-		assert.NoError(t, ji3.Calculate(folder))
+		assert.NoError(t, ji3.UpdateIntervalSize(folder))
 		assert.NoError(t, ji2.Read(folder))
 		assert.NoError(t, ji1.Read(folder))
 	}

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -51,7 +51,6 @@ func generateAndUploadData(t *testing.T, mockUploader internal.Uploader) {
 	recordSize := 1
 
 	record := strings.Repeat("a", recordSize)
-	// numerate journal names from 1 to make "MinimalJournalNumber" the minimal journal
 	for i := 1; i <= recordCount; i++ {
 		journalPath := fmt.Sprintf("%s/"+JournalFmt, DefaultJournalDirectory, i)
 

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -96,9 +96,9 @@ func CreateThreeJournals(
 	assert.NoError(t, ji2.Read(folder))
 	assert.NoError(t, ji1.Read(folder))
 
-	assert.Equal(t, int64(33), ji1.JournalSize)
-	assert.Equal(t, int64(33), ji2.JournalSize)
-	assert.Equal(t, int64(0), ji3.JournalSize)
+	assert.Equal(t, int64(33), ji1.SizeToNextBackup)
+	assert.Equal(t, int64(33), ji2.SizeToNextBackup)
+	assert.Equal(t, int64(0), ji3.SizeToNextBackup)
 
 	return ji1, ji2, ji3
 }
@@ -119,8 +119,8 @@ func TestDeleteJournalInMiddle(t *testing.T) {
 	assert.NoError(t, ji2.Delete(folder))
 	assert.NoError(t, ji1.Read(folder))
 	assert.NoError(t, ji3.Read(folder))
-	assert.Equal(t, int64(66), ji1.JournalSize)
-	assert.Equal(t, int64(0), ji3.JournalSize)
+	assert.Equal(t, int64(66), ji1.SizeToNextBackup)
+	assert.Equal(t, int64(0), ji3.SizeToNextBackup)
 }
 
 func TestDeleteJournalInBegin(t *testing.T) {
@@ -132,8 +132,8 @@ func TestDeleteJournalInBegin(t *testing.T) {
 	assert.NoError(t, ji1.Delete(folder))
 	assert.NoError(t, ji2.Read(folder))
 	assert.NoError(t, ji3.Read(folder))
-	assert.Equal(t, int64(33), ji2.JournalSize)
-	assert.Equal(t, int64(0), ji3.JournalSize)
+	assert.Equal(t, int64(33), ji2.SizeToNextBackup)
+	assert.Equal(t, int64(0), ji3.SizeToNextBackup)
 }
 
 func TestDeleteJournalInEnd(t *testing.T) {
@@ -145,8 +145,8 @@ func TestDeleteJournalInEnd(t *testing.T) {
 	assert.NoError(t, ji3.Delete(folder))
 	assert.NoError(t, ji1.Read(folder))
 	assert.NoError(t, ji2.Read(folder))
-	assert.Equal(t, int64(33), ji1.JournalSize)
-	assert.Equal(t, int64(0), ji2.JournalSize)
+	assert.Equal(t, int64(33), ji1.SizeToNextBackup)
+	assert.Equal(t, int64(0), ji2.SizeToNextBackup)
 }
 
 func TestSafetyOfRepeatingMethodCalls(t *testing.T) {
@@ -168,7 +168,7 @@ func TestSafetyOfRepeatingMethodCalls(t *testing.T) {
 		assert.NoError(t, ji1.Read(folder))
 	}
 
-	assert.Equal(t, int64(33), ji1.JournalSize)
-	assert.Equal(t, int64(33), ji2.JournalSize)
-	assert.Equal(t, int64(0), ji3.JournalSize)
+	assert.Equal(t, int64(33), ji1.SizeToNextBackup)
+	assert.Equal(t, int64(33), ji2.SizeToNextBackup)
+	assert.Equal(t, int64(0), ji3.SizeToNextBackup)
 }


### PR DESCRIPTION
### Database name
MySQL

# Pull request description

Corresponding to the comments in my previous PR (#1806), I create the PR about the deletion logic of `JournalInfo`.

There is a thing that we should notice. `JournalInfo` of a backup contains information about binlogs we can use for PiTR recovery. So when the oldest backup is deleted, we can't use PiTR with the binlogs from the journal, and consequently the journal can be safely deleted without any calculations. On another hand, if we delete a backup in the middle, we need to take actions in a particular way:
1. Assume the beginning of the binlog semi-interval of the next journal to the beginning of the binlog semi-interval of the deleting `JournalInfo`. The gap between backups was increased after deletion, so we should take it into account for the next `JournalInfo`.
2. Delete the `JournalInfo` of the backup.
3. Calculate the journals size of the semi-interval and assume the new value for the previous `JournalInfo` relate to the deleted one.

We have 4 deletion methods in wal-g, and according to the information above:
1. Delete everything. It deletes all include journals automatically, so we shouldn't do something.
2. Delete before. It deletes only the oldest backups and automatically deletes journals, so we shouldn't do something.
3. Delete retain. It deletes only the oldest backups and automatically deletes journals, so we shouldn't do something.
4. Delete target. It deletes target backup and it can be a backup in the middle. So we should using the algorithm above.

There are a few another changes:
0. `JournalInfo` now is a structure with methods.
1. I refactor code in a more readable way.
2. I refactor tests in a more readable way.