### PR TITLE
switch docker tests to ubuntu-latest

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   buildimages:
     name: Build images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       #  use cache to pass docker images to the test jobs
       - name: Docker images caching
@@ -66,7 +66,7 @@ jobs:
 
   test:
     name: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ buildimages ]
     strategy:
       matrix:


### PR DESCRIPTION
MDTGA: make docker tests great again

@fanfuxiaoran  can you have a look please ? for some time docker tests were broken (due to GHA deprecation of ubuntu-20), 
now tests fail on the recently edited file: https://github.com/wal-g/wal-g/commit/6c72b281000b78a157811bbdd78e5d395d77eb47