### PR TITLE
feat: allow configuration of S3_ENABLE_VERSIONING

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -95,6 +95,10 @@ COMPLIANCE mode prohibits deletion for everyone before retention period is over.
 
 By default wal-g validates s3 credentials before work. If you want to disable validation, set this setting to true.
 
+* `S3_ENABLE_VERSIONING`
+
+By default, WAL-G checks whether versioning is enabled on the bucket. When the user already knows the bucket’s versioning state, this setting allows them to specify `enabled` or `disabled`, avoiding an unnecessary round trip to the server.
+
 GCS
 -----------
 To store backups in Google Cloud Storage, WAL-G requires that this variable be set:

--- a/pkg/storages/s3/configure.go
+++ b/pkg/storages/s3/configure.go
@@ -46,6 +46,7 @@ const (
 	minThrottlingRetryDelaySetting = "S3_MIN_THROTTLING_RETRY_DELAY"
 	maxThrottlingRetryDelaySetting = "S3_MAX_THROTTLING_RETRY_DELAY"
 	disable100ContinueSetting      = "S3_DISABLE_100_CONTINUE"
+	enableVersioningSetting        = "S3_ENABLE_VERSIONING"
 )
 
 var SettingList = []string{
@@ -82,6 +83,7 @@ var SettingList = []string{
 	retentionPeriodSetting,
 	retentionModeSetting,
 	disable100ContinueSetting,
+	enableVersioningSetting,
 }
 
 const (
@@ -213,6 +215,7 @@ func ConfigureStorage(
 		MinThrottlingRetryDelay: time.Duration(minThrottlingRetryDelay) * time.Millisecond,
 		MaxThrottlingRetryDelay: time.Duration(maxThrottlingRetryDelay) * time.Millisecond,
 		Disable100Continue:      disable100Continue,
+		EnableVersioning:        settings[enableVersioningSetting],
 	}
 
 	st, err := NewStorage(config, rootWraps...)


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description
By default, WAL-G checks whether versioning is enabled on the bucket. When the user already knows the bucket’s versioning state, this setting allows them to specify `enabled` or `disabled`, avoiding an unnecessary round trip to the server.
