### PR TITLE
Store old timestamp for archive consistency, but skip oplog entry to prevent oplog entry duplications

### DIFF
--- a/cmd/mongo/oplog_push.go
+++ b/cmd/mongo/oplog_push.go
@@ -96,7 +96,7 @@ func runOplogPush(ctx context.Context, pushArgs oplogPushRunArgs, statsArgs oplo
 	tracelog.InfoLogger.Printf("Archiving storage last known timestamp is %s", since)
 
 	// fetch cursor started from since TS or from newest TS (if since is not exists)
-	oplogCursor, since, err := discovery.BuildCursorFromTS(ctx, since, initial, uploader, mongoClient)
+	oplogCursor, since, err := discovery.BuildCursorFromTS(ctx, since, uploader, mongoClient)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,8 @@ func runOplogPush(ctx context.Context, pushArgs oplogPushRunArgs, statsArgs oplo
 		memoryBatchBuffer,
 		pushArgs.archiveAfterSize,
 		pushArgs.archiveTimeout,
-		uploadStatsUpdater)
+		uploadStatsUpdater,
+		initial)
 	oplogFetcher := stages.NewCursorMajFetcher(mongoClient, oplogCursor, pushArgs.lwUpdate)
 
 	// run working cycle

--- a/internal/databases/mongo/discovery/discovery.go
+++ b/internal/databases/mongo/discovery/discovery.go
@@ -35,7 +35,6 @@ func ResolveStartingTS(ctx context.Context,
 // BuildCursorFromTS finds point to resume archiving or _restarts_ procedure from newest oplog document
 func BuildCursorFromTS(ctx context.Context,
 	since models.Timestamp,
-	initial bool,
 	uploader archive.Uploader,
 	mongoClient client.MongoDriver) (oplogCursor client.OplogCursor, fromTS models.Timestamp, err error) {
 	oplogCursor, err = mongoClient.TailOplogFrom(ctx, since)
@@ -55,11 +54,6 @@ func BuildCursorFromTS(ctx context.Context,
 	}
 
 	if op.TS == since {
-		if !initial {
-			// If we resume oplog-pushing, there will be same oplog entry in last position of last oplog archive
-			// and first position of current archive, so we skip one operation
-			oplogCursor.Next(ctx)
-		}
 		return oplogCursor, since, nil
 	}
 

--- a/internal/databases/mongo/discovery/discovery_test.go
+++ b/internal/databases/mongo/discovery/discovery_test.go
@@ -321,7 +321,7 @@ func TestBuildCursorFromFolderTS(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotCur, gotSince, err := BuildCursorFromTS(tc.args.ctx, tc.args.since, true, tc.args.uploader, tc.args.mongo.client)
+			gotCur, gotSince, err := BuildCursorFromTS(tc.args.ctx, tc.args.since, tc.args.uploader, tc.args.mongo.client)
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error())
 				tc.args.uploader.AssertExpectations(t)

--- a/internal/databases/mongo/oplog_push_handler_bench_test.go
+++ b/internal/databases/mongo/oplog_push_handler_bench_test.go
@@ -74,7 +74,7 @@ func BenchmarkHandleOplogPush(b *testing.B) {
 				uploader := archive.NewDiscardUploader(tc.compression, tc.readerFrom)
 
 				membuf := stages.NewMemoryBuffer()
-				applier := stages.NewStorageApplier(uploader, membuf, tc.archiveAfterSize, tc.archiveAfterTime, nil)
+				applier := stages.NewStorageApplier(uploader, membuf, tc.archiveAfterSize, tc.archiveAfterTime, nil, false)
 
 				err := HandleOplogPush(context.TODO(), fetcher, applier)
 

--- a/internal/databases/mongo/oplog_push_handler_test.go
+++ b/internal/databases/mongo/oplog_push_handler_test.go
@@ -186,6 +186,7 @@ func TestHandleOplogPush_CancelLongUpload(t *testing.T) {
 		1,
 		time.Hour,
 		statsUpdater,
+		false,
 	)
 
 	err := HandleOplogPush(ctx, fetcher, applier)

--- a/internal/databases/mongo/stages/applier.go
+++ b/internal/databases/mongo/stages/applier.go
@@ -62,6 +62,7 @@ type StorageApplier struct {
 	size         int
 	timeout      time.Duration
 	statsUpdater stats.OplogUploadStatsUpdater
+	initial      bool
 }
 
 // NewStorageApplier builds StorageApplier.
@@ -70,8 +71,10 @@ func NewStorageApplier(uploader archive.Uploader,
 	buf Buffer,
 	archiveAfterSize int,
 	archiveTimeout time.Duration,
-	statsUpdater stats.OplogUploadStatsUpdater) *StorageApplier {
-	return &StorageApplier{uploader, buf, archiveAfterSize, archiveTimeout, statsUpdater}
+	statsUpdater stats.OplogUploadStatsUpdater,
+	initial bool,
+) *StorageApplier {
+	return &StorageApplier{uploader, buf, archiveAfterSize, archiveTimeout, statsUpdater, initial}
 }
 
 // Apply runs working cycle that sends oplog records to storage.
@@ -98,6 +101,10 @@ func (sa *StorageApplier) Apply(ctx context.Context, oplogc chan *models.Oplog) 
 				}
 				if restartBatch {
 					batchStartTS = op.TS
+					if sa.initial {
+						sa.initial = false
+						continue
+					}
 					restartBatch = false
 				}
 				lastKnownTS = op.TS


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
