### PR TITLE
fix: HTTP-headers sent by S3 client

### DIFF
--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -19,8 +19,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/wal-g/tracelog"
-	"github.com/wal-g/wal-g/utility"
 	"gopkg.in/yaml.v3"
+
+	"github.com/wal-g/wal-g/utility"
 )
 
 func createSession(config *Config) (*session.Session, error) {
@@ -55,7 +56,7 @@ func createSession(config *Config) (*session.Session, error) {
 			sess.Config.WithCredentials(cred)
 			sess.Handlers.Send.PushFront(func(r *request.Request) {
 				token := r.HTTPRequest.Header.Get("X-Amz-Security-Token")
-				r.HTTPRequest.Header.Add("X-YaCloud-SubjectToken", token)
+				r.HTTPRequest.Header.Set("X-YaCloud-SubjectToken", token)
 			})
 		}
 	}
@@ -67,7 +68,6 @@ func createSession(config *Config) (*session.Session, error) {
 				tracelog.DebugLogger.Printf("using S3 endpoint %s", *endpoint)
 				host := strings.TrimPrefix(*sess.Config.Endpoint, "https://")
 				request.HTTPRequest.Host = host
-				request.HTTPRequest.Header.Add("Host", host)
 				request.HTTPRequest.URL.Host = *endpoint
 				request.HTTPRequest.URL.Scheme = "http"
 			} else {


### PR DESCRIPTION
### Greenplum

From time to time we are getting HTTP 403 SignatureDoesNotMatch error:
```
ERROR: 2025/08/05 05:04:22.053632 failed to upload 'wal-e/mydatabase/6/segments_005/seg12/basebackups_005/base_000000190000791300000002/tar_partitions/part_512.tar.br' to bucket 'mydatabase': MultipartUpload: upload multipart failed
        upload id: 000FFB97256FFFFF
caused by: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.
        status code: 403, request id: 8fda35753dffffff, host id:
ERROR: 2025/08/05 05:04:22.053655 Unable to continue the backup process because of the loss of a part 512.
ERROR: 2025/08/05 05:04:23.531918 command failed: exit status 1
```

signed request has duplicate host field (and missing expect):
> `expect:\nhost:S3FQDN.net\nhost:S3FQDN.net\n`

In this PR I am fixing `Host` header. It shouldn't be sent twice.