### PR TITLE
fix: close file at creation

### DIFF
--- a/internal/fsutil/disk_data_folder.go
+++ b/internal/fsutil/disk_data_folder.go
@@ -56,9 +56,11 @@ func (folder *DiskDataFolder) FileExists(filename string) bool {
 
 func (folder *DiskDataFolder) CreateFile(filename string) error {
 	filePath := filepath.Join(folder.Path, filename)
-	_, err := os.Create(filePath)
-
-	return err
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	return file.Close()
 }
 
 func (folder *DiskDataFolder) DeleteFile(filename string) error {


### PR DESCRIPTION
### Database name
Any

# Pull request description

Call of `os.Create(filePath)` create file handle. Clean code should close this handle to avoid leak after function exit