### PR TITLE
Fix cloudberry test by pinning Cloudberry 2.0 as stable version we support

### DIFF
--- a/docker/cloudberry/Dockerfile
+++ b/docker/cloudberry/Dockerfile
@@ -74,7 +74,8 @@ WORKDIR /usr/local
 #RUN git clone https://github.com/arenadata/gpdb.git gpdb_src --single-branch --branch adb-7.2.0 --depth 1 \
 # && ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
 
-RUN git clone https://github.com/cloudberrydb/cloudberrydb.git gpdb_src --single-branch --branch main --depth 1
+# Use REL_2_STABLE as oldest-supported version of cloudberry
+RUN git clone https://github.com/cloudberrydb/cloudberrydb.git gpdb_src --single-branch --branch REL_2_STABLE --depth 1
 
 COPY docker/cloudberry/setup_gpadmin_user.bash /root/setup_gpadmin_user.bash
 RUN chmod +x /root/setup_gpadmin_user.bash \

--- a/docker/cloudberry/Dockerfile
+++ b/docker/cloudberry/Dockerfile
@@ -90,7 +90,7 @@ RUN locale-gen en_US.utf8 \
  && chown gpadmin:gpadmin /home/gpadmin/run_greenplum.sh \
  && chmod a+x /home/gpadmin/run_greenplum.sh \
  && echo "export MASTER_DATA_DIRECTORY=/usr/local/gpdb_src/gpAux/gpdemo/datadirs/qddir/demoDataDir-1" > /home/gpadmin/.bash_profile \
- && echo "source /usr/local/gpdb_src/cloudberry-env.sh" > /home/gpadmin/.bash_profile \
+ && echo "source /usr/local/gpdb_src/greenplum_path.sh || source /usr/local/gpdb_src/cloudberry-env.sh" >> /home/gpadmin/.bash_profile \
  && chown gpadmin:gpadmin /home/gpadmin/.bash_profile \
  && echo "gpadmin ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
  && echo "root ALL=NOPASSWD: ALL" >> /etc/sudoers \

--- a/docker/cloudberry/run_greenplum.sh
+++ b/docker/cloudberry/run_greenplum.sh
@@ -4,7 +4,7 @@ set +ex
 
 sudo /etc/init.d/ssh start
 
-source /usr/local/gpdb_src/cloudberry-env.sh
+source /usr/local/gpdb_src/greenplum_path.sh || source /usr/local/gpdb_src/cloudberry-env.sh
 
 cd /usr/local/gpdb_src
 

--- a/docker/cloudberry_tests/scripts/tests/test_functions/util.sh
+++ b/docker/cloudberry_tests/scripts/tests/test_functions/util.sh
@@ -30,7 +30,7 @@ insert_a_lot_of_data() {
 }
 
 bootstrap_gp_cluster() {
-  source /usr/local/gpdb_src/cloudberry-env.sh
+  source /usr/local/gpdb_src/greenplum_path.sh || source /usr/local/gpdb_src/cloudberry-env.sh
   cd /usr/local/gpdb_src
   # FIXME: mirrors & standby?
   export WITH_STANDBY="false"
@@ -41,7 +41,7 @@ bootstrap_gp_cluster() {
 }
 
 cleanup() {
-  source /usr/local/gpdb_src/cloudberry-env.sh
+  source /usr/local/gpdb_src/greenplum_path.sh || source /usr/local/gpdb_src/cloudberry-env.sh
   cd /usr/local/gpdb_src
   make destroy-demo-cluster
   pkill -9 postgres || true


### PR DESCRIPTION
Cloudberry `main` branch quite volatile. Use v2.0 as stable version we support. Expect that all newer Cloudberry releases compatible with 2.0.