### PR TITLE
remove folder cleanup

### DIFF
--- a/internal/databases/redis/aof/backup.go
+++ b/internal/databases/redis/aof/backup.go
@@ -83,7 +83,6 @@ func (bs *BackupService) DoBackup(backupName string, permanent bool) error {
 	}
 
 	backupFiles := bs.backupFilesListProvider.Get()
-	defer bs.backupFilesListProvider.Cleanup()
 
 	pinnedBackupFiles, err := bs.filesPinner.Pin(backupFiles)
 	defer bs.filesPinner.Unpin()

--- a/internal/databases/redis/aof/manifest.go
+++ b/internal/databases/redis/aof/manifest.go
@@ -32,14 +32,6 @@ func (p *BackupFilesListProvider) Get() []string {
 	return res
 }
 
-func (p *BackupFilesListProvider) Cleanup() {
-	folder := filepath.Dir(p.UploadManifestPath)
-	err := os.RemoveAll(folder)
-	if err != nil {
-		tracelog.WarningLogger.Printf("failed to remove folder %s: %v", folder, err)
-	}
-}
-
 func copyManifestToUpload(lines []string, path string) {
 	folder := filepath.Dir(path)
 	err := os.MkdirAll(folder, 0644)


### PR DESCRIPTION
### Database name
redis

# Pull request description
leave tmp folder cleanup to infra outside

### Describe what this PR fixes
tmp folder could be created and removed outside of wal-g in some envs, removing it in wal-g could break that

### Please provide steps to reproduce (if it's a bug)
none

### Please add config and wal-g stdout/stderr logs for debug purpose
none