### PR TITLE
Fix GPDB/CBDB/etcd build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,8 @@ etcd_clean:
 
 # refactor
 etcd_integration_test: load_docker_common
-	docker compose build --with-dependencies etcd_tests
+	docker compose build etcd
+	docker compose build etcd_tests
 	docker compose up --exit-code-from etcd_tests etcd_tests
 
 gp_build: $(CMD_FILES) $(PKG_FILES)
@@ -245,7 +246,8 @@ gp_install: gp_build
 gp_test: deps gp_build unlink_brotli gp_integration_test
 
 gp_integration_test: load_docker_common
-	docker compose build --with-dependencies gp_tests
+	docker compose build gp
+	docker compose build gp_tests
 	docker compose up --exit-code-from gp_tests gp_tests
 
 cloudberry_build: gp_build
@@ -257,7 +259,8 @@ cloudberry_install: gp_install
 cloudberry_test: deps cloudberry_build unlink_brotli cloudberry_integration_test
 
 cloudberry_integration_test: load_docker_common
-	docker compose build --with-dependencies cloudberry_tests
+	docker compose build cloudberry
+	docker compose build cloudberry_tests
 	docker compose up s3 cloudberry_tests --force-recreate --exit-code-from cloudberry_tests
 
 st_test: deps pg_build unlink_brotli st_integration_test

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ etcd_clean:
 
 # refactor
 etcd_integration_test: load_docker_common
-	docker compose build etcd etcd_tests
+	docker compose build --with-dependencies etcd_tests
 	docker compose up --exit-code-from etcd_tests etcd_tests
 
 gp_build: $(CMD_FILES) $(PKG_FILES)
@@ -245,7 +245,7 @@ gp_install: gp_build
 gp_test: deps gp_build unlink_brotli gp_integration_test
 
 gp_integration_test: load_docker_common
-	docker compose build gp gp_tests
+	docker compose build --with-dependencies gp_tests
 	docker compose up --exit-code-from gp_tests gp_tests
 
 cloudberry_build: gp_build
@@ -257,7 +257,7 @@ cloudberry_install: gp_install
 cloudberry_test: deps cloudberry_build unlink_brotli cloudberry_integration_test
 
 cloudberry_integration_test: load_docker_common
-	docker compose build cloudberry cloudberry_tests
+	docker compose build --with-dependencies cloudberry_tests
 	docker compose up s3 cloudberry_tests --force-recreate --exit-code-from cloudberry_tests
 
 st_test: deps pg_build unlink_brotli st_integration_test

--- a/docker/cloudberry_tests/Dockerfile
+++ b/docker/cloudberry_tests/Dockerfile
@@ -11,6 +11,7 @@ COPY main/ main/
 COPY utility/ utility/
 COPY Makefile Makefile
 
+# we test wal-g logic, not our deps. So, no brotli in these tests.
 RUN cd main/gp && \
     go build -mod vendor -race -o wal-g -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
 

--- a/docker/gp/Dockerfile
+++ b/docker/gp/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 ADD docker/gp/run_greenplum.sh /home/gpadmin/run_greenplum.sh
 
 WORKDIR /usr/local
-RUN git clone https://github.com/yezzey-gp/ygp.git gpdb_src --single-branch --branch 6X_STABLE --depth 1 \
+RUN git clone https://github.com/open-gpdb/gpdb.git gpdb_src --single-branch --branch 6X_STABLE --depth 1 \
  && ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 
 WORKDIR /usr/local/gpdb_src

--- a/docker/gp_tests/Dockerfile
+++ b/docker/gp_tests/Dockerfile
@@ -10,13 +10,10 @@ COPY cmd/ cmd/
 COPY main/ main/
 COPY utility/ utility/
 COPY Makefile Makefile
-ENV USE_BROTLI 1
 
-RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
-        vendor/github.com/google/brotli/go/cbrotli/cgo.go
-
+# we test wal-g logic, not our deps. So, no brotli in these tests.
 RUN cd main/gp && \
-    go build -mod vendor -tags brotli -race -o wal-g -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+    go build -mod vendor -race -o wal-g -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
 
 FROM wal-g/gp:latest
 


### PR DESCRIPTION
For some reason, `docker compose` stopped tracking build dependencies between images. As a result it doesn't know about some local images. docker compose tried to fetch this images from dockerhub. That failed.

```
#5 [etcd_tests internal] load metadata for docker.io/wal-g/etcd:latest
#5 ERROR: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed

<...>

#8 [etcd internal] load metadata for docker.io/bitnami/etcd:3.5.21
#8 CANCELED
------
 > [etcd_tests internal] load metadata for docker.io/wal-g/etcd:latest:
------
Dockerfile:35
--------------------
  33 |     RUN make etcd_build
  34 |     
  35 | >>> FROM wal-g/etcd:latest
  36 |     COPY --from=build /go/src/github.com/wal-g/wal-g/main/etcd/wal-g /usr/bin
  37 |     
--------------------
target etcd_tests: failed to solve: wal-g/etcd:latest: failed to resolve source metadata for docker.io/wal-g/etcd:latest: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
make: *** [Makefile:232: etcd_integration_test] Error 1
```