### PR TITLE
Add noname0443 to mysql CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,8 +20,8 @@
 
 * @wal-g/committers
 
-/internal/databases/mysql/ @mialinx @ostinru @teem0n
-/cmd/mysql/ @mialinx @ostinru @teem0n
+/internal/databases/mysql/ @mialinx @ostinru @teem0n @noname0443
+/cmd/mysql/ @mialinx @ostinru @teem0n @noname0443
 
 /internal/databases/sqlserver/ @mialinx @ostinru @teem0n
 /cmd/sqlserver/ @mialinx @ostinru @teem0n


### PR DESCRIPTION
### MySQL

Add @noname0443 to CODEOWNERS for MySQL. Given that other code owners are currently very busy, this change will enable us to continue processing pull requests promptly.