### PR TITLE
Wal-g write an error to logs when there are no backups in a S3 storage

### DIFF
--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -41,7 +41,7 @@ func NewNoBackupsFoundError() NoBackupsFoundError {
 	return NoBackupsFoundError{errors.New("No backups found")}
 }
 
-func CheckIsNoBackupFoundError(err error, json bool) error {
+func FilterOutNoBackupFoundError(err error, json bool) error {
 	if errors.Is(err, ErrNoBackupsFound) {
 		// Having zero backups is not an error that should be handled in most cases.
 		if !json {

--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -19,6 +19,10 @@ type NoBackupsFoundError struct {
 	error
 }
 
+var (
+	ErrNoBackupsFound = NewNoBackupsFoundError()
+)
+
 type TimedBackup interface {
 	Name() string
 	StartTime() time.Time

--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -19,10 +19,6 @@ type NoBackupsFoundError struct {
 	error
 }
 
-var (
-	ErrNoBackupsFound = NewNoBackupsFoundError()
-)
-
 type TimedBackup interface {
 	Name() string
 	StartTime() time.Time
@@ -42,7 +38,7 @@ func NewNoBackupsFoundError() NoBackupsFoundError {
 }
 
 func FilterOutNoBackupFoundError(err error, json bool) error {
-	if errors.Is(err, ErrNoBackupsFound) {
+	if _, isNoBackupsErr := err.(NoBackupsFoundError); isNoBackupsErr {
 		// Having zero backups is not an error that should be handled in most cases.
 		if !json {
 			tracelog.InfoLogger.Println("No backups found")

--- a/internal/backup_util.go
+++ b/internal/backup_util.go
@@ -41,6 +41,17 @@ func NewNoBackupsFoundError() NoBackupsFoundError {
 	return NoBackupsFoundError{errors.New("No backups found")}
 }
 
+func CheckIsNoBackupFoundError(err error, json bool) error {
+	if errors.Is(err, ErrNoBackupsFound) {
+		// Having zero backups is not an error that should be handled in most cases.
+		if !json {
+			tracelog.InfoLogger.Println("No backups found")
+		}
+		return nil
+	}
+	return err
+}
+
 func (err NoBackupsFoundError) Error() string {
 	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
 }

--- a/internal/databases/greenplum/backup_list_handler.go
+++ b/internal/databases/greenplum/backup_list_handler.go
@@ -1,6 +1,7 @@
 package greenplum
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -147,10 +148,9 @@ func MakeBackupDetails(backups []Backup) []BackupDetail {
 // TODO: unit tests (table output)
 func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backups, err := ListStorageBackups(folder)
-
-	if len(backups) == 0 {
-		tracelog.InfoLogger.Println("No backups found")
-		return
+	if errors.Is(err, internal.ErrNoBackupsFound) {
+		// Having zero backups is not an error that should be handled.
+		err = nil
 	}
 	tracelog.ErrorLogger.FatalOnError(err)
 

--- a/internal/databases/greenplum/backup_list_handler.go
+++ b/internal/databases/greenplum/backup_list_handler.go
@@ -1,7 +1,6 @@
 package greenplum
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -148,13 +147,7 @@ func MakeBackupDetails(backups []Backup) []BackupDetail {
 // TODO: unit tests (table output)
 func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backups, err := ListStorageBackups(folder)
-	if errors.Is(err, internal.ErrNoBackupsFound) {
-		// Having zero backups is not an error that should be handled.
-		if !json {
-			tracelog.InfoLogger.Println("No backups found")
-		}
-		err = nil
-	}
+	err = internal.CheckIsNoBackupFoundError(err, json)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	backupDetails := MakeBackupDetails(backups)

--- a/internal/databases/greenplum/backup_list_handler.go
+++ b/internal/databases/greenplum/backup_list_handler.go
@@ -150,6 +150,9 @@ func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backups, err := ListStorageBackups(folder)
 	if errors.Is(err, internal.ErrNoBackupsFound) {
 		// Having zero backups is not an error that should be handled.
+		if !json {
+			tracelog.InfoLogger.Println("No backups found")
+		}
 		err = nil
 	}
 	tracelog.ErrorLogger.FatalOnError(err)

--- a/internal/databases/greenplum/backup_list_handler.go
+++ b/internal/databases/greenplum/backup_list_handler.go
@@ -147,7 +147,7 @@ func MakeBackupDetails(backups []Backup) []BackupDetail {
 // TODO: unit tests (table output)
 func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backups, err := ListStorageBackups(folder)
-	err = internal.CheckIsNoBackupFoundError(err, json)
+	err = internal.FilterOutNoBackupFoundError(err, json)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	backupDetails := MakeBackupDetails(backups)

--- a/internal/databases/mongo/backup_list_handler.go
+++ b/internal/databases/mongo/backup_list_handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/mongo/common"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
@@ -46,6 +47,9 @@ func HandleDetailedBackupList(folder storage.Folder, output io.Writer, pretty, j
 	backupTimes, err := internal.GetBackups(folder)
 	if errors.Is(err, internal.ErrNoBackupsFound) {
 		// Having zero backups is not an error that should be handled.
+		if !json {
+			tracelog.InfoLogger.Println("No backups found")
+		}
 		err = nil
 	}
 	if err != nil {

--- a/internal/databases/mongo/backup_list_handler.go
+++ b/internal/databases/mongo/backup_list_handler.go
@@ -44,6 +44,10 @@ func NewBackupDetail(backupTime internal.BackupTime, sentinel *models.Backup) *B
 // TODO: unit tests
 func HandleDetailedBackupList(folder storage.Folder, output io.Writer, pretty, json bool) error {
 	backupTimes, err := internal.GetBackups(folder)
+	if errors.Is(err, internal.ErrNoBackupsFound) {
+		// Having zero backups is not an error that should be handled.
+		err = nil
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/databases/mongo/backup_list_handler.go
+++ b/internal/databases/mongo/backup_list_handler.go
@@ -44,7 +44,7 @@ func NewBackupDetail(backupTime internal.BackupTime, sentinel *models.Backup) *B
 // TODO: unit tests
 func HandleDetailedBackupList(folder storage.Folder, output io.Writer, pretty, json bool) error {
 	backupTimes, err := internal.GetBackups(folder)
-	err = internal.CheckIsNoBackupFoundError(err, json)
+	err = internal.FilterOutNoBackupFoundError(err, json)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/mongo/backup_list_handler.go
+++ b/internal/databases/mongo/backup_list_handler.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/mongo/common"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
@@ -45,13 +44,7 @@ func NewBackupDetail(backupTime internal.BackupTime, sentinel *models.Backup) *B
 // TODO: unit tests
 func HandleDetailedBackupList(folder storage.Folder, output io.Writer, pretty, json bool) error {
 	backupTimes, err := internal.GetBackups(folder)
-	if errors.Is(err, internal.ErrNoBackupsFound) {
-		// Having zero backups is not an error that should be handled.
-		if !json {
-			tracelog.InfoLogger.Println("No backups found")
-		}
-		err = nil
-	}
+	err = internal.CheckIsNoBackupFoundError(err, json)
 	if err != nil {
 		return err
 	}

--- a/internal/databases/mysql/backup_list_handler.go
+++ b/internal/databases/mysql/backup_list_handler.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -116,13 +115,7 @@ func NewBackupDetail(backupTime internal.BackupTime, sentinel StreamSentinelDto)
 // TODO: unit tests
 func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backupTimes, err := internal.GetBackups(folder)
-	if errors.Is(err, internal.ErrNoBackupsFound) {
-		// Having zero backups is not an error that should be handled.
-		if !json {
-			tracelog.InfoLogger.Println("No backups found")
-		}
-		err = nil
-	}
+	err = internal.CheckIsNoBackupFoundError(err, json)
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch list of backups in storage: %s", err)
 
 	backupDetails := make([]BackupDetail, 0, len(backupTimes))

--- a/internal/databases/mysql/backup_list_handler.go
+++ b/internal/databases/mysql/backup_list_handler.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -115,8 +116,7 @@ func NewBackupDetail(backupTime internal.BackupTime, sentinel StreamSentinelDto)
 // TODO: unit tests
 func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backupTimes, err := internal.GetBackups(folder)
-	_, isNoBackupsErr := err.(internal.NoBackupsFoundError)
-	if isNoBackupsErr {
+	if errors.Is(err, internal.ErrNoBackupsFound) {
 		// Having zero backups is not an error that should be handled.
 		err = nil
 	}

--- a/internal/databases/mysql/backup_list_handler.go
+++ b/internal/databases/mysql/backup_list_handler.go
@@ -115,6 +115,11 @@ func NewBackupDetail(backupTime internal.BackupTime, sentinel StreamSentinelDto)
 // TODO: unit tests
 func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backupTimes, err := internal.GetBackups(folder)
+	_, isNoBackupsErr := err.(internal.NoBackupsFoundError)
+	if isNoBackupsErr {
+		// Having zero backups is not an error that should be handled.
+		err = nil
+	}
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch list of backups in storage: %s", err)
 
 	backupDetails := make([]BackupDetail, 0, len(backupTimes))

--- a/internal/databases/mysql/backup_list_handler.go
+++ b/internal/databases/mysql/backup_list_handler.go
@@ -118,6 +118,9 @@ func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backupTimes, err := internal.GetBackups(folder)
 	if errors.Is(err, internal.ErrNoBackupsFound) {
 		// Having zero backups is not an error that should be handled.
+		if !json {
+			tracelog.InfoLogger.Println("No backups found")
+		}
 		err = nil
 	}
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch list of backups in storage: %s", err)

--- a/internal/databases/mysql/backup_list_handler.go
+++ b/internal/databases/mysql/backup_list_handler.go
@@ -115,7 +115,7 @@ func NewBackupDetail(backupTime internal.BackupTime, sentinel StreamSentinelDto)
 // TODO: unit tests
 func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backupTimes, err := internal.GetBackups(folder)
-	err = internal.CheckIsNoBackupFoundError(err, json)
+	err = internal.FilterOutNoBackupFoundError(err, json)
 	tracelog.ErrorLogger.FatalfOnError("Failed to fetch list of backups in storage: %s", err)
 
 	backupDetails := make([]BackupDetail, 0, len(backupTimes))

--- a/internal/databases/postgres/backup_list_handler.go
+++ b/internal/databases/postgres/backup_list_handler.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/printlist"
@@ -11,9 +12,9 @@ import (
 
 func HandleDetailedBackupList(folder storage.Folder, pretty bool, json bool) {
 	backups, err := internal.GetBackups(folder)
-	if len(backups) == 0 {
-		tracelog.InfoLogger.Println("No backups found")
-		return
+	if errors.Is(err, internal.ErrNoBackupsFound) {
+		// Having zero backups is not an error that should be handled.
+		err = nil
 	}
 	tracelog.ErrorLogger.FatalfOnError("Get backups from folder: %v", err)
 

--- a/internal/databases/postgres/backup_list_handler.go
+++ b/internal/databases/postgres/backup_list_handler.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/printlist"
@@ -12,13 +11,7 @@ import (
 
 func HandleDetailedBackupList(folder storage.Folder, pretty bool, json bool) {
 	backups, err := internal.GetBackups(folder)
-	if errors.Is(err, internal.ErrNoBackupsFound) {
-		// Having zero backups is not an error that should be handled.
-		if !json {
-			tracelog.InfoLogger.Println("No backups found")
-		}
-		err = nil
-	}
+	err = internal.CheckIsNoBackupFoundError(err, json)
 	tracelog.ErrorLogger.FatalfOnError("Get backups from folder: %v", err)
 
 	backupDetails, err := GetBackupsDetails(folder, backups)

--- a/internal/databases/postgres/backup_list_handler.go
+++ b/internal/databases/postgres/backup_list_handler.go
@@ -11,7 +11,7 @@ import (
 
 func HandleDetailedBackupList(folder storage.Folder, pretty bool, json bool) {
 	backups, err := internal.GetBackups(folder)
-	err = internal.CheckIsNoBackupFoundError(err, json)
+	err = internal.FilterOutNoBackupFoundError(err, json)
 	tracelog.ErrorLogger.FatalfOnError("Get backups from folder: %v", err)
 
 	backupDetails, err := GetBackupsDetails(folder, backups)

--- a/internal/databases/postgres/backup_list_handler.go
+++ b/internal/databases/postgres/backup_list_handler.go
@@ -14,6 +14,9 @@ func HandleDetailedBackupList(folder storage.Folder, pretty bool, json bool) {
 	backups, err := internal.GetBackups(folder)
 	if errors.Is(err, internal.ErrNoBackupsFound) {
 		// Having zero backups is not an error that should be handled.
+		if !json {
+			tracelog.InfoLogger.Println("No backups found")
+		}
 		err = nil
 	}
 	tracelog.ErrorLogger.FatalfOnError("Get backups from folder: %v", err)

--- a/internal/databases/redis/backup_list_handler.go
+++ b/internal/databases/redis/backup_list_handler.go
@@ -13,7 +13,7 @@ import (
 
 func HandleDetailedBackupList(folder storage.Folder, pretty bool, json bool) {
 	backups, err := internal.GetBackups(folder)
-	err = internal.CheckIsNoBackupFoundError(err, json)
+	err = internal.FilterOutNoBackupFoundError(err, json)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	backupDetails, err := GetBackupDetails(folder, backups)

--- a/internal/databases/redis/backup_list_handler.go
+++ b/internal/databases/redis/backup_list_handler.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"errors"
 	"os"
 	"sort"
 
@@ -13,9 +14,9 @@ import (
 
 func HandleDetailedBackupList(folder storage.Folder, pretty bool, json bool) {
 	backups, err := internal.GetBackups(folder)
-	if len(backups) == 0 {
-		tracelog.InfoLogger.Println("No backups found")
-		return
+	if errors.Is(err, internal.ErrNoBackupsFound) {
+		// Having zero backups is not an error that should be handled.
+		err = nil
 	}
 	tracelog.ErrorLogger.FatalOnError(err)
 

--- a/internal/databases/redis/backup_list_handler.go
+++ b/internal/databases/redis/backup_list_handler.go
@@ -16,6 +16,9 @@ func HandleDetailedBackupList(folder storage.Folder, pretty bool, json bool) {
 	backups, err := internal.GetBackups(folder)
 	if errors.Is(err, internal.ErrNoBackupsFound) {
 		// Having zero backups is not an error that should be handled.
+		if !json {
+			tracelog.InfoLogger.Println("No backups found")
+		}
 		err = nil
 	}
 	tracelog.ErrorLogger.FatalOnError(err)

--- a/internal/databases/redis/backup_list_handler.go
+++ b/internal/databases/redis/backup_list_handler.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"errors"
 	"os"
 	"sort"
 
@@ -14,13 +13,7 @@ import (
 
 func HandleDetailedBackupList(folder storage.Folder, pretty bool, json bool) {
 	backups, err := internal.GetBackups(folder)
-	if errors.Is(err, internal.ErrNoBackupsFound) {
-		// Having zero backups is not an error that should be handled.
-		if !json {
-			tracelog.InfoLogger.Println("No backups found")
-		}
-		err = nil
-	}
+	err = internal.CheckIsNoBackupFoundError(err, json)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	backupDetails, err := GetBackupDetails(folder, backups)


### PR DESCRIPTION
### Database name
MySQL, PostgreSQL, Greenplum, MongoDB, Redis

### Describe what this PR fixes
In MySQL, I suppose wal-g shouldn't write an error to logs when there are no backups in a S3 storage, so I suggest to ignore the error.

In PostgreSQL, Greenplum, and Redis, we shouldn't ignore possible errors from S3.

### Please provide steps to reproduce (if it's a bug)
In MySQL and MongoDB I got:
```
> wal-g backup-list --json --detail
WARNING: 2025/02/25 10:06:35.262719 WALG_FAILOVER_STORAGES_CHECK_TIMEOUT is unknown
WARNING: 2025/02/25 10:06:35.262746 WALG_FAILOVER_STORAGES_CACHE_LIFETIME is unknown
WARNING: 2025/02/25 10:06:35.262753 We found that some variables in your config file detected as 'Unknown'. 
  If this is not right, please create issue https://github.com/wal-g/wal-g/issues/new
ERROR: 2025/02/25 10:06:35.305854 Failed to fetch list of backups in storage: No backups found
```
After the fix:
```
> wal-g backup-list --json --detail
WARNING: 2025/02/25 10:07:14.844834 WALG_FAILOVER_STORAGES_CACHE_LIFETIME is unknown
WARNING: 2025/02/25 10:07:14.844859 WALG_FAILOVER_STORAGES_CHECK_TIMEOUT is unknown
WARNING: 2025/02/25 10:07:14.844911 We found that some variables in your config file detected as 'Unknown'. 
  If this is not right, please create issue https://github.com/wal-g/wal-g/issues/new
[]
```