### PR TITLE
Allow restore between different patches of the same redis minor version

### DIFF
--- a/internal/databases/redis/archive/redis.go
+++ b/internal/databases/redis/archive/redis.go
@@ -36,12 +36,14 @@ func (p *VersionParser) Get() (string, error) {
 }
 
 func EnsureRestoreCompatibility(backupVersion, restoreVersion string) (bool, error) {
-	b, err := version.NewVersion(backupVersion)
+	backupVersionNoPatch := strings.Join(strings.Split(backupVersion, ".")[:2], ".")
+	b, err := version.NewVersion(backupVersionNoPatch)
 	if err != nil {
 		return false, fmt.Errorf("backup version error: %v", err)
 	}
 
-	r, err := version.NewVersion(restoreVersion)
+	restoreVersionNoPatch := strings.Join(strings.Split(restoreVersion, ".")[:2], ".")
+	r, err := version.NewVersion(restoreVersionNoPatch)
 	if err != nil {
 		return false, fmt.Errorf("restore version error: %v", err)
 	}

--- a/internal/databases/redis/archive/redis_test.go
+++ b/internal/databases/redis/archive/redis_test.go
@@ -29,13 +29,31 @@ func TestEnsureRestoreCompatibility(t *testing.T) {
 		{
 			"b":    "6.4.19",
 			"r":    "6.4.18",
-			"res":  false,
+			"res":  true,
 			"errr": nil,
 		},
 		{
 			"b":    "6.4.18",
 			"r":    "6.4.18",
 			"res":  true,
+			"errr": nil,
+		},
+		{
+			"b":    "7.2.5",
+			"r":    "7.2.8",
+			"res":  true,
+			"errr": nil,
+		},
+		{
+			"b":    "7.2.8",
+			"r":    "7.2.5",
+			"res":  true,
+			"errr": nil,
+		},
+		{
+			"b":    "7.2.8",
+			"r":    "7.0.10",
+			"res":  false,
 			"errr": nil,
 		},
 	}


### PR DESCRIPTION
### Database name
Redis, Valkey

# Pull request description

### Describe what this PR fixes
This PR allows restore between any patches of the same minor version. For example: `7.2.8 -> 7.2.5`