### PR TITLE
Fix firstNotUsedWalSegmentNo used by getLocationsFromWals

### DIFF
--- a/internal/databases/postgres/delta_map_downloader.go
+++ b/internal/databases/postgres/delta_map_downloader.go
@@ -31,7 +31,9 @@ func getDeltaMap(reader internal.StorageFolderReader,
 	}
 	deltaMap.AddLocationsToDelta(lastDeltaFile.Locations)
 
-	firstUsedWalSegmentNo, firstNotUsedWalSegmentNo := getWalSegmentRange(firstNotUsedDeltaNo, firstNotUsedLSN)
+	firstUsedWalSegmentNo := firstNotUsedDeltaNo.firstWalSegmentNo()
+	firstNotUsedWalSegmentNo := NewWalSegmentNo(firstNotUsedLSN)
+
 	// we handle WAL files from [firstUsedWalSegmentNo, lastUsedWalSegmentNo]
 	err = deltaMap.getLocationsFromWals(reader, timeline, firstUsedWalSegmentNo,
 		firstNotUsedWalSegmentNo, lastDeltaFile.WalParser)
@@ -45,11 +47,4 @@ func getDeltaRange(firstUsedLsn, firstNotUsedLsn LSN) (DeltaNo, DeltaNo) {
 	firstUsedDeltaNo := newDeltaNoFromLsn(firstUsedLsn)
 	firstNotUsedDeltaNo := newDeltaNoFromLsn(firstNotUsedLsn)
 	return firstUsedDeltaNo, firstNotUsedDeltaNo
-}
-
-func getWalSegmentRange(firstNotUsedDeltaNo DeltaNo, firstNotUsedLsn LSN) (WalSegmentNo, WalSegmentNo) {
-	firstUsedWalSegmentNo := firstNotUsedDeltaNo.firstWalSegmentNo()
-	lastUsedLsn := firstNotUsedLsn - 1
-	lastUsedWalSegmentNo := NewWalSegmentNo(lastUsedLsn)
-	return firstUsedWalSegmentNo, lastUsedWalSegmentNo.Next()
 }


### PR DESCRIPTION
When doing backup, the firstNotUsedLsn is not the start of the wal log file, but the location after XLogLongPageHeaderData, for example 'lsn: 3/A0500028', so using the following method to compute the last segment file is not correct.

lastUsedLsn := firstNotUsedLsn - 1
lastUsedWalSegmentNo := NewWalSegmentNo(lastUsedLsn)

The lastUsedLsn should be 'firstNotUsedLsn - SizeOfXLogLongPHD'

Here we can directly get the last not used wal segment by NewWalSegmentNo(firstNotUsedLSN)

### Database name
Postgres

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
