### PR TITLE
Add workflow to build and publish WAL-G DEB packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,22 @@ TOOLS_MOD_DIR := ./internal/tools
 MOCKS_DESTINATION := ./testtools/mocks
 FILE_TO_MOCKS := ./internal/uploader.go .\pkg\storages\memory\folder.go ##перечисление путей до интерфейсов
 
+# During DEB package builds from a source tarball, Git metadata (revision, tag) is unavailable.
+# In CI/CD, we generate a BUILDINFO_FILE before packaging, using Git info from the repo.
+# - If BUILDINFO_FILE is present, values are loaded from it.
+# - Otherwise, values are pulled directly using Git — this is the default behavior for most builds.
+BUILDINFO_FILE := walg.buildinfo
+
+ifeq ($(wildcard $(BUILDINFO_FILE)),)
+  WALG_BUILD_DATE    := $(shell date -u +%Y.%m.%d_%H:%M:%S)
+  WALG_GIT_REVISION  := $(shell git rev-parse --short HEAD)
+  WALG_VERSION       := $(shell git tag -l --points-at HEAD)
+else
+  WALG_BUILD_DATE    := $(shell grep ^WALG_BUILD_DATE $(BUILDINFO_FILE) | cut -d= -f2)
+  WALG_GIT_REVISION  := $(shell grep ^WALG_GIT_REVISION $(BUILDINFO_FILE) | cut -d= -f2)
+  WALG_VERSION       := $(shell grep ^WALG_VERSION $(BUILDINFO_FILE) | cut -d= -f2)
+endif
+
 BUILD_TAGS:=
 
 ifdef USE_BROTLI
@@ -47,7 +63,12 @@ test: deps unittest pg_build mysql_build redis_build mongo_build gp_build cloudb
 pg_test: deps pg_build unlink_brotli pg_integration_test
 
 pg_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_PG_PATH) && go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/pg.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/pg.gitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd/pg.walgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_PG_PATH) && \
+		go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g \
+		-ldflags "-s -w \
+			-X github.com/wal-g/wal-g/cmd/pg.buildDate=$(WALG_BUILD_DATE) \
+			-X github.com/wal-g/wal-g/cmd/pg.gitRevision=$(WALG_GIT_REVISION) \
+			-X github.com/wal-g/wal-g/cmd/pg.walgVersion=$(WALG_VERSION)")
 
 install_and_build_pg: deps pg_build
 
@@ -124,10 +145,21 @@ mysql_base: deps mysql_build unlink_brotli
 mysql_test: deps mysql_build unlink_brotli mysql_integration_test
 
 mysql_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_MYSQL_PATH) && go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/mysql.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/mysql.gitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd/mysql.walgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_MYSQL_PATH) && \
+		go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g \
+		-ldflags "-s -w \
+			-X github.com/wal-g/wal-g/cmd/mysql.buildDate=$(WALG_BUILD_DATE) \
+			-X github.com/wal-g/wal-g/cmd/mysql.gitRevision=$(WALG_GIT_REVISION) \
+			-X github.com/wal-g/wal-g/cmd/mysql.walgVersion=$(WALG_VERSION)")
 
 sqlserver_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_SQLSERVER_PATH) && go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/sqlserver.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/sqlserver.gitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd/sqlserver.walgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_SQLSERVER_PATH) && \
+		go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g \
+		-ldflags "-s -w \
+			-X github.com/wal-g/wal-g/cmd/sqlserver.buildDate=$(WALG_BUILD_DATE) \
+			-X github.com/wal-g/wal-g/cmd/sqlserver.gitRevision=$(WALG_GIT_REVISION) \
+			-X github.com/wal-g/wal-g/cmd/sqlserver.walgVersion=$(WALG_VERSION)")
+
 
 load_docker_common:
 	@if [ "x" = "${CACHE_FOLDER}x" ]; then\
@@ -165,7 +197,12 @@ mariadb_integration_test: unlink_brotli load_docker_common
 mongo_test: deps mongo_build unlink_brotli
 
 mongo_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_MONGO_PATH) && go build $(BUILD_ARGS) -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/mongo.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/mongo.gitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd/mongo.walgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_MONGO_PATH) && \
+		go build $(BUILD_ARGS) -mod vendor -tags "$(BUILD_TAGS)" -o wal-g \
+		-ldflags "-s -w \
+			-X github.com/wal-g/wal-g/cmd/mongo.buildDate=$(WALG_BUILD_DATE) \
+			-X github.com/wal-g/wal-g/cmd/mongo.gitRevision=$(WALG_GIT_REVISION) \
+			-X github.com/wal-g/wal-g/cmd/mongo.walgVersion=$(WALG_VERSION)")
 
 mongo_install: mongo_build
 	mv $(MAIN_MONGO_PATH)/wal-g $(GOBIN)/wal-g
@@ -193,7 +230,12 @@ fdb_integration_test: load_docker_common
 redis_test: deps redis_build unlink_brotli redis_integration_test
 
 redis_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_REDIS_PATH) && go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/redis.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/redis.gitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd/redis.walgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_REDIS_PATH) && \
+		go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g \
+		-ldflags "-s -w \
+			-X github.com/wal-g/wal-g/cmd/redis.buildDate=$(WALG_BUILD_DATE) \
+			-X github.com/wal-g/wal-g/cmd/redis.gitRevision=$(WALG_GIT_REVISION) \
+			-X github.com/wal-g/wal-g/cmd/redis.walgVersion=$(WALG_VERSION)")
 
 redis_integration_test: load_docker_common
 	docker compose build redis && docker compose build redis_tests
@@ -218,7 +260,12 @@ clean_redis_features:
 etcd_test: deps etcd_build unlink_brotli etcd_integration_test
 
 etcd_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_ETCD_PATH) && go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/etcd.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/etcd.gitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd/etcd.walgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_ETCD_PATH) && \
+		go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g \
+		-ldflags "-s -w \
+			-X github.com/wal-g/wal-g/cmd/etcd.buildDate=$(WALG_BUILD_DATE) \
+			-X github.com/wal-g/wal-g/cmd/etcd.gitRevision=$(WALG_GIT_REVISION) \
+			-X github.com/wal-g/wal-g/cmd/etcd.walgVersion=$(WALG_VERSION)")
 
 etcd_install: etcd_build
 	mv $(MAIN_ETCD_PATH)/wal-g $(GOBIN)/wal-g
@@ -233,7 +280,12 @@ etcd_integration_test: load_docker_common
 	docker compose up --exit-code-from etcd_tests etcd_tests
 
 gp_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_GP_PATH) && go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/gp.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/gp.gitRevision=`git rev-parse --short HEAD` -X github.com/wal-g/wal-g/cmd/gp.walgVersion=`git tag -l --points-at HEAD`")
+	(cd $(MAIN_GP_PATH) && \
+		go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g \
+		-ldflags "-s -w \
+			-X github.com/wal-g/wal-g/cmd/gp.buildDate=$(WALG_BUILD_DATE) \
+			-X github.com/wal-g/wal-g/cmd/gp.gitRevision=$(WALG_GIT_REVISION) \
+			-X github.com/wal-g/wal-g/cmd/gp.walgVersion=$(WALG_VERSION)")
 
 gp_clean:
 	(cd $(MAIN_GP_PATH) && go clean)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,3 @@
+# NOTE: This changelog is generated automatically via GitHub Actions
+# as part of the build & deployment workflow.
+# Manual edits will be overwritten. You’ve been warned.

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,64 @@
+Source: wal-g
+Maintainer: mdb <mdb-admin@yandex-team.ru>  # CHANGE !!!!
+Section: database
+Priority: extra
+Standards-Version: 4.6.0
+Build-Depends:
+ brotli,
+ cmake,
+ curl,
+ debhelper-compat (= 12),
+ gcc,
+ git,
+ liblzo2-dev,
+ libsodium-dev,
+ make
+Rules-Requires-Root: no
+XS-Go-Import-Path: github.com/wal-g/wal-g
+
+Package: wal-g-pg
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: WAL-G backup tool for PostgreSQL
+ WAL-G is an archival restoration tool for PostgreSQL. This package
+ includes support for PostgreSQL backups and restore with page compression,
+ streaming, and cloud integration.
+
+Package: wal-g-mongo
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: WAL-G backup tool for MongoDB
+ WAL-G is an archival restoration tool for MongoDB. This package
+ includes support for MongoDB backups to cloud storage.
+
+Package: wal-g-redis
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: WAL-G backup tool for Redis
+ WAL-G is an archival restoration tool for Redis. This package
+ includes support for Redis backup and restore functionality.
+
+Package: wal-g-mysql
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: WAL-G backup tool for MySQL
+ WAL-G is an archival restoration tool for MySQL. This package
+ includes support for MySQL backups and restore.
+
+Package: wal-g-sqlserver
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: WAL-G backup tool for SQL Server
+ WAL-G is an archival restoration tool for Microsoft SQL Server backups.
+
+Package: wal-g-fdb
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: WAL-G backup tool for FoundationDB
+ WAL-G is an archival restoration tool for FoundationDB backups.
+
+Package: wal-g-gp
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: WAL-G backup tool for Greenplum
+ WAL-G is an archival restoration tool for Greenplum backups. 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,7 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: WAL-G
+Source: https://github.com/wal-g/wal-g
+
+Files: *
+Copyright: 2024-2025 WAL-G contributors
+License: Apache-2.0

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,60 @@
+#!/usr/bin/make -f
+
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+export DH_GOLANG_EXCLUDES := iphlpapi
+export GO111MODULE=on
+export GOFLAGS=-mod=vendor -buildvcs=false
+export GOPROXY=off 
+export USE_BROTLI=1
+export USE_LIBSODIUM=1
+export USE_LZO=1
+export GOCACHE := $(CURDIR)/.gocache
+export GOMODCACHE := $(CURDIR)/.gomodcache
+
+# Переменные Go
+GO_TAR_AMD := $(CURDIR)/build/golang-amd64.tar.gz
+GO_TAR_ARM := $(CURDIR)/build/golang-arm64.tar.gz
+GO_DIR := $(CURDIR)/build/go
+
+# Подключение Go из build/go
+export GOROOT := $(GO_DIR)
+export PATH := $(GOROOT)/bin:$(PATH)
+
+%:
+	dh $@
+
+override_dh_auto_build:
+	mkdir -p $(GOCACHE) $(GOMODCACHE) $(GO_DIR)
+
+	# Определение архитектуры и распаковка Go
+	if dpkg --print-architecture | grep -q amd64; then \
+		tar -C $(GO_DIR) --strip-components=1 -xzf $(GO_TAR_AMD); \
+	elif dpkg --print-architecture | grep -q arm64; then \
+		tar -C $(GO_DIR) --strip-components=1 -xzf $(GO_TAR_ARM); \
+	else \
+		echo "Unsupported architecture"; \
+		exit 1; \
+	fi
+
+	make link_external_deps
+	make pg_build
+	make mysql_build
+	make mongo_build
+	make redis_build
+	make sqlserver_build
+	make fdb_build
+	make gp_build	
+
+override_dh_auto_install:
+	dh_auto_install
+
+override_dh_install:
+	dh_install
+
+override_dh_auto_clean:
+	make clean
+
+override_dh_auto_test:
+	true

--- a/debian/source/include-binaries
+++ b/debian/source/include-binaries
@@ -1,0 +1,3 @@
+build/golang-amd64.tar.gz
+build/golang-arm64.tar.gz
+tmp/libsodium/libsodium-1.0.20.tar.gz

--- a/debian/wal-g-fdb.install
+++ b/debian/wal-g-fdb.install
@@ -1,0 +1,1 @@
+main/fdb/wal-g usr/bin/wal-g

--- a/debian/wal-g-gp.install
+++ b/debian/wal-g-gp.install
@@ -1,0 +1,1 @@
+main/gp/wal-g usr/bin/wal-g

--- a/debian/wal-g-mongo.install
+++ b/debian/wal-g-mongo.install
@@ -1,0 +1,1 @@
+main/mongo/wal-g usr/bin/wal-g

--- a/debian/wal-g-mysql.install
+++ b/debian/wal-g-mysql.install
@@ -1,0 +1,1 @@
+main/mysql/wal-g usr/bin/wal-g

--- a/debian/wal-g-pg.install
+++ b/debian/wal-g-pg.install
@@ -1,0 +1,1 @@
+main/pg/wal-g usr/bin/wal-g

--- a/debian/wal-g-redis.install
+++ b/debian/wal-g-redis.install
@@ -1,0 +1,1 @@
+main/redis/wal-g usr/bin/wal-g

--- a/debian/wal-g-sqlserver.install
+++ b/debian/wal-g-sqlserver.install
@@ -1,0 +1,1 @@
+main/sqlserver/wal-g usr/bin/wal-g

--- a/link_libsodium.sh
+++ b/link_libsodium.sh
@@ -10,7 +10,14 @@ test -d tmp/libsodium || mkdir -p tmp/libsodium
 
 cd tmp/libsodium
 
-curl --retry 5 --retry-delay 0 -sL https://github.com/jedisct1/libsodium/releases/download/$LIBSODIUM_VERSION-RELEASE/libsodium-$LIBSODIUM_VERSION.tar.gz -o libsodium-$LIBSODIUM_VERSION.tar.gz
+# In isolated build environments (e.g., for packaging or Launchpad),
+# we must include the libsodium tarball in our source archive.
+# This check ensures we reuse the local tarball if it already exists,
+# or download it from GitHub for regular workflows.
+if [ ! -f "libsodium-$LIBSODIUM_VERSION.tar.gz" ]; then
+  curl --retry 5 --retry-delay 0 -sL "https://github.com/jedisct1/libsodium/releases/download/${LIBSODIUM_VERSION}-RELEASE/libsodium-${LIBSODIUM_VERSION}.tar.gz" -o "libsodium-${LIBSODIUM_VERSION}.tar.gz"
+fi
+
 tar xfz libsodium-$LIBSODIUM_VERSION.tar.gz --strip-components=1
 
 CONFIGURE_ARGS="--prefix ${PWD}"


### PR DESCRIPTION
### Database name
all

# DO NOT MERGE this code — it should be adjusted

# Pull request description
This pull request adds a workflow that enables publishing all WAL-G DEB packages for supported backends:
- PostgreSQL
- MySQL
- Mongo
- Redis
- SQL Server
- FDB
- Greenplum

It allows publishing to two different APT repositories:
1. GitHub Pages — a custom APT repository hosted in the WAL-G GitHub repository.
2. Launchpad (PPA) — using ppa:boosterykt/wal-g2.

The workflow is triggered manually and supports two inputs:
- The version you want to build.
- The destination where you want to publish the packages (GitHub or Launchpad).

This setup gives flexibility for testing, development, and official release management. It also helps users easily install WAL-G packages via the APT package manager.

# Additional Notes
✅ GitHub Pages — Pros
	•	Fully managed and controlled by the WAL-G community.
	•	Simple setup and easy to extend.
	•	Keeps the full version history — users can install **any** available WAL-G version.
	•	Currently supports Ubuntu, but can be extended to Debian or other systems in the future.

⚠️ GitHub Pages — Cons
	•	GitHub Actions primarily use amd64 runners.
	•	To build for arm64, we must use container-based cross-compilation (e.g. run-on-arch-action).
	•	Supporting additional architectures (e.g. armhf, riscv64) depends on the availability of compatible containers in GitHub Actions.

⸻

✅ Launchpad (PPA) — Pros
	•	Easy to set up and use.
	•	DEB packages are built automatically for both amd64 and arm64.
	•	Very easy to extend builds to additional architectures — for example: i386, armhf, ppc64el, riscv64, and others (just by ticking checkboxes in the Launchpad UI).

⚠️ Launchpad (PPA) — Cons
	•	arm64 builds sometimes fail, but usually succeed on retry.
	•	Launchpad does not support version history — only the latest uploaded version is available to users via APT.
	•	In rare cases, builds are delayed due to limited build farm capacity (e.g. up to 28 hours wait time for amd64 observed once).

# User Instructions
### 🟢 Using Launchpad PPA

```
# add the WAL-G PPA
sudo add-apt-repository ppa:walg/wal-g
sudo apt update

```


```
# install packages:
apt-cache policy wal-g-pg
sudo apt install wal-g-pg
sudo apt install wal-g-mongo
sudo apt install wal-g-pg wal-g-mongo
```

### 🟢 Using GitHub Pages APT repository


```
# add the signing key and APT source
curl -fsSL https://wal-g.github.io/wal-g/public-key.asc | sudo tee /etc/apt/trusted.gpg.d/walg.asc
echo "deb https://wal-g.github.io/wal-g/  $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/walg.list

```

```
# update and Install packages:
sudo apt update
apt-cache policy wal-g-pg

# Install latest version
sudo apt install wal-g-pg

# Install MongoDB variant
sudo apt install wal-g-mongo

# Install multiple variants
sudo apt install wal-g-pg wal-g-mongo

# 🎯 Install a specific version (example)
sudo apt install wal-g-pg=20.0.1-1~jammy

```
This demonstrates how GitHub Pages APT repo supports installing specific versions,
which is not possible via Launchpad PPA due to the lack of package history support.


#  Open Questions for Discussion
Before we finalize and enable this workflow, there are a few questions that we need to discuss and agree on as a community:
	1.	Do we want to support both APT repositories or only one?
	•	Should we maintain both the GitHub Pages APT repository and the Launchpad PPA?
	•	Or should we choose only one for simplicity?
	2.	If we keep GitHub Pages — what is the starting WAL-G version we want to publish?
	•	Do we publish all past versions, or only versions starting from a certain point (e.g. 2.x.x or 3.x.x)?
	•	This decision affects which packages we prepare and upload.
	3.	Based on the answers above, what are the next setup steps?
	•	Add secret variables to GitHub (for GPG key, Launchpad credentials, etc.).
	•	Enable GitHub Pages for the APT repository.
	•	Register and configure Launchpad account (if not done yet).
	•	Schedule initial publication of selected versions.

Once these questions are resolved, we can move forward with fully enabling automated DEB publishing for WAL-G.

# TODO (Future Steps)

1. Expand the workflow to support publishing packages for Debian
2. Use this debian/ folder to start discussions about including WAL-G for PostgreSQL in the official PGDG repository

- Prepare a cleaned-up version of the PostgreSQL-only package.
- Reach out to the pgsql-pkg-debian mailing list to propose inclusion.
- Align with PGDG packaging standards and guidelines.
