### PR TITLE
Deprecate MariaDB support

### DIFF
--- a/docs/MySQL.md
+++ b/docs/MySQL.md
@@ -1,8 +1,8 @@
 # WAL-G for MySQL
 
-**Interface of MySQL and MariaDB now is unstable**
-
 You can use wal-g as a tool for encrypting, compressing MySQL backups and push/fetch them to/from storage without saving it on your filesystem.
+
+**MariaDB support is deprecated**
 
 Configuration
 -------------
@@ -310,6 +310,8 @@ Restore procedure is straightforward:
 
 ### MariaDB - using with `mariabackup`
 
+**MariaDB support is deprecated**
+
 It's recommended to use wal-g with `mariabackup` tool in case of MariaDB for creating lock-less backups.
 Here's typical wal-g configuration for that case:
 ```bash
@@ -340,5 +342,7 @@ mysqlbinlog --stop-datetime="some point in time" --start-position [position abov
 ```
 
 ### MariaDB - using with `mysqldump`
+
+**MariaDB support is deprecated**
 
 The procedure is same as in case of [MySQL. You can follow the instructions from the previous section.](#mysql---using-with-mysqldump)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 [This documentation is also available at wal-g.readthedocs.io](https://wal-g.readthedocs.io)
 
-WAL-G is an archival restoration tool for PostgreSQL, MySQL/MariaDB, and MS SQL Server (beta for MongoDB and Redis).
+WAL-G is an archival restoration tool for PostgreSQL, MySQL, and MS SQL Server (beta for MongoDB and Redis).
 
 WAL-G is the successor of WAL-E with a number of key differences. WAL-G uses LZ4, LZMA, ZSTD, or Brotli compression, multiple processors, and non-exclusive base backups for Postgres. More information on the original design and implementation of WAL-G can be found on the Citus Data blog post ["Introducing WAL-G by Citus: Faster Disaster Recovery for Postgres"](https://www.citusdata.com/blog/2017/08/18/introducing-wal-g-faster-restores-for-postgres/).
 
@@ -255,7 +255,7 @@ Databases
 ### PostgreSQL
 [Information about installing, configuration and usage](PostgreSQL.md)
 
-### MySQL/MariaDB
+### MySQL
 [Information about installing, configuration and usage](MySQL.md)
 
 ### SQLServer


### PR DESCRIPTION
Unfortunately, wal-g for MariaDB had never reached production-ready state. It lack of maintainers with real production clusters.