### PR TITLE
Add `wal-g st get-stream` command to fetch backup as a single stream

### DIFF
--- a/cmd/common/st/get_stream.go
+++ b/cmd/common/st/get_stream.go
@@ -15,7 +15,8 @@ import (
 
 const (
 	getStreamShortDescription = "Download the backup as single stream"
-	getStreamLongDescription  = "Download, decrypt (if encrypted), decompress (if compressed) and assemble (if stream where split) single-stream backups to single stream."
+	getStreamLongDescription  = "Download, decrypt (if encrypted), decompress (if compressed) and assemble " +
+		"(if stream where split) single-stream backups to single stream."
 )
 
 // getObjectCmd represents the getObject command

--- a/cmd/common/st/get_stream.go
+++ b/cmd/common/st/get_stream.go
@@ -21,7 +21,7 @@ const (
 
 // getObjectCmd represents the getObject command
 var getStreamCmd = &cobra.Command{
-	Use:   "get backup_name destination_path",
+	Use:   "get-stream backup_name destination_path",
 	Short: getStreamShortDescription,
 	Long:  getStreamLongDescription,
 	Args:  cobra.RangeArgs(1, 2),

--- a/cmd/common/st/get_stream.go
+++ b/cmd/common/st/get_stream.go
@@ -1,0 +1,55 @@
+package st
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/mysql"
+	"github.com/wal-g/wal-g/internal/multistorage/exec"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
+)
+
+const (
+	getStreamShortDescription = "Download the backup as single stream"
+	getStreamLongDescription  = "Download, decrypt (if encrypted), decompress (if compressed) and assemble (if stream where split) single-stream backups to single stream."
+)
+
+// getObjectCmd represents the getObject command
+var getStreamCmd = &cobra.Command{
+	Use:   "get backup_name destination_path",
+	Short: getStreamShortDescription,
+	Long:  getStreamLongDescription,
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		backupName := args[0]
+		dstPath := args[1]
+
+		if targetStorage == "all" {
+			tracelog.ErrorLogger.Fatalf("'all' target is not supported for st get command")
+		}
+
+		backupSelector, err := internal.NewTargetBackupSelector("", backupName, mysql.NewGenericMetaFetcher())
+		tracelog.ErrorLogger.FatalOnError(err)
+
+		file, err := os.Create(dstPath)
+		defer utility.LoggedClose(file, "got an error during stream-file close()")
+
+		err = exec.OnStorage(targetStorage, func(folder storage.Folder) error {
+			backup, err := backupSelector.Select(folder)
+			tracelog.ErrorLogger.FatalOnError(err)
+			fetcher, err := internal.GetBackupStreamFetcher(backup)
+			tracelog.ErrorLogger.FatalfOnError("Failed to detect backup format: %v\n", err)
+
+			return fetcher(backup, file)
+		})
+		tracelog.ErrorLogger.FatalOnError(err)
+	},
+}
+
+func init() {
+	StorageToolsCmd.AddCommand(getStreamCmd)
+}

--- a/docker/mysql_tests/scripts/mysql8_tests/xbtool.sh
+++ b/docker/mysql_tests/scripts/mysql8_tests/xbtool.sh
@@ -41,7 +41,7 @@ wal-g xtrabackup-push
 mysql_kill_and_clean_data
 
 FIRST_BACKUP=$(wal-g backup-list | awk 'NR==2{print $1}')
-wal-g st get "basebackups_005/${FIRST_BACKUP}/stream.zst" stream.xb
+wal-g st get-stream "${FIRST_BACKUP}" stream.xb
 
 cat <<EOF
 ##########

--- a/docs/StorageTools.md
+++ b/docs/StorageTools.md
@@ -62,6 +62,20 @@ Example:
 
 ``wal-g st put path/to/local_file path/to/remote_file`` upload the local file to the storage.
 
+
+### ``get-stream``
+Download the specified backup as single stream (when backup is stream-based backup). This command will:
+* decrypt backup
+* decompress backup
+* assemble parts of backups (when `WALG_STREAM_SPLITTER_*` used)
+* save to file
+
+Example:
+
+``wal-g st get-stream BACKUP_NAME path/to/local_file`` upload the local file to the storage.
+
+``wal-g st get-stream BACKUP_NAME | xbstream --extract`` upload the local file to the storage.
+
 ### `transfer`
 Transfer files from one configured storage to another. Is usually used to move files from a failover storage to the primary one when it becomes alive.
 


### PR DESCRIPTION
### MySQL / Mongodb

`wal-g st get-stream` will allow users to fetch stream-like backups as single stream. This command will:
* decrypt backup
* decompress backup
* assemble parts of backups (when `WALG_STREAM_SPLITTER_*` used)
* save to file

