### PR TITLE
Have CompressAndEncrypt's errors wrap the root cause

### DIFF
--- a/internal/compress_and_encrypt.go
+++ b/internal/compress_and_encrypt.go
@@ -18,7 +18,11 @@ type CompressAndEncryptError struct {
 }
 
 func newCompressingPipeWriterError(reason string, cause error) CompressAndEncryptError {
-	return CompressAndEncryptError{errors.Wrap(cause, reason)}
+	err := errors.Wrap(cause, reason)
+	if err == nil {
+		err = errors.New(reason)
+	}
+	return CompressAndEncryptError{err}
 }
 
 func (err CompressAndEncryptError) Error() string {


### PR DESCRIPTION
Fixes #2113

I'm not really a golang dev but I think this will improve the error message I'm seeing.

### Database name
Wal-g provides support for many databases, please write down name of database you uses.

PostgreSQL
### Describe what this PR fixes
I don't know why something isn't working.

### Please provide steps to reproduce (if it's a bug)
I don't know what causes the problem.

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
wal-g-1  | ERROR: 2025/11/19 12:55:08.453875 ReadRequestBody: read upload data failed
wal-g-1  | caused by: CompressAndEncrypt: compression failed
wal-g-1  | github.com/wal-g/wal-g/internal.newCompressingPipeWriterError
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/compress_and_encrypt.go:21
wal-g-1  | github.com/wal-g/wal-g/internal.CompressAndEncrypt.func1
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/compress_and_encrypt.go:55
wal-g-1  | runtime.goexit
wal-g-1  |      /opt/hostedtoolcache/go/1.22.12/x64/src/runtime/asm_amd64.s:1695
wal-g-1  | failed to upload 'basebackups_005/base_000000010000000000000042/tar_partitions/part_001.tar.lz4' to bucket 'qddAhsGKklGSBKfL7AB6'
wal-g-1  | github.com/wal-g/wal-g/pkg/storages/s3.(*Uploader).upload
wal-g-1  |      /home/runner/work/wal-g/wal-g/pkg/storages/s3/uploader.go:107
wal-g-1  | github.com/wal-g/wal-g/pkg/storages/s3.(*Folder).PutObjectWithContext
wal-g-1  |      /home/runner/work/wal-g/wal-g/pkg/storages/s3/folder.go:76
wal-g-1  | github.com/wal-g/wal-g/internal/multistorage.Folder.PutObjectToFirst
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/multistorage/folder.go:460
wal-g-1  | github.com/wal-g/wal-g/internal/multistorage.Folder.PutObjectWithContext
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/multistorage/folder.go:443
wal-g-1  | github.com/wal-g/wal-g/internal.(*RegularUploader).Upload
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/uploader.go:178
wal-g-1  | github.com/wal-g/wal-g/internal/databases/postgres.(*StreamingBaseBackup).Upload
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/databases/postgres/streaming_base_backup.go:135
wal-g-1  | github.com/wal-g/wal-g/internal/databases/postgres.(*BackupHandler).runRemoteBackup
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/databases/postgres/backup_push_handler.go:553
wal-g-1  | github.com/wal-g/wal-g/internal/databases/postgres.(*BackupHandler).createAndPushRemoteBackup
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/databases/postgres/backup_push_handler.go:452
wal-g-1  | github.com/wal-g/wal-g/internal/databases/postgres.(*BackupHandler).handleBackupPushRemote
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/databases/postgres/backup_push_handler.go:407
wal-g-1  | github.com/wal-g/wal-g/internal/databases/postgres.(*BackupHandler).HandleBackupPush
wal-g-1  |      /home/runner/work/wal-g/wal-g/internal/databases/postgres/backup_push_handler.go:388
wal-g-1  | github.com/wal-g/wal-g/cmd/pg.init.func11
wal-g-1  |      /home/runner/work/wal-g/wal-g/cmd/pg/backup_push.go:117
wal-g-1  | github.com/spf13/cobra.(*Command).execute
wal-g-1  |      /home/runner/work/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:860
wal-g-1  | github.com/spf13/cobra.(*Command).ExecuteC
wal-g-1  |      /home/runner/work/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:974
wal-g-1  | github.com/spf13/cobra.(*Command).Execute
wal-g-1  |      /home/runner/work/wal-g/wal-g/vendor/github.com/spf13/cobra/command.go:902
wal-g-1  | github.com/wal-g/wal-g/cmd/pg.Execute
wal-g-1  |      /home/runner/work/wal-g/wal-g/cmd/pg/pg.go:55
wal-g-1  | main.main
wal-g-1  |      /home/runner/work/wal-g/wal-g/main/pg/main.go:8
wal-g-1  | runtime.main
wal-g-1  |      /opt/hostedtoolcache/go/1.22.12/x64/src/runtime/proc.go:271
wal-g-1  | runtime.goexit
wal-g-1  |      /opt/hostedtoolcache/go/1.22.12/x64/src/runtime/asm_amd64.s:1695
```
</p>
</details>
