### PR TITLE
postgres/orioledb: update page iterator format to beta13

### DIFF
--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/gocache cd pkg/storages/sh && GOCACHE=/gocache go
 
 FROM wal-g/ubuntu:22.04
 
-ENV PGDATA=/var/lib/postgresql/16/main
+ENV PGDATA /var/lib/postgresql/17/main
 
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --no-install-suggests \
@@ -43,14 +43,14 @@ WORKDIR /usr/src/postgresql/contrib/orioledb
 RUN set -eux; \
 	git init; \
 	git remote add origin https://github.com/orioledb/orioledb.git; \
-	git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +466738fe9d9a0f225ee5e5c776182ad426ae2008:refs/remotes/origin/main; \
+	git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +beta16-pre-2:refs/remotes/origin/main; \
 	git checkout --progress --force -B main refs/remotes/origin/main;
 
 WORKDIR /
 RUN set -eux; \
 	\
 	# don't forget to change PGTAG below
-	PGTAG=$(grep "^16: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
+	PGTAG=$(grep "^17: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
 	\
 	curl -o postgresql.tar.gz \
 			--header "Accept: application/vnd.github.v3.raw" \
@@ -95,7 +95,7 @@ ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
 RUN set -eux; \
 	\
 	# don't forget to change PGTAG above
-	PGTAG=$(grep "^16: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
+	PGTAG=$(grep "^17: " /usr/src/postgresql/contrib/orioledb/.pgtags | cut -d' ' -f2-) ; \
 	ORIOLEDB_VERSION=$(grep "^#define ORIOLEDB_VERSION" /usr/src/postgresql/contrib/orioledb/include/orioledb.h | cut -d'"' -f2) ; \
 	ORIOLEDB_BUILDTIME=$(date -Iseconds) ; \
 	\
@@ -119,13 +119,21 @@ RUN set -eux; \
 		--with-zstd \
 		--with-extra-version=" ${ORIOLEDB_VERSION} PGTAG=${PGTAG} ubuntu:jammy+clang build:${ORIOLEDB_BUILDTIME}" \
 	|| cat config.log ); \
-	echo "ORIOLEDB_PATCHSET_VERSION = `echo $PGTAG | cut -d'_' -f2`" >> src/Makefile.global; \
+	if printf "%s\n" "$PGTAG" | grep -Fqe "patches${PG_MAJOR}_"; then \
+		echo "ORIOLEDB_PATCHSET_VERSION = `echo $PGTAG | cut -d'_' -f2`" >> src/Makefile.global; \
+	else \
+		echo "ORIOLEDB_PATCHSET_VERSION = $PGTAG" >> src/Makefile.global; \
+	fi ; \
+	# install postgresql
 	make -j "$(nproc)"; \
 	make -C contrib -j "$(nproc)"; \
-	make -C contrib/orioledb -j "$(nproc)"; \
 	make install; \
 	make -C contrib install; \
-	make -C contrib/orioledb install; \
+	# install orioledb extension
+	cd /usr/src/postgresql/contrib/orioledb; \
+	make USE_PGXS=1 IS_DEV=1 -j "$(nproc)"; \
+	make USE_PGXS=1 IS_DEV=1 install; \
+
 	postgres --version
 
 COPY docker/common/s3cfg /var/lib/postgresql/.s3cfg

--- a/docker/orioledb/scripts/tests/compatibility_test.sh
+++ b/docker/orioledb/scripts/tests/compatibility_test.sh
@@ -31,13 +31,12 @@ psql -d postgres -c "CREATE TABLE o_test(a int) USING orioledb;"
 psql -d postgres -c "INSERT INTO o_test VALUES (1), (5), (2);"
 psql -d postgres -c "TABLE o_test;"
 psql -d postgres -c "DROP TABLE o_test;"
-psql -d postgres -c "DROP EXTENSION orioledb;"
 
 pgbench -i -s 4 postgres
 wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
 
 pgbench -i -s 8 postgres
-pg_dumpall -f /tmp/dump1
+pg_dumpall -f /tmp/dump1 --restrict-key=orioledbkey
 pgbench -c 2 -T 100000000 -S &
 sleep 1
 wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
@@ -53,11 +52,11 @@ pg_ctl -D ${PGDATA} -w start
 
 /tmp/scripts/wait_while_pg_not_ready.sh
 
-pg_dumpall -f /tmp/dump2
+pg_dumpall -f /tmp/dump2 --restrict-key=orioledbkey
 
 diff /tmp/dump1 /tmp/dump2
 
-psql -f /tmp/scripts/amcheck.sql -v "ON_ERROR_STOP=1" postgres
+psql -f /tmp/scripts/orioledb_check.sql -v "ON_ERROR_STOP=1" postgres
 wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
 
 rm ${TMP_CONFIG}

--- a/docker/orioledb/scripts/tests/compressed_test.sh
+++ b/docker/orioledb/scripts/tests/compressed_test.sh
@@ -33,7 +33,7 @@ pgbench -Id -i -s 4 postgres
 
 psql -d postgres -f /tmp/scripts/compressed_prepare.sql
 pgbench -Igvpf -i -s 8 postgres
-pg_dumpall -f /tmp/dump1
+pg_dumpall -f /tmp/dump1 --restrict-key=orioledbkey
 pgbench -c 2 -T 100000000 -S &
 sleep 1
 wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
@@ -49,11 +49,10 @@ pg_ctl -D ${PGDATA} -w start
 
 /tmp/scripts/wait_while_pg_not_ready.sh
 
-pg_dumpall -f /tmp/dump2
+pg_dumpall -f /tmp/dump2 --restrict-key=orioledbkey
 
 diff /tmp/dump1 /tmp/dump2
 
-psql -f /tmp/scripts/amcheck.sql -v "ON_ERROR_STOP=1" postgres
 psql -f /tmp/scripts/orioledb_check.sql -v "ON_ERROR_STOP=1" postgres
 psql -f /tmp/scripts/orioledb_compressed_check.sql -v "ON_ERROR_STOP=1" postgres
 wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm

--- a/docker/orioledb/scripts/tests/simple_test.sh
+++ b/docker/orioledb/scripts/tests/simple_test.sh
@@ -33,7 +33,7 @@ pgbench -Id -i -s 4 postgres
 
 psql -d postgres -f /tmp/scripts/simple_prepare.sql
 pgbench -Igvpf -i -s 8 postgres
-pg_dumpall -f /tmp/dump1
+pg_dumpall -f /tmp/dump1 --restrict-key=orioledbkey
 pgbench -c 2 -T 100000000 -S &
 sleep 1
 wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
@@ -49,11 +49,10 @@ pg_ctl -D ${PGDATA} -w start
 
 /tmp/scripts/wait_while_pg_not_ready.sh
 
-pg_dumpall -f /tmp/dump2
+pg_dumpall -f /tmp/dump2 --restrict-key=orioledbkey
 
 diff /tmp/dump1 /tmp/dump2
 
-psql -f /tmp/scripts/amcheck.sql -v "ON_ERROR_STOP=1" postgres
 psql -f /tmp/scripts/orioledb_check.sql -v "ON_ERROR_STOP=1" postgres
 wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -322,6 +322,8 @@ export USE_BROTLI=1
 export USE_LIBSODIUM=1
 export USE_LZO=1
 
+# until it become stable https://go.dev/blog/jsonv2-exp
+export GOEXPERIMENT=jsonv2
 make deps
 make pg_build
 main/pg/wal-g --version

--- a/internal/databases/postgres/orioledb/incremental_page_reader.go
+++ b/internal/databases/postgres/orioledb/incremental_page_reader.go
@@ -225,20 +225,7 @@ func (pageReader *incrementalPageReader) WriteDiffMapToHeader(headerWriter io.Wr
 }
 
 type pageHeader struct {
-	state             uint32
-	usageCount        uint32
-	pageChangeCount   uint32
-	checkpointNum     uint32
-	undoLocation      uint64
-	csn               uint64
-	rightLink         uint64
-	flagsField1Field2 uint32
-	maxKeyLen         uint16
-	prevInsertOffset  uint16
-	chunksCount       uint16
-	itemsCount        uint16
-	hikeysEnd         uint16
-	dataSize          uint16
+	checkpointNum uint32
 }
 
 func (header *pageHeader) isValid() bool {
@@ -250,21 +237,7 @@ func (header *pageHeader) isValid() bool {
 func parsePageHeader(reader io.Reader) (*pageHeader, error) {
 	pageHeader := pageHeader{}
 	fields := []parsingutil.FieldToParse{
-		{Field: &pageHeader.state, Name: "state"},
-		{Field: &pageHeader.usageCount, Name: "usageCount"},
-		{Field: &pageHeader.pageChangeCount, Name: "pageChangeCount"},
-
 		{Field: &pageHeader.checkpointNum, Name: "checkpointNum"},
-		{Field: &pageHeader.undoLocation, Name: "undoLocation"},
-		{Field: &pageHeader.csn, Name: "csn"},
-		{Field: &pageHeader.rightLink, Name: "rightLink"},
-		{Field: &pageHeader.flagsField1Field2, Name: "flagsField1Field2"},
-		{Field: &pageHeader.maxKeyLen, Name: "maxKeyLen"},
-		{Field: &pageHeader.prevInsertOffset, Name: "prevInsertOffset"},
-		{Field: &pageHeader.chunksCount, Name: "chunksCount"},
-		{Field: &pageHeader.itemsCount, Name: "itemsCount"},
-		{Field: &pageHeader.hikeysEnd, Name: "hikeysEnd"},
-		{Field: &pageHeader.dataSize, Name: "dataSize"},
 	}
 	err := parsingutil.ParseMultipleFieldsFromReader(fields, reader)
 	if err != nil {


### PR DESCRIPTION
### Database name
postgres / orioledb

# Pull request description

### Describe what this PR fixes
- updated page iterator for page level incremental backup to conform to orioledb beta13 and up (Probably there is not much usage for previous versions), page structure should not change In the future that much (and now it only checks first field on page that should not move anywhere) 
- updated Dockerfille for orioledb test to postgres 17 and to use latest orioledb build scheme

### Small fixes not related to PR:
- updated docs to mention GOEXPERIMENT=jsonv2
- updated docker_lint in makefile, because it was not working with go 1.25

