### PR TITLE
Fix batch deletion in s3

### DIFF
--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -363,12 +363,14 @@ func (folder *Folder) listObjectsPagesV2(prefix *string, delimiter *string, maxK
 }
 
 func (folder *Folder) DeleteObjects(objectRelativePaths []string) error {
-	parts := partitionStrings(objectRelativePaths, 1000)
 	needsVersioning := folder.isVersioningEnabled()
+	objects := folder.partitionToObjects(objectRelativePaths, needsVersioning)
+
+	parts := partitionObjects(objects, 1000)
 
 	for _, part := range parts {
 		input := &s3.DeleteObjectsInput{Bucket: folder.bucket, Delete: &s3.Delete{
-			Objects: folder.partitionToObjects(part, needsVersioning),
+			Objects: part,
 		}}
 		_, err := folder.s3API.DeleteObjects(input)
 		if err != nil {

--- a/pkg/storages/s3/uploader.go
+++ b/pkg/storages/s3/uploader.go
@@ -132,3 +132,18 @@ func partitionStrings(strings []string, blockSize int) [][]string {
 	}
 	return partition
 }
+
+func partitionObjects(objects []*s3.ObjectIdentifier, blockSize int) [][]*s3.ObjectIdentifier {
+	if blockSize <= 0 {
+		return [][]*s3.ObjectIdentifier{objects}
+	}
+	partition := make([][]*s3.ObjectIdentifier, 0)
+	for i := 0; i < len(objects); i += blockSize {
+		if i+blockSize > len(objects) {
+			partition = append(partition, objects[i:])
+		} else {
+			partition = append(partition, objects[i:i+blockSize])
+		}
+	}
+	return partition
+}

--- a/pkg/storages/s3/uploader_test.go
+++ b/pkg/storages/s3/uploader_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -136,6 +137,30 @@ func TestPartitionStrings(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			actual := partitionStrings(tc.strings, tc.blockSize)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestPartitionObjects(t *testing.T) {
+	testCases := []struct {
+		strings   []*s3.ObjectIdentifier
+		blockSize int
+		expected  [][]*s3.ObjectIdentifier
+	}{
+		{[]*s3.ObjectIdentifier{{}, {}, {}, {}, {}}, 2, [][]*s3.ObjectIdentifier{{{}, {}}, {{}, {}}, {{}}}},
+		{[]*s3.ObjectIdentifier{{}, {}, {}, {}, {}, {}}, 3, [][]*s3.ObjectIdentifier{{{}, {}, {}}, {{}, {}, {}}}},
+		{[]*s3.ObjectIdentifier{{}, {}, {}, {}, {}}, 1000, [][]*s3.ObjectIdentifier{{{}, {}, {}, {}, {}}}},
+		{[]*s3.ObjectIdentifier{{}, {}, {}, {}, {}}, 1, [][]*s3.ObjectIdentifier{{{}}, {{}}, {{}}, {{}}, {{}}}},
+		{[]*s3.ObjectIdentifier{{}, {}, {}, {}, {}}, 0, [][]*s3.ObjectIdentifier{{{}, {}, {}, {}, {}}}},
+		{[]*s3.ObjectIdentifier{{}, {}, {}, {}, {}}, -1, [][]*s3.ObjectIdentifier{{{}, {}, {}, {}, {}}}},
+		{[]*s3.ObjectIdentifier{{}, {}}, 5, [][]*s3.ObjectIdentifier{{{}, {}}}},
+		{[]*s3.ObjectIdentifier{{}}, 1, [][]*s3.ObjectIdentifier{{{}}}},
+		{[]*s3.ObjectIdentifier{}, 1, [][]*s3.ObjectIdentifier{}},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			actual := partitionObjects(tc.strings, tc.blockSize)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}


### PR DESCRIPTION
### Storage name
S3

# Pull request description
When using versioned buckets encountered an error, when trying to delete many wal files. wal-g splits file names in to batches, but then checks if any versions are present. So batch becomes larger than s3 constraints (by default 1000 objects at once)
