### PR TITLE
fix: remove warning when alicloud oss valid configurations are present

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -467,6 +467,12 @@ var (
 		AlicloudAccessKeyID:     true,
 		AlicloudAccessKeySecret: true,
 		AlicloudSecurityToken:   true,
+		"OSS_ENDPOINT":          true,
+		"OSS_REGION":            true,
+		"OSS_ROLE_ARN":          true,
+		"OSS_ROLE_SESSION_NAME": true,
+		"OSS_MAX_RETRIES":       true,
+		"OSS_CONNECT_TIMEOUT":   true,
 
 		// Yandex Cloud
 		YcSaKeyFileSetting: true,


### PR DESCRIPTION
### Database name
Alicloud OSS storage implementation

# Pull request description

### Describe what this PR fixes

Received a warning saying that `OSS_ENDPOINT` env var is unknown when it is present. This should not show warning since it is a valid config.

### Please provide steps to reproduce (if it's a bug)
Use this configuration and run `wal-g st ls`
```
OSS_ACCESS_KEY_ID=
OSS_ACCESS_KEY_SECRET=
OSS_REGION=ap-southeast-5
OSS_ENDPOINT=https://oss-ap-southeast-5-internal.aliyuncs.com
WALG_OSS_PREFIX=oss://bucket/path/to/file
```

### Please add config and wal-g stdout/stderr logs for debug purpose

```bash
WARNING: 2025/07/22 22:28:20.849314 OSS_ENDPOINT is unknown
WARNING: 2025/07/22 22:28:20.849406 We found that some variables in your config file detected as 'Unknown'.
  If this is not right, please create issue https://github.com/wal-g/wal-g/issues/new
```
