### PR TITLE
perf: reduce command executions and requests in WAL-G exporter

### DIFF
--- a/cmd/pg/exporter/README.md
+++ b/cmd/pg/exporter/README.md
@@ -112,9 +112,9 @@ The exporter requires WAL-G to be properly configured and accessible. Ensure tha
 ### WAL-G Commands Used
 
 The exporter executes the following WAL-G commands:
-- `wal-g backup-list --detail --json` - Get backup information
-- `wal-g wal-show --detailed-json` - Get WAL segment information
-- `wal-g st ls` - Check storage connectivity
+
+- `wal-g wal-show --detailed-json` - Get WAL segment information and backup information
+- `wal-g st check read` - Check storage connectivity
 
 ## Prometheus Configuration
 

--- a/cmd/pg/exporter/mock-wal-g
+++ b/cmd/pg/exporter/mock-wal-g
@@ -1,62 +1,381 @@
 #!/bin/bash
 set -euo pipefail
+
 case "$1" in
-  "backup-list")
-    if [[ "$2" == "--detail" && "$3" == "--json" ]]; then
-      # Generate realistic timestamps (recent backups) - compatible with both GNU and BSD date
-      if date -d '2 hours ago' '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
-        # GNU date (Linux)
-        full_time=$(date -u -d '2 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
-        delta1_time=$(date -u -d '1 hour ago' '+%Y-%m-%dT%H:%M:%SZ') 
-        delta2_time=$(date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
-        old_full_time=$(date -u -d '1 day ago' '+%Y-%m-%dT%H:%M:%SZ')
-      else
-        # BSD date (macOS)
-        full_time=$(date -u -v-2H '+%Y-%m-%dT%H:%M:%SZ')
-        delta1_time=$(date -u -v-1H '+%Y-%m-%dT%H:%M:%SZ')
-        delta2_time=$(date -u -v-30M '+%Y-%m-%dT%H:%M:%SZ')
-        old_full_time=$(date -u -v-1d '+%Y-%m-%dT%H:%M:%SZ')
-      fi
-      
-      echo "[
-        {\"backup_name\":\"base_$(date +%s)\",\"time\":\"$full_time\",\"start_time\":\"$full_time\",\"finish_time\":\"$full_time\",\"wal_file_name\":\"000000010000000000000010\",\"start_lsn\":268435456,\"finish_lsn\":301989888,\"is_permanent\":false,\"user_data\":\"\"},
-        {\"backup_name\":\"base_$(date +%s)_D_000000010000000000000010\",\"time\":\"$delta1_time\",\"start_time\":\"$delta1_time\",\"finish_time\":\"$delta1_time\",\"wal_file_name\":\"000000010000000000000015\",\"start_lsn\":301989888,\"finish_lsn\":335544320,\"is_permanent\":false,\"user_data\":\"\"},
-        {\"backup_name\":\"base_$(date +%s)_D_000000010000000000000015\",\"time\":\"$delta2_time\",\"start_time\":\"$delta2_time\",\"finish_time\":\"$delta2_time\",\"wal_file_name\":\"000000010000000000000018\",\"start_lsn\":335544320,\"finish_lsn\":369098752,\"is_permanent\":false,\"user_data\":\"\"},
-        {\"backup_name\":\"base_daily_backup\",\"time\":\"$old_full_time\",\"start_time\":\"$old_full_time\",\"finish_time\":\"$old_full_time\",\"wal_file_name\":\"000000010000000000000005\",\"start_lsn\":83886080,\"finish_lsn\":134217728,\"is_permanent\":true,\"user_data\":\"daily-backup\"}
-      ]"
-    fi
-    ;;
   "wal-show")
     if [[ "$2" == "--detailed-json" ]]; then
       echo '[
-        {
-          "id": 1,
-          "parent_id": 0,
-          "switch_point_lsn": 0,
-          "start_segment": "000000010000000000000001",
-          "end_segment": "000000010000000000000020",
-          "segments_count": 20,
-          "missing_segments": [],
-          "segment_range_size": 20,
-          "status": "OK"
-        },
-        {
-          "id": 2,
-          "parent_id": 1,
-          "switch_point_lsn": 536870912,
-          "start_segment": "000000020000000000000001",
-          "end_segment": "000000020000000000000003",
-          "segments_count": 3,
-          "missing_segments": [],
-          "segment_range_size": 3,
-          "status": "OK"
-        }
-      ]'
+  {
+    "id": 44,
+    "parent_id": 43,
+    "switch_point_lsn": 729909559296,
+    "start_segment": "0000002C000000A9000000F7",
+    "end_segment": "0000002C000000AD00000098",
+    "segments_count": 930,
+    "missing_segments": [],
+    "backups": [
+      {
+        "backup_name": "base_0000002C000000AC00000088",
+        "time": "2025-10-10T02:00:26.334Z",
+        "wal_file_name": "0000002C000000AC00000088",
+        "storage_name": "default",
+        "start_time": "2025-10-10T02:00:02.347758Z",
+        "finish_time": "2025-10-10T02:00:26.171921Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-0",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 741016099832,
+        "finish_lsn": 741016515464,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 997500318,
+        "compressed_size": 274949509
+      },
+      {
+        "backup_name": "base_0000002C000000A9000000F7",
+        "time": "2025-10-09T15:08:34.497Z",
+        "wal_file_name": "0000002C000000A9000000F7",
+        "storage_name": "default",
+        "start_time": "2025-10-09T15:08:07.90559Z",
+        "finish_time": "2025-10-09T15:08:34.311378Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-0",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 729993445480,
+        "finish_lsn": 729993775144,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 992626366,
+        "compressed_size": 269604136
+      }
+    ],
+    "segment_range_size": 930,
+    "status": "OK"
+  },
+  {
+    "id": 45,
+    "parent_id": 44,
+    "switch_point_lsn": 745579479200,
+    "start_segment": "0000002D000000AD00000098",
+    "end_segment": "0000002D000000AD0000009C",
+    "segments_count": 5,
+    "missing_segments": [],
+    "segment_range_size": 5,
+    "status": "OK"
+  },
+  {
+    "id": 46,
+    "parent_id": 45,
+    "switch_point_lsn": 745663365280,
+    "start_segment": "0000002E000000AD0000009D",
+    "end_segment": "0000002E000000AF000000B6",
+    "segments_count": 538,
+    "missing_segments": [],
+    "backups": [
+      {
+        "backup_name": "base_0000002E000000AE00000096",
+        "time": "2025-10-13T02:00:10.485Z",
+        "wal_file_name": "0000002E000000AE00000096",
+        "storage_name": "default",
+        "start_time": "2025-10-13T02:00:01.923297Z",
+        "finish_time": "2025-10-13T02:00:10.267034Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-0",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 749840891944,
+        "finish_lsn": 749841051648,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1027556766,
+        "compressed_size": 287118176
+      },
+      {
+        "backup_name": "base_0000002E000000AE00000044",
+        "time": "2025-10-12T02:00:21.458Z",
+        "wal_file_name": "0000002E000000AE00000044",
+        "storage_name": "default",
+        "start_time": "2025-10-12T02:00:02.043085Z",
+        "finish_time": "2025-10-12T02:00:21.357112Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-0",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 748465160232,
+        "finish_lsn": 748465441864,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1020495262,
+        "compressed_size": 284295033
+      },
+      {
+        "backup_name": "base_0000002E000000AD000000E8",
+        "time": "2025-10-11T02:00:28.791Z",
+        "wal_file_name": "0000002E000000AD000000E8",
+        "storage_name": "default",
+        "start_time": "2025-10-11T02:00:02.026749Z",
+        "finish_time": "2025-10-11T02:00:28.644501Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-0",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 746921656536,
+        "finish_lsn": 746956335952,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1010673054,
+        "compressed_size": 279390283
+      },
+      {
+        "backup_name": "base_0000002E000000AD000000A2",
+        "time": "2025-10-10T12:59:31.843Z",
+        "wal_file_name": "0000002E000000AD000000A2",
+        "storage_name": "default",
+        "start_time": "2025-10-10T12:59:06.107163Z",
+        "finish_time": "2025-10-10T12:59:31.657741Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-0",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 745747251240,
+        "finish_lsn": 745747568928,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1003823942,
+        "compressed_size": 276103092
+      }
+    ],
+    "segment_range_size": 538,
+    "status": "OK"
+  },
+  {
+    "id": 47,
+    "parent_id": 46,
+    "switch_point_lsn": 754689507488,
+    "start_segment": "0000002F000000AF000000B7",
+    "end_segment": "0000002F000000B3000000F9",
+    "segments_count": 1091,
+    "missing_segments": [],
+    "backups": [
+      {
+        "backup_name": "base_0000002F000000B100000054",
+        "time": "2025-10-14T02:00:11.713Z",
+        "wal_file_name": "0000002F000000B100000054",
+        "storage_name": "default",
+        "start_time": "2025-10-14T02:00:01.501304Z",
+        "finish_time": "2025-10-14T02:00:11.564657Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 761618503888,
+        "finish_lsn": 761689503688,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1037526607,
+        "compressed_size": 282305724
+      },
+      {
+        "backup_name": "base_0000002F000000AF000000BD",
+        "time": "2025-10-13T15:48:04.909Z",
+        "wal_file_name": "0000002F000000AF000000BD",
+        "storage_name": "default",
+        "start_time": "2025-10-13T15:47:50.068642Z",
+        "finish_time": "2025-10-13T15:48:04.749569Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 754790170664,
+        "finish_lsn": 754790622680,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1032836075,
+        "compressed_size": 279568370
+      }
+    ],
+    "segment_range_size": 1091,
+    "status": "FAIL"
+  },
+  {
+    "id": 48,
+    "parent_id": 47,
+    "switch_point_lsn": 772993450144,
+    "start_segment": "00000030000000B3000000FA",
+    "end_segment": "00000030000000B500000082",
+    "segments_count": 393,
+    "missing_segments": [],
+    "backups": [
+      {
+        "backup_name": "base_00000030000000B400000000",
+        "time": "2025-10-14T14:26:02.548Z",
+        "wal_file_name": "00000030000000B400000000",
+        "storage_name": "default",
+        "start_time": "2025-10-14T14:25:41.073288Z",
+        "finish_time": "2025-10-14T14:26:02.319207Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-0",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 773094113320,
+        "finish_lsn": 773095362240,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1044382653,
+        "compressed_size": 291195330
+      }
+    ],
+    "segment_range_size": 393,
+    "status": "OK"
+  },
+  {
+    "id": 49,
+    "parent_id": 48,
+    "switch_point_lsn": 779586896032,
+    "start_segment": "00000031000000B500000083",
+    "end_segment": "00000031000000D6000000E0",
+    "segments_count": 8542,
+    "missing_segments": [],
+    "backups": [
+      {
+        "backup_name": "base_00000031000000D400000065",
+        "time": "2025-10-20T02:00:14.31Z",
+        "wal_file_name": "00000031000000D400000065",
+        "storage_name": "default",
+        "start_time": "2025-10-20T02:00:01.434713Z",
+        "finish_time": "2025-10-20T02:00:14.127517Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 912227565608,
+        "finish_lsn": 912227600576,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1087719121,
+        "compressed_size": 308666362
+      },
+      {
+        "backup_name": "base_00000031000000CE000000AE",
+        "time": "2025-10-19T02:00:21.261Z",
+        "wal_file_name": "00000031000000CE000000AE",
+        "storage_name": "default",
+        "start_time": "2025-10-19T02:00:01.967577Z",
+        "finish_time": "2025-10-19T02:00:15.697636Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 887682498776,
+        "finish_lsn": 887682507344,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1079805649,
+        "compressed_size": 306074568
+      },
+      {
+        "backup_name": "base_00000031000000C80000006C",
+        "time": "2025-10-18T02:00:13.781Z",
+        "wal_file_name": "00000031000000C80000006C",
+        "storage_name": "default",
+        "start_time": "2025-10-18T02:00:01.695668Z",
+        "finish_time": "2025-10-18T02:00:13.671095Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 860805398568,
+        "finish_lsn": 860805435592,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1071081169,
+        "compressed_size": 302000038
+      },
+      {
+        "backup_name": "base_00000031000000C20000000D",
+        "time": "2025-10-17T02:00:20.827Z",
+        "wal_file_name": "00000031000000C20000000D",
+        "storage_name": "default",
+        "start_time": "2025-10-17T02:00:01.922176Z",
+        "finish_time": "2025-10-17T02:00:20.466947Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 833441759448,
+        "finish_lsn": 833441788912,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1062561487,
+        "compressed_size": 297972865
+      },
+      {
+        "backup_name": "base_00000031000000BC0000005E",
+        "time": "2025-10-16T02:00:30.487Z",
+        "wal_file_name": "00000031000000BC0000005E",
+        "storage_name": "default",
+        "start_time": "2025-10-16T02:00:01.352995Z",
+        "finish_time": "2025-10-16T02:00:27.165608Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 809030909992,
+        "finish_lsn": 809030951216,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1055598289,
+        "compressed_size": 292836135
+      },
+      {
+        "backup_name": "base_00000031000000B600000097",
+        "time": "2025-10-15T02:00:32.614Z",
+        "wal_file_name": "00000031000000B600000097",
+        "storage_name": "default",
+        "start_time": "2025-10-15T02:00:01.304134Z",
+        "finish_time": "2025-10-15T02:00:32.336193Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 784217407704,
+        "finish_lsn": 784217491752,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1046955729,
+        "compressed_size": 286857720
+      },
+      {
+        "backup_name": "base_00000031000000B500000089",
+        "time": "2025-10-14T21:45:08.965Z",
+        "wal_file_name": "00000031000000B500000089",
+        "storage_name": "default",
+        "start_time": "2025-10-14T21:44:51.134862Z",
+        "finish_time": "2025-10-14T21:45:08.20306Z",
+        "date_fmt": "%Y-%m-%dT%H:%M:%S.%fZ",
+        "hostname": "database-1",
+        "data_dir": "/home/postgres/pgdata/pgroot/data",
+        "pg_version": 150014,
+        "start_lsn": 779687559208,
+        "finish_lsn": 779688054144,
+        "is_permanent": false,
+        "system_identifier": 7507672962298573000,
+        "uncompressed_size": 1046045216,
+        "compressed_size": 285748514
+      }
+    ],
+    "segment_range_size": 8542,
+    "status": "OK"
+  }
+]'
     fi
     ;;
   "st")
-    if [[ "$2" == "ls" ]]; then
+    if [[ "$2" == "check" && "$3" == "read" ]]; then
       # Mock storage listing - simulate successful storage connectivity
+      sleep 0.$(( $((RANDOM % 10)) + 1 ))
       echo "Storage connection successful - S3 bucket accessible"
       exit 0
     fi


### PR DESCRIPTION
### Database name
PostgreSQL

## Pull request description

Optimized command usage to improve performance by reducing the number of executed commands and external requests.

Previously, the exporter ran:
  - `wal-g backup-list --detail --json` for backup information
  - `wal-g wal-show --detailed-json` for WAL segment information
  - `wal-g st ls` to check storage connectivity

Now it only runs:
  - `wal-g wal-show --detailed-json` to retrieve both WAL segment and backup info
  - `wal-g st check read` to verify storage connectivity

This reduces command executions from three to two and lowers the total number of
requests, resulting in faster metrics collection and lower resource usage.