### PR TITLE
Add 'connection refused' to ShouldRetry

### DIFF
--- a/pkg/storages/s3/retryer.go
+++ b/pkg/storages/s3/retryer.go
@@ -17,8 +17,11 @@ type ConnResetRetryer struct {
 }
 
 func (r ConnResetRetryer) ShouldRetry(req *request.Request) bool {
-	if req.Error != nil && strings.Contains(req.Error.Error(), "connection reset by peer") {
-		return true
+	if req.Error != nil {
+		if strings.Contains(req.Error.Error(), "connection reset by peer") ||
+			strings.Contains(req.Error.Error(), "connection refused") {
+			return true
+		}
 	}
 
 	return r.Retryer.ShouldRetry(req)


### PR DESCRIPTION
Explicitly retry `connection refused` error

```
ERROR: 2025/09/06 23:43:25.393138 failed to upload 'wal-e/abc/6/segments_005/seg47/basebackups_005/base_00000024000022DD0000003A/tar_partitions/part_040.tar.br' to bucket 'abc': MultipartUpload: upload multipart failed
        upload id: 00063E2A132A0000
caused by: RequestError: send request failed
caused by: Put "http://FQDN:4080/abc/wal-e/abc/6/segments_005/seg47/basebackups_005/base_00000024000022DD0000003A/tar_partitions/part_040.tar.br?partNumber=5&uploadId=00063E2A132A0000": dial tcp [ipv6]:4080: connect: connection refused
```