### PR TITLE
Fix connection break

### DIFF
--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -239,7 +239,7 @@ func (queryRunner *PgQueryRunner) StopBackup() (label string, offsetMap string, 
 
 	tracelog.InfoLogger.Println("Calling pg_stop_backup()")
 
-	//during long backups conn might break, so we check if connection is still alive
+	//during long backups connection might break, so we check if connection is still alive
 	errPing := queryRunner.Connection.Ping(context.TODO())
 	if errPing != nil {
 		queryRunner.Connection, err = Connect()


### PR DESCRIPTION
### Database name
Postgres/Greenplum

# Pull request description

Sometimes when performing long backups on unstable clusters i get error
```
INFO: 2025/02/18 21:13:53.117534 Calling pg_stop_backup()
ERROR: 2025/02/18 21:13:53.117705 UploadLabelFiles: failed to stop backup: QueryRunner StopBackup: transaction begin failed: conn is dead
```
I believe that it is better to check if connection is alive after processing files. And if it is not, reconnect to database