### PR TITLE
Fix greenplum_path.sh usage for Cloudberry

### DIFF
--- a/docker/cloudberry/Dockerfile
+++ b/docker/cloudberry/Dockerfile
@@ -89,7 +89,7 @@ RUN locale-gen en_US.utf8 \
  && chown gpadmin:gpadmin /home/gpadmin/run_greenplum.sh \
  && chmod a+x /home/gpadmin/run_greenplum.sh \
  && echo "export MASTER_DATA_DIRECTORY=/usr/local/gpdb_src/gpAux/gpdemo/datadirs/qddir/demoDataDir-1" > /home/gpadmin/.bash_profile \
- && echo "source /usr/local/gpdb_src/greenplum_path.sh" > /home/gpadmin/.bash_profile \
+ && echo "source /usr/local/gpdb_src/cloudberry-env.sh" > /home/gpadmin/.bash_profile \
  && chown gpadmin:gpadmin /home/gpadmin/.bash_profile \
  && echo "gpadmin ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
  && echo "root ALL=NOPASSWD: ALL" >> /etc/sudoers \

--- a/docker/cloudberry/run_greenplum.sh
+++ b/docker/cloudberry/run_greenplum.sh
@@ -4,7 +4,7 @@ set +ex
 
 sudo /etc/init.d/ssh start
 
-source /usr/local/gpdb_src/greenplum_path.sh
+source /usr/local/gpdb_src/cloudberry-env.sh
 
 cd /usr/local/gpdb_src
 

--- a/docker/cloudberry_tests/scripts/tests/test_functions/util.sh
+++ b/docker/cloudberry_tests/scripts/tests/test_functions/util.sh
@@ -30,7 +30,7 @@ insert_a_lot_of_data() {
 }
 
 bootstrap_gp_cluster() {
-  source /usr/local/gpdb_src/greenplum_path.sh
+  source /usr/local/gpdb_src/cloudberry-env.sh
   cd /usr/local/gpdb_src
   # FIXME: mirrors & standby?
   export WITH_STANDBY="false"
@@ -41,7 +41,7 @@ bootstrap_gp_cluster() {
 }
 
 cleanup() {
-  source /usr/local/gpdb_src/greenplum_path.sh
+  source /usr/local/gpdb_src/cloudberry-env.sh
   cd /usr/local/gpdb_src
   make destroy-demo-cluster
   pkill -9 postgres || true


### PR DESCRIPTION
### Cloudberry

Cloudberry replaced `greenplum_path.sh` to `cloudberry-env.sh` due to legal reasons:
https://github.com/apache/cloudberry/pull/1166

So, we should use correct scripts. Otherwise tests fails:
```
wal-g_cloudberry_tests  | + /home/gpadmin/run_greenplum.sh
wal-g_cloudberry_tests  |  * Starting OpenBSD Secure Shell server sshd
wal-g_cloudberry_tests  |    ...done.
wal-g_cloudberry_tests  | /home/gpadmin/run_greenplum.sh: line 7: /usr/local/gpdb_src/greenplum_path.sh: No such file or directory
wal-g_cloudberry_tests  | Error: unable to import module: No module named 'gppylib'
Aborting on container exit...
```