### PR TITLE
Fix index out of range in `wal-g xb extract`

### DIFF
--- a/cmd/mysql/xb/extract.go
+++ b/cmd/mysql/xb/extract.go
@@ -24,7 +24,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 			var src *os.File
-			if len(args) == 1 {
+			if len(args) == 0 {
 				src = os.Stdin
 			} else {
 				src, err = os.Open(args[0])


### PR DESCRIPTION
### MySQL

Simple bugfix for inverted if condition.


```bash
cat xbstream | wal-g-mysql xb extract   --data-dir /home/mysql/stream_20250228T100901Z/
 panic: runtime error: index out of range [0] with length 0
 
 goroutine 1 [running]:
 github.com/wal-g/wal-g/cmd/mysql/xb.init.func1(0x3eb83a0?, {0xc0006628e0?, 0x0?, 0x2?})
 	/root/wal-g/cmd/mysql/xb/extract.go:30 +0x1cc
 github.com/spf13/cobra.(*Command).execute(0x3eb83a0, {0xc0006628c0, 0x2, 0x2})
 	/root/wal-g/vendor/github.com/spf13/cobra/command.go:860 +0x684
 github.com/spf13/cobra.(*Command).ExecuteC(0x3eb7ea0)
 	/root/wal-g/vendor/github.com/spf13/cobra/command.go:974 +0x38d
 github.com/spf13/cobra.(*Command).Execute(...)
 	/root/wal-g/vendor/github.com/spf13/cobra/command.go:902
 github.com/wal-g/wal-g/cmd/mysql.Execute()
 	/root/wal-g/cmd/mysql/mysql.go:43 +0x1a
 main.main()
 	/root/wal-g/main/mysql/main.go:8 +0xf
 cat: write error: Broken pipe
```