### PR TITLE
tests: migrate from "bitnami" to "bitnamilegacy"

### DIFF
--- a/docker/etcd/Dockerfile
+++ b/docker/etcd/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/etcd:3.5.21
+FROM bitnamilegacy/etcd:3.5.21
 # in 3.6 which is latest "etcdctl snapshot restore" -> "etcdutl snapshot restore" 
 
 # FROM wal-g/ubuntu:latest


### PR DESCRIPTION
💅 Bye Bitnami, we’re legacy now — migrated with grace, attitude, and zero tolerance for vendor lock-in.
