### PR TITLE
Use Greenplum database directory from config

### DIFF
--- a/cmd/gp/check_ao_length_segment.go
+++ b/cmd/gp/check_ao_length_segment.go
@@ -2,8 +2,10 @@ package gp
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"
 )
@@ -21,7 +23,8 @@ var checkAOLengthSegmentCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		rootFolder, err := getMultistorageRootFolder(false, policies.UniteAllStorages)
 		tracelog.ErrorLogger.FatalOnError(err)
-		handler, err := greenplum.NewAOLengthCheckSegmentHandler(port, segnum, rootFolder)
+		dbDir := viper.GetString(conf.GPDatabaseDir)
+		handler, err := greenplum.NewAOLengthCheckSegmentHandler(port, segnum, rootFolder, dbDir)
 		tracelog.ErrorLogger.FatalOnError(err)
 		if checkBackup {
 			handler.CheckAOBackupLengthSegment(backupName)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,6 +190,7 @@ const (
 	GPAoDeduplicationAgeLimit    = "WALG_GP_AOSEG_DEDUPLICATION_AGE_LIMIT"
 	GPRelativeRecoveryConfPath   = "WALG_GP_RELATIVE_RECOVERY_CONF_PATH"
 	GPRelativePostgresqlConfPath = "WALG_GP_RELATIVE_POSTGRESQL_CONF_PATH"
+	GPDatabaseDir                = "WALG_GP_DATABASE_DIR"
 
 	ETCDMemberDataDirectory = "WALG_ETCD_DATA_DIR"
 	ETCDWalDirectory        = "WALG_ETCD_WAL_DIR"
@@ -340,6 +341,7 @@ var (
 		GPRelativePostgresqlConfPath: "postgresql.conf",
 		ForceWalDetal:                "false",
 		PgAppName:                    "wal-g",
+		GPDatabaseDir:                "/var/lib/greenplum/data1",
 	}
 
 	AllowedSettings map[string]bool
@@ -610,6 +612,7 @@ var (
 		FailoverStoragesCheckSize:            true,
 		DisablePartialRestore:                true,
 		ForceWalDetal:                        true,
+		GPDatabaseDir:                        true,
 	}
 
 	RequiredSettings       = make(map[string]bool)


### PR DESCRIPTION
### Database name
Greenplum

# Pull request description
Added an option to change default hard-coded Greenplum database path via config using `WALG_GP_DATABASE_DIR` option.

### Describe what this PR fixes
This PR fixes #1888 
