### PR TITLE
add max db number to walg sentinel

### DIFF
--- a/cmd/redis/aof_backup_push.go
+++ b/cmd/redis/aof_backup_push.go
@@ -33,7 +33,7 @@ var aofBackupPushCmd = &cobra.Command{
 
 		uploader.ChangeDirectory(utility.BaseBackupPath + "/")
 
-		memoryDataGetter := client.NewMemoryDataGetter()
+		memoryDataGetter := client.NewServerDataGetter()
 
 		processName, _ := conf.GetSetting(conf.RedisServerProcessName)
 		versionParser := archive.NewVersionParser(processName)

--- a/cmd/redis/rdb_backup_push.go
+++ b/cmd/redis/rdb_backup_push.go
@@ -53,7 +53,7 @@ var backupPushCmd = &cobra.Command{
 			backupCmd.Env = append(backupCmd.Env, fmt.Sprintf("REDISCLI_AUTH=%s", redisPassword))
 		}
 
-		memoryDataGetter := client.NewMemoryDataGetter()
+		memoryDataGetter := client.NewServerDataGetter()
 
 		metaConstructor := archive.NewBackupRedisMetaConstructor(ctx, uploader.Folder(), permanent, archive.RDBBackupType, nil, memoryDataGetter)
 

--- a/internal/databases/redis/archive/backup.go
+++ b/internal/databases/redis/archive/backup.go
@@ -32,6 +32,7 @@ type Backup struct {
 	Version         string      `json:"Version,omitempty"`
 	UsedMemory      int64       `json:"UsedMemory,omitempty"`
 	UsedMemoryRss   int64       `json:"UsedMemoryRss,omitempty"`
+	MaxDBNumber     int64       `json:"MaxDBNumber,omitempty"`
 }
 
 func (b Backup) Name() string {
@@ -174,6 +175,7 @@ type BackupMeta struct {
 	Version        string
 	UsedMemory     int64
 	UsedMemoryRss  int64
+	MaxDBNumber    int64
 }
 
 type RedisMetaConstructor struct {
@@ -183,7 +185,7 @@ type RedisMetaConstructor struct {
 	permanent        bool
 	backupType       string
 	versionParser    *VersionParser
-	memoryDataGetter client.MemoryDataGetter
+	serverDataGetter client.ServerDataGetter
 }
 
 // Init - required for internal.MetaConstructor
@@ -192,14 +194,15 @@ func (m *RedisMetaConstructor) Init() error {
 	if err != nil {
 		return err
 	}
-	memData := m.memoryDataGetter.Get()
+	serverData := m.serverDataGetter.Get()
 	m.meta = BackupMeta{
 		Permanent:     m.permanent,
 		User:          userData,
 		StartTime:     utility.TimeNowCrossPlatformLocal(),
 		BackupType:    m.backupType,
-		UsedMemory:    memData.UsedMemory,
-		UsedMemoryRss: memData.UsedMemoryRss,
+		UsedMemory:    serverData.UsedMemory,
+		UsedMemoryRss: serverData.UsedMemoryRss,
+		MaxDBNumber:   serverData.MaxDBNumber,
 	}
 	if m.versionParser != nil {
 		m.meta.Version, err = m.versionParser.Get()
@@ -221,6 +224,7 @@ func (m *RedisMetaConstructor) MetaInfo() interface{} {
 		Version:         meta.Version,
 		UsedMemory:      meta.UsedMemory,
 		UsedMemoryRss:   meta.UsedMemoryRss,
+		MaxDBNumber:     meta.MaxDBNumber,
 	}
 }
 
@@ -230,13 +234,13 @@ func (m *RedisMetaConstructor) Finalize(backupName string) error {
 }
 
 func NewBackupRedisMetaConstructor(ctx context.Context, folder storage.Folder, permanent bool, backupType string,
-	versionParser *VersionParser, memoryDataGetter client.MemoryDataGetter) internal.MetaConstructor {
+	versionParser *VersionParser, memoryDataGetter client.ServerDataGetter) internal.MetaConstructor {
 	return &RedisMetaConstructor{
 		ctx: ctx, folder: folder,
 		permanent:        permanent,
 		backupType:       backupType,
 		versionParser:    versionParser,
-		memoryDataGetter: memoryDataGetter,
+		serverDataGetter: memoryDataGetter,
 	}
 }
 

--- a/internal/databases/redis/backup_list_handler_test.go
+++ b/internal/databases/redis/backup_list_handler_test.go
@@ -32,7 +32,7 @@ func TestHandleDetailedBackupList(t *testing.T) {
 		curTime := time.Unix(1690000000, 0)
 
 		backups := []archive.Backup{
-			archive.Backup{
+			{
 				BackupName:      "b0",
 				StartLocalTime:  curTime.Add(4 * time.Second).UTC(),
 				FinishLocalTime: curTime.Add(5 * time.Second).UTC(),
@@ -43,7 +43,7 @@ func TestHandleDetailedBackupList(t *testing.T) {
 				Version:         "4.5.4",
 				BackupType:      "rdb",
 			},
-			archive.Backup{
+			{
 				BackupName:      "b1",
 				StartLocalTime:  curTime.Add(0 * time.Second).UTC(),
 				FinishLocalTime: curTime.Add(time.Second).UTC(),
@@ -54,7 +54,7 @@ func TestHandleDetailedBackupList(t *testing.T) {
 				Version:         "4.5.4",
 				BackupType:      "rdb",
 			},
-			archive.Backup{
+			{
 				BackupName:      "b2",
 				StartLocalTime:  curTime.Add(2 * time.Second).UTC(),
 				FinishLocalTime: curTime.Add(3 * time.Second).UTC(),

--- a/internal/databases/redis/client/redis.go
+++ b/internal/databases/redis/client/redis.go
@@ -11,6 +11,8 @@ import (
 	conf "github.com/wal-g/wal-g/internal/config"
 )
 
+const dontPanic = false
+
 // DISCUSS: In some cases, we have default values, but we don't want to store it at global default settings.
 // Naming is far from best, if Go allowed overloads, name GetSettingWithDefault would be more appropriate
 func GetSettingWithLocalDefault(key string, defaultValue string) string {
@@ -45,18 +47,24 @@ func getRedisConnection(strict bool) *redis.Client {
 	})
 }
 
-type MemoryData struct {
+type ServerData struct {
 	UsedMemory    int64 `json:"used_memory"`
 	UsedMemoryRss int64 `json:"used_memory_rss"`
+	MaxDBNumber   int64 `json:"max_db_number"`
 }
 
-type MemoryDataGetter struct{}
+type ServerDataGetter struct {
+	conn *redis.Client
+}
 
-func NewMemoryDataGetter() MemoryDataGetter {
-	return MemoryDataGetter{}
+func NewServerDataGetter() ServerDataGetter {
+	return ServerDataGetter{
+		conn: getRedisConnection(dontPanic),
+	}
 }
 
 func parseInfoLine(line, name string) (i int64) {
+	// used_memory:20019376
 	var err error
 	if strings.HasPrefix(line, fmt.Sprintf("%s:", name)) {
 		s := strings.Split(line, ":")[1]
@@ -69,13 +77,9 @@ func parseInfoLine(line, name string) (i int64) {
 	return
 }
 
-const dontPanic = false
-
-func (m *MemoryDataGetter) Get() (res *MemoryData) {
-	res = &MemoryData{}
-	conn := getRedisConnection(dontPanic)
+func (m *ServerDataGetter) fillMemoryData(res *ServerData) {
 	ctx := context.Background()
-	data, err := conn.Info(ctx, "memory").Result()
+	data, err := m.conn.Info(ctx, "memory").Result()
 	if err != nil {
 		tracelog.InfoLogger.Printf("memory info getting failed: %v", err)
 		return
@@ -89,5 +93,42 @@ func (m *MemoryDataGetter) Get() (res *MemoryData) {
 			res.UsedMemoryRss = i
 		}
 	}
+}
+
+func parseInfoLineNumberedName(line, name string) (i int64) {
+	// db0:keys=2,expires=0,avg_ttl=0
+	var err error
+	if strings.HasPrefix(line, name) {
+		numberedName := strings.Split(line, ":")[0]
+		number := strings.Split(numberedName, name)[1]
+		i, err = strconv.ParseInt(number, 10, 64)
+		if err != nil {
+			tracelog.InfoLogger.Printf("%s parsing from %s to int64 failed: %v", name, line, err)
+			return
+		}
+	}
+	return
+}
+
+func (m *ServerDataGetter) fillMaxDBNumData(res *ServerData) {
+	ctx := context.Background()
+	data, err := m.conn.Info(ctx, "keyspace").Result()
+	if err != nil {
+		tracelog.InfoLogger.Printf("keyspace info getting failed: %v", err)
+		return
+	}
+	data = strings.ReplaceAll(data, "\r", "")
+	for _, line := range strings.Split(data, "\n") {
+		i := parseInfoLineNumberedName(line, "db")
+		if i > res.MaxDBNumber {
+			res.MaxDBNumber = i
+		}
+	}
+}
+
+func (m *ServerDataGetter) Get() (res *ServerData) {
+	res = &ServerData{}
+	m.fillMemoryData(res)
+	m.fillMaxDBNumData(res)
 	return
 }


### PR DESCRIPTION
### Database name
redis

# Pull request description
add max db number to sentinel file for restore

### Describe what this PR fixes
if several databases are used in redis, restoring could break up without knowing what's the maximum number was used during backup

### Please provide steps to reproduce (if it's a bug)
none

### Please add config and wal-g stdout/stderr logs for debug purpose
none