### PR TITLE
Check for pageHeader.isNew before pageHeader.isValid

### DIFF
--- a/internal/databases/postgres/paged_file_verifier.go
+++ b/internal/databases/postgres/paged_file_verifier.go
@@ -140,16 +140,17 @@ func isPageCorrupted(path string, blockNo uint32, page []byte) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	valid := pageHeader.isValid()
-	if !valid {
-		// If the pageHeader is not valid, there is no sense in proceeding with the page checking.
-		tracelog.WarningLogger.Printf("Invalid page header encountered: blockNo %d, path %s", blockNo, path)
-		return false, nil
-	}
 
 	// We only calculate the checksum for properly-initialized pages
 	isNew := pageHeader.isNew()
 	if isNew {
+		return false, nil
+	}
+
+	valid := pageHeader.isValid()
+	if !valid {
+		// If the pageHeader is not valid, there is no sense in proceeding with the page checking.
+		tracelog.WarningLogger.Printf("Invalid page header encountered: blockNo %d, path %s", blockNo, path)
 		return false, nil
 	}
 


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description

### Describe what this PR fixes

`pageHeader.isNew` will check for zeroed pages and skip them. However, `pageHeader.isValid` is called before. A zeroed page will fail `isValid` as checks like `header.pdLower > header.pdUpper` will always be false.

Thus, wal-g generates "Invalid page header encountered..." errors when encountering zeroed page. This patch moves the isNew check before the isValid to skip zeroed and not initialised pages and avoid generating a warning log.