### PR TITLE
Update go version to 1.24

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -16,7 +16,7 @@ env:
   IMAGE: wal-g/docker_prefix
   IMAGE_GOLANG: wal-g/golang
   IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   LIBSODIUM_VERSION: "1.0.20"
 
 jobs:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
 
 jobs:
   golangci:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*' # Push events to matching v*, i.e. v0.2.19, v0.2.14a
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   USE_BROTLI: 1
   USE_LIBSODIUM: 1
   USE_LZO: 1

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   USE_BROTLI: 1
 
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.22"
+  go: "1.24"
   modules-download-mode: readonly
 linters:
   default: none

--- a/docker/golang/Dockerfile
+++ b/docker/golang/Dockerfile
@@ -1,8 +1,6 @@
-FROM debian:buster
+FROM ubuntu:bionic
 
-# Note: we used `golang:buster` here... however it provides go 1.20.x, while we upgraded to 1.22+
-# Migration to `golang:bullseye` doesn't work - it incompatible with ubuntu 18.04 (GLIBC version issues).
-# So, install it manually:
+# custom golang image with CMake and Brotli support (compatible with ubuntu 18.04..22.04)
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm-256color
@@ -14,7 +12,7 @@ RUN apt-get update && \
         net-tools dnsutils \
         wget
 
-RUN wget -O - "https://go.dev/dl/go1.23.8.linux-amd64.tar.gz" | tar -C /usr/local -xz && \
+RUN wget -O - "https://go.dev/dl/go1.24.5.linux-amd64.tar.gz" | tar -C /usr/local -xz && \
 	export PATH="/usr/local/go/bin:$PATH" && \
 	go version
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/wal-g/wal-g
 
-go 1.23.0
+go 1.24
 
-toolchain go1.24.2
+toolchain go1.24.5
 
 require (
 	cloud.google.com/go/storage v1.10.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaegertracing/jaeger-clickhouse/internal/tools
 
-go 1.22
+go 1.24
 
 require (
 	github.com/golangci/golangci-lint v1.41.1

--- a/tests_func/images/base/Dockerfile
+++ b/tests_func/images/base/Dockerfile
@@ -1,9 +1,5 @@
 # vim:set ft=dockerfile:
-FROM debian:buster
-
-# Note: we used `golang:buster` here... however it provides go 1.20.x, while we upgraded to 1.22+
-# Migration to `golang:bullseye` doesn't work - it incompatible with ubuntu 18.04 (GLIBC version issues).
-# So, install it manually:
+FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm-256color
@@ -14,7 +10,7 @@ RUN apt-get update -q && \
     cmake build-essential wget ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -O - "https://go.dev/dl/go1.23.8.linux-amd64.tar.gz" | tar -C /usr/local -xz && \
+RUN wget -O - "https://go.dev/dl/go1.24.5.linux-amd64.tar.gz" | tar -C /usr/local -xz && \
 	export PATH="/usr/local/go/bin:$PATH" && \
 	go version
 


### PR DESCRIPTION
* Update golang to 1.24
* Use ubuntu 18.04 as base golang image instead of debian one. `debian:buster` reached end of life year ago, and now repositories are nor available anymore