### PR TITLE
fix: rename walg_backup_count to walg_backups

### DIFF
--- a/cmd/pg/exporter/README.md
+++ b/cmd/pg/exporter/README.md
@@ -22,7 +22,7 @@ The exporter provides the following metrics:
 - `walg_backup_finish_timestamp{backup_name, backup_type, wal_file, start_lsn, finish_lsn, permanent, base_backup}` - Unix timestamp when backup completed successfully
 - `walg_backup_compressed_size_bytes{backup_name, backup_type, wal_file, start_lsn, finish_lsn, permanent, base_backup}` - Compressed size of the backup in bytes
 - `walg_backup_uncompressed_size_bytes{backup_name, backup_type, wal_file, start_lsn, finish_lsn, permanent, base_backup}` - Uncompressed size of the backup in bytes
-- `walg_backup_count{backup_type}` - Number of successful backups (full/delta)
+- `walg_backups{backup_type}` - Number of successful backups (full/delta)
 
 **Label Details:**
 - `backup_name`: Full backup name (e.g., `base_000000010000000000000025` or `base_000000010000000500000007_D_000000010000000000000025`)

--- a/cmd/pg/exporter/exporter.go
+++ b/cmd/pg/exporter/exporter.go
@@ -181,7 +181,7 @@ func NewWalgExporter(walgPath string, scrapeInterval time.Duration, walgConfigPa
 
 		backupCount: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "walg_backup_count",
+				Name: "walg_backups",
 				Help: "Number of backups by type",
 			},
 			[]string{"backup_type"},


### PR DESCRIPTION
### Database name
PostgreSQL

## Pull request description

`promtool check metrics` reported:

    walg_backup_count non-histogram and non-summary metrics should not have "_count" suffix

This change renames the metric `walg_backup_count` to `walg_backups` to follow Prometheus naming conventions. The metric represents the current number of WAL-G backups in storage (a gauge), not a counter or histogram.
