### PR TITLE
Greenplum: add --force-delete flag to delete command

### DIFF
--- a/cmd/gp/delete.go
+++ b/cmd/gp/delete.go
@@ -3,12 +3,16 @@ package gp
 import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"
 )
 
 var confirmed = false
+var forceDelete = false
+var forceDeleteShortDescription = "force delete (ignore missing segments)"
+
 var deleteTargetUserData = ""
 
 const DeleteGarbageExamples = `  garbage           Deletes outdated WAL archives and leftover backups files from storage`
@@ -60,7 +64,7 @@ func runDeleteBefore(cmd *cobra.Command, args []string) {
 	rootFolder, err := getMultistorageRootFolder(true, policies.UniteAllStorages)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	delArgs := greenplum.DeleteArgs{Confirmed: confirmed}
+	delArgs := greenplum.DeleteArgs{Confirmed: confirmed, Force: forceDelete}
 	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, delArgs)
 	tracelog.ErrorLogger.FatalOnError(err)
 
@@ -71,7 +75,7 @@ func runDeleteRetain(cmd *cobra.Command, args []string) {
 	rootFolder, err := getMultistorageRootFolder(true, policies.UniteAllStorages)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	delArgs := greenplum.DeleteArgs{Confirmed: confirmed}
+	delArgs := greenplum.DeleteArgs{Confirmed: confirmed, Force: forceDelete}
 	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, delArgs)
 	tracelog.ErrorLogger.FatalOnError(err)
 
@@ -82,7 +86,7 @@ func runDeleteEverything(cmd *cobra.Command, args []string) {
 	rootFolder, err := getMultistorageRootFolder(true, policies.UniteAllStorages)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	delArgs := greenplum.DeleteArgs{Confirmed: confirmed}
+	delArgs := greenplum.DeleteArgs{Confirmed: confirmed, Force: forceDelete}
 	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, delArgs)
 	tracelog.ErrorLogger.FatalOnError(err)
 
@@ -101,7 +105,7 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 		args = args[1:]
 	}
 
-	delArgs := greenplum.DeleteArgs{Confirmed: confirmed, FindFull: findFullBackup}
+	delArgs := greenplum.DeleteArgs{Confirmed: confirmed, FindFull: findFullBackup, Force: forceDelete}
 	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, delArgs)
 	tracelog.ErrorLogger.FatalOnError(err)
 
@@ -116,7 +120,7 @@ func runDeleteGarbage(cmd *cobra.Command, args []string) {
 	rootFolder, err := getMultistorageRootFolder(true, policies.UniteAllStorages)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	delArgs := greenplum.DeleteArgs{Confirmed: confirmed, Garbage: true}
+	delArgs := greenplum.DeleteArgs{Confirmed: confirmed, Force: true}
 	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, delArgs)
 	tracelog.ErrorLogger.FatalOnError(err)
 
@@ -132,4 +136,6 @@ func init() {
 
 	deleteCmd.AddCommand(deleteRetainCmd, deleteBeforeCmd, deleteEverythingCmd, deleteTargetCmd, deleteGarbageCmd)
 	deleteCmd.PersistentFlags().BoolVar(&confirmed, internal.ConfirmFlag, false, "Confirms backup deletion")
+	deleteCmd.PersistentFlags().BoolVar(&forceDelete, "force-delete", false, "Force delete")
+	_ = deleteCmd.PersistentFlags().MarkHidden("force-delete")
 }

--- a/cmd/gp/delete.go
+++ b/cmd/gp/delete.go
@@ -11,7 +11,6 @@ import (
 
 var confirmed = false
 var forceDelete = false
-var forceDeleteShortDescription = "force delete (ignore missing segments)"
 
 var deleteTargetUserData = ""
 

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -22,7 +22,7 @@ import (
 type DeleteArgs struct {
 	Confirmed bool
 	FindFull  bool
-	Garbage   bool
+	Force     bool
 }
 
 type DeleteHandler struct {
@@ -185,7 +185,7 @@ func (h *DeleteHandler) dispatchDeleteCmd(target internal.BackupObject, delType 
 			}
 			segBackup, err := backup.GetSegmentBackup(meta.BackupID, meta.ContentID)
 			if err != nil {
-				if h.args.Garbage {
+				if h.args.Force {
 					tracelog.ErrorLogger.Printf("Processing segment %d (backupId=%s): %v", meta.ContentID, meta.BackupID, err)
 					return nil // skip non-critical errors in garbage deletion
 				}


### PR DESCRIPTION
### Greenplum

There is chance to have broken backup with a sentinel (e.g. after pressing Control+C during backup deletion). Currently there is no way to delete such backups:
* `wal-g delete garbage` will not delete backups for which we have sentinel.
* `wal-g delete targe XXX` will not delete sentinel because it will fail as soon as it find missing segment data. (however it will continue deleting segment's data)