### PR TITLE
One oplog entry more correct fix

### DIFF
--- a/internal/databases/mongo/client/client.go
+++ b/internal/databases/mongo/client/client.go
@@ -78,7 +78,7 @@ type MongoDriver interface {
 	EnsureIsMaster(ctx context.Context) error
 	IsMaster(ctx context.Context) (models.IsMaster, error)
 	LastWriteTS(ctx context.Context) (lastTS, lastMajTS models.Timestamp, err error)
-	TailOplogFrom(ctx context.Context, from models.Timestamp, initial bool) (OplogCursor, error)
+	TailOplogFrom(ctx context.Context, from models.Timestamp) (OplogCursor, error)
 	ApplyOp(ctx context.Context, op *db.Oplog) error
 	Close(ctx context.Context, shutdown bool) error
 	ChangeOplogLastTimestamp(ctx context.Context, opTime models.OpTime) error
@@ -324,19 +324,14 @@ func (mc *MongoClient) Close(ctx context.Context, shutdown bool) error {
 }
 
 // TailOplogFrom gives OplogCursor to tail oplog from
-func (mc *MongoClient) TailOplogFrom(ctx context.Context, from models.Timestamp, initial bool) (OplogCursor, error) {
+func (mc *MongoClient) TailOplogFrom(ctx context.Context, from models.Timestamp) (OplogCursor, error) {
 	coll, err := mc.getOplogCollection(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	bsonTS := models.BsonTimestampFromOplogTS(from)
-	filterTS := bson.M{"$gt": bsonTS}
-	if initial {
-		filterTS = bson.M{"$gte": bsonTS}
-	}
-
-	filter := bson.M{"ts": filterTS}
+	filter := bson.M{"ts": bson.M{"$gte": bsonTS}}
 	cur, err := coll.Find(ctx, filter, options.Find().SetCursorType(options.TailableAwait))
 
 	if err == nil && cur.ID() == 0 {

--- a/internal/databases/mongo/client/mocks/MongoDriver.go
+++ b/internal/databases/mongo/client/mocks/MongoDriver.go
@@ -220,9 +220,9 @@ func (_m *MongoDriver) LastWriteTS(ctx context.Context) (models.Timestamp, model
 	return r0, r1, r2
 }
 
-// TailOplogFrom provides a mock function with given fields: ctx, from, initial
-func (_m *MongoDriver) TailOplogFrom(ctx context.Context, from models.Timestamp, initial bool) (client.OplogCursor, error) {
-	ret := _m.Called(ctx, from, initial)
+// TailOplogFrom provides a mock function with given fields: ctx, from
+func (_m *MongoDriver) TailOplogFrom(ctx context.Context, from models.Timestamp) (client.OplogCursor, error) {
+	ret := _m.Called(ctx, from)
 
 	if len(ret) == 0 {
 		panic("no return value specified for TailOplogFrom")
@@ -230,19 +230,19 @@ func (_m *MongoDriver) TailOplogFrom(ctx context.Context, from models.Timestamp,
 
 	var r0 client.OplogCursor
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, models.Timestamp, bool) (client.OplogCursor, error)); ok {
-		return rf(ctx, from, initial)
+	if rf, ok := ret.Get(0).(func(context.Context, models.Timestamp) (client.OplogCursor, error)); ok {
+		return rf(ctx, from)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, models.Timestamp, bool) client.OplogCursor); ok {
-		r0 = rf(ctx, from, initial)
+	if rf, ok := ret.Get(0).(func(context.Context, models.Timestamp) client.OplogCursor); ok {
+		r0 = rf(ctx, from)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(client.OplogCursor)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, models.Timestamp, bool) error); ok {
-		r1 = rf(ctx, from, initial)
+	if rf, ok := ret.Get(1).(func(context.Context, models.Timestamp) error); ok {
+		r1 = rf(ctx, from)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/databases/mongo/discovery/discovery.go
+++ b/internal/databases/mongo/discovery/discovery.go
@@ -38,7 +38,7 @@ func BuildCursorFromTS(ctx context.Context,
 	initial bool,
 	uploader archive.Uploader,
 	mongoClient client.MongoDriver) (oplogCursor client.OplogCursor, fromTS models.Timestamp, err error) {
-	oplogCursor, err = mongoClient.TailOplogFrom(ctx, since, initial)
+	oplogCursor, err = mongoClient.TailOplogFrom(ctx, since)
 	if err != nil {
 		return nil, models.Timestamp{}, fmt.Errorf("can not build oplog cursor from ts '%s': %+v", since, err)
 	}
@@ -55,6 +55,11 @@ func BuildCursorFromTS(ctx context.Context,
 	}
 
 	if op.TS == since {
+		if !initial {
+			// If we resume oplog-pushing, there will be same oplog entry in last position of last oplog archive
+			// and first position of current archive, so we skip one operation
+			oplogCursor.Next(ctx)
+		}
 		return oplogCursor, since, nil
 	}
 
@@ -72,7 +77,7 @@ func BuildCursorFromTS(ctx context.Context,
 		return nil, models.Timestamp{}, err
 	}
 
-	oplogCursor, err = mongoClient.TailOplogFrom(ctx, newestTS, true)
+	oplogCursor, err = mongoClient.TailOplogFrom(ctx, newestTS)
 	if err != nil {
 		return nil, models.Timestamp{}, fmt.Errorf("can not build oplog cursor from ts '%s': %+v", newestTS, err)
 	}

--- a/internal/databases/mongo/discovery/discovery_test.go
+++ b/internal/databases/mongo/discovery/discovery_test.go
@@ -94,10 +94,10 @@ func TestBuildCursorFromFolderTS(t *testing.T) {
 						secondCur.On("Data").Return(secondCurDoc).Once()
 
 						md := &mocks.MongoDriver{}
-						md.On("TailOplogFrom", mock.Anything, reqTS, true).Return(firstCur, nil).Once().
+						md.On("TailOplogFrom", mock.Anything, reqTS).Return(firstCur, nil).Once().
 							On("IsMaster", mock.Anything).
 							Return(models.IsMaster{LastWrite: models.IsMasterLastWrite{MajorityOpTime: models.OpTime{TS: newestTS}}}, nil).
-							On("TailOplogFrom", mock.Anything, newestTS, true).Return(secondCur, nil).Once()
+							On("TailOplogFrom", mock.Anything, newestTS).Return(secondCur, nil).Once()
 						return MongoDriverFields{
 							client:    md,
 							firstCur:  firstCur,
@@ -132,7 +132,7 @@ func TestBuildCursorFromFolderTS(t *testing.T) {
 							On("Push", firstDoc).Return(nil).Once()
 
 						md := &mocks.MongoDriver{}
-						md.On("TailOplogFrom", mock.Anything, reqTS, true).Return(cur, nil).Once()
+						md.On("TailOplogFrom", mock.Anything, reqTS).Return(cur, nil).Once()
 						return MongoDriverFields{
 							client:   md,
 							firstCur: cur,
@@ -156,7 +156,7 @@ func TestBuildCursorFromFolderTS(t *testing.T) {
 					}(),
 					mongo: func() MongoDriverFields {
 						md := &mocks.MongoDriver{}
-						md.On("TailOplogFrom", mock.Anything, reqTS, true).
+						md.On("TailOplogFrom", mock.Anything, reqTS).
 							Return(nil, fmt.Errorf("can not create first cursor")).Once()
 						return MongoDriverFields{
 							client: md,
@@ -184,7 +184,7 @@ func TestBuildCursorFromFolderTS(t *testing.T) {
 							On("Err").Return(fmt.Errorf("next failed")).Once()
 
 						md := &mocks.MongoDriver{}
-						md.On("TailOplogFrom", mock.Anything, reqTS, true).Return(firstCur, nil).Once()
+						md.On("TailOplogFrom", mock.Anything, reqTS).Return(firstCur, nil).Once()
 						return MongoDriverFields{
 							client:   md,
 							firstCur: firstCur,
@@ -218,7 +218,7 @@ func TestBuildCursorFromFolderTS(t *testing.T) {
 							On("Push", firstCurDoc).Return(nil).Once()
 
 						md := &mocks.MongoDriver{}
-						md.On("TailOplogFrom", mock.Anything, reqTS, true).Return(firstCur, nil).Once().
+						md.On("TailOplogFrom", mock.Anything, reqTS).Return(firstCur, nil).Once().
 							On("IsMaster", mock.Anything).Return(models.IsMaster{}, fmt.Errorf("isMaster error"))
 
 						return MongoDriverFields{
@@ -260,7 +260,7 @@ func TestBuildCursorFromFolderTS(t *testing.T) {
 							On("Push", firstCurDoc).Return(nil).Once()
 
 						md := &mocks.MongoDriver{}
-						md.On("TailOplogFrom", mock.Anything, reqTS, true).Return(firstCur, nil).Once().
+						md.On("TailOplogFrom", mock.Anything, reqTS).Return(firstCur, nil).Once().
 							On("IsMaster", mock.Anything).
 							Return(models.IsMaster{LastWrite: models.IsMasterLastWrite{MajorityOpTime: models.OpTime{TS: newestTS}}}, nil)
 						return MongoDriverFields{
@@ -303,10 +303,10 @@ func TestBuildCursorFromFolderTS(t *testing.T) {
 							On("Push", firstCurDoc).Return(nil).Once()
 
 						md := &mocks.MongoDriver{}
-						md.On("TailOplogFrom", mock.Anything, reqTS, true).Return(firstCur, nil).Once().
+						md.On("TailOplogFrom", mock.Anything, reqTS).Return(firstCur, nil).Once().
 							On("IsMaster", mock.Anything).
 							Return(models.IsMaster{LastWrite: models.IsMasterLastWrite{MajorityOpTime: models.OpTime{TS: newestTS}}}, nil).
-							On("TailOplogFrom", mock.Anything, newestTS, true).
+							On("TailOplogFrom", mock.Anything, newestTS).
 							Return(nil, fmt.Errorf("can not create second cursor")).Once()
 						return MongoDriverFields{
 							client:   md,


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
