### PR TITLE
Pipe for oplog fetching improvements

### DIFF
--- a/internal/databases/mongo/archive/loader.go
+++ b/internal/databases/mongo/archive/loader.go
@@ -125,6 +125,7 @@ func (sd *StorageDownloader) DownloadOplogArchive(arch models.Archive, writeClos
 
 // ListOplogArchives fetches all oplog archives existed in storage.
 func (sd *StorageDownloader) ListOplogArchives() ([]models.Archive, error) {
+	tracelog.DebugLogger.Printf("Listing %s", sd.oplogsFolder.GetPath())
 	objects, _, err := sd.oplogsFolder.ListFolder()
 	if err != nil {
 		return nil, fmt.Errorf("can not list oplog archives folder: %w", err)
@@ -139,6 +140,8 @@ func (sd *StorageDownloader) ListOplogArchives() ([]models.Archive, error) {
 		}
 		archives = append(archives, arch)
 	}
+
+	tracelog.DebugLogger.Printf("%s listed", sd.oplogsFolder.GetPath())
 	return archives, nil
 }
 


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
Before that commit, oplog fetcher consistently dowdloaded archives to a buffer and bson serialised it after. Now it will download archives to buffer and serialised it in parallel

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
