### PR TITLE
Fix WalPageSize and BlockSize for gp and cloudberry

### DIFF
--- a/cmd/gp/copy.go
+++ b/cmd/gp/copy.go
@@ -7,6 +7,8 @@ import (
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
+	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
+	"github.com/wal-g/wal-g/internal/walparser"
 )
 
 const (
@@ -42,6 +44,14 @@ var (
 		PersistentPreRun: func(*cobra.Command, []string) {
 			if viper.IsSet(conf.PgWalSize) {
 				postgres.SetWalSize(viper.GetUint64(conf.PgWalSize))
+			}
+			if viper.IsSet(conf.PgWalPageSize) {
+				walparser.SetWalPageSize(viper.GetUint64(conf.PgWalPageSize))
+			}
+			if viper.IsSet(conf.PgBlockSize) {
+				walparser.SetBlockSize(viper.GetUint64(conf.PgBlockSize))
+				postgres.SetDatabasePageSize(viper.GetUint64(conf.PgBlockSize))
+				orioledb.SetDatabasePageSize(viper.GetUint64(conf.PgBlockSize))
 			}
 		},
 	}

--- a/cmd/gp/gp.go
+++ b/cmd/gp/gp.go
@@ -15,8 +15,10 @@ import (
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
+	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"
+	"github.com/wal-g/wal-g/internal/walparser"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
@@ -37,6 +39,10 @@ var (
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// Greenplum uses the 64MB WAL segment size by default
 			postgres.SetWalSize(viper.GetUint64(conf.PgWalSize))
+			walparser.SetWalPageSize(viper.GetUint64(conf.PgWalPageSize))
+			walparser.SetBlockSize(viper.GetUint64(conf.PgBlockSize))
+			postgres.SetDatabasePageSize(viper.GetUint64(conf.PgBlockSize))
+			orioledb.SetDatabasePageSize(viper.GetUint64(conf.PgBlockSize))
 			err := internal.AssertRequiredSettingsSet()
 			tracelog.ErrorLogger.FatalOnError(err)
 			err = conf.ConfigureAndRunDefaultWebServer()

--- a/cmd/pg/pg.go
+++ b/cmd/pg/pg.go
@@ -12,6 +12,8 @@ import (
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
+	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
+	"github.com/wal-g/wal-g/internal/walparser"
 )
 
 const WalgShortDescription = "PostgreSQL backup tool"
@@ -35,7 +37,14 @@ var (
 			if viper.IsSet(conf.PgWalSize) {
 				postgres.SetWalSize(viper.GetUint64(conf.PgWalSize))
 			}
-
+			if viper.IsSet(conf.PgWalPageSize) {
+				walparser.SetWalPageSize(viper.GetUint64(conf.PgWalPageSize))
+			}
+			if viper.IsSet(conf.PgBlockSize) {
+				walparser.SetBlockSize(viper.GetUint64(conf.PgBlockSize))
+				postgres.SetDatabasePageSize(viper.GetUint64(conf.PgBlockSize))
+				orioledb.SetDatabasePageSize(viper.GetUint64(conf.PgBlockSize))
+			}
 			// In case the --target-storage flag isn't specified (the variable is set in commands' init() funcs),
 			// we take the value from the config.
 			if targetStorage == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,8 @@ const (
 	PgSslRootCert                        = "PGSSLROOTCERT"
 	PgSlotName                           = "WALG_SLOTNAME"
 	PgWalSize                            = "WALG_PG_WAL_SIZE"
+	PgWalPageSize                        = "WALG_PG_WAL_PAGE_SIZE"
+	PgBlockSize                          = "WALG_PG_BLOCK_SIZE"
 	TotalBgUploadedLimit                 = "TOTAL_BG_UPLOADED_LIMIT"
 	NameStreamCreateCmd                  = "WALG_STREAM_CREATE_COMMAND"
 	NameStreamRestoreCmd                 = "WALG_STREAM_RESTORE_COMMAND"
@@ -304,6 +306,8 @@ var (
 
 	PGDefaultSettings = map[string]string{
 		PgWalSize:                 "16",
+		PgWalPageSize:             "8192",
+		PgBlockSize:               "8192",
 		PgBackRestStanza:          "main",
 		PgAliveCheckInterval:      "1m",
 		FailoverStoragesCheckSize: "1mb",
@@ -314,6 +318,8 @@ var (
 	GPDefaultSettings = map[string]string{
 		GPLogsDirectory:              "/var/log",
 		PgWalSize:                    "64",
+		PgWalPageSize:                "32768",
+		PgBlockSize:                  "32768",
 		GPSegmentsPollInterval:       "5m",
 		GPSegmentsUpdInterval:        "10s",
 		GPSegmentsPollRetries:        "5",
@@ -478,6 +484,8 @@ var (
 		PgSslRootCert:                        true,
 		PgSlotName:                           true,
 		PgWalSize:                            true,
+		PgWalPageSize:                        true,
+		PgBlockSize:                          true,
 		PrefetchDir:                          true,
 		PgReadyRename:                        true,
 		PgBackRestStanza:                     true,

--- a/internal/databases/postgres/orioledb/incremental_page_reader.go
+++ b/internal/databases/postgres/orioledb/incremental_page_reader.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	DatabasePageSize          = int64(walparser.BlockSize)
 	CompressedPageSize        = 512
 	SignatureMagicNumber byte = 0x55
 )
+
+var DatabasePageSize = int64(walparser.BlockSize)
 
 // IncrementFileHeader contains "wi" at the head which stands for "wal-g increment"
 // format version "1", signature magic number
@@ -35,6 +36,10 @@ type incrementalPageReader struct {
 	ChkpNum    uint32
 	Next       []byte
 	Blocks     []uint32
+}
+
+func SetDatabasePageSize(pageSize uint64) {
+	DatabasePageSize = int64(pageSize)
 }
 
 func (pageReader *incrementalPageReader) Read(p []byte) (n int, err error) {

--- a/internal/databases/postgres/paged_file_delta_map.go
+++ b/internal/databases/postgres/paged_file_delta_map.go
@@ -17,9 +17,10 @@ import (
 
 const (
 	RelFileSizeBound               = 1 << 30
-	BlocksInRelFile                = int(RelFileSizeBound / DatabasePageSize)
 	DefaultSpcNode   walparser.Oid = 1663
 )
+
+var BlocksInRelFile = int(RelFileSizeBound / DatabasePageSize)
 
 type NoBitmapFoundError struct {
 	error

--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -30,8 +30,9 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
+var DatabasePageSize int64 = int64(walparser.BlockSize)
+
 const (
-	DatabasePageSize          = int64(walparser.BlockSize)
 	sizeofInt32               = 4
 	sizeofInt64               = 8
 	SignatureMagicNumber byte = 0x55
@@ -48,6 +49,10 @@ const (
 	ClogDir      = "pg_clog"      // Legacy name for transaction status
 	MultiXactDir = "pg_multixact" // Multi-transaction status
 )
+
+func SetDatabasePageSize(pageSize uint64) {
+	DatabasePageSize = int64(pageSize)
+}
 
 type InvalidIncrementFileHeaderError struct {
 	error

--- a/internal/databases/postgres/pagefile_test.go
+++ b/internal/databases/postgres/pagefile_test.go
@@ -16,11 +16,12 @@ import (
 const (
 	pagedFileName            = "../../../test/testdata/base_paged_file.bin"
 	pagedFileSizeInBytes     = 65536
-	pagedFileBlockCount      = pagedFileSizeInBytes / DatabasePageSize
 	sampleLSN            LSN = 0xc6bd4600
 	smallLSN             LSN = 0
 	bigLSN                   = sampleLSN * 2
 )
+
+var pagedFileBlockCount = pagedFileSizeInBytes / DatabasePageSize
 
 // TestIncrement holds information about some increment for easy testing
 type TestIncrement struct {

--- a/internal/walparser/wal_parser.go
+++ b/internal/walparser/wal_parser.go
@@ -11,11 +11,20 @@ import (
 	"github.com/wal-g/wal-g/internal/walparser/parsingutil"
 )
 
-const (
-	WalPageSize         uint16 = 8192
-	BlockSize           uint16 = 8192
-	XLogRecordAlignment        = 8
+const XLogRecordAlignment = 8
+
+var (
+	WalPageSize uint16 = 8192
+	BlockSize   uint16 = 8192
 )
+
+func SetWalPageSize(sizeByte uint64) {
+	WalPageSize = uint16(sizeByte)
+}
+
+func SetBlockSize(sizeByte uint64) {
+	BlockSize = uint16(sizeByte)
+}
 
 type ZeroPageError struct {
 	error


### PR DESCRIPTION
In both greenplum and cloudberry, the default WalPageSize and BlockSize are 32768 instead of 8192.

Add config item WALG_PG_WAL_PAGE_SIZE and WALG_PG_BLOCK_SIZE

### Database name
Greenplum, Cloudberry

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
