### PR TITLE
Update delete_handler.go for counting the objects

### DIFF
--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -489,12 +489,17 @@ func DeleteObjectsWhere(
 		}
 	}
 	if len(filteredRelativePathsObjects) == 0 {
+		tracelog.InfoLogger.Println("No backup sets matched the deletion criteria.")
 		return nil
 	}
 	if confirm {
-		return folder.DeleteObjects(filteredRelativePathsObjects)
+		err := folder.DeleteObjects(filteredRelativePathsObjects)
+		if err == nil {
+			tracelog.InfoLogger.Printf("Succession: %d objects were successfully deleted.", len(filteredRelativePathsObjects))
+		}
+		return err
 	}
-	tracelog.InfoLogger.Println("Dry run, nothing were deleted")
+	tracelog.InfoLogger.Printf("Dry run: %d objects would be deleted. Run with --confirm to execute.", len(filteredRelativePathsObjects))
 	return nil
 }
 


### PR DESCRIPTION
### Database name
PostgreSQL

**Describe what this PR fixes**

Currently, wal-g delete operations either exit silently or provide a long list of individual file deletions without a summary. This makes it difficult for administrators or automated scripts to verify at a glance how many objects were actually removed. 

**Changes**

Added a summary message Succession: X objects were successfully deleted. after a confirmed deletion.

Added a clearer dry-run message: Dry run: X objects would be deleted. Run with --confirm to execute.

Added a message for cases where no backups match the deletion criteria: No backup sets matched the deletion criteria.

**Please provide steps to reproduce**

- Run a deletion command (e.g., wal-g delete retain 5 --confirm).

- Observe that previously, there was no final summary of the total objects deleted.

- With this PR, a summary line is printed at the end of the operation.

lease add config and wal-g stdout/stderr logs for debug purpose
<details><summary>If you can, provide logs</summary>
<p>
....
INFO: 2026/03/18 09:05:24.768020 Backup to delete will be searched in storages: [default]
INFO: 2026/03/18 09:05:24.768082 retrieving permanent objects
INFO: 2026/03/18 09:05:35.356957 Start delete
INFO: 2026/03/18 09:05:40.853790 Objects in folder:
INFO: 2026/03/18 09:05:40.853827        will be deleted: basebackups_005/base_00000002000000000000004D_backup_stop_sentinel.json, from storage: default
.....
......
INFO: 2026/03/18 09:06:07.331460 Succession: 754 objects were successfully deleted.
</p>
</details>