### PR TITLE
feat: change log to slog for wal-g exporter

### DIFF
--- a/cmd/pg/exporter/exporter.go
+++ b/cmd/pg/exporter/exporter.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog" // Replaced standard log with structured slog
-	"os"
+	"log/slog"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -149,10 +148,7 @@ func (b *BackupInfo) GetDeltaOriginName(backups []BackupInfo) string {
 }
 
 // NewWalgExporter creates a new WAL-G exporter
-func NewWalgExporter(walgPath string, backupScrapeInterval time.Duration, verifyScrapeInterval time.Duration, storageScrapeInterval time.Duration, walgConfigPath string) (*WalgExporter, error) {
-	// Initialize slog with a JSON handler (Standard for structured logging)
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-
+func NewWalgExporter(logger *slog.Logger, walgPath string, backupScrapeInterval time.Duration, verifyScrapeInterval time.Duration, storageScrapeInterval time.Duration, walgConfigPath string) (*WalgExporter, error) {
 	return &WalgExporter{
 		logger:                logger,
 		walgPath:              walgPath,
@@ -464,8 +460,8 @@ func (e *WalgExporter) updateBackupMetrics(backups []BackupInfo) {
 			backupType,                     // backup_type
 			backup.WalFileName,             // wal_file
 			strconv.Itoa(backup.PgVersion), // pg_version
-			strconv.FormatUint(backup.StartLSN, 10),  // Converted to string for metric labels
-			strconv.FormatUint(backup.FinishLSN, 10), // Converted to string for metric labels
+			LSN(backup.StartLSN).String(),  // start_lsn
+			LSN(backup.FinishLSN).String(), // finish_lsn
 			isPermanent,                    // is_permanent
 			deltaOriginBackupName,          // delta_origin
 		}
@@ -594,11 +590,11 @@ func (e *WalgExporter) checkStorageAliveness() {
 	e.storageLatency.Set(latency)
 
 	if err != nil {
-		e.logger.Error("Storage aliveness check failed", "error", err, "latency", latency)
+		e.logger.Error("Storage aliveness check failed", "error", err, "duration", latency)
 		e.storageAlive.Set(0)
 		e.errors.WithLabelValues("storage-check", "connectivity_failed").Inc()
 	} else {
 		e.storageAlive.Set(1)
-		e.logger.Info("Storage check completed", "duration", time.Since(start))
+		e.logger.Info("Storage check completed", "duration", latency)
 	}
 }

--- a/cmd/pg/exporter/main.go
+++ b/cmd/pg/exporter/main.go
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 
 	// Initialize structured logger
-	// Using JSONHandler for production-ready structured logs
+	// Using TextHandler for production-ready structured logs
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	logger.Info("Starting WAL-G Prometheus exporter",
@@ -61,7 +61,7 @@ func main() {
 	}
 
 	// Create and register the exporter
-	exporter, err := NewWalgExporter(*walgPath, *backupScrapeInterval, *verifyScrapeInterval, *storageScrapeInterval, *walgConfigPath)
+	exporter, err := NewWalgExporter(logger, *walgPath, *backupScrapeInterval, *verifyScrapeInterval, *storageScrapeInterval, *walgConfigPath)
 	if err != nil {
 		logger.Error("Failed to create exporter", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description
This PR migrates the exporter's logging system from the standard log package to log/slog.

### Describe what this PR fixes
problem is that currently we have logs in non-human readable format. So this PR converts the current logging into slog which makes it a more readable json.

### Please provide steps to reproduce (if it's a bug)
Go WAL-G Exporter container and check for logs and one can see non comprehensible logs. 

### Please add config and wal-g stdout/stderr logs for debug purpose
The new logs look like this:

{"time":"2026-03-17T16:06:45.96616+01:00","level":"INFO","msg":"Starting WAL-G Prometheus exporter","listen_address":":9351","metrics_path":"/metrics","walg_path":"./mock-wal-g.sh","walg_config":"","intervals":{"backup":10000000000,"verify":300000000000,"storage":30000000000}}
{"time":"2026-03-17T16:06:45.966918+01:00","level":"INFO","msg":"Starting HTTP server","addr":":9351"}
{"time":"2026-03-17T16:06:45.974043+01:00","level":"INFO","msg":"Storage check completed","duration":7374125}
{"time":"2026-03-17T16:06:45.993661+01:00","level":"INFO","msg":"Metrics for backups scrape completed","duration":19580416}
{"time":"2026-03-17T16:06:46.005295+01:00","level":"INFO","msg":"Metrics for WALs verify scrape completed","duration":11605875}
{"time":"2026-03-17T16:06:46.005315+01:00","level":"INFO","msg":"Initial WAL-G metrics scrape completed; starting periodic collection"}
{"time":"2026-03-17T16:06:55.996644+01:00","level":"INFO","msg":"Metrics for backups scrape completed","duration":28833042}
