### PR TITLE
DIRECT-IO Reader for PostgreSQL

### DIFF
--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -23,6 +23,10 @@ To configure how many goroutines to use during ```backup-fetch``` and ```wal-fet
 
 To configure how many times failed file will be retried during ```backup-fetch``` and ```wal-fetch```, use `WALG_DOWNLOAD_FILE_RETRIES`. By default is set to 15.
 
+* `WALG_DIRECT_IO`
+
+An experimental feature that allows you to perform direct_io reads during a ```backup-push``` without flushing the disk cache. To activate it, set the value of the environment variable to `true`.
+
 * `WALG_PREFETCH_DIR`
 
 By default WAL prefetch is storing prefetched data in pg_wal directory. This ensures that WAL can be easily moved from prefetch location to actual WAL consumption directory. But it may have negative consequences if you use it with pg_rewind in PostgreSQL 13.

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/google/brotli/go/cbrotli v0.0.0-20220110100810-f4153a09f87c
 	github.com/klauspost/compress v1.17.8
 	github.com/mongodb/mongo-tools v0.0.0-20240724183527-6d4f001be3fc
+	github.com/ncw/directio v1.0.5
 	github.com/ncw/swift/v2 v2.0.2
 	github.com/pkg/profile v1.6.0
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae h1:VeRdUYdCw49yizlSbM
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/ncw/directio v1.0.5 h1:JSUBhdjEvVaJvOoyPAbcW0fnd0tvRXD76wEfZ1KcQz4=
+github.com/ncw/directio v1.0.5/go.mod h1:rX/pKEYkOXBGOggmcyJeJGloCkleSvphPx2eV3t6ROk=
 github.com/ncw/swift/v2 v2.0.2 h1:jx282pcAKFhmoZBSdMcCRFn9VWkoBIRsCpe+yZq7vEk=
 github.com/ncw/swift/v2 v2.0.2/go.mod h1:z0A9RVdYPjNjXVo2pDOPxZ4eu3oarO1P91fTItcb+Kg=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal/logging"
 	"github.com/wal-g/wal-g/internal/webserver"
 )
@@ -77,6 +78,7 @@ const (
 	PgpEnvelopeYcSaKeyFileSetting = "WALG_ENVELOPE_PGP_YC_SERVICE_ACCOUNT_KEY_FILE"
 	PgpEnvelopeYcEndpointSetting  = "WALG_ENVELOPE_PGP_YC_ENDPOINT"
 	PgpEnvelopeCacheExpiration    = "WALG_ENVELOPE_CACHE_EXPIRATION"
+	DirectIO                      = "WALG_DIRECT_IO"
 
 	PgDataSetting                        = "PGDATA"
 	UserSetting                          = "USER" // TODO : do something with it
@@ -271,6 +273,7 @@ var (
 		FailoverStoragesCheckTimeout: "30s",
 		FailoverStorageCacheLifetime: "15m",
 		PgpEnvelopeCacheExpiration:   "0",
+		DirectIO:                     "false",
 		LogLevelSetting:              "NORMAL",
 	}
 
@@ -367,6 +370,7 @@ var (
 		PgpEnvelopeYcKmsKeyIDSetting:  true,
 		PgpEnvelopeYcSaKeyFileSetting: true,
 		PgpEnvelopeYcEndpointSetting:  true,
+		DirectIO:                      false,
 		LibsodiumKeySetting:           true,
 		LibsodiumKeyPathSetting:       true,
 		LibsodiumKeyTransform:         true,

--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -22,7 +22,9 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
+	"github.com/wal-g/wal-g/internal/fsutil"
 	"github.com/wal-g/wal-g/internal/ioextensions"
 	"github.com/wal-g/wal-g/internal/limiters"
 	"github.com/wal-g/wal-g/internal/walparser"
@@ -137,7 +139,7 @@ func ReadIncrementalFile(filePath string,
 	fileSize int64,
 	lsn LSN,
 	deltaBitmap *roaring.Bitmap) (fileReader io.ReadCloser, size int64, err error) {
-	file, err := os.Open(filePath)
+	file, err := fsutil.NewDirectIOReadSeekCloserReadOnly(filePath)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -139,7 +139,7 @@ func ReadIncrementalFile(filePath string,
 	fileSize int64,
 	lsn LSN,
 	deltaBitmap *roaring.Bitmap) (fileReader io.ReadCloser, size int64, err error) {
-	file, err := fsutil.NewDirectIOReadSeekCloserReadOnly(filePath)
+	file, err := fsutil.OpenReadOnlyMayBeDirectIO(filePath)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/fsutil/direct_io_reader.go
+++ b/internal/fsutil/direct_io_reader.go
@@ -1,0 +1,95 @@
+package fsutil
+
+import (
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"syscall"
+
+	"github.com/ncw/directio"
+)
+
+const directIOBlockCount = 32
+
+type reader struct {
+	mu           *sync.Mutex
+	fd           *os.File
+	buff         []byte
+	buffOffset   int
+	alignedBlock []byte
+}
+
+// NewDirectIOReadSeekCloserReadOnly returns read-only io.ReadSeekCloser.
+func NewDirectIOReadSeekCloserReadOnly(path string) (io.ReadSeekCloser, error) {
+	return NewDirectIOReadSeekCloser(path, syscall.O_RDONLY, 0)
+}
+
+// NewDirectIOReadSeekCloser returns io.ReadSeekCloser.
+func NewDirectIOReadSeekCloser(path string, flag int, perm os.FileMode) (io.ReadSeekCloser, error) {
+	in, errOpen := directio.OpenFile(path, flag, perm)
+	if errOpen != nil {
+		return nil, errOpen
+	}
+	return &reader{
+		mu:           &sync.Mutex{},
+		fd:           in,
+		buff:         nil,
+		alignedBlock: directio.AlignedBlock(directIOBlockCount * directio.BlockSize),
+	}, nil
+}
+
+func (r *reader) readBuff() error {
+	if n, err := io.ReadFull(r.fd, r.alignedBlock); err != nil {
+		r.buff = append(r.buff[r.buffOffset:], r.alignedBlock[0:n]...)
+		r.buffOffset = 0
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			err = io.EOF
+		}
+		return err
+	}
+	r.buff = append(r.buff[r.buffOffset:], r.alignedBlock...)
+	r.buffOffset = 0
+	return nil
+}
+
+func (r *reader) copyBuff(p []byte) int {
+	n := copy(p, r.buff[r.buffOffset:])
+	r.buffOffset += n
+	return n
+}
+
+func (r *reader) Seek(offset int64, whence int) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buffOffset = 0
+	r.buff = nil
+	r.alignedBlock = make([]byte, len(r.alignedBlock))
+	return r.fd.Seek(offset, whence)
+}
+
+func (r *reader) Read(p []byte) (n int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for {
+		if len(r.buff)-r.buffOffset >= len(p) {
+			break
+		}
+		if errRead := r.readBuff(); errRead != nil {
+			if errors.Is(io.EOF, errRead) {
+				if len(p) > len(r.buff)-r.buffOffset {
+					n = copy(p, r.buff[r.buffOffset:])
+					r.buff = nil
+					return n, errRead
+				}
+				return r.copyBuff(p), nil
+			}
+			return 0, errRead
+		}
+	}
+	return r.copyBuff(p), nil
+}
+
+func (r *reader) Close() error {
+	return r.fd.Close()
+}

--- a/internal/fsutil/direct_io_reader.go
+++ b/internal/fsutil/direct_io_reader.go
@@ -8,6 +8,9 @@ import (
 	"syscall"
 
 	"github.com/ncw/directio"
+	"github.com/spf13/viper"
+
+	conf "github.com/wal-g/wal-g/internal/config"
 )
 
 const directIOBlockCount = 32
@@ -20,9 +23,12 @@ type reader struct {
 	alignedBlock []byte
 }
 
-// NewDirectIOReadSeekCloserReadOnly returns read-only io.ReadSeekCloser.
-func NewDirectIOReadSeekCloserReadOnly(path string) (io.ReadSeekCloser, error) {
-	return NewDirectIOReadSeekCloser(path, syscall.O_RDONLY, 0)
+// OpenReadOnlyMayBeDirectIO returns read-only io.ReadSeekCloser.
+func OpenReadOnlyMayBeDirectIO(path string) (io.ReadSeekCloser, error) {
+	if viper.GetBool(conf.DirectIO) {
+		return NewDirectIOReadSeekCloser(path, syscall.O_RDONLY, 0)
+	}
+	return os.OpenFile(path, os.O_RDONLY, 0)
 }
 
 // NewDirectIOReadSeekCloser returns io.ReadSeekCloser.

--- a/internal/fsutil/direct_io_reader.go
+++ b/internal/fsutil/direct_io_reader.go
@@ -70,7 +70,7 @@ func (r *reader) Seek(offset int64, whence int) (int64, error) {
 	defer r.mu.Unlock()
 	r.buffOffset = 0
 	r.buff = nil
-	r.alignedBlock = make([]byte, len(r.alignedBlock))
+	r.alignedBlock = directio.AlignedBlock(directIOBlockCount * directio.BlockSize)
 	return r.fd.Seek(offset, whence)
 }
 

--- a/internal/fsutil/direct_io_reader.go
+++ b/internal/fsutil/direct_io_reader.go
@@ -77,12 +77,9 @@ func (r *reader) Seek(offset int64, whence int) (int64, error) {
 func (r *reader) Read(p []byte) (n int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for {
-		if len(r.buff)-r.buffOffset >= len(p) {
-			break
-		}
+	for len(p) > len(r.buff)-r.buffOffset {
 		if errRead := r.readBuff(); errRead != nil {
-			if errors.Is(io.EOF, errRead) {
+			if errors.Is(errRead, io.EOF) {
 				if len(p) > len(r.buff)-r.buffOffset {
 					n = copy(p, r.buff[r.buffOffset:])
 					r.buff = nil

--- a/internal/fsutil/direct_io_reader_test.go
+++ b/internal/fsutil/direct_io_reader_test.go
@@ -27,10 +27,10 @@ func Test_NewDirectIOReadSeekCloser(t *testing.T) {
 		t.Run(fmt.Sprintf("run with file size: %d (seek 0)", testCaseSize), func(t *testing.T) {
 			directNewDirectIOReadSeekCloser(t, testCaseSize, 0)
 		})
-		for _, testCaseSeek := range []int64{0, 1, 8 * 1024} {
+		for _, testCaseSeek := range []int64{0, 8 * 1024, 3 * 8 * 1024, 5 * 8 * 1024} {
 			if testCaseSize > testCaseSeek {
 				t.Run(fmt.Sprintf("run with file size: %d (seek %d)", testCaseSize, testCaseSeek), func(t *testing.T) {
-					directNewDirectIOReadSeekCloser(t, testCaseSize, 0)
+					directNewDirectIOReadSeekCloser(t, testCaseSize, testCaseSeek)
 				})
 			}
 		}

--- a/internal/fsutil/direct_io_reader_test.go
+++ b/internal/fsutil/direct_io_reader_test.go
@@ -27,7 +27,7 @@ func Test_NewDirectIOReadSeekCloser(t *testing.T) {
 		t.Run(fmt.Sprintf("run with file size: %d (seek 0)", testCaseSize), func(t *testing.T) {
 			directNewDirectIOReadSeekCloser(t, testCaseSize, 0)
 		})
-		for _, testCaseSeek := range []int64{0, 8 * 1024, 3 * 8 * 1024, 5 * 8 * 1024} {
+		for _, testCaseSeek := range []int64{0, 1, 8 * 1024} {
 			if testCaseSize > testCaseSeek {
 				t.Run(fmt.Sprintf("run with file size: %d (seek %d)", testCaseSize, testCaseSeek), func(t *testing.T) {
 					directNewDirectIOReadSeekCloser(t, testCaseSize, testCaseSeek)

--- a/internal/fsutil/direct_io_reader_test.go
+++ b/internal/fsutil/direct_io_reader_test.go
@@ -1,0 +1,64 @@
+package fsutil_test
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/ncw/directio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wal-g/wal-g/internal/fsutil"
+)
+
+func Test_NewDirectIOReadSeekCloser(t *testing.T) {
+	for _, testCase := range []int64{
+		0,
+		8*1024*1024 - 1,
+		directio.BlockSize,
+		32 * directio.BlockSize,
+		32*directio.BlockSize + 1,
+	} {
+		t.Run(fmt.Sprintf("run with file size: %d", testCase), func(t *testing.T) {
+			directNewDirectIOReadSeekCloser(t, testCase)
+		})
+	}
+}
+
+func directNewDirectIOReadSeekCloser(t *testing.T, fileSize int64) {
+	fd, errFD := os.CreateTemp(os.TempDir(), "directio_read_seek_closer")
+	require.NoError(t, errFD)
+	defer fd.Close()
+	{ // write random
+		buf := make([]byte, fileSize)
+		size, errRand := rand.Read(buf)
+		require.NoError(t, errRand)
+		assert.Equal(t, len(buf), size)
+		for {
+			n, err := fd.Write(buf)
+			assert.NoError(t, err)
+			if n == len(buf) {
+				break
+			}
+			buf = buf[:size]
+		}
+	}
+	ioFD, errIOFD := os.Open(fd.Name())
+	require.NoError(t, errIOFD)
+	defer ioFD.Close()
+	directIOReadSeekCloser, errDirectIOFD := fsutil.NewDirectIOReadSeekCloserReadOnly(fd.Name())
+	require.NoError(t, errDirectIOFD)
+	defer directIOReadSeekCloser.Close()
+	assert.Equal(t, getSHA256(t, ioFD), getSHA256(t, directIOReadSeekCloser))
+}
+
+func getSHA256(t *testing.T, r io.ReadCloser) string {
+	h := sha256.New()
+	_, err := io.Copy(h, r)
+	require.NoError(t, err)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/internal/fsutil/disk_data_folder.go
+++ b/internal/fsutil/disk_data_folder.go
@@ -24,7 +24,7 @@ func ExistingDiskDataFolder(folderPath string) (*DiskDataFolder, error) {
 
 func (folder *DiskDataFolder) OpenReadonlyFile(filename string) (io.ReadCloser, error) {
 	filePath := filepath.Join(folder.Path, filename)
-	file, err := os.Open(filePath)
+	file, err := NewDirectIOReadSeekCloserReadOnly(filePath)
 	if err != nil && os.IsNotExist(err) {
 		return file, NewNoSuchFileError(filename)
 	}

--- a/internal/fsutil/disk_data_folder.go
+++ b/internal/fsutil/disk_data_folder.go
@@ -24,7 +24,7 @@ func ExistingDiskDataFolder(folderPath string) (*DiskDataFolder, error) {
 
 func (folder *DiskDataFolder) OpenReadonlyFile(filename string) (io.ReadCloser, error) {
 	filePath := filepath.Join(folder.Path, filename)
-	file, err := NewDirectIOReadSeekCloserReadOnly(filePath)
+	file, err := OpenReadOnlyMayBeDirectIO(filePath)
 	if err != nil && os.IsNotExist(err) {
 		return file, NewNoSuchFileError(filename)
 	}

--- a/internal/tar_ball_file_packer.go
+++ b/internal/tar_ball_file_packer.go
@@ -78,7 +78,7 @@ func (p *RegularTarBallFilePacker) PackFileIntoTar(cfi *ComposeFileInfo, tarBall
 // TODO : unit tests
 func StartReadingFile(fileInfoHeader *tar.Header, info os.FileInfo, path string) (io.ReadSeekCloser, error) {
 	fileInfoHeader.Size = info.Size()
-	file, err := fsutil.NewDirectIOReadSeekCloserReadOnly(path)
+	file, err := fsutil.OpenReadOnlyMayBeDirectIO(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, NewFileNotExistError(path)

--- a/internal/tar_ball_file_packer.go
+++ b/internal/tar_ball_file_packer.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+
+	"github.com/wal-g/wal-g/internal/fsutil"
 	"github.com/wal-g/wal-g/internal/ioextensions"
 	"github.com/wal-g/wal-g/internal/limiters"
 	"github.com/wal-g/wal-g/utility"
@@ -76,7 +78,7 @@ func (p *RegularTarBallFilePacker) PackFileIntoTar(cfi *ComposeFileInfo, tarBall
 // TODO : unit tests
 func StartReadingFile(fileInfoHeader *tar.Header, info os.FileInfo, path string) (io.ReadSeekCloser, error) {
 	fileInfoHeader.Size = info.Size()
-	file, err := os.Open(path)
+	file, err := fsutil.NewDirectIOReadSeekCloserReadOnly(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, NewFileNotExistError(path)

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -159,6 +159,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=


### PR DESCRIPTION
### Database name

PostgreSQL

# Pull request description

### Describe what this PR fixes

Problem is disk-cache flushing when using wal-g push-backup, this PR solves the problem.

Without patch:
![CleanShot 2025-06-05 at 18 35 34@2x](https://github.com/user-attachments/assets/68b89c28-128d-43b8-b3c1-ba4262a2035c)

With patch:
![CleanShot 2025-06-05 at 18 36 49@2x](https://github.com/user-attachments/assets/01f3856f-5305-49bb-9aba-6e490b197ca1)


