### PR TITLE
MySQL: fix how --inplace handles delta files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -360,6 +360,11 @@ To build on ARM64, set the corresponding `GOOS`/`GOARCH` environment variables:
 env GOOS=darwin GOARCH=arm64 make install_and_build_pg
 ```
 
+To build linux build on ARM MacOS:
+```
+GOOS=linux GOARCH=amd64 make mysql_build
+```
+
 The compiled binary to run is `main/pg/wal-g`
 
 ### Testing

--- a/internal/databases/mysql/xbstream/file_sink_diff.go
+++ b/internal/databases/mysql/xbstream/file_sink_diff.go
@@ -216,6 +216,7 @@ func (sink *diffFileSink) getHandlingStrategy(chunk *Chunk) (diffFileStrategy, e
 	}, nil
 }
 
+// nolint: funlen,gocyclo
 func (sink *diffFileSink) applyDiff() error {
 	miniDeltaWritten := false
 


### PR DESCRIPTION
### Database name
MySQL

In this PR 2 issues addressed:

1. xtrabackup may contain empty delta-files (single header, no data pages):
   ```
   00000000  58 54 52 41 ff ff ff ff  00 00 00 00 00 00 00 00  |XTRA............|
   00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
   *
   00004000
   ```
   current code writes '.meta' file and skips '.delta' file that is confusing.
2. xtrabackup may contain several `xtra`/`XTRA` blocks on big deltas... so we should loop all of them