### PR TITLE
Remove many recursive queries in metadata collection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,7 @@ const (
 	FailoverStoragesCheckSize            = "WALG_FAILOVER_STORAGES_CHECK_SIZE"
 	PgDaemonWALUploadTimeout             = "WALG_DAEMON_WAL_UPLOAD_TIMEOUT"
 	PgTargetStorage                      = "WALG_TARGET_STORAGE"
+	DisablePartialRestore                = "WALG_DISABLE_PARTIAL_RESTORE"
 
 	ProfileSamplingRatio = "PROFILE_SAMPLING_RATIO"
 	ProfileMode          = "PROFILE_MODE"
@@ -489,6 +490,7 @@ var (
 		FailoverStorageCacheEMAAlphaDeadMin:  true,
 		FailoverStoragesCheckSize:            true,
 		PgDaemonWALUploadTimeout:             true,
+		DisablePartialRestore:                true,
 	}
 
 	MongoAllowedSettings = map[string]bool{
@@ -579,6 +581,7 @@ var (
 		FailoverStorageCacheEMAAlphaDeadMax:  true,
 		FailoverStorageCacheEMAAlphaDeadMin:  true,
 		FailoverStoragesCheckSize:            true,
+		DisablePartialRestore:                true,
 	}
 
 	RequiredSettings       = make(map[string]bool)

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -291,7 +291,7 @@ func (bh *BackupHandler) setupDTO(tarFileSets internal.TarFileSets) (sentinelDto
 	sentinelDto = NewBackupSentinelDto(bh, tablespaceSpec)
 	filesMeta.setFiles(bh.Workers.Bundle.GetFiles())
 	filesMeta.TarFileSets = tarFileSets.Get()
-	if !viper.IsSet(conf.DisablePartialRestore) {
+	if !(viper.IsSet(conf.DisablePartialRestore) && viper.GetBool(conf.DisablePartialRestore)) {
 		filesMeta.DatabasesByNames, err = bh.collectDatabaseNamesMetadata()
 	}
 	return sentinelDto, filesMeta, err

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -291,7 +291,9 @@ func (bh *BackupHandler) setupDTO(tarFileSets internal.TarFileSets) (sentinelDto
 	sentinelDto = NewBackupSentinelDto(bh, tablespaceSpec)
 	filesMeta.setFiles(bh.Workers.Bundle.GetFiles())
 	filesMeta.TarFileSets = tarFileSets.Get()
-	filesMeta.DatabasesByNames, err = bh.collectDatabaseNamesMetadata()
+	if !viper.IsSet(conf.DisablePartialRestore) {
+		filesMeta.DatabasesByNames, err = bh.collectDatabaseNamesMetadata()
+	}
 	return sentinelDto, filesMeta, err
 }
 

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -568,50 +568,15 @@ func (queryRunner *PgQueryRunner) GetLockingPID() (int, error) {
 
 // builds query to list tables.
 //
-// Parameters:
-//   - getPartitioned (bool): If set to true, returns only root partitions of partitioned tables.
-//     Othervise returns all tables except partitioned.
-//
 // Returns:
 // - string: SQL query
 // - error: An error if faces problems, otherwise nil.
-func (queryRunner *PgQueryRunner) BuildGetTablesQuery(getPartitioned bool) (string, error) {
+func (queryRunner *PgQueryRunner) BuildGetTablesQuery() (string, error) {
 	switch {
 	case queryRunner.Version >= 90000:
-		query := "SELECT c.relfilenode, c.oid, pg_relation_filepath(c.oid), c.relname, pg_namespace.nspname, c.relkind FROM pg_class " +
-			"AS c JOIN pg_namespace ON c.relnamespace = pg_namespace.oid " +
-			"WHERE NOT EXISTS (SELECT 1 FROM pg_inherits AS i WHERE i.inhrelid = c.oid) "
-		if getPartitioned {
-			query = query + "AND EXISTS (SELECT 1 FROM pg_inherits AS i WHERE i.inhparent = c.oid)"
-		} else {
-			query = query + "AND NOT EXISTS (SELECT 1 FROM pg_inherits AS i WHERE i.inhparent = c.oid)"
-		}
-		return query, nil
-	case queryRunner.Version == 0:
-		return "", NewNoPostgresVersionError()
-	default:
-		return "", NewUnsupportedPostgresVersionError(queryRunner.Version)
-	}
-}
-
-func (queryRunner *PgQueryRunner) BuildGetPartitionsForTableQuery(tablename string) (string, error) {
-	switch {
-	case queryRunner.Version >= 90000:
-		query := fmt.Sprintf("WITH RECURSIVE partition_hierarchy AS ( "+
-			"SELECT c.oid AS child_oid, c.relname AS partition_name, parent.oid AS parent_oid, parent.relname AS parent_name "+
-			"FROM pg_class c "+
-			"JOIN pg_inherits i ON c.oid = i.inhrelid "+
-			"JOIN pg_class parent ON i.inhparent = parent.oid "+
-			"WHERE parent.relname = '%s' "+
-			"UNION ALL "+
-			"SELECT c.oid, c.relname, ph.child_oid, ph.partition_name "+
-			"FROM pg_class c "+
-			"JOIN pg_inherits i ON c.oid = i.inhrelid "+
-			"JOIN partition_hierarchy ph ON i.inhparent = ph.child_oid "+
-			") "+
-			"SELECT c.relfilenode, c.oid, pg_relation_filepath(c.oid), c.relname, pg_namespace.nspname, c.relkind FROM pg_class "+
-			"AS c JOIN pg_namespace ON c.relnamespace = pg_namespace.oid "+
-			"JOIN partition_hierarchy ON c.oid = partition_hierarchy.child_oid; ", tablename)
+		query := "SELECT c.relfilenode, c.oid, pg_relation_filepath(c.oid), c.relname, pg_namespace.nspname, c.relkind, parent.relname AS parent_name " +
+			"FROM pg_class c JOIN pg_namespace ON c.relnamespace = pg_namespace.oid " +
+			"LEFT JOIN pg_inherits i ON c.oid = i.inhrelid LEFT JOIN pg_class parent ON i.inhparent = parent.oid;"
 		return query, nil
 	case queryRunner.Version == 0:
 		return "", NewNoPostgresVersionError()
@@ -624,66 +589,72 @@ func (queryRunner *PgQueryRunner) getTables() (map[string]TableInfo, error) {
 	queryRunner.Mu.Lock()
 	defer queryRunner.Mu.Unlock()
 
-	tables := make(map[string]TableInfo)
+	tables := make(map[string]TableInfo, 0)
+	parentTables := make([]string, 0)
 
-	getTablesQuery, err := queryRunner.BuildGetTablesQuery(false)
+	getTablesQuery, err := queryRunner.BuildGetTablesQuery()
 	if err != nil {
 		return nil, errors.Wrap(err, "QueryRunner GetTables: Building query failed")
 	}
+
 	err = queryRunner.processTables(queryRunner.Connection, getTablesQuery,
-		func(relFileNode, oid uint32, tableName, namespaceName string) {
+		func(relFileNode, oid uint32, tableName, namespaceName, parentTableName string) {
+
 			tracelog.DebugLogger.Printf("adding %s as %d with filenode %d", tableName, oid, relFileNode)
-			tables[fmt.Sprintf("%s.%s", namespaceName, tableName)] = TableInfo{Oid: oid, Relfilenode: relFileNode, SubTables: map[string]TableInfo{}}
+			parent := fmt.Sprintf("%s.%s", namespaceName, parentTableName)
+			child := fmt.Sprintf("%s.%s", namespaceName, tableName)
+
+			_, ok := tables[child]
+			if !ok {
+				tables[child] = TableInfo{Oid: oid, Relfilenode: relFileNode, SubTables: map[string]TableInfo{}}
+			} else {
+				tables[child] = TableInfo{Oid: oid, Relfilenode: relFileNode, SubTables: tables[child].SubTables}
+			}
+
+			if parentTableName == "" {
+				parentTables = append(parentTables, child)
+				return
+			}
+
+			_, ok = tables[parent]
+			if !ok {
+				tables[parent] = TableInfo{Oid: oid, Relfilenode: relFileNode, SubTables: map[string]TableInfo{child: TableInfo{}}}
+			} else {
+				tables[parent].SubTables[child] = TableInfo{}
+			}
 		})
 	if err != nil {
 		return nil, errors.Wrap(err, "QueryRunner GetTables: getting regular tables failed")
 	}
-	tracelog.DebugLogger.Println("got regular tables")
 
-	getPartitionedTablesQuery, err := queryRunner.BuildGetTablesQuery(true)
-	if err != nil {
-		return nil, errors.Wrap(err, "QueryRunner GetTables: Building query failed")
-	}
-	parentTableNames := make(map[string]string, 0)
-	err = queryRunner.processTables(queryRunner.Connection, getPartitionedTablesQuery,
-		func(relFileNode, oid uint32, tableName, namespaceName string) {
-			parentTable := fmt.Sprintf("%s.%s", namespaceName, tableName)
-			tracelog.DebugLogger.Printf("adding %s", tableName)
-			tables[parentTable] = TableInfo{Oid: oid, Relfilenode: relFileNode, SubTables: map[string]TableInfo{}}
+	formatedTables := make(map[string]TableInfo)
+	vis := make([]string, 0)
 
-			parentTableNames[tableName] = parentTable
-		})
-	if err != nil {
-		return nil, errors.Wrap(err, "QueryRunner GetTables: getting parrtitioned tables failed")
-	}
-
-	tracelog.DebugLogger.Println("got partitioned tables` root partitions")
-
-	for parTabNam, parTabFullNam := range parentTableNames {
-		tracelog.DebugLogger.Printf("getting subtables for %s", parTabNam)
-		getSubtablesQuery, err := queryRunner.BuildGetPartitionsForTableQuery(parTabNam)
-		if err != nil {
-			return nil, errors.Wrap(err, "QueryRunner GetTables: Building query failed")
+	for _, val := range parentTables {
+		formatedTables[val] = TableInfo{Oid: tables[val].Oid, Relfilenode: tables[val].Relfilenode, SubTables: map[string]TableInfo{}}
+		vis = append(vis, val)
+		for len(vis) > 0 {
+			cur := vis[len(vis)-1]
+			vis = vis[:len(vis)-1]
+			if tables[cur].SubTables == nil {
+				continue
+			}
+			for k, _ := range tables[cur].SubTables {
+				formatedTables[val].SubTables[k] = TableInfo{Oid: formatedTables[val].SubTables[k].Oid, Relfilenode: formatedTables[val].SubTables[k].Relfilenode}
+				vis = append(vis, k)
+			}
 		}
-		err = queryRunner.processTables(queryRunner.Connection, getSubtablesQuery,
-			func(relFileNode, oid uint32, tableName, namespaceName string) {
-				tracelog.DebugLogger.Printf("adding %s", tableName)
-				tables[parTabFullNam].SubTables[fmt.Sprintf("%s.%s", namespaceName, tableName)] = TableInfo{Oid: oid, Relfilenode: relFileNode}
-			})
-		if err != nil {
-			return nil, errors.Wrap(err, "QueryRunner GetTables: getting partitioned subtables failed")
-		}
+
 	}
 
-	tracelog.DebugLogger.Println("got partitioned tables` partitions")
-
-	return tables, nil
+	return formatedTables, nil
 }
 
 func (queryRunner *PgQueryRunner) processTables(conn *pgx.Conn,
-	getTablesQuery string, process func(relFileNode, oid uint32, tableName, namespaceName string)) error {
+	getTablesQuery string, process func(relFileNode, oid uint32, tableName, namespaceName, parentTableName string)) error {
 	rows, err := conn.Query(context.TODO(), getTablesQuery)
 	if err != nil {
+		tracelog.WarningLogger.Printf("GetTables:  %v\n", err.Error())
 		return errors.Wrap(err, "QueryRunner GetTables: Query failed")
 	}
 	defer rows.Close()
@@ -695,7 +666,8 @@ func (queryRunner *PgQueryRunner) processTables(conn *pgx.Conn,
 		var namespaceName string
 		var path pgtype.Text
 		var relKind rune
-		if err := rows.Scan(&relFileNode, &oid, &path, &tableName, &namespaceName, &relKind); err != nil {
+		var parentTableName string
+		if err := rows.Scan(&relFileNode, &oid, &path, &tableName, &namespaceName, &relKind, &parentTableName); err != nil {
 			tracelog.WarningLogger.Printf("GetTables:  %v\n", err.Error())
 			continue
 		}
@@ -705,7 +677,7 @@ func (queryRunner *PgQueryRunner) processTables(conn *pgx.Conn,
 			// don't need to be added to the tables map, we still process them here.
 			// This is because we need the parent partitioned table information to locate and process
 			// all its child partition tables later in DatabasesByNames.ResolveRegexp function.
-			process(relFileNode, oid, tableName, namespaceName)
+			process(relFileNode, oid, tableName, namespaceName, parentTableName)
 			continue
 		}
 
@@ -731,7 +703,7 @@ func (queryRunner *PgQueryRunner) processTables(conn *pgx.Conn,
 			}
 			relFileNode = uint32(chis)
 		}
-		process(relFileNode, oid, tableName, namespaceName)
+		process(relFileNode, oid, tableName, namespaceName, parentTableName)
 	}
 
 	return nil


### PR DESCRIPTION
### Database name
Greenplum

# Pull request description

Current way of collecting metadata for partial restore is resource intensive
