### PR TITLE
Fixed backward compatibility with files metadata

### DIFF
--- a/internal/databases/postgres/names_metadata.go
+++ b/internal/databases/postgres/names_metadata.go
@@ -12,7 +12,7 @@ import (
 type DatabasesByNames map[string]DatabaseObjectsInfo
 type DatabaseObjectsInfo struct {
 	Oid    uint32               `json:"oid"`
-	Tables map[string]TableInfo `json:"tables,omitempty"`
+	Tables map[string]TableInfo `json:"tables_new,omitempty"`
 }
 type TableInfo struct {
 	Oid         uint32               `json:"oid"`


### PR DESCRIPTION
### Database name
Postgres/Greenplum.

### Pull request description
There was fixes for partial restore which led to change in the structure of files_metadata. ( https://github.com/wal-g/wal-g/pull/1816 )

As a result, exception raised when incompatible versions of wal-g tried to create incremental backup on top of backup created by previous version of wal-g:
```
INFO: 2024/12/10 13:14:24.316010 Delta backup from base_0000001800000A7B00000031 with LSN A7B/C4000028.
ERROR: 2024/12/10 13:14:36.389060 failed to fetch files metadata: failed to fetch dto from base_0000001800000A7B00000031/files_metadata.json: json: cannot unmarshal number into Go struct field DatabaseObjectsInfo.DatabasesByNames.tables of type postgres.TableInfo
ERROR: 2024/12/10 13:14:36.423779 command failed: exit status 1
```

because `files_metadata.json` contained:
```
    "tpch": {
      "oid": 11049314,
      "tables": {
        "pg_aoseg.pg_xxx_11103546": 9182412,
        "pg_aoseg.pg_xxx_11103546_index": 9182416,
```

This pr makes this changes backward compatible (by ignoring old metadata - because it lacks of information we need)