### PR TITLE
Fix catchup issuing premature stop

### DIFF
--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -54,10 +54,10 @@ func HandleCatchupSend(pgDataDirectory string, destination string) {
 			lsn, control.Checkpoint)
 	}
 
+	sendFileCommands(encoder, pgDataDirectory, fileList, control.Checkpoint)
+
 	label, offsetMap, _, err := runner.StopBackup()
 	tracelog.ErrorLogger.FatalOnError(err)
-
-	sendFileCommands(encoder, pgDataDirectory, fileList, control.Checkpoint)
 
 	err = encoder.Encode(
 		CatchupCommandDto{BinaryContents: []byte(label), FileName: BackupLabelFilename, IsBinContents: true})


### PR DESCRIPTION
### Database name
Postgres

# Pull request description

### Describe what this PR fixes
Backup stop is issued at wrong place

### Please provide steps to reproduce (if it's a bug)
Promotion of a standby immediately after catchup can lead to corruption issues

