### PR TITLE
Use cast to convert config values

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -953,7 +954,7 @@ func ToFlagName(s string) string {
 // Applicable for Swift/Postgres/etc libs that waiting config paramenters only from ENV.
 func bindConfigToEnv(globalViper *viper.Viper) {
 	for k, v := range globalViper.AllSettings() {
-		val := fmt.Sprint(v)
+		val := cast.ToString(v)
 		k = strings.ToUpper(k)
 
 		// avoid filling environment with empty values :


### PR DESCRIPTION
### Database name
Any

# Pull request description

### Describe what this PR fixes

The pull request solves the problem with converting some data types from the config to a string to set them in Env. In particular, we encountered a problem when using config.json and specifying the variable `WALG_TAR_SIZE_THRESHOLD` as an int. In the current version, viper will return this as a float, `fmt.Sprint` will convert it to the string `2.212e+10`, this string will be written to the environment variables and `viper.GetInt64("WALG_TAR_SIZE_THRESHOLD")` returned 0.
I don't usually write in GO, so I'll take any recommendations.


### Please provide steps to reproduce (if it's a bug)

```go
package main

import (
 "fmt"
 "os"
 "reflect"
 "strings"

 "github.com/spf13/cast"
 "github.com/spf13/viper"
)

func main() {
 gv := viper.GetViper()
 gv.SetConfigFile("config.json")

 gv.AutomaticEnv()
 gv.ReadInConfig()

 fmt.Println(viper.GetString("WALG_TAR_SIZE_THRESHOLD"))

 for k, v := range gv.AllSettings() {
  fmt.Println(reflect.TypeOf(v)) // float64
  // val := cast.ToString(v)
  val := fmt.Sprint(v)
  k = strings.ToUpper(k)
  fmt.Println(val)  // 2.212e+10
  os.Setenv(k, val)
 }

 fmt.Println(viper.GetInt64("WALG_TAR_SIZE_THRESHOLD"))  // Print 0
}


```

example **config.json**
```json
{
  "WALG_LOG_LEVEL": "DEVEL",
  "WALG_TAR_SIZE_THRESHOLD": 22120000000
}
```

### Please add config and wal-g stdout/stderr logs for debug purpose
<details><summary>COMPILED ENVIRONMENT VARS</summary>
<p>

```
DEBUG: 2025/08/07 12:51:30.067995 --- COMPILED ENVIRONMENT VARS ---
...
 WALG_TAR_SIZE_THRESHOLD=2.212e+10
...

```
</p>
</details>
