### PR TITLE
Fix failed restore gp cbdb

### DIFF
--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -204,7 +204,7 @@ func (fh *FetchHandler) createRecoveryConfigs() error {
 		recoveryTarget = fh.restorePoint
 	}
 	tracelog.InfoLogger.Printf("Recovery target is %s", recoveryTarget)
-	restoreCfgMaker := NewRecoveryConfigMaker("/usr/bin/wal-g", conf.CfgFile, recoveryTarget)
+	restoreCfgMaker := NewRecoveryConfigMaker("wal-g", conf.CfgFile, recoveryTarget)
 	pathToRecoveryConf := viper.GetString(conf.GPRelativeRecoveryConfPath)
 	pathToPostgresqlConf := viper.GetString(conf.GPRelativePostgresqlConfPath)
 

--- a/internal/databases/greenplum/pg_hba_cfg_maker_test.go
+++ b/internal/databases/greenplum/pg_hba_cfg_maker_test.go
@@ -49,3 +49,45 @@ host    replication     gpadmin         sdw2              trust`
 
 	assert.Equal(t, expectedOutput, output, "generated pg_hba.conf does not match the expected one")
 }
+
+func TestGeneratePgHbaConf_IP(t *testing.T) {
+	segments := map[int][]*cluster.SegConfig{
+		-1: {{
+			DbID:      1,
+			ContentID: -1,
+			Role:      "p",
+			Port:      5432,
+			Hostname:  "192.168.1.1",
+			DataDir:   "/path/to/gpseg-1",
+		}},
+		0: {{
+			DbID:      2,
+			ContentID: 0,
+			Role:      "p",
+			Port:      6000,
+			Hostname:  "192.168.1.2",
+			DataDir:   "/path/to/gpseg0",
+		}},
+		1: {{
+			DbID:      3,
+			ContentID: 1,
+			Role:      "p",
+			Port:      6001,
+			Hostname:  "192.168.1.3",
+			DataDir:   "/path/to/gpseg1",
+		}},
+	}
+	expectedOutput := greenplum.PgHbaTemplate + `
+host    all             all             192.168.1.1/32              trust
+host    all             gpadmin         192.168.1.2/32              trust
+host    all             gpadmin         192.168.1.3/32              trust
+host    replication     gpadmin         samehost                trust
+host    replication     gpadmin         192.168.1.2/32              trust
+host    replication     gpadmin         192.168.1.3/32              trust`
+
+	pgHbaMaker := greenplum.NewPgHbaMaker(segments)
+	output, err := pgHbaMaker.Make()
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedOutput, output, "generated pg_hba.conf does not match the expected one")
+}

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -3,6 +3,7 @@ package greenplum
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"os"
 	"sort"
 	"strings"
@@ -151,12 +152,38 @@ func createRestorePoint(conn *pgx.Conn, restorePointName string) (restoreLSNs ma
 	tracelog.InfoLogger.Printf("Creating restore point with name %s", restorePointName)
 	queryRunner, err := NewGpQueryRunner(conn)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	for retries := 0; retries < RestorePointCreateRetries; retries++ {
 		restoreLSNs, err = queryRunner.CreateGreenplumRestorePoint(restorePointName)
 		if err == nil {
+			// After create restore point should archive related WAL log segments.
+			// This ensures the new cluster can retrieve complete WAL logs with the restore point for restoration.
+			globalCluster, gpVersion, _, err := getGpClusterInfo(conn)
+			if err != nil {
+				return nil, err
+			}
+			tracelog.InfoLogger.Println("Switch xlog on cluster")
+			remoteOutput := globalCluster.GenerateAndExecuteCommand("Running wal-g", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER,
+				func(contentID int) string {
+					seg, ok := globalCluster.ByContent[contentID]
+					if ok {
+						var pgOptions, switchFunction string
+						if gpVersion.Flavor == Greenplum && gpVersion.Major == 6 {
+							pgOptions = "-c gp_session_role=utility"
+							switchFunction = "pg_switch_xlog()"
+						} else {
+							pgOptions = "-c gp_role=utility"
+							switchFunction = "pg_switch_wal()"
+						}
+						return fmt.Sprintf("PGOPTIONS='%s' psql -p %d -d postgres -c 'select %s;'", pgOptions, seg[0].Port, switchFunction)
+					}
+					return ""
+				})
+			globalCluster.CheckClusterError(remoteOutput, "Unable to switch xlog on cluster", func(contentID int) string {
+				return "Unable to switch xlog on cluster"
+			}, true)
 			return restoreLSNs, nil
 		}
 	}


### PR DESCRIPTION
### Database name
greenplumn and cloudberrydb

# Pull request description

### Describe what this PR fixes
- Instead of hard-coding wal-g in the /usr/bin directory, users are allowed to specify its location by configuring environment variables.
- Fix failed to restore CloudberryDB，After the full backup is completed, a restore point needs to be inserted, and the WAL log segments related to this restore point should be manually archived.This operation ensures that the new cluster can obtain the complete WAL logs containing this restore point, thus enabling the execution of the restoration process.
- Fix wal-g manipulates pg_hba.conf on all segments incorrectly not specifying /32 after host IP

This pull request aims to address the issue reported in https://github.com/wal-g/wal-g/issues/1952. For more detailed information, please refer to the same issue link.

