### PR TITLE
fix: Added missing backup size metrics for pg exporter

### DIFF
--- a/cmd/pg/exporter/README.md
+++ b/cmd/pg/exporter/README.md
@@ -20,6 +20,8 @@ The exporter provides the following metrics:
 ### Backup Metrics
 - `walg_backup_start_timestamp{backup_name, backup_type, wal_file, start_lsn, finish_lsn, permanent, base_backup}` - Unix timestamp when backup started
 - `walg_backup_finish_timestamp{backup_name, backup_type, wal_file, start_lsn, finish_lsn, permanent, base_backup}` - Unix timestamp when backup completed successfully
+- `walg_backup_compressed_size_bytes{backup_name, backup_type, wal_file, start_lsn, finish_lsn, permanent, base_backup}` - Compressed size of the backup in bytes
+- `walg_backup_uncompressed_size_bytes{backup_name, backup_type, wal_file, start_lsn, finish_lsn, permanent, base_backup}` - Uncompressed size of the backup in bytes
 - `walg_backup_count{backup_type}` - Number of successful backups (full/delta)
 
 **Label Details:**
@@ -185,7 +187,7 @@ The exporter provides both start and finish timestamps for comprehensive backup 
   - Failed or interrupted backups do not generate finish timestamps
   - Represents the moment when the backup became available for recovery
 
-### WAL Timestamps  
+### WAL Timestamps
 - `walg_wal_timestamp` = When the WAL segment **finished uploading**
   - This is when the WAL segment became available in storage
   - Represents the completion of the wal-push operation
@@ -241,7 +243,7 @@ func (b *BackupInfo) GetBaseBackupName() string {
     if b.IsFullBackup() {
         return "" // Full backups don't have a base backup
     }
-    
+
     // Extract identifier after "_D_" and prepend "base_"
     deltaIndex := strings.Index(b.BackupName, "_D_")
     baseIdentifier := b.BackupName[deltaIndex+3:]


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description
The data for CompressedSize and UnCompressedSize were missing, preventing these values from being exported as metrics. These are key metrics for measuring the amount of space occupied by backups.

Documentation for these other metrics was added as well.

### Describe what this PR fixes
Added missing metrics for backup size


### Example of metrics generated with the change:

```bash
# HELP walg_backup_compressed_size_bytes Compressed size of the backup in storage in bytes.
# TYPE walg_backup_compressed_size_bytes gauge
walg_backup_compressed_size_bytes{backup_name="base_000000010000000000000002",backup_type="full",base_backup="",finish_lsn="0/2000100",permanent="false",start_lsn="0/2000028",wal_file="000000010000000000000002"} 132948274
# HELP walg_backup_uncompressed_size_bytes Uncompressed size of the backup in bytes.
# TYPE walg_backup_uncompressed_size_bytes gauge
walg_backup_uncompressed_size_bytes{backup_name="base_000000010000000000000002",backup_type="full",base_backup="",finish_lsn="0/2000100",permanent="false",start_lsn="0/2000028",wal_file="00000001000000000000000C"} 549382749
```
