### PR TITLE
add flag to count journal info

### DIFF
--- a/internal/databases/mongo/backup_delete_handler.go
+++ b/internal/databases/mongo/backup_delete_handler.go
@@ -10,7 +10,7 @@ import (
 func purgeJournalInfo(backupName string, dryRun bool) {
 	storage, err := internal.ConfigureStorage()
 	if err != nil {
-		tracelog.WarningLogger.Printf("Can't configure storage: %s", err.Error())
+		tracelog.WarningLogger.Printf("Can't configure storage: %+v", err)
 		return
 	}
 
@@ -21,7 +21,7 @@ func purgeJournalInfo(backupName string, dryRun bool) {
 	)
 	// Backup could be created without journal
 	if err != nil {
-		tracelog.WarningLogger.Printf("Can't find the journal info: %s", err.Error())
+		tracelog.WarningLogger.Printf("Can't find the journal info: %+v", err)
 		return
 	}
 

--- a/internal/databases/mongo/backup_delete_handler.go
+++ b/internal/databases/mongo/backup_delete_handler.go
@@ -2,9 +2,41 @@ package mongo
 
 import (
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
 )
+
+func purgeJournalInfo(backupName string, dryRun bool) {
+	storage, err := internal.ConfigureStorage()
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can't configure storage: %s", err.Error())
+		return
+	}
+
+	journalInfo, err := internal.NewJournalInfo(
+		backupName,
+		storage.RootFolder(),
+		models.OplogArchBasePath,
+	)
+	// Backup could be created without journal
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can't find the journal info: %s", err.Error())
+		return
+	}
+
+	if dryRun {
+		tracelog.InfoLogger.Printf("About to delete journal info: %+v", journalInfo)
+		return
+	}
+
+	err = journalInfo.Delete(storage.RootFolder())
+	if err != nil {
+		tracelog.ErrorLogger.Print(err)
+	} else {
+		tracelog.InfoLogger.Printf("Deleted journal info: %+v", journalInfo)
+	}
+}
 
 // HandleBackupDelete deletes backup.
 func HandleBackupDelete(backupName string, downloader archive.Downloader, purger archive.Purger, dryRun bool) error {
@@ -22,5 +54,6 @@ func HandleBackupDelete(backupName string, downloader archive.Downloader, purger
 		return err
 	}
 	tracelog.InfoLogger.Printf("Backup was deleted: %+v", backup)
+	purgeJournalInfo(backupName, dryRun)
 	return nil
 }

--- a/internal/databases/mongo/binary/backup.go
+++ b/internal/databases/mongo/binary/backup.go
@@ -43,7 +43,7 @@ type CalculateSizesArgs struct {
 	CountJournals bool
 }
 
-func (backupService *BackupService) createInitialJournals(journalFiles internal.JournalFiles) internal.JournalInfo {
+func (backupService *BackupService) createInitialJournals(journalFiles *internal.JournalFiles) internal.JournalInfo {
 	backupFolder, err := common.GetBackupFolder()
 	if err != nil {
 		tracelog.ErrorLogger.Printf("can not get backup folder: %+v", err)
@@ -74,7 +74,7 @@ type addJournalInfoArgs struct {
 	backupName            string
 	mostRecentJournalInfo internal.JournalInfo
 	timeStop              time.Time
-	journalFiles          internal.JournalFiles
+	journalFiles          *internal.JournalFiles
 }
 
 func (backupService *BackupService) addJournalInfo(args addJournalInfoArgs) internal.JournalInfo {
@@ -123,7 +123,7 @@ func (backupService *BackupService) calculateSizes(args CalculateSizesArgs) {
 		return
 	}
 
-	var journalFiles internal.JournalFiles
+	journalFiles := &internal.JournalFiles{}
 	mostRecentJournalInfo, err := internal.GetMostRecentJournalInfo(
 		storage.RootFolder(),
 		models.OplogArchBasePath,

--- a/internal/databases/mongo/binary/backup.go
+++ b/internal/databases/mongo/binary/backup.go
@@ -2,8 +2,11 @@ package binary
 
 import (
 	"context"
-	"github.com/wal-g/tracelog"
 	"os"
+	"strings"
+	"time"
+
+	"github.com/wal-g/tracelog"
 
 	"github.com/pkg/errors"
 	"github.com/wal-g/wal-g/internal"
@@ -35,19 +38,135 @@ func CreateBackupService(ctx context.Context, mongodService *MongodService, uplo
 	}, nil
 }
 
-func (backupService *BackupService) DoBackup(backupName string, permanent, skipMetadata bool) error {
-	err := backupService.InitializeMongodBackupMeta(backupName, permanent)
+type CalculateSizesArgs struct {
+	BackupName    string
+	CountJournals bool
+}
+
+func (backupService *BackupService) createInitialJournals() internal.JournalInfo {
+	backupFolder, err := common.GetBackupFolder()
+	if err != nil {
+		tracelog.ErrorLogger.Printf("can not get backup folder: %s", err.Error())
+		return internal.JournalInfo{}
+	}
+	backupTimes, err := internal.GetBackups(backupFolder)
+	if err != nil {
+		// no backups is a valid case, no journals should be created then
+		tracelog.WarningLogger.Printf("can not get backups: %s", err.Error())
+		return internal.JournalInfo{}
+	}
+
+	tracelog.WarningLogger.Printf("trying to create initial journals")
+	internal.SortBackupTimeSlices(backupTimes)
+	mostRecentJournalInfo := internal.JournalInfo{}
+	for _, backupTime := range backupTimes {
+		mostRecentJournalInfo = backupService.addJournalInfo(addJournalInfoArgs{
+			backupName:            backupTime.BackupName,
+			mostRecentJournalInfo: mostRecentJournalInfo,
+			timeStop:              backupTime.Time,
+		})
+	}
+	return mostRecentJournalInfo
+}
+
+type addJournalInfoArgs struct {
+	backupName            string
+	mostRecentJournalInfo internal.JournalInfo
+	timeStop              time.Time
+}
+
+func (backupService *BackupService) addJournalInfo(args addJournalInfoArgs) internal.JournalInfo {
+	if !strings.HasPrefix(args.backupName, common.BinaryBackupType) {
+		return args.mostRecentJournalInfo
+	}
+
+	storage, err := internal.ConfigureStorage()
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can't configure storage: %s", err.Error())
+		return internal.JournalInfo{}
+	}
+
+	rootFolder := storage.RootFolder()
+	journalInfo := internal.NewEmptyJournalInfo(
+		args.backupName,
+		args.mostRecentJournalInfo.CurrentBackupEnd, args.timeStop,
+		models.OplogArchBasePath,
+	)
+
+	err = journalInfo.Upload(rootFolder)
+	if err != nil {
+		tracelog.WarningLogger.Printf("can not upload the journal info: %s", err.Error())
+		return internal.JournalInfo{}
+	}
+
+	err = journalInfo.UpdateIntervalSize(rootFolder)
+	if err != nil {
+		tracelog.WarningLogger.Printf("can not calculate journal size: %s", err.Error())
+		return internal.JournalInfo{}
+	}
+
+	tracelog.InfoLogger.Printf("uploaded journal info for %s", args.backupName)
+	return journalInfo
+}
+
+func (backupService *BackupService) calculateSizes(args CalculateSizesArgs) {
+	if !args.CountJournals {
+		tracelog.InfoLogger.Printf("oplog counting mode is disabled: option is disabled")
+		return
+	}
+
+	storage, err := internal.ConfigureStorage()
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can't configure storage: %s", err.Error())
+		return
+	}
+
+	mostRecentJournalInfo, err := internal.GetMostRecentJournalInfo(
+		storage.RootFolder(),
+		models.OplogArchBasePath,
+	)
+	if err != nil {
+		// there can be no backups on S3 or we do it first time
+		tracelog.WarningLogger.Printf("can not find the last journal info: %s", err.Error())
+		mostRecentJournalInfo = backupService.createInitialJournals()
+	}
+
+	timeStop := utility.TimeNowCrossPlatformLocal()
+	backupService.addJournalInfo(addJournalInfoArgs{
+		backupName:            args.BackupName,
+		mostRecentJournalInfo: mostRecentJournalInfo,
+		timeStop:              timeStop,
+	})
+}
+
+type DoBackupArgs struct {
+	BackupName    string
+	CountJournals bool
+	Permanent     bool
+	SkipMetadata  bool
+}
+
+func (backupService *BackupService) initializeBackup(args DoBackupArgs) error {
+	err := backupService.InitializeMongodBackupMeta(args.BackupName, args.Permanent)
 	if err != nil {
 		return err
 	}
 
 	var backupRoutes *models.BackupRoutesInfo
-	if !skipMetadata {
+	if !args.SkipMetadata {
 		backupRoutes, err = CreateBackupRoutesInfo(backupService.MongodService)
 		if err != nil {
 			return err
 		}
 		backupService.BackupRoutesInfo = *backupRoutes
+	}
+	return nil
+}
+
+func (backupService *BackupService) DoBackup(args DoBackupArgs) error {
+	err := backupService.initializeBackup(args)
+	if err != nil {
+		return err
 	}
 
 	backupCursor, err := CreateBackupCursor(backupService.MongodService)
@@ -67,7 +186,7 @@ func (backupService *BackupService) DoBackup(backupName string, permanent, skipM
 	concurrentUploader, err := internal.CreateConcurrentUploader(
 		internal.CreateConcurrentUploaderArgs{
 			Uploader:             backupService.Uploader,
-			BackupName:           backupName,
+			BackupName:           args.BackupName,
 			Directory:            mongodDBPath,
 			TarBallComposerMaker: NewDirDatabaseTarBallComposerMaker(),
 		})
@@ -102,14 +221,18 @@ func (backupService *BackupService) DoBackup(backupName string, permanent, skipM
 		return err
 	}
 
-	if !skipMetadata {
+	if !args.SkipMetadata {
 		if err = backupService.AddMetadata(tarFileSets); err != nil {
 			tracelog.InfoLogger.Printf("error while uploading metadata, %v", err)
 			return err
 		}
 	}
 
-	return backupService.Finalize(concurrentUploader, backupCursor.BackupCursorMeta)
+	err = backupService.Finalize(concurrentUploader, backupCursor.BackupCursorMeta, args.CountJournals)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (backupService *BackupService) InitializeMongodBackupMeta(backupName string, permanent bool) error {
@@ -139,7 +262,8 @@ func (backupService *BackupService) InitializeMongodBackupMeta(backupName string
 	return nil
 }
 
-func (backupService *BackupService) Finalize(uploader *internal.ConcurrentUploader, backupCursorMeta *BackupCursorMeta) error {
+func (backupService *BackupService) Finalize(uploader *internal.ConcurrentUploader, backupCursorMeta *BackupCursorMeta,
+	countJournals bool) error {
 	sentinel := &backupService.Sentinel
 	sentinel.FinishLocalTime = utility.TimeNowCrossPlatformLocal()
 	sentinel.UncompressedSize = uploader.UncompressedSize
@@ -152,7 +276,17 @@ func (backupService *BackupService) Finalize(uploader *internal.ConcurrentUpload
 	sentinel.MongoMeta.After.LastMajTS = backupLastTS
 	sentinel.MongoMeta.After.LastTS = backupLastTS
 
-	return internal.UploadSentinel(backupService.Uploader, sentinel, sentinel.BackupName)
+	err := internal.UploadSentinel(backupService.Uploader, sentinel, sentinel.BackupName)
+	if err != nil {
+		return err
+	}
+
+	calculateArgs := CalculateSizesArgs{
+		BackupName:    sentinel.BackupName,
+		CountJournals: countJournals,
+	}
+	backupService.calculateSizes(calculateArgs)
+	return nil
 }
 
 func (backupService *BackupService) AddMetadata(tarFilesSet internal.TarFileSets) error {

--- a/internal/databases/mongo/binary/mongod.go
+++ b/internal/databases/mongo/binary/mongod.go
@@ -134,7 +134,7 @@ func (mongodService *MongodService) GetBackupCursor() (cursor *mongo.Cursor, err
 		}
 		if i < cursorCreateRetries {
 			minutes := time.Duration(i + 1)
-			tracelog.WarningLogger.Printf("%v. Sleep %d minutes and retry", err.Error(), minutes)
+			tracelog.WarningLogger.Printf("%+v. Sleep %d minutes and retry", err, minutes)
 			time.Sleep(time.Minute * minutes)
 		}
 	}

--- a/internal/databases/mongo/binary_backup_push_handler.go
+++ b/internal/databases/mongo/binary_backup_push_handler.go
@@ -10,14 +10,19 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-func HandleBinaryBackupPush(ctx context.Context, permanent, skipMetadata bool, appName string) error {
-	backupName := binary.GenerateNewBackupName()
+type HandleBinaryBackupPushArgs struct {
+	AppName       string
+	CountJournals bool
+	Permanent     bool
+	SkipMetadata  bool
+}
 
+func HandleBinaryBackupPush(ctx context.Context, args HandleBinaryBackupPushArgs) error {
 	mongodbURI, err := conf.GetRequiredSetting(conf.MongoDBUriSetting)
 	if err != nil {
 		return err
 	}
-	mongodService, err := binary.CreateMongodService(ctx, appName, mongodbURI, 10*time.Minute)
+	mongodService, err := binary.CreateMongodService(ctx, args.AppName, mongodbURI, 10*time.Minute)
 	if err != nil {
 		return err
 	}
@@ -33,5 +38,11 @@ func HandleBinaryBackupPush(ctx context.Context, permanent, skipMetadata bool, a
 		return err
 	}
 
-	return backupService.DoBackup(backupName, permanent, skipMetadata)
+	doBackupArgs := binary.DoBackupArgs{
+		BackupName:    binary.GenerateNewBackupName(),
+		CountJournals: args.CountJournals,
+		Permanent:     args.Permanent,
+		SkipMetadata:  args.SkipMetadata,
+	}
+	return backupService.DoBackup(doBackupArgs)
 }

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -153,7 +153,7 @@ func HandleBackupPush(
 		return
 	}
 
-	err = journalInfo.UpdateIntervalSize(folder, internal.JournalFiles{})
+	err = journalInfo.UpdateIntervalSize(folder, &internal.JournalFiles{})
 	if err != nil {
 		tracelog.WarningLogger.Printf("can not calculate journal size: %s", err.Error())
 		return

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -153,7 +153,7 @@ func HandleBackupPush(
 		return
 	}
 
-	err = journalInfo.UpdateIntervalSize(folder)
+	err = journalInfo.UpdateIntervalSize(folder, internal.JournalFiles{})
 	if err != nil {
 		tracelog.WarningLogger.Printf("can not calculate journal size: %s", err.Error())
 		return

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -30,6 +30,8 @@ const (
 	newer direction = 1
 )
 
+var JournalsNotFound = xerrors.New("there are no journals on the S3")
+
 // JournalInfo is a projection of the S3 journal info object.
 // When a JournalInfo instance was changed, it should be synced with S3 using the upload/read method.
 type JournalInfo struct {
@@ -184,7 +186,7 @@ func (ji *JournalInfo) Delete(folder storage.Folder) error {
 		return err
 	}
 
-	err = newerJi.UpdateIntervalSize(folder)
+	err = newerJi.UpdateIntervalSize(folder, JournalFiles{})
 	if err != nil {
 		return err
 	}
@@ -208,7 +210,7 @@ func GetMostRecentJournalInfo(
 	objs = filterJournalsInfoFiles(objs)
 	objs = sortJournalsInfo(objs)
 	if len(objs) == 0 {
-		return JournalInfo{}, xerrors.New("there are no journals on the S3")
+		return JournalInfo{}, JournalsNotFound
 	}
 
 	theMostRecentJournalObject := objs[len(objs)-1]
@@ -225,13 +227,26 @@ func GetMostRecentJournalInfo(
 	return backupInfo, nil
 }
 
+type JournalFiles struct {
+	files       []storage.Object
+	initialized bool
+}
+
 // UpdateIntervalSize calculates the size of the SizeToNextBackup in the semi-interval (PriorBackupEnd; CurrentBackupEnd]
 // using journal files on JournalDirectoryName and save it for the previous JournalInfo
-func (ji *JournalInfo) UpdateIntervalSize(folder storage.Folder) error {
-	journalFiles, _, err := folder.GetSubFolder(ji.JournalDirectoryName).ListFolder()
-	if err != nil {
-		return err
+func (ji *JournalInfo) UpdateIntervalSize(folder storage.Folder, journalFilesObj JournalFiles) error {
+	var err error
+	if !journalFilesObj.initialized {
+		// doing this 1 time for reusing it in next runs during single calculation
+		journalFiles, _, err := folder.GetSubFolder(ji.JournalDirectoryName).ListFolder()
+		if err != nil {
+			return err
+		}
+		journalFilesObj.files = journalFiles
+		journalFilesObj.initialized = true
 	}
+
+	journalFiles := journalFilesObj.files
 	if len(journalFiles) == 0 {
 		return nil
 	}

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -186,7 +186,7 @@ func (ji *JournalInfo) Delete(folder storage.Folder) error {
 		return err
 	}
 
-	err = newerJi.UpdateIntervalSize(folder, JournalFiles{})
+	err = newerJi.UpdateIntervalSize(folder, &JournalFiles{})
 	if err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ type JournalFiles struct {
 
 // UpdateIntervalSize calculates the size of the SizeToNextBackup in the semi-interval (PriorBackupEnd; CurrentBackupEnd]
 // using journal files on JournalDirectoryName and save it for the previous JournalInfo
-func (ji *JournalInfo) UpdateIntervalSize(folder storage.Folder, journalFilesObj JournalFiles) error {
+func (ji *JournalInfo) UpdateIntervalSize(folder storage.Folder, journalFilesObj *JournalFiles) error {
 	var err error
 	if !journalFilesObj.initialized {
 		// doing this 1 time for reusing it in next runs during single calculation

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -103,7 +103,7 @@ func CreateThreeJournals(
 	)
 
 	assert.NoError(t, ji2.Upload(folder))
-	assert.NoError(t, ji2.UpdateIntervalSize(folder))
+	assert.NoError(t, ji2.UpdateIntervalSize(folder, internal.JournalFiles{}))
 	assert.NoError(t, ji1.Read(folder))
 
 	ji3 := internal.NewEmptyJournalInfo(
@@ -120,7 +120,7 @@ func CreateThreeJournals(
 	)
 
 	assert.NoError(t, ji3.Upload(folder))
-	assert.NoError(t, ji3.UpdateIntervalSize(folder))
+	assert.NoError(t, ji3.UpdateIntervalSize(folder, internal.JournalFiles{}))
 	assert.NoError(t, ji2.Read(folder))
 	assert.NoError(t, ji1.Read(folder))
 
@@ -186,13 +186,13 @@ func TestSafetyOfRepeatingMethodCalls(t *testing.T) {
 
 	// There are random method calls
 	for i := 0; i < 10; i++ {
-		assert.NoError(t, ji1.UpdateIntervalSize(folder))
+		assert.NoError(t, ji1.UpdateIntervalSize(folder, internal.JournalFiles{}))
 		assert.NoError(t, ji1.Upload(folder))
 		assert.NoError(t, ji3.Read(folder))
 		assert.NoError(t, ji2.Upload(folder))
-		assert.NoError(t, ji2.UpdateIntervalSize(folder))
+		assert.NoError(t, ji2.UpdateIntervalSize(folder, internal.JournalFiles{}))
 		assert.NoError(t, ji3.Upload(folder))
-		assert.NoError(t, ji3.UpdateIntervalSize(folder))
+		assert.NoError(t, ji3.UpdateIntervalSize(folder, internal.JournalFiles{}))
 		assert.NoError(t, ji2.Read(folder))
 		assert.NoError(t, ji1.Read(folder))
 	}

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -103,7 +103,7 @@ func CreateThreeJournals(
 	)
 
 	assert.NoError(t, ji2.Upload(folder))
-	assert.NoError(t, ji2.UpdateIntervalSize(folder, internal.JournalFiles{}))
+	assert.NoError(t, ji2.UpdateIntervalSize(folder, &internal.JournalFiles{}))
 	assert.NoError(t, ji1.Read(folder))
 
 	ji3 := internal.NewEmptyJournalInfo(
@@ -120,7 +120,7 @@ func CreateThreeJournals(
 	)
 
 	assert.NoError(t, ji3.Upload(folder))
-	assert.NoError(t, ji3.UpdateIntervalSize(folder, internal.JournalFiles{}))
+	assert.NoError(t, ji3.UpdateIntervalSize(folder, &internal.JournalFiles{}))
 	assert.NoError(t, ji2.Read(folder))
 	assert.NoError(t, ji1.Read(folder))
 
@@ -186,13 +186,13 @@ func TestSafetyOfRepeatingMethodCalls(t *testing.T) {
 
 	// There are random method calls
 	for i := 0; i < 10; i++ {
-		assert.NoError(t, ji1.UpdateIntervalSize(folder, internal.JournalFiles{}))
+		assert.NoError(t, ji1.UpdateIntervalSize(folder, &internal.JournalFiles{}))
 		assert.NoError(t, ji1.Upload(folder))
 		assert.NoError(t, ji3.Read(folder))
 		assert.NoError(t, ji2.Upload(folder))
-		assert.NoError(t, ji2.UpdateIntervalSize(folder, internal.JournalFiles{}))
+		assert.NoError(t, ji2.UpdateIntervalSize(folder, &internal.JournalFiles{}))
 		assert.NoError(t, ji3.Upload(folder))
-		assert.NoError(t, ji3.UpdateIntervalSize(folder, internal.JournalFiles{}))
+		assert.NoError(t, ji3.UpdateIntervalSize(folder, &internal.JournalFiles{}))
 		assert.NoError(t, ji2.Read(folder))
 		assert.NoError(t, ji1.Read(folder))
 	}

--- a/tests_func/features/mongodb/binary_backup_with_pitr.feature
+++ b/tests_func/features/mongodb/binary_backup_with_pitr.feature
@@ -12,6 +12,7 @@ Feature: MongoDB binary backups with PITR
     Given mongodb01 has test mongodb data test1
     When we create binary mongo-backup on mongodb01
     Then we got 1 backup entries of mongodb01
+    And journal info count is #1
 
     # First load
     Given mongodb01 has been loaded with "load1"
@@ -21,6 +22,7 @@ Feature: MongoDB binary backups with PITR
     # Second backup was done successfully
     When we create binary mongo-backup on mongodb01
     Then we got 2 backup entries of mongodb01
+    And journal info count is #2
 
     # Second load
     Given mongodb01 has been loaded with "load2"

--- a/tests_func/helpers/walg.go
+++ b/tests_func/helpers/walg.go
@@ -136,7 +136,7 @@ func (w *WalgUtil) PushBackup() (string, error) {
 }
 
 func (w *WalgUtil) PushBinaryBackup() error {
-	_, err := w.runCmd("binary-backup-push")
+	_, err := w.runCmd("binary-backup-push", "--count-journals")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Database name
mongo

# Pull request description
add flag to count journal info

### Describe what this PR fixes
we need info about oplog sizes necessary to restore to specified point in time between binary backups - we are adding this info here (pls see mysql as a reference for analogue)