### PR TITLE
differ 0 and missing data

### DIFF
--- a/internal/databases/redis/archive/backup.go
+++ b/internal/databases/redis/archive/backup.go
@@ -32,7 +32,7 @@ type Backup struct {
 	Version         string      `json:"Version,omitempty"`
 	UsedMemory      int64       `json:"UsedMemory,omitempty"`
 	UsedMemoryRss   int64       `json:"UsedMemoryRss,omitempty"`
-	MaxDBNumber     int64       `json:"MaxDBNumber,omitempty"`
+	MaxDBNumber     int64       `json:"MaxDBNumber"`
 }
 
 func (b Backup) Name() string {


### PR DESCRIPTION
### Database name
redis

# Pull request description
it's convenient to differ whether sentinel is made by an old version of wal-g (no data) or made for a single database server (0)

### Describe what this PR fixes
it's a sentinel with missing field for both cases now

### Please provide steps to reproduce (if it's a bug)
none

### Please add config and wal-g stdout/stderr logs for debug purpose
none