### PR TITLE
refactoring oplog replay

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
-
 	"github.com/wal-g/wal-g/internal/logging"
 	"github.com/wal-g/wal-g/internal/webserver"
 )
@@ -126,23 +125,24 @@ const (
 	ProfileMode          = "PROFILE_MODE"
 	ProfilePath          = "PROFILE_PATH"
 
-	MongoDBUriSetting                  = "MONGODB_URI"
-	MongoDBLastWriteUpdateInterval     = "MONGODB_LAST_WRITE_UPDATE_INTERVAL"
-	MongoDBExtendBackupCursor          = "MONGODB_EXTEND_BACKUP_CURSOR"
-	MongoDBDeletionProtectionWhitelist = "MONGODB_DELETION_PROTECTION_WHITELIST"
-	OplogArchiveAfterSize              = "OPLOG_ARCHIVE_AFTER_SIZE"
-	OplogArchiveTimeoutInterval        = "OPLOG_ARCHIVE_TIMEOUT_INTERVAL"
-	OplogPITRDiscoveryInterval         = "OPLOG_PITR_DISCOVERY_INTERVAL"
-	OplogPushStatsEnabled              = "OPLOG_PUSH_STATS_ENABLED"
-	OplogPushStatsLoggingInterval      = "OPLOG_PUSH_STATS_LOGGING_INTERVAL"
-	OplogPushStatsUpdateInterval       = "OPLOG_PUSH_STATS_UPDATE_INTERVAL"
-	OplogPushStatsExposeHTTP           = "OPLOG_PUSH_STATS_EXPOSE_HTTP"
-	OplogPushWaitForBecomePrimary      = "OPLOG_PUSH_WAIT_FOR_BECOME_PRIMARY"
-	OplogPushPrimaryCheckInterval      = "OPLOG_PUSH_PRIMARY_CHECK_INTERVAL"
-	OplogReplayOplogAlwaysUpsert       = "OPLOG_REPLAY_OPLOG_ALWAYS_UPSERT"
-	OplogReplayOplogApplicationMode    = "OPLOG_REPLAY_OPLOG_APPLICATION_MODE"
-	OplogReplayIgnoreErrorCodes        = "OPLOG_REPLAY_IGNORE_ERROR_CODES"
-	OplogRecoverTimeout                = "OPLOG_RECOVER_TIMEOUT"
+	MongoDBUriSetting                   = "MONGODB_URI"
+	MongoDBLastWriteUpdateInterval      = "MONGODB_LAST_WRITE_UPDATE_INTERVAL"
+	MongoDBExtendBackupCursor           = "MONGODB_EXTEND_BACKUP_CURSOR"
+	MongoDBDeletionProtectionWhitelist  = "MONGODB_DELETION_PROTECTION_WHITELIST"
+	OplogArchiveAfterSize               = "OPLOG_ARCHIVE_AFTER_SIZE"
+	OplogArchiveTimeoutInterval         = "OPLOG_ARCHIVE_TIMEOUT_INTERVAL"
+	OplogPITRDiscoveryInterval          = "OPLOG_PITR_DISCOVERY_INTERVAL"
+	OplogBackupAdditionalSavingInterval = "OPLOG_BACKUP_ADDITIONAL_SAVING_INTERVAL"
+	OplogPushStatsEnabled               = "OPLOG_PUSH_STATS_ENABLED"
+	OplogPushStatsLoggingInterval       = "OPLOG_PUSH_STATS_LOGGING_INTERVAL"
+	OplogPushStatsUpdateInterval        = "OPLOG_PUSH_STATS_UPDATE_INTERVAL"
+	OplogPushStatsExposeHTTP            = "OPLOG_PUSH_STATS_EXPOSE_HTTP"
+	OplogPushWaitForBecomePrimary       = "OPLOG_PUSH_WAIT_FOR_BECOME_PRIMARY"
+	OplogPushPrimaryCheckInterval       = "OPLOG_PUSH_PRIMARY_CHECK_INTERVAL"
+	OplogReplayOplogAlwaysUpsert        = "OPLOG_REPLAY_OPLOG_ALWAYS_UPSERT"
+	OplogReplayOplogApplicationMode     = "OPLOG_REPLAY_OPLOG_APPLICATION_MODE"
+	OplogReplayIgnoreErrorCodes         = "OPLOG_REPLAY_IGNORE_ERROR_CODES"
+	OplogRecoverTimeout                 = "OPLOG_RECOVER_TIMEOUT"
 
 	MysqlDatasourceNameSetting     = "WALG_MYSQL_DATASOURCE_NAME"
 	MysqlSslCaSetting              = "WALG_MYSQL_SSL_CA"
@@ -1035,6 +1035,18 @@ func GetOplogPITRDiscoveryIntervalSetting() (*time.Duration, error) {
 	dur, err := time.ParseDuration(durStr)
 	if err != nil {
 		return nil, fmt.Errorf("duration expected for %s setting but given '%s': %w", OplogPITRDiscoveryInterval, durStr, err)
+	}
+	return &dur, nil
+}
+
+func GetOplogBackupAdditionalSavingTimeSetting() (*time.Duration, error) {
+	durStr, ok := GetSetting(OplogBackupAdditionalSavingInterval)
+	if !ok {
+		return nil, nil
+	}
+	dur, err := time.ParseDuration(durStr)
+	if err != nil {
+		return nil, fmt.Errorf("duration expected for %s setting but given '%s': %w", OplogBackupAdditionalSavingInterval, durStr, err)
 	}
 	return &dur, nil
 }

--- a/internal/databases/mongo/archive/layout.go
+++ b/internal/databases/mongo/archive/layout.go
@@ -174,7 +174,8 @@ func OldestBackupAfterTime(backups []*models.Backup, after time.Time) (*models.B
 // SelectPurgingOplogArchives builds archive list to be deleted.
 func SelectPurgingOplogArchives(archives []models.Archive,
 	backups []*models.Backup,
-	retainAfterTS *models.Timestamp) []models.Archive {
+	retainAfterTS *models.Timestamp,
+	additionalIntervalAfterBackup *time.Duration) []models.Archive {
 	var purgeArchives []models.Archive
 	var arch models.Archive
 	for i := range archives {
@@ -187,8 +188,8 @@ func SelectPurgingOplogArchives(archives []models.Archive,
 			continue
 		}
 
-		// retain if arch is part of backup
-		if backup := models.FirstOverlappingBackupForArch(arch, backups); backup != nil {
+		// retain if arch is part of [backup.start: backup.end + additionalIntervalAfterBackup]
+		if backup := models.FirstOverlappingBackupForArch(arch, backups, additionalIntervalAfterBackup); backup != nil {
 			tracelog.DebugLogger.Printf(
 				"Keeping oplog archive due to overlapping with backup (%+v): %s", backup, arch.Filename())
 			continue

--- a/internal/databases/mongo/archive/layout_test.go
+++ b/internal/databases/mongo/archive/layout_test.go
@@ -866,7 +866,7 @@ func TestSelectPurgingOplogArchives(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := SelectPurgingOplogArchives(tt.args.archives, tt.args.backups, tt.args.retainAfterTS)
+			got := SelectPurgingOplogArchives(tt.args.archives, tt.args.backups, tt.args.retainAfterTS, nil)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/databases/mongo/binary_backup_fetch_handler.go
+++ b/internal/databases/mongo/binary_backup_fetch_handler.go
@@ -62,9 +62,12 @@ func HandleBinaryFetchPush(
 		return err
 	}
 
-	replyOplogConfig, err := binary.NewReplyOplogConfig(pitrSince, pitrUntil)
-	if err != nil {
-		return err
+	var replyOplogConfig binary.ReplyOplogConfig
+	if pitrSince != "" && pitrUntil != "" {
+		replyOplogConfig, err = binary.NewReplyOplogConfig(pitrSince, pitrUntil)
+		if err != nil {
+			return err
+		}
 	}
 
 	return restoreService.DoRestore(

--- a/internal/databases/mongo/models/backup.go
+++ b/internal/databases/mongo/models/backup.go
@@ -141,9 +141,9 @@ type BackupMeta struct {
 
 // FirstOverlappingBackupForArch checks if archive overlaps any backup from given list.
 // TODO: build btree to fix ugly complexity here
-func FirstOverlappingBackupForArch(arch Archive, backups []*Backup) *Backup {
+func FirstOverlappingBackupForArch(arch Archive, backups []*Backup, backupAdditionalSavingInterval *time.Duration) *Backup {
 	for _, backup := range backups {
-		if ArchInBackup(arch, backup) {
+		if ArchInBackup(arch, backup, backupAdditionalSavingInterval) {
 			return backup
 		}
 	}
@@ -151,9 +151,12 @@ func FirstOverlappingBackupForArch(arch Archive, backups []*Backup) *Backup {
 }
 
 // ArchInBackup checks if archive and given backup overlaps each over.
-func ArchInBackup(arch Archive, backup *Backup) bool {
+func ArchInBackup(arch Archive, backup *Backup, addInterval *time.Duration) bool {
 	backupStart := backup.MongoMeta.Before.LastMajTS
 	backupEnd := backup.MongoMeta.After.LastMajTS
+	if addInterval != nil {
+		backupEnd.TS += uint32(*addInterval / time.Second)
+	}
 	return TimestampInInterval(arch.Start, backupStart, backupEnd) ||
 		TimestampInInterval(arch.End, backupStart, backupEnd) ||
 		TimestampInInterval(backupStart, arch.Start, arch.End) ||

--- a/internal/databases/mongo/models/backup_test.go
+++ b/internal/databases/mongo/models/backup_test.go
@@ -229,7 +229,7 @@ func TestArchInBackup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ArchInBackup(tt.args.arch, &tt.args.backup)
+			got := ArchInBackup(tt.args.arch, &tt.args.backup, nil)
 			assert.Equal(t, got, tt.want)
 		})
 	}
@@ -313,7 +313,7 @@ func TestFirstOverlappingBackupForArch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FirstOverlappingBackupForArch(tt.args.arch, tt.args.backups)
+			got := FirstOverlappingBackupForArch(tt.args.arch, tt.args.backups, nil)
 			assert.Equal(t, got, tt.want)
 		})
 	}

--- a/internal/databases/mongo/oplog_purge_handler.go
+++ b/internal/databases/mongo/oplog_purge_handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
 )
@@ -42,12 +43,16 @@ func HandleOplogPurge(downloader archive.Downloader, purger archive.Purger, reta
 	if err != nil {
 		return err
 	}
+	additionalInterval, err := conf.GetOplogBackupAdditionalSavingTimeSetting()
+	if err != nil {
+		return err
+	}
+
 	retainArchivesAfterTS := pitrBackup.MongoMeta.Before.LastMajTS
 
 	tracelog.DebugLogger.Printf("Oldest backup in PITR interval is %+v\n", pitrBackup)
 	tracelog.DebugLogger.Printf("Oplog archives newer than %+v will be retained\n", retainArchivesAfterTS)
-
-	purgeArchives := archive.SelectPurgingOplogArchives(archives, backups, &retainArchivesAfterTS)
+	purgeArchives := archive.SelectPurgingOplogArchives(archives, backups, &retainArchivesAfterTS, additionalInterval)
 	tracelog.DebugLogger.Printf("Oplog archives selected to be deleted: %v", purgeArchives)
 	if !dryRun {
 		if err := purger.DeleteOplogArchives(purgeArchives); err != nil {


### PR DESCRIPTION
1) supported LATEST and LATEST_BACKUP pitr aliases 2) added additionalIntervalAfterBackup for saving additional oplog time for backup

### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
