### PR TITLE
Update google.golang.org/grpc to resolve a vuln

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -159,7 +159,7 @@ require (
 	golang.org/x/tools v0.23.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20211021150943-2b146023228c // indirect
-	google.golang.org/grpc v1.64.0 // indirect
+	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -953,8 +953,8 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
-google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
-google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
+google.golang.org/grpc v1.64.1 h1:LKtvyfbX3UGVPFcGqJ9ItpVWW6oN/2XqTxfAnwRRXiA=
+google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvyjeP0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
```
┌────────────────────────────────┬─────────────────────┬──────────┬────────┬─────────────────────┬─────────────────────────────┬──────────────────────────────────────────────────────────────┐
│            Library             │    Vulnerability    │ Severity │ Status │  Installed Version  │        Fixed Version        │                            Title                             │
├────────────────────────────────┼─────────────────────┼──────────┼────────┼─────────────────────┼─────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc         │ GHSA-xr7q-jx4m-x55m │ LOW      │ fixed  │ v1.64.0             │ 1.64.1                      │ Private tokens could appear in logs if context containing    │
│                                │                     │          │        │                     │                             │ gRPC metadata is...                                          │
│                                │                     │          │        │                     │                             │ https://github.com/advisories/GHSA-xr7q-jx4m-x55m            │
└────────────────────────────────┴─────────────────────┴──────────┴────────┴─────────────────────┴─────────────────────────────┴──────────────────────────────────────────────────────────────┘
```