### PR TITLE
Switch to container due to Ubuntu 20.04 deprecation on GitHub (fix the worflow release.yml)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release workflow for tagged versions
 on:
   push:
+    # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*'
+      - 'v*' # Push events to matching v*, i.e. v0.2.19, v0.2.14a
 
 env:
   GO_VERSION: "1.22"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ env:
   USE_BROTLI: 1
   USE_LIBSODIUM: 1
   USE_LZO: 1
+  DEBIAN_FRONTEND: noninteractive
 
 jobs:
   # Prevents race conditions by creating the release only once before uploads.
@@ -38,7 +39,6 @@ jobs:
     steps:
       - name: Install build dependencies
         run: |
-          export DEBIAN_FRONTEND=noninteractive
           apt-get update
           apt-get install -y liblzo2-dev brotli libsodium-dev curl git cmake build-essential tzdata
 
@@ -114,7 +114,6 @@ jobs:
             USE_LZO: ${{ env.USE_LZO }}
           shell: /bin/bash
           run: |            
-            export DEBIAN_FRONTEND=noninteractive
             apt-get update
             apt-get install -y build-essential curl git cmake liblzo2-dev brotli libsodium-dev
             

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release workflow for tagged versions
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*' # Push events to matching v*, i.e. v0.2.19, v0.2.14a
+      - 'v*'
 
 env:
   GO_VERSION: "1.22"
@@ -12,16 +11,35 @@ env:
   USE_LZO: 1
 
 jobs:
+  # Prevents race conditions by creating the release only once before uploads.
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   release-ubuntu:
+    needs: create-release
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
-        db: [ pg, mysql, sqlserver, redis, mongo, fdb, gp ]
+        os: [20.04, 22.04, 24.04]
+        db: [pg, mysql, sqlserver, redis, mongo, fdb, gp]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:${{ matrix.os }}
     steps:
-      - name: Install deps
-        run: sudo apt-get install liblzo2-dev brotli libsodium-dev
+      - name: Install build dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y liblzo2-dev brotli libsodium-dev curl git cmake build-essential tzdata
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,9 +51,13 @@ jobs:
         id: go
 
       - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
+        run: go get -v -t -d ./...
 
+      - name: Mark repo and submodule as safe
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE/submodules/brotli
+ 
       - name: Make deps
         run: make deps
 
@@ -66,7 +88,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-ubuntu-arm:
-    runs-on: ubuntu-24.04
+    needs: create-release
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ { distro: ubuntu20.04, label: ubuntu-20.04 }, { distro: ubuntu22.04, label: ubuntu-22.04 } ]
@@ -90,6 +113,7 @@ jobs:
             USE_LZO: ${{ env.USE_LZO }}
           shell: /bin/bash
           run: |            
+            export DEBIAN_FRONTEND=noninteractive
             apt-get update
             apt-get install -y build-essential curl git cmake liblzo2-dev brotli libsodium-dev
             
@@ -101,12 +125,13 @@ jobs:
             
             go get -v -t -d ./...
             
-            git config --global --add safe.directory /home/runner/work/wal-g/wal-g
-            git config --global --add safe.directory /home/runner/work/wal-g/wal-g/submodules/brotli
-            
+            git config --global --add safe.directory $GITHUB_WORKSPACE
+            git config --global --add safe.directory $GITHUB_WORKSPACE/submodules/brotli
+                      
             make deps
             
             make ${{ matrix.db }}_build
+
       - name: Rename WAL-G binary
         run: mv main/${{ matrix.db }}/wal-g wal-g-${{ matrix.db }}-${{ matrix.os.label }}-${{ matrix.arch }}
 


### PR DESCRIPTION
### Database name
all

# Pull request description
This PR switches the Ubuntu 20.04 job to use a container image instead of the deprecated GitHub-hosted runner.

More details in the issue:  https://github.com/wal-g/wal-g/issues/1963


Here  is a screenshot of the new proposed workflow
<img width="790" alt="image" src="https://github.com/user-attachments/assets/d388952a-f023-460c-8726-9beb9ef1f7f0" />

