### PR TITLE
Fix WALG_FAILOVER_STORAGES_CHECK unknown setting warning

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -504,6 +504,7 @@ var (
 		PgAliveCheckInterval:                 true,
 		PgStopBackupTimeout:                  true,
 		FailoverStorages:                     true,
+		FailoverStoragesCheck:                true,
 		FailoverStoragesCheckTimeout:         true,
 		FailoverStorageCacheLifetime:         true,
 		FailoverStorageCacheEMAAliveLimit:    true,


### PR DESCRIPTION
### Database name

PostgreSQL

# Pull request description

Fix the following warning if WALG_FAILOVER_STORAGES_CHECK is set:

```
WARNING: We found that some variables in your config file detected as 'Unknown'.
```

### Describe what this PR fixes

```
walg-pg[2707000]: WARNING: 2025/07/11 11:42:00.292212 WALG_FAILOVER_STORAGES_CHECK is unknown
walg-pg[2707000]: WARNING: 2025/07/11 11:42:00.292497 We found that some variables in your config file detected as 'Unknown'.
```

### Please provide steps to reproduce (if it's a bug)
add WALG_FAILOVER_STORAGES_CHECK=false to .walg.json
