### PR TITLE
Feat: Add new commands to support gpdb/cbdb continuous recovery

### DIFF
--- a/cmd/gp/follow_primary.go
+++ b/cmd/gp/follow_primary.go
@@ -1,0 +1,37 @@
+package gp
+
+import (
+	"github.com/spf13/viper"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	followPrimaryDescription = "Resumes cluster recovery using primary-created restore points " +
+		"to apply transaction logs and advance recovery state"
+)
+
+var (
+	// followPrimaryCmd represents the followPrimaryCmd command
+	followPrimaryCmd = &cobra.Command{
+		Use:   "follow-primary restore_point",
+		Short: followPrimaryDescription,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			logsDir := viper.GetString(conf.GPLogsDirectory)
+
+			follower := greenplum.NewFollowPrimaryHandler(logsDir, restoreConfigPath, args[0], timeout)
+			follower.Follow()
+		},
+	}
+	timeout int
+)
+
+func init() {
+	followPrimaryCmd.Flags().StringVar(&restoreConfigPath, "restore-config", "", restoreConfigPathDescription)
+	followPrimaryCmd.Flags().IntVarP(&timeout, "timeout", "t", 60000, "timeout (in seconds)")
+	_ = followPrimaryCmd.MarkFlagRequired("restore-config")
+	cmd.AddCommand(followPrimaryCmd)
+}

--- a/cmd/gp/recovery_action.go
+++ b/cmd/gp/recovery_action.go
@@ -1,0 +1,32 @@
+package gp
+
+import (
+	"github.com/spf13/viper"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	recoveryActionDescription = "Update recovery.conf recovery_target_action"
+)
+
+var (
+	actionCmd = &cobra.Command{
+		Use:   "recovery-action [promote|pause|shutdown]",
+		Short: recoveryActionDescription,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			logsDir := viper.GetString(conf.GPLogsDirectory)
+			follower := greenplum.NewActionHandler(logsDir, restoreConfigPath)
+			follower.UpdateAction(args[0])
+		},
+	}
+)
+
+func init() {
+	actionCmd.Flags().StringVar(&restoreConfigPath, "restore-config", "", restoreConfigPathDescription)
+	_ = actionCmd.MarkFlagRequired("restore-config")
+	cmd.AddCommand(actionCmd)
+}

--- a/docker/cloudberry_tests/scripts/configs/follow_primary_restore_config.json
+++ b/docker/cloudberry_tests/scripts/configs/follow_primary_restore_config.json
@@ -1,0 +1,24 @@
+{
+    "segments": {
+        "-1": {
+            "hostname": "localhost",
+            "port": 7000,
+            "data_dir": "/usr/local/gpdb_src/gpAux/gpdemo/datadirs/qddir/demoDataDir-1"
+        },
+        "0": {
+            "hostname": "localhost",
+            "port": 7002,
+            "data_dir": "/usr/local/gpdb_src/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0"
+        },
+        "1": {
+            "hostname": "localhost",
+            "port": 7003,
+            "data_dir": "/usr/local/gpdb_src/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1"
+        },
+        "2": {
+            "hostname": "localhost",
+            "port": 7004,
+            "data_dir": "/usr/local/gpdb_src/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2"
+        }
+    }
+}

--- a/docker/cloudberry_tests/scripts/tests/follow_primary.sh
+++ b/docker/cloudberry_tests/scripts/tests/follow_primary.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e -x
+CONFIG_FILE="/tmp/configs/create_restore_point_config.json"
+RESTORE_CONFIG="/tmp/configs/follow_primary_restore_config.json"
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/pg_scripts/wrap_config_file.sh ${TMP_CONFIG}
+source /tmp/tests/test_functions/util.sh
+
+bootstrap_gp_cluster
+setup_wal_archiving
+
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+wal-g backup-push --config=${TMP_CONFIG}
+echo "Inserting sample data..."
+psql -p 7000 -c "DROP DATABASE IF EXISTS test"
+psql -p 7000 -c "CREATE DATABASE test"
+psql -p 7000 -d test -c "CREATE TABLE heap AS SELECT a FROM generate_series(1,10) AS a;"
+wal-g create-restore-point rp1 --config=${TMP_CONFIG}
+psql -p 7000 -d test -c "INSERT INTO heap (a) SELECT a FROM generate_series(1, 10) AS a;"
+wal-g create-restore-point rp2 --config=${TMP_CONFIG}
+psql -p 7000 -d test -c "INSERT INTO heap (a) SELECT a FROM generate_series(1, 10) AS a;"
+wal-g create-restore-point rp3 --config=${TMP_CONFIG}
+wal-g backup-list --config=${TMP_CONFIG}
+wal-g restore-point-list --config=${TMP_CONFIG}
+stop_and_delete_cluster_dir
+
+wal-g backup-fetch LATEST --restore-config=${RESTORE_CONFIG} --config=${TMP_CONFIG}
+wal-g recovery-action shutdown --restore-config=${RESTORE_CONFIG} --config=${TMP_CONFIG}
+wal-g follow-primary rp1 --restore-config=${RESTORE_CONFIG} --config=${TMP_CONFIG}
+sleep 30
+wal-g follow-primary rp2 --restore-config=${RESTORE_CONFIG} --config=${TMP_CONFIG}
+sleep 30
+wal-g follow-primary rp3 --restore-config=${RESTORE_CONFIG} --config=${TMP_CONFIG}
+sleep 30
+wal-g recovery-action promote --restore-config=${RESTORE_CONFIG} --config=${TMP_CONFIG}
+prepare_cluster
+start_cluster
+test "$(psql -p 7000 -d test -t -A -c "SELECT count(*) FROM heap;")" -eq 30 || { echo "Test failed: The count is not equal to 30."; exit 1; }
+
+cleanup
+rm ${TMP_CONFIG}

--- a/docker/cloudberry_tests/scripts/tests/restore_point.sh
+++ b/docker/cloudberry_tests/scripts/tests/restore_point.sh
@@ -18,6 +18,37 @@ wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
 wal-g create-restore-point rp1 --config=${TMP_CONFIG}
 wal-g create-restore-point rp2 --config=${TMP_CONFIG}
 
+# Check whether the WAL log is correctly switched and uploaded to S3 after create-restore-point
+# gpadmin@10f4a227f02b:/usr/local/gpdb_src$ wal-g st ls  segments_005/seg0/wal_005/ --config=${TMP_CONFIG}
+# type size    last modified                     name
+# obj  4624920 2025-05-21 07:17:16.052 +0000 UTC 000000010000000000000001.lz4
+# obj  264275  2025-05-21 07:26:06.265 +0000 UTC 000000010000000000000002.lz4
+
+#wait for wal-g to upload WALs
+sleep 5
+
+check_wal_upload() {
+    local path=$1
+
+    wal-g st ls "$path" --config=${TMP_CONFIG} \
+        | awk '/^obj/ {count++} END {print count+0}' \
+        | grep -q '^2$'
+}
+
+# Check each segment
+for seg_path in \
+    segments_005/seg-1/wal_005/ \
+    segments_005/seg0/wal_005/ \
+    segments_005/seg1/wal_005/ \
+    segments_005/seg2/wal_005/
+do
+    if ! check_wal_upload "$seg_path"; then
+        echo "Error: WAL files after create-restore-point were not correctly uploaded to S3 for $seg_path"
+        exit 1
+    fi
+done
+
+
 # check verify results to end with 'OK'
 if ! (wal-g st ls basebackups_005 --config=${TMP_CONFIG} | grep -q 'rp1_restore_point.json') then
   echo "Error: restore point rp1 metadata file does not exist"

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -44,6 +44,16 @@ type SegmentRestoreConfig struct {
 	DataDir  string `json:"data_dir"`
 }
 
+func (cfg SegmentRestoreConfig) ToSegConfig(contentID int) cluster.SegConfig {
+	return cluster.SegConfig{
+		ContentID: contentID,
+		Role:      string(Primary),
+		Port:      cfg.Port,
+		Hostname:  cfg.Hostname,
+		DataDir:   cfg.DataDir,
+	}
+}
+
 // ClusterRestoreConfig is used to describe the restored cluster
 type ClusterRestoreConfig struct {
 	Segments map[int]SegmentRestoreConfig `json:"segments"`
@@ -204,7 +214,7 @@ func (fh *FetchHandler) createRecoveryConfigs() error {
 		recoveryTarget = fh.restorePoint
 	}
 	tracelog.InfoLogger.Printf("Recovery target is %s", recoveryTarget)
-	restoreCfgMaker := NewRecoveryConfigMaker("wal-g", conf.CfgFile, recoveryTarget)
+	restoreCfgMaker := NewRecoveryConfigMaker("wal-g", conf.CfgFile, recoveryTarget, false)
 	pathToRecoveryConf := viper.GetString(conf.GPRelativeRecoveryConfPath)
 	pathToPostgresqlConf := viper.GetString(conf.GPRelativePostgresqlConfPath)
 

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -204,7 +204,7 @@ func (fh *FetchHandler) createRecoveryConfigs() error {
 		recoveryTarget = fh.restorePoint
 	}
 	tracelog.InfoLogger.Printf("Recovery target is %s", recoveryTarget)
-	restoreCfgMaker := NewRecoveryConfigMaker("/usr/bin/wal-g", conf.CfgFile, recoveryTarget)
+	restoreCfgMaker := NewRecoveryConfigMaker("wal-g", conf.CfgFile, recoveryTarget)
 	pathToRecoveryConf := viper.GetString(conf.GPRelativeRecoveryConfPath)
 	pathToPostgresqlConf := viper.GetString(conf.GPRelativePostgresqlConfPath)
 

--- a/internal/databases/greenplum/follow_primary_handler.go
+++ b/internal/databases/greenplum/follow_primary_handler.go
@@ -1,0 +1,110 @@
+package greenplum
+
+import (
+	"fmt"
+	"github.com/spf13/viper"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"path"
+	"strings"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/wal-g/tracelog"
+)
+
+type FollowPrimaryHandler struct {
+	cluster            *cluster.Cluster
+	stopAtRestorePoint string
+	timeoutInSeconds   int
+}
+
+// nolint:gocritic
+func NewFollowPrimaryHandler(
+	logsDir string,
+	restoreCfgPath, stopAtRestorePoint string,
+	timeoutInSeconds int,
+) *FollowPrimaryHandler {
+	restoreCfg, err := readRestoreConfig(restoreCfgPath)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	initGpLog(logsDir)
+
+	segmentConfigs := make([]cluster.SegConfig, 0)
+	for contentID, segRestoreCfg := range restoreCfg.Segments {
+		segmentConfigs = append(segmentConfigs, segRestoreCfg.ToSegConfig(contentID))
+	}
+
+	globalCluster := cluster.NewCluster(segmentConfigs)
+	tracelog.DebugLogger.Printf("cluster %v\n", globalCluster)
+
+	return &FollowPrimaryHandler{
+		cluster:            globalCluster,
+		stopAtRestorePoint: stopAtRestorePoint,
+		timeoutInSeconds:   timeoutInSeconds,
+	}
+}
+
+func (fh *FollowPrimaryHandler) Follow() {
+	tracelog.InfoLogger.Println("Updating recovery.conf on segments and master...")
+	fh.updateRecoveryConfigs()
+
+	tracelog.InfoLogger.Println("Running recovery on segments and master...")
+	// Run WAL-G to restore the each segment as a single Postgres instance
+	remoteOutput := fh.cluster.GenerateAndExecuteCommand("Running wal-g",
+		cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER,
+		func(contentID int) string {
+			return fh.buildSegmentStartCommand(contentID)
+		})
+
+	fh.cluster.CheckClusterError(remoteOutput, "Unable to run wal-g", func(contentID int) string {
+		return "Unable to run wal-g"
+	})
+
+	for _, command := range remoteOutput.Commands {
+		tracelog.DebugLogger.Printf("WAL-G output (segment %d):\n%s\n", command.Content, command.Stderr)
+	}
+}
+
+// updateRecoveryConfigs generates and uploads the correct recovery.conf
+// files to each segment instance (including master) so they can recover correctly
+// up to the expected restore point
+func (fh *FollowPrimaryHandler) updateRecoveryConfigs() {
+	recoveryTarget := fh.stopAtRestorePoint
+	tracelog.InfoLogger.Printf("Recovery target is %s", recoveryTarget)
+	restoreCfgMaker := NewRecoveryConfigMaker(
+		"wal-g", conf.CfgFile, recoveryTarget, true)
+
+	remoteOutput := fh.cluster.GenerateAndExecuteCommand("Updating recovery.conf on segments and master",
+		cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER,
+		func(contentID int) string {
+			segment := fh.cluster.ByContent[contentID][0]
+			pathToRestore := path.Join(segment.DataDir, viper.GetString(conf.GPRelativeRecoveryConfPath))
+			fileContents := restoreCfgMaker.Make(contentID, 0)
+			cmd := fmt.Sprintf("cat > %s << EOF\n%s\nEOF", pathToRestore, fileContents)
+			tracelog.DebugLogger.Printf("Command to run on segment %d: %s", contentID, cmd)
+			return cmd
+		})
+
+	fh.cluster.CheckClusterError(remoteOutput, "Unable to update recovery.conf", func(contentID int) string {
+		return fmt.Sprintf("Unable to create recovery.conf on segment %d", contentID)
+	})
+
+	for _, command := range remoteOutput.Commands {
+		tracelog.DebugLogger.Printf("Update recovery.conf output (segment %d):\n%s\n", command.Content, command.Stderr)
+	}
+}
+
+func (fh *FollowPrimaryHandler) buildSegmentStartCommand(contentID int) string {
+	segment := fh.cluster.ByContent[contentID][0]
+	cmd := []string{
+		"pg_ctl",
+		fmt.Sprintf("-t %d", fh.timeoutInSeconds),
+		fmt.Sprintf("-D %s", segment.DataDir),
+		"start",
+		// forward STDOUT& STDERR to log file
+		">>", formatSegmentLogPath(contentID), "2>&1",
+	}
+
+	cmdLine := strings.Join(cmd, " ")
+	tracelog.DebugLogger.Printf("Command to run on segment %d: %s", contentID, cmdLine)
+	return cmdLine
+}

--- a/internal/databases/greenplum/pg_hba_cfg_maker_test.go
+++ b/internal/databases/greenplum/pg_hba_cfg_maker_test.go
@@ -49,3 +49,45 @@ host    replication     gpadmin         sdw2              trust`
 
 	assert.Equal(t, expectedOutput, output, "generated pg_hba.conf does not match the expected one")
 }
+
+func TestGeneratePgHbaConf_IP(t *testing.T) {
+	segments := map[int][]*cluster.SegConfig{
+		-1: {{
+			DbID:      1,
+			ContentID: -1,
+			Role:      "p",
+			Port:      5432,
+			Hostname:  "192.168.1.1",
+			DataDir:   "/path/to/gpseg-1",
+		}},
+		0: {{
+			DbID:      2,
+			ContentID: 0,
+			Role:      "p",
+			Port:      6000,
+			Hostname:  "192.168.1.2",
+			DataDir:   "/path/to/gpseg0",
+		}},
+		1: {{
+			DbID:      3,
+			ContentID: 1,
+			Role:      "p",
+			Port:      6001,
+			Hostname:  "192.168.1.3",
+			DataDir:   "/path/to/gpseg1",
+		}},
+	}
+	expectedOutput := greenplum.PgHbaTemplate + `
+host    all             all             192.168.1.1/32              trust
+host    all             gpadmin         192.168.1.2/32              trust
+host    all             gpadmin         192.168.1.3/32              trust
+host    replication     gpadmin         samehost                trust
+host    replication     gpadmin         192.168.1.2/32              trust
+host    replication     gpadmin         192.168.1.3/32              trust`
+
+	pgHbaMaker := greenplum.NewPgHbaMaker(segments)
+	output, err := pgHbaMaker.Make()
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedOutput, output, "generated pg_hba.conf does not match the expected one")
+}

--- a/internal/databases/greenplum/recovery_action.go
+++ b/internal/databases/greenplum/recovery_action.go
@@ -1,0 +1,57 @@
+package greenplum
+
+import (
+	"fmt"
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/spf13/viper"
+	"github.com/wal-g/tracelog"
+	conf "github.com/wal-g/wal-g/internal/config"
+	"path"
+)
+
+type ActionHandler struct {
+	cluster *cluster.Cluster
+}
+
+const actionCmd = "sed -i '/^recovery_target_action = /d' %s && echo 'recovery_target_action = %s' >> %s"
+
+// nolint:gocritic
+func NewActionHandler(logsDir string, restoreCfgPath string) *ActionHandler {
+	restoreCfg, err := readRestoreConfig(restoreCfgPath)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	initGpLog(logsDir)
+
+	segmentConfigs := make([]cluster.SegConfig, 0)
+	for contentID, segRestoreCfg := range restoreCfg.Segments {
+		segmentConfigs = append(segmentConfigs, segRestoreCfg.ToSegConfig(contentID))
+	}
+
+	globalCluster := cluster.NewCluster(segmentConfigs)
+	tracelog.DebugLogger.Printf("cluster %v\n", globalCluster)
+
+	return &ActionHandler{
+		cluster: globalCluster,
+	}
+}
+
+func (fh *ActionHandler) UpdateAction(action string) {
+	tracelog.InfoLogger.Printf("Updating recovery.conf recovery_target_action %s on segments and master...", action)
+	remoteOutput := fh.cluster.GenerateAndExecuteCommand("Updating recovery.conf on segments and master",
+		cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER,
+		func(contentID int) string {
+			segment := fh.cluster.ByContent[contentID][0]
+			pathToRestore := path.Join(segment.DataDir, viper.GetString(conf.GPRelativeRecoveryConfPath))
+			cmd := fmt.Sprintf(actionCmd, pathToRestore, action, pathToRestore)
+			tracelog.DebugLogger.Printf("Command to run on segment %d: %s", contentID, cmd)
+			return cmd
+		})
+
+	fh.cluster.CheckClusterError(remoteOutput, "Unable to update recovery_target_action", func(contentID int) string {
+		return fmt.Sprintf("Unable to create recovery.conf on segment %d", contentID)
+	})
+
+	for _, command := range remoteOutput.Commands {
+		tracelog.DebugLogger.Printf("Update recovery.conf output (segment %d):\n%s\n", command.Content, command.Stderr)
+	}
+}

--- a/internal/databases/greenplum/recovery_cfg_maker.go
+++ b/internal/databases/greenplum/recovery_cfg_maker.go
@@ -5,18 +5,21 @@ import (
 	"strings"
 )
 
-func NewRecoveryConfigMaker(walgBinaryPath, cfgPath, recoveryTargetName string) RecoveryConfigMaker {
+func NewRecoveryConfigMaker(walgBinaryPath, cfgPath, recoveryTargetName string,
+	shutdownOnRecoveryTarget bool) RecoveryConfigMaker {
 	return RecoveryConfigMaker{
-		walgBinaryPath:     walgBinaryPath,
-		cfgPath:            cfgPath,
-		recoveryTargetName: recoveryTargetName,
+		walgBinaryPath:           walgBinaryPath,
+		cfgPath:                  cfgPath,
+		recoveryTargetName:       recoveryTargetName,
+		shutdownOnRecoveryTarget: shutdownOnRecoveryTarget,
 	}
 }
 
 type RecoveryConfigMaker struct {
-	walgBinaryPath     string
-	cfgPath            string
-	recoveryTargetName string
+	walgBinaryPath           string
+	cfgPath                  string
+	recoveryTargetName       string
+	shutdownOnRecoveryTarget bool
 }
 
 func (m RecoveryConfigMaker) Make(contentID int, pgVersion int) string {
@@ -28,7 +31,11 @@ func (m RecoveryConfigMaker) Make(contentID int, pgVersion int) string {
 	)
 
 	if pgVersion >= 120000 {
-		lines = append(lines, "recovery_target_action = 'promote'")
+		if m.shutdownOnRecoveryTarget {
+			lines = append(lines, "recovery_target_action = 'shutdown'")
+		} else {
+			lines = append(lines, "recovery_target_action = 'promote'")
+		}
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/databases/greenplum/recovery_cfg_maker_test.go
+++ b/internal/databases/greenplum/recovery_cfg_maker_test.go
@@ -8,16 +8,31 @@ import (
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 )
 
+const (
+	walgPath           = "/usr/bin/wal-g"
+	cfgPath            = "/etc/wal-g/wal-g.yaml"
+	recoveryTargetName = "some_backup"
+)
+
 func TestGenerateRecoveryConf(t *testing.T) {
-	walgPath := "/usr/bin/wal-g"
-	cfgPath := "/etc/wal-g/wal-g.yaml"
-	recoveryTargetName := "some_backup"
-	recCfgMaker := greenplum.NewRecoveryConfigMaker(walgPath, cfgPath, recoveryTargetName)
+	recCfgMaker := greenplum.NewRecoveryConfigMaker(walgPath, cfgPath, recoveryTargetName, false)
 	contentID := -1
 
 	expectedCfg := `restore_command = '/usr/bin/wal-g seg wal-fetch "%f" "%p" --content-id=-1 --config /etc/wal-g/wal-g.yaml'
 recovery_target_name = 'some_backup'
 recovery_target_timeline = latest`
 	actualCfg := recCfgMaker.Make(contentID, 90400)
+	assert.Equal(t, expectedCfg, actualCfg, "Actual recovery.conf does not match the expected one")
+}
+
+func TestGenerateRecoveryConfWithShutdown(t *testing.T) {
+	recCfgMaker := greenplum.NewRecoveryConfigMaker(walgPath, cfgPath, recoveryTargetName, true)
+	contentID := -1
+
+	expectedCfg := `restore_command = '/usr/bin/wal-g seg wal-fetch "%f" "%p" --content-id=-1 --config /etc/wal-g/wal-g.yaml'
+recovery_target_name = 'some_backup'
+recovery_target_timeline = latest
+recovery_target_action = 'shutdown'`
+	actualCfg := recCfgMaker.Make(contentID, 120000)
 	assert.Equal(t, expectedCfg, actualCfg, "Actual recovery.conf does not match the expected one")
 }

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -3,6 +3,7 @@ package greenplum
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"os"
 	"sort"
 	"strings"
@@ -150,12 +151,41 @@ func createRestorePoint(conn *pgx.Conn, restorePointName string) (restoreLSNs ma
 	tracelog.InfoLogger.Printf("Creating restore point with name %s", restorePointName)
 	queryRunner, err := NewGpQueryRunner(conn)
 	if err != nil {
-		return
+		return nil, err
 	}
 	restoreLSNs, err = queryRunner.CreateGreenplumRestorePoint(restorePointName)
 	if err != nil {
 		return nil, err
 	}
+
+	globalCluster, gpVersion, _, err := getGpClusterInfo(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	// After create restore point should archive related WAL log segments.
+	// This ensures the new cluster can retrieve complete WAL logs with the restore point for restoration.
+	tracelog.InfoLogger.Println("Switch xlog on cluster")
+	remoteOutput := globalCluster.GenerateAndExecuteCommand("Running wal-g", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER,
+		func(contentID int) string {
+			seg, ok := globalCluster.ByContent[contentID]
+			if ok {
+				var pgOptions, switchFunction string
+				if gpVersion.Flavor == Greenplum && gpVersion.Major == 6 {
+					pgOptions = "-c gp_session_role=utility"
+					switchFunction = "pg_switch_xlog()"
+				} else {
+					pgOptions = "-c gp_role=utility"
+					switchFunction = "pg_switch_wal()"
+				}
+				return fmt.Sprintf("PGOPTIONS='%s' psql -p %d -d postgres -c 'select %s;'", pgOptions, seg[0].Port, switchFunction)
+			}
+			return ""
+		})
+	globalCluster.CheckClusterError(remoteOutput, "Unable to switch xlog on cluster", func(contentID int) string {
+		return "Unable to switch xlog on cluster"
+	}, true)
+
 	return restoreLSNs, nil
 }
 


### PR DESCRIPTION
### Database name
greenplum / cloudberrry

# Pull request description

### Describe what this PR fixes
When using wal-g to restore to a specific restore point, the recovery_target_action is defaulted to promote, which causes the database to start a new timeline after successful startup. This prevents reapplying restore points with later timestamps. This PR adds two commands to address this issue.

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
