### PR TITLE
Fix PG and GP checksums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test: deps unittest pg_build mysql_build redis_build mongo_build gp_build cloudb
 pg_test: deps pg_build unlink_brotli pg_integration_test
 
 pg_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_PG_PATH) && go build -v -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -gcflags "$(BUILD_GCFLAGS)" -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/pg.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/pg.gitRevision=$(GIT_REVISION) -X github.com/wal-g/wal-g/cmd/pg.walgVersion=$(WALG_VERSION)")
+	(cd $(MAIN_PG_PATH) && go build -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -gcflags "$(BUILD_GCFLAGS)" -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/pg.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/pg.gitRevision=$(GIT_REVISION) -X github.com/wal-g/wal-g/cmd/pg.walgVersion=$(WALG_VERSION)")
 
 install_and_build_pg: deps pg_build
 

--- a/internal/databases/postgres/paged_file_verifier.go
+++ b/internal/databases/postgres/paged_file_verifier.go
@@ -132,16 +132,17 @@ func isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage) (bool, e
 	if err != nil {
 		return false, err
 	}
-	valid := pageHeader.isValid()
-	if !valid {
-		// If the pageHeader is not valid, there is no sense in proceeding with the page checking.
-		tracelog.WarningLogger.Printf("Invalid page header encountered: blockNo %d, path %s", blockNo, path)
-		return false, nil
-	}
 
 	// We only calculate the checksum for properly-initialized pages
 	isNew := pageHeader.isNew()
 	if isNew {
+		return false, nil
+	}
+
+	valid := pageHeader.isValid()
+	if !valid {
+		// If the pageHeader is not valid, there is no sense in proceeding with the page checking.
+		tracelog.WarningLogger.Printf("Invalid page header encountered: blockNo %d, path %s", blockNo, path)
 		return false, nil
 	}
 
@@ -237,7 +238,6 @@ func verifyPageBlocks(path string, fileInfo os.FileInfo, pageBlocks io.Reader,
 // verifySinglePage reads and verifies single paged file block
 func verifySinglePage(path string, blockNo uint32, pageBlocks io.Reader) (bool, error) {
 	page := PgDatabasePage{}
-	tracelog.WarningLogger.Printf("PgDatabasePage %d DatabasePageSize %d\n", MaxDatabasePageSize, DatabasePageSize)
 	_, err := io.ReadFull(pageBlocks, page[:DatabasePageSize])
 	if err != nil {
 		return false, err


### PR DESCRIPTION
#1968 seems to be braking page checksums validation with:
```

runtime: pointer 0xc000cb9f08 to unused region of span span.base()=0xc000cb6000 span.limit=0xc000cb9f00 span.state=1
fatal error: found bad pointer in Go heap (incorrect use of unsafe or cgo?)

runtime stack:
runtime.throw({0x24a577d?, 0x7cb034e96da8?})
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-amd64/src/runtime/panic.go:1101 +0x48 fp=0x7cb034e96d88 sp=0x7cb034e96d58 pc=0x47cea8
runtime.badPointer(0x7cb034633938, 0xc000cb9f08, 0x0, 0x0)
```

This PR restores original computation logic and adapts to different page sizes.

@fanfuxiaoran please review.

TODO: It would be nice to have checksums enabled somewhere in tests.