### PR TITLE
add user data into etcd sentinel

### DIFF
--- a/internal/databases/etcd/delete_handler.go
+++ b/internal/databases/etcd/delete_handler.go
@@ -17,7 +17,18 @@ func NewEtcdDeleteHandler(folder storage.Folder) (*internal.DeleteHandler, error
 		backupObjects = append(backupObjects, internal.NewDefaultBackupObject(object))
 	}
 
-	return internal.NewDeleteHandler(folder, backupObjects, makeLessFunc()), nil
+	permanentBackups := internal.GetPermanentBackups(folder.GetSubFolder(utility.BaseBackupPath), NewGenericMetaFetcher())
+
+	isPermanentFunc := func(object storage.Object) bool {
+		return internal.IsPermanent(object.GetName(), permanentBackups, internal.StreamBackupNameLength)
+	}
+
+	return internal.NewDeleteHandler(
+			folder,
+			backupObjects,
+			makeLessFunc(),
+			internal.IsPermanentFunc(isPermanentFunc)),
+		nil
 }
 
 func makeLessFunc() func(object1, object2 storage.Object) bool {

--- a/internal/databases/etcd/generic_meta_fetcher.go
+++ b/internal/databases/etcd/generic_meta_fetcher.go
@@ -1,0 +1,32 @@
+package etcd
+
+import (
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+type GenericMetaFetcher struct{}
+
+func NewGenericMetaFetcher() GenericMetaFetcher {
+	return GenericMetaFetcher{}
+}
+
+// TODO: Unit tests
+func (mf GenericMetaFetcher) Fetch(backupName string, backupFolder storage.Folder) (internal.GenericMetadata, error) {
+	backup, err := internal.NewBackup(backupFolder, backupName)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+	var sentinel StreamSentinelDto
+	err = backup.FetchSentinel(&sentinel)
+	if err != nil {
+		return internal.GenericMetadata{}, err
+	}
+
+	return internal.GenericMetadata{
+		BackupName:  backupName,
+		StartTime:   sentinel.StartLocalTime,
+		IsPermanent: sentinel.IsPermanent,
+		UserData:    sentinel.UserData,
+	}, nil
+}

--- a/internal/databases/etcd/generic_meta_fetcher_test.go
+++ b/internal/databases/etcd/generic_meta_fetcher_test.go
@@ -1,0 +1,54 @@
+package etcd_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/etcd"
+	"github.com/wal-g/wal-g/testtools"
+)
+
+func init() {
+	internal.ConfigureSettings("")
+	config.InitConfig()
+	config.Configure()
+}
+
+func TestFetch(t *testing.T) {
+	folder := testtools.CreateMockStorageFolder()
+	backupName := "test"
+	data := "Data"
+	date := time.Date(2002, 3, 21, 0, 0, 0, 0, time.UTC)
+
+	testObject := etcd.StreamSentinelDto{
+		StartLocalTime: date,
+		IsPermanent:    false,
+		UserData:       data,
+	}
+
+	var expectedResult = internal.GenericMetadata{
+		BackupName:  backupName,
+		StartTime:   date,
+		IsPermanent: false,
+		UserData:    data,
+	}
+
+	marshaller, _ := internal.NewDtoSerializer()
+	file, _ := marshaller.Marshal(testObject)
+	_ = folder.PutObject(internal.SentinelNameFromBackup(backupName), file)
+
+	actualResult, err := etcd.NewGenericMetaFetcher().Fetch(backupName, folder)
+	assert.NoError(t, err)
+
+	isEqualTimeStart := expectedResult.StartTime.Equal(actualResult.StartTime)
+	assert.True(t, isEqualTimeStart)
+
+	expectedResult.StartTime = actualResult.StartTime
+	expectedResult.FinishTime = actualResult.FinishTime
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResult, actualResult)
+}


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

ETCD

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
