### PR TITLE
releases: add ubuntu24 for aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ { distro: ubuntu20.04, label: ubuntu-20.04 }, { distro: ubuntu22.04, label: ubuntu-22.04 } ]
+        os: [ { distro: ubuntu20.04, label: ubuntu-20.04 }, { distro: ubuntu22.04, label: ubuntu-22.04 }, { distro: ubuntu24.04, label: ubuntu-24.04 } ]
         db: [ pg, mysql, sqlserver, redis, mongo, fdb, gp ]
         include:
           - arch: aarch64


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

PostgreSQL

### Describe what this PR fixes
24.04 arm builds

There is some discussion here: https://github.com/wal-g/wal-g/pull/1956
I wasn't able to get any of the arm things building 24.04 or not.
https://github.com/sixcorners/walg/actions/runs/19503691114/job/55824875713