### PR TITLE
Cloudberry: accept 'Apache Cloudbery' in version()

### DIFF
--- a/internal/databases/greenplum/version.go
+++ b/internal/databases/greenplum/version.go
@@ -31,8 +31,11 @@ func NewVersion(version semver.Version, flavor Flavor) Version {
 }
 
 func parseGreenplumVersion(version string) (Version, error) {
-	pattern := regexp.MustCompile(`(Greenplum Database|Cloudberry Database) (\d+\.\d+\.\d+)`)
+	pattern := regexp.MustCompile(`(Greenplum Database|Cloudberry Database|Apache Cloudberry) (\d+\.\d+\.\d+)`)
 	groups := pattern.FindStringSubmatch(version)
+	if groups == nil {
+		return Version{}, fmt.Errorf("unknown flavor: %s", version)
+	}
 	semVer, err := semver.Make(groups[2])
 	if err != nil {
 		return Version{}, err
@@ -41,7 +44,7 @@ func parseGreenplumVersion(version string) (Version, error) {
 	var flavor Flavor
 	if groups[1] == "Greenplum Database" {
 		flavor = Greenplum
-	} else if groups[1] == "Cloudberry Database" {
+	} else if groups[1] == "Cloudberry Database" || groups[1] == "Apache Cloudberry" {
 		flavor = Cloudberry
 	} else {
 		return Version{}, fmt.Errorf("unknown flavor: %s", groups[1])

--- a/internal/databases/greenplum/version_test.go
+++ b/internal/databases/greenplum/version_test.go
@@ -23,6 +23,11 @@ func TestParseGreenplumVersion(t *testing.T) {
 			input:  "PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Sep 13 2024 07:33:38",
 			result: NewVersion(semver.MustParse("1.6.0"), Cloudberry),
 		},
+		{
+			name:   "apache cloudberry dev",
+			input:  "PostgreSQL 14.4 (Apache Cloudberry 1.0.0+00da831 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit compiled on Feb 25 2025 10:24:41",
+			result: NewVersion(semver.MustParse("1.0.0"), Cloudberry),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Apache cloudberry has changed its name in `version()`. Add new one.