### PR TITLE
Fix SIGSEGV errors of wal-g delete

### DIFF
--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -299,6 +299,13 @@ func (h *DeleteHandler) FindTargetRetainAfterName(
 		return nil, err
 	}
 
+	if target1 == nil {
+		return target2, nil
+	}
+	if target2 == nil {
+		return target1, nil
+	}
+
 	if h.greater(target2, target1) {
 		return target1, nil
 	}


### PR DESCRIPTION
This fix addresses the following WAL-G command: `wal-g delete retain 5 --after DATE`


Currently, If there are no backups with a date greater than DATE, WAL-G will get a runtime error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1876aa6]

goroutine 1 [running]:
github.com/wal-g/wal-g/internal/databases/postgres.timelineAndSegmentNoLess({0x77df70246718?, 0xc000492310?}, {0x0, 0x0})
        /home/runner/work/wal-g/wal-g/internal/databases/postgres/delete.go:204 +0x46
github.com/wal-g/wal-g/internal.NewDeleteHandler.func1({0x0?, 0x0?}, {0x77df70246718?, 0xc000492310?})
        /home/runner/work/wal-g/wal-g/internal/delete_handler.go:91 +0x3d
github.com/wal-g/wal-g/internal.(*DeleteHandler).FindTargetRetainAfterName(0xc00082bd80, 0x5, {0x7ffe6e7506f3, 0x13}, 0x0)
        /home/runner/work/wal-g/wal-g/internal/delete_handler.go:302 +0x42b
github.com/wal-g/wal-g/internal.(*DeleteHandler).FindTargetRetainAfter(0xc00082bd80, 0x5, {0x7ffe6e7506f3, 0x13}, 0x0)
        /home/runner/work/wal-g/wal-g/internal/delete_handler.go:274 +0x5b
github.com/wal-g/wal-g/internal.(*DeleteHandler).HandleDeleteRetainAfter(0xc00082bd80, {0xc0006c4960?, 0xc000de2b10?, 0xc000de2b40?}, 0x0)
        /home/runner/work/wal-g/wal-g/internal/delete_handler.go:148 +0x20c
github.com/wal-g/wal-g/cmd/pg.runDeleteRetain(0x3cd9d20, {0xc0006c4960, 0x1, 0x5})
        /home/runner/work/wal-g/wal-g/cmd/pg/delete.go:91 +0x1d4
github.com/spf13/cobra.(*Command).execute(0x3cd9d20, {0xc0006c4910, 0x5, 0x5})
        /home/runner/work/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:860 +0x684
github.com/spf13/cobra.(*Command).ExecuteC(0x3cdaea0)
        /home/runner/work/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:974 +0x38d
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/work/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:902
github.com/wal-g/wal-g/cmd/pg.Execute()
        /home/runner/work/wal-g/wal-g/cmd/pg/pg.go:55 +0x1f
main.main()
        /home/runner/work/wal-g/wal-g/main/pg/main.go:8 +0xf

```

This fix adds the necessary checks for nulls as we did in https://github.com/wal-g/wal-g/pull/818
Fixes #1863