### PR TITLE
Add `HandleDetailedBackupList` table output unit-tests

### DIFF
--- a/internal/databases/greenplum/backup_list_handler.go
+++ b/internal/databases/greenplum/backup_list_handler.go
@@ -69,7 +69,7 @@ func (bd *BackupDetail) PrintableFields() []printlist.TableField {
 	return []printlist.TableField{
 		{
 			Name:       "name",
-			PrettyName: "Name time",
+			PrettyName: "Name",
 			Value:      bd.Name,
 		},
 		{
@@ -144,7 +144,6 @@ func MakeBackupDetails(backups []Backup) []BackupDetail {
 	return details
 }
 
-// TODO: unit tests (table output)
 func HandleDetailedBackupList(folder storage.Folder, pretty, json bool) {
 	backups, err := ListStorageBackups(folder)
 	err = internal.FilterOutNoBackupFoundError(err, json)


### PR DESCRIPTION
### Database name
Greenplum

# Pull request description
Add table output unit-tests for `HandleDetailedBackupList`.

### Describe what this PR fixes
The name of the `name` column in pretty table mode was in fact `NAME TIME`. Now it is just `NAME`.