### PR TITLE
Support the xid64 patch's page layout.

### DIFF
--- a/internal/databases/postgres/pagefile.go
+++ b/internal/databases/postgres/pagefile.go
@@ -40,7 +40,7 @@ const (
 	SignatureMagicNumber byte = 0x55
 	invalidLsn           LSN  = 0
 	validFlags                = 7
-	layoutVersion             = 4
+	layoutVersion             = 5 // We know WAL-G is compatibe with any page version that has LSN, including 64-bit xid patch version
 	headerSize                = 24
 
 	DefaultTablespace    = "base"

--- a/internal/databases/postgres/postgres_page_header.go
+++ b/internal/databases/postgres/postgres_page_header.go
@@ -29,7 +29,8 @@ func (header *PageHeader) isValid() bool {
 		header.pdUpper > header.pdSpecial ||
 		int64(header.pdSpecial) > DatabasePageSize ||
 		(header.lsn() == invalidLsn) ||
-		int64(header.pdPageSizeVersion) != DatabasePageSize+layoutVersion)
+		int64(header.pdPageSizeVersion&0xFF00) != DatabasePageSize ||
+		int64(header.pdPageSizeVersion&0xFF) > layoutVersion)
 }
 
 func (header *PageHeader) isNew() bool {


### PR DESCRIPTION
Nowadays, the xid64 patch is widely used by community and by commercial forks of Postgres, even despite the fact that the patch is not merged into the master. This commit implements support of the xid64 patch's page layout.