### PR TITLE
fix environment vars are empty but they are present bug

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -308,9 +308,12 @@ var (
 	}
 
 	MysqlDefaultSettings = map[string]string{
-		StreamSplitterBlockSize:     "1048576",
-		MysqlBackupDownloadMaxRetry: "1",
-		MysqlIncrementalBackupDst:   "/tmp",
+		StreamSplitterBlockSize:      "1048576",
+		MysqlBackupDownloadMaxRetry:  "1",
+		MysqlIncrementalBackupDst:    "/tmp",
+		FailoverStoragesCheckTimeout: "30s",
+		FailoverStorageCacheLifetime: "15m",
+		FailoverStoragesCheckSize:    "1mb",
 	}
 
 	SQLServerDefaultSettings = map[string]string{
@@ -571,25 +574,37 @@ var (
 
 	MysqlAllowedSettings = map[string]bool{
 		// MySQL
-		MysqlDatasourceNameSetting:     true,
-		MysqlSslCaSetting:              true,
-		MysqlBinlogReplayCmd:           true,
-		MysqlBinlogDstSetting:          true,
-		MysqlBackupPrepareCmd:          true,
-		MysqlTakeBinlogsFromMaster:     true,
-		MysqlCheckGTIDs:                true,
-		StreamSplitterPartitions:       true,
-		StreamSplitterBlockSize:        true,
-		StreamSplitterMaxFileSize:      true,
-		MysqlBinlogServerHost:          true,
-		MysqlBinlogServerPort:          true,
-		MysqlBinlogServerUser:          true,
-		MysqlBinlogServerPassword:      true,
-		MysqlBinlogServerID:            true,
-		MysqlBinlogServerReplicaSource: true,
-		MysqlBackupDownloadMaxRetry:    true,
-		MysqlIncrementalBackupDst:      true,
-		MysqlDataDir:                   true,
+		MysqlDatasourceNameSetting:           true,
+		MysqlSslCaSetting:                    true,
+		MysqlBinlogReplayCmd:                 true,
+		MysqlBinlogDstSetting:                true,
+		MysqlBackupPrepareCmd:                true,
+		MysqlTakeBinlogsFromMaster:           true,
+		MysqlCheckGTIDs:                      true,
+		StreamSplitterPartitions:             true,
+		StreamSplitterBlockSize:              true,
+		StreamSplitterMaxFileSize:            true,
+		MysqlBinlogServerHost:                true,
+		MysqlBinlogServerPort:                true,
+		MysqlBinlogServerUser:                true,
+		MysqlBinlogServerPassword:            true,
+		MysqlBinlogServerID:                  true,
+		MysqlBinlogServerReplicaSource:       true,
+		MysqlBackupDownloadMaxRetry:          true,
+		MysqlIncrementalBackupDst:            true,
+		MysqlDataDir:                         true,
+		FailoverStorages:                     true,
+		FailoverStoragesCheck:                true,
+		FailoverStoragesCheckTimeout:         true,
+		FailoverStorageCacheLifetime:         true,
+		FailoverStorageCacheEMAAliveLimit:    true,
+		FailoverStorageCacheEMADeadLimit:     true,
+		FailoverStorageCacheEMAAlphaAliveMax: true,
+		FailoverStorageCacheEMAAlphaAliveMin: true,
+		FailoverStorageCacheEMAAlphaDeadMax:  true,
+		FailoverStorageCacheEMAAlphaDeadMin:  true,
+		FailoverStoragesCheckSize:            true,
+		PgTargetStorage:                      true,
 	}
 
 	RedisAllowedSettings = map[string]bool{

--- a/internal/config/mysql_failover_test.go
+++ b/internal/config/mysql_failover_test.go
@@ -125,16 +125,3 @@ func TestMysqlFailoverStoragesEMA_AllSettingsAllowed(t *testing.T) {
 
 	viper.Reset()
 }
-
-func TestMysqlTargetStorage_IsAllowed(t *testing.T) {
-	viper.Reset()
-	internal.ConfigureSettings(config.MYSQL)
-	config.InitConfig()
-
-	viper.Set(config.PgTargetStorage, "default")
-
-	allowed := config.AllowedSettings[config.PgTargetStorage]
-	assert.True(t, allowed)
-
-	viper.Reset()
-}

--- a/internal/config/mysql_failover_test.go
+++ b/internal/config/mysql_failover_test.go
@@ -1,0 +1,140 @@
+﻿package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/config"
+)
+
+func TestMysqlFailoverStoragesCheckTimeout_IsAllowed(t *testing.T) {
+	viper.Reset()
+	internal.ConfigureSettings(config.MYSQL)
+	config.InitConfig()
+
+	_ = os.Setenv("WALG_FAILOVER_STORAGES_CHECK_TIMEOUT", "3600")
+	defer func() { _ = os.Unsetenv("WALG_FAILOVER_STORAGES_CHECK_TIMEOUT") }()
+
+	viper.Set(config.FailoverStoragesCheckTimeout, "3600")
+
+	allowed := config.AllowedSettings[config.FailoverStoragesCheckTimeout]
+	assert.True(t, allowed)
+
+	value := viper.GetString(config.FailoverStoragesCheckTimeout)
+	assert.Equal(t, "3600", value)
+
+	viper.Reset()
+}
+
+func TestMysqlFailoverStoragesCacheLifetime_IsAllowed(t *testing.T) {
+	viper.Reset()
+	internal.ConfigureSettings(config.MYSQL)
+	config.InitConfig()
+
+	_ = os.Setenv("WALG_FAILOVER_STORAGES_CACHE_LIFETIME", "3600")
+	defer func() { _ = os.Unsetenv("WALG_FAILOVER_STORAGES_CACHE_LIFETIME") }()
+
+	viper.Set(config.FailoverStorageCacheLifetime, "3600")
+
+	allowed := config.AllowedSettings[config.FailoverStorageCacheLifetime]
+	assert.True(t, allowed)
+
+	value := viper.GetString(config.FailoverStorageCacheLifetime)
+	assert.Equal(t, "3600", value)
+
+	viper.Reset()
+}
+
+func TestMysqlFailoverStorages_IsAllowed(t *testing.T) {
+	viper.Reset()
+	internal.ConfigureSettings(config.MYSQL)
+	config.InitConfig()
+
+	viper.Set(config.FailoverStorages, "storage1,storage2")
+
+	allowed := config.AllowedSettings[config.FailoverStorages]
+	assert.True(t, allowed)
+
+	viper.Reset()
+}
+
+func TestMysqlFailoverStoragesCheck_IsAllowed(t *testing.T) {
+	viper.Reset()
+	internal.ConfigureSettings(config.MYSQL)
+	config.InitConfig()
+
+	viper.Set(config.FailoverStoragesCheck, "true")
+
+	allowed := config.AllowedSettings[config.FailoverStoragesCheck]
+	assert.True(t, allowed)
+
+	viper.Reset()
+}
+
+func TestMysqlFailoverStoragesCheckSize_IsAllowed(t *testing.T) {
+	viper.Reset()
+	internal.ConfigureSettings(config.MYSQL)
+	config.InitConfig()
+
+	viper.Set(config.FailoverStoragesCheckSize, "1mb")
+
+	allowed := config.AllowedSettings[config.FailoverStoragesCheckSize]
+	assert.True(t, allowed)
+
+	viper.Reset()
+}
+
+func TestMysqlFailoverStorages_DefaultValues(t *testing.T) {
+	viper.Reset()
+	internal.ConfigureSettings(config.MYSQL)
+	config.InitConfig()
+
+	assert.Contains(t, config.DefaultConfigValues, config.FailoverStoragesCheckTimeout)
+	assert.Contains(t, config.DefaultConfigValues, config.FailoverStorageCacheLifetime)
+
+	checkTimeout := config.DefaultConfigValues[config.FailoverStoragesCheckTimeout]
+	assert.Equal(t, "30s", checkTimeout)
+
+	cacheLifetime := config.DefaultConfigValues[config.FailoverStorageCacheLifetime]
+	assert.Equal(t, "15m", cacheLifetime)
+
+	viper.Reset()
+}
+
+func TestMysqlFailoverStoragesEMA_AllSettingsAllowed(t *testing.T) {
+	viper.Reset()
+	internal.ConfigureSettings(config.MYSQL)
+	config.InitConfig()
+
+	emaSettings := []string{
+		config.FailoverStorageCacheEMAAliveLimit,
+		config.FailoverStorageCacheEMADeadLimit,
+		config.FailoverStorageCacheEMAAlphaAliveMax,
+		config.FailoverStorageCacheEMAAlphaAliveMin,
+		config.FailoverStorageCacheEMAAlphaDeadMax,
+		config.FailoverStorageCacheEMAAlphaDeadMin,
+	}
+
+	for _, setting := range emaSettings {
+		allowed := config.AllowedSettings[setting]
+		assert.True(t, allowed, setting)
+	}
+
+	viper.Reset()
+}
+
+func TestMysqlTargetStorage_IsAllowed(t *testing.T) {
+	viper.Reset()
+	internal.ConfigureSettings(config.MYSQL)
+	config.InitConfig()
+
+	viper.Set(config.PgTargetStorage, "default")
+
+	allowed := config.AllowedSettings[config.PgTargetStorage]
+	assert.True(t, allowed)
+
+	viper.Reset()
+}


### PR DESCRIPTION
# Pull request description

Fixes MySQL/MariaDB failover storage environment variables being treated as unknown (#1986).

Failover-related WALG_FAILOVER_STORAGES_* environment variables were present and parsed, but not marked as allowed for MySQL, which caused misleading “unknown variable” warnings.

# Tests

Added unit tests covering MySQL failover storage configuration.
