### PR TITLE
Refactor: Move CheckArchiveCommand from "connect.go" to queryRunner

### DIFF
--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -173,6 +173,8 @@ func (bh *BackupHandler) createAndPushBackup(ctx context.Context) {
 	tracelog.ErrorLogger.FatalOnError(err)
 	err = bh.checkDataChecksums()
 	tracelog.ErrorLogger.FatalOnError(err)
+	err = bh.CheckArchiveCommand()
+	tracelog.ErrorLogger.FatalOnError(err)
 
 	if orioledbEnabled {
 		chkpNum := orioledb.GetChkpNum(bh.PgInfo.PgDataDirectory)
@@ -683,6 +685,54 @@ func (bh *BackupHandler) checkDataChecksums() error {
 			"checkDataChecksums: Checking if data_checksums is enabled in DB is skipped " +
 				"because the --verify parameter is not set.")
 	}
+	return nil
+}
+
+// CheckArchiveCommand verifies the archive_mode and archive_command settings.
+func (bh *BackupHandler) CheckArchiveCommand() error {
+	// Check if the server is in recovery mode (standby)
+	standby, err := bh.Workers.QueryRunner.IsStandby()
+	if err != nil {
+		tracelog.ErrorLogger.Printf("CheckArchiveCommand: failed to determine standby mode: %v", err)
+		return err
+	}
+
+	if standby {
+		// If the server is in standby mode, no further checks are needed
+		tracelog.DebugLogger.Println("Server is in standby mode. Skipping archive settings checks.")
+		return nil
+	}
+
+	// Retrieve the current archive_mode setting
+	archiveMode, err := bh.Workers.QueryRunner.GetArchiveMode()
+	if err != nil {
+		tracelog.ErrorLogger.Printf("CheckArchiveCommand: failed to get archive_mode: %v", err)
+		return err
+	}
+
+	// Check if archive_mode is enabled
+	if archiveMode != "on" && archiveMode != "always" {
+		tracelog.WarningLogger.Println(
+			"archive_mode is not enabled. This may cause inconsistent backups. " +
+				"Please consider configuring WAL archiving.")
+	} else {
+		// Retrieve the current archive_command setting
+		archiveCommand, err := bh.Workers.QueryRunner.GetArchiveCommand()
+		if err != nil {
+			tracelog.ErrorLogger.Printf("CheckArchiveCommand: failed to get archive_command: %v", err)
+			return err
+		}
+
+		// Check if archive_command is properly configured
+		if len(archiveCommand) == 0 || archiveCommand == "(disabled)" {
+			tracelog.WarningLogger.Println(
+				"archive_command is not configured. This may cause inconsistent backups. " +
+					"Please consider configuring WAL archiving.")
+		} else {
+			tracelog.DebugLogger.Println("WAL archiving settings are configured.")
+		}
+	}
+
 	return nil
 }
 

--- a/internal/databases/postgres/connect.go
+++ b/internal/databases/postgres/connect.go
@@ -45,57 +45,7 @@ func Connect(configOptions ...func(config *pgx.ConnConfig) error) (*pgx.Conn, er
 		}
 	}
 
-	err = checkArchiveCommand(conn)
-	if err != nil {
-		return nil, err
-	}
-
 	return conn, nil
-}
-
-func checkArchiveCommand(conn *pgx.Conn) error {
-	// TODO: Move this logic to queryRunner
-
-	var standby bool
-
-	err := conn.QueryRow(context.TODO(), "select pg_is_in_recovery()").Scan(&standby)
-	if err != nil {
-		return errors.Wrap(err, "Connect: postgres standby test failed")
-	}
-
-	if standby {
-		// archive_mode may be configured on primary
-		return nil
-	}
-
-	var archiveMode string
-
-	err = conn.QueryRow(context.TODO(), "show archive_mode").Scan(&archiveMode)
-
-	if err != nil {
-		return errors.Wrap(err, "Connect: postgres archive_mode test failed")
-	}
-
-	if archiveMode != "on" && archiveMode != "always" {
-		tracelog.WarningLogger.Println(
-			"It seems your archive_mode is not enabled. This will cause inconsistent backup. " +
-				"Please consider configuring WAL archiving.")
-	} else {
-		var archiveCommand string
-
-		err = conn.QueryRow(context.TODO(), "show archive_command").Scan(&archiveCommand)
-
-		if err != nil {
-			return errors.Wrap(err, "Connect: postgres archive_mode test failed")
-		}
-
-		if len(archiveCommand) == 0 || archiveCommand == "(disabled)" {
-			tracelog.WarningLogger.Println(
-				"It seems your archive_command is not configured. This will cause inconsistent backup." +
-					" Please consider configuring WAL archiving.")
-		}
-	}
-	return nil
 }
 
 // nolint:gocritic

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -741,3 +741,42 @@ func (queryRunner *PgQueryRunner) GetDataChecksums() (string, error) {
 
 	return dataChecksums, nil
 }
+
+// GetArchiveMode retrieves the current archive_mode setting.
+func (queryRunner *PgQueryRunner) GetArchiveMode() (string, error) {
+	queryRunner.Mu.Lock()
+	defer queryRunner.Mu.Unlock()
+
+	var archiveMode string
+	err := queryRunner.Connection.QueryRow(context.TODO(), "SHOW archive_mode").Scan(&archiveMode)
+	if err != nil {
+		return "", errors.Wrap(err, "GetArchiveMode: failed to retrieve archive_mode")
+	}
+	return archiveMode, nil
+}
+
+// GetArchiveCommand retrieves the current archive_command setting.
+func (queryRunner *PgQueryRunner) GetArchiveCommand() (string, error) {
+	queryRunner.Mu.Lock()
+	defer queryRunner.Mu.Unlock()
+
+	var archiveCommand string
+	err := queryRunner.Connection.QueryRow(context.TODO(), "SHOW archive_command").Scan(&archiveCommand)
+	if err != nil {
+		return "", errors.Wrap(err, "GetArchiveCommand: failed to retrieve archive_command")
+	}
+	return archiveCommand, nil
+}
+
+// IsStandby checks if the PostgreSQL server is in recovery mode (standby).
+func (queryRunner *PgQueryRunner) IsStandby() (bool, error) {
+	queryRunner.Mu.Lock()
+	defer queryRunner.Mu.Unlock()
+
+	var standby bool
+	err := queryRunner.Connection.QueryRow(context.TODO(), "SELECT pg_is_in_recovery()").Scan(&standby)
+	if err != nil {
+		return false, errors.Wrap(err, "IsStandby: failed to determine recovery mode")
+	}
+	return standby, nil
+}


### PR DESCRIPTION
**Database name**
PostgreSQL

**Pull request description**
The primary goal of this refactor is to eliminate the multiple executions of the CheckArchiveCommand function triggered each time a new PostgreSQL connection was established via the Connect function. By relocating CheckArchiveCommand outside of Connect, we ensure that the archive settings are checked only once
