### PR TITLE
Greenplum follow-primary: print missing WAL file names

### DIFF
--- a/internal/databases/greenplum/follow_primary_handler.go
+++ b/internal/databases/greenplum/follow_primary_handler.go
@@ -74,6 +74,8 @@ func FatalIfWalLogMissing(restorePoint string, folder storage.Folder) {
 		tracelog.ErrorLogger.FatalOnError(err)
 	}
 
+	var foundCnt int
+outer:
 	for seg, lsn := range metadata.LsnBySegment {
 		LSN, err := postgres.ParseLSN(lsn)
 		if err != nil {
@@ -88,17 +90,18 @@ func FatalIfWalLogMissing(restorePoint string, folder storage.Folder) {
 		}
 
 		// WAL file example: "000000010000000000000003.lz4" -> base name is "000000010000000000000003"
-		found := false
+		walName := walSegmentNo.GetFilename(metadata.TimeLine)
 		for _, obj := range folderObjects {
-			if strings.HasPrefix(obj.GetName(), walSegmentNo.GetFilename(metadata.TimeLine)) {
-				found = true
-				break
+			if strings.HasPrefix(obj.GetName(), walName) {
+				foundCnt++
+				continue outer
 			}
 		}
+		tracelog.WarningLogger.Printf("WAL file was not found for segment %v (WAL name: %v)", seg, walName)
 
-		if !found {
-			tracelog.ErrorLogger.Fatalln("WAL file was not uploaded for all segments and master")
-		}
+	}
+	if foundCnt < len(metadata.LsnBySegment) {
+		tracelog.ErrorLogger.Fatalln("WAL file was not uploaded for all segments and master")
 	}
 }
 

--- a/internal/databases/greenplum/follow_primary_handler.go
+++ b/internal/databases/greenplum/follow_primary_handler.go
@@ -99,7 +99,7 @@ outer:
 		}
 		tracelog.WarningLogger.Printf("WAL file was not found for segment %v (WAL name: %v)", seg, walName)
 	}
-	
+
 	if foundCnt < len(metadata.LsnBySegment) {
 		tracelog.ErrorLogger.Fatalln("WAL file was not uploaded for all segments and master")
 	}

--- a/internal/databases/greenplum/follow_primary_handler.go
+++ b/internal/databases/greenplum/follow_primary_handler.go
@@ -98,8 +98,8 @@ outer:
 			}
 		}
 		tracelog.WarningLogger.Printf("WAL file was not found for segment %v (WAL name: %v)", seg, walName)
-
 	}
+	
 	if foundCnt < len(metadata.LsnBySegment) {
 		tracelog.ErrorLogger.Fatalln("WAL file was not uploaded for all segments and master")
 	}


### PR DESCRIPTION
### Greenplum

Add verbose logging to `wal-g follow-primary`. Instead of 

```
gpadmin@~$ wal-g --config /etc/wal-g/wal-g.yaml follow-primary backup_20250921T003032Z --restore-config /etc/wal-g/wal-g-restore-config.json
INFO: 2025/09/22 16:43:11.091393 Using storages: [default]
ERROR: 2025/09/22 16:43:11.788321 WAL file was not uploaded for all segments and master
```

get verbose error:
```
gpadmin@:~$ wal-g --config /etc/wal-g/wal-g.yaml follow-primary backup_20250921T003032Z --restore-config /etc/wal-g/wal-g-restore-config.json
INFO: 2025/09/22 17:05:47.250024 Using storages: [default]
WARNING: 2025/09/22 17:05:47.488830 WAL file was not found for segment -1 (WAL name: 00000000000000080000002F)
WARNING: 2025/09/22 17:05:47.655491 WAL file was not found for segment 0 (WAL name: 000000000000000800000024)
WARNING: 2025/09/22 17:05:47.832324 WAL file was not found for segment 1 (WAL name: 000000000000000800000024)
WARNING: 2025/09/22 17:05:47.994715 WAL file was not found for segment 2 (WAL name: 000000000000000800000024)
WARNING: 2025/09/22 17:05:48.103865 WAL file was not found for segment 3 (WAL name: 000000000000000800000024)
ERROR: 2025/09/22 17:05:48.103894 WAL file was not uploaded for all segments and master
```