### PR TITLE
Added length validator for s3 object read

### DIFF
--- a/pkg/storages/s3/content_length_validator.go
+++ b/pkg/storages/s3/content_length_validator.go
@@ -1,0 +1,60 @@
+package s3
+
+import (
+	"fmt"
+	"io"
+)
+
+// ContentLengthMismatchError is returned when the actual number of bytes read
+// from an S3 object body does not match the Content-Length header value.
+type ContentLengthMismatchError struct {
+	ObjectPath string
+	Expected   int
+	Actual     int
+}
+
+func (e ContentLengthMismatchError) Error() string {
+	return fmt.Sprintf(
+		"content length mismatch for S3 object %q: Content-Length header says %d bytes, but got %d bytes",
+		e.ObjectPath, e.Expected, e.Actual,
+	)
+}
+
+// СontentLengthValidator wraps an io.ReadCloser and validates that the total
+// number of bytes read matches the expected Content-Length when EOF is reached.
+// If expectedSize is 0 (e.g. Content-Length was not set), the validator
+// is a transparent pass-through and performs no length check.
+type ContentLengthValidator struct {
+	underlying     io.ReadCloser
+	objectPath     string
+	expectedLength int
+	actualLengts   int
+}
+
+func NewContentLengthValidator(body io.ReadCloser, expectedSize int64, objectPath string) io.ReadCloser {
+	if expectedSize == 0 {
+		return body
+	}
+	return &ContentLengthValidator{
+		underlying:     body,
+		objectPath:     objectPath,
+		expectedLength: int(expectedSize),
+	}
+}
+
+func (v *ContentLengthValidator) Read(p []byte) (int, error) {
+	n, err := v.underlying.Read(p)
+	v.actualLengts += n
+	if err == io.EOF && v.actualLengts != v.expectedLength {
+		return n, ContentLengthMismatchError{
+			ObjectPath: v.objectPath,
+			Expected:   v.expectedLength,
+			Actual:     v.actualLengts,
+		}
+	}
+	return n, err
+}
+
+func (v *ContentLengthValidator) Close() error {
+	return v.underlying.Close()
+}

--- a/pkg/storages/s3/content_length_validator_test.go
+++ b/pkg/storages/s3/content_length_validator_test.go
@@ -1,0 +1,85 @@
+package s3_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/pkg/storages/s3"
+)
+
+type ErrOnCloseCloser struct{ io.Reader }
+
+func (ErrOnCloseCloser) Close() error { return errors.New("close error") }
+
+func TestContentLengthValidator_PassThrough(t *testing.T) {
+	body := io.NopCloser(strings.NewReader("hello"))
+	result := s3.NewContentLengthValidator(body, 0, "bucket/key")
+	assert.Equal(t, body, result)
+}
+
+func TestContentLengthValidator_ExactMatchReadAll(t *testing.T) {
+	data := "hello world"
+	v := s3.NewContentLengthValidator(io.NopCloser(strings.NewReader(data)), int64(len(data)), "bucket/key")
+	got, err := io.ReadAll(v)
+	require.NoError(t, err)
+	assert.Equal(t, data, string(got))
+}
+
+func TestContentLengthValidator_ExactMatchRead(t *testing.T) {
+	data := "hello world"
+	v := s3.NewContentLengthValidator(io.NopCloser(strings.NewReader(data)), int64(len(data)), "bucket/key")
+	buf := make([]byte, len(data))
+	_, err := v.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, data, string(buf))
+
+	_, err = v.Read(buf)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestContentLengthValidator_TooFewBytes(t *testing.T) {
+	data := "short"
+	v := s3.NewContentLengthValidator(io.NopCloser(strings.NewReader(data)), 100, "bucket/key")
+
+	_, err := io.ReadAll(v)
+	require.Error(t, err)
+
+	mismatchError, ok := err.(s3.ContentLengthMismatchError)
+	assert.True(t, ok)
+	assert.Equal(t, 100, mismatchError.Expected)
+	assert.Equal(t, len(data), mismatchError.Actual)
+	assert.Equal(t, "bucket/key", mismatchError.ObjectPath)
+}
+
+func TestContentLengthValidator_TooManyBytes(t *testing.T) {
+	data := "too long to fit in expected length"
+	v := s3.NewContentLengthValidator(io.NopCloser(strings.NewReader(data)), 10, "bucket/key")
+
+	_, err := io.ReadAll(v)
+	require.Error(t, err)
+
+	mismatchError, ok := err.(s3.ContentLengthMismatchError)
+	assert.True(t, ok)
+	assert.Equal(t, 10, mismatchError.Expected)
+	assert.Equal(t, len(data), mismatchError.Actual)
+	assert.Equal(t, "bucket/key", mismatchError.ObjectPath)
+}
+
+func TestContentLengthValidator_Close(t *testing.T) {
+	v := s3.NewContentLengthValidator(io.NopCloser(strings.NewReader("hello")), 5, "bucket/key")
+	_, err := io.ReadAll(v)
+	require.NoError(t, err)
+	assert.NoError(t, v.Close())
+}
+
+func TestContentLengthValidator_CloseError(t *testing.T) {
+	body := ErrOnCloseCloser{strings.NewReader("hello")}
+	v := s3.NewContentLengthValidator(body, 5, "bucket/key")
+	_, err := io.ReadAll(v)
+	require.NoError(t, err)
+	assert.EqualError(t, v.Close(), "close error")
+}

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -149,12 +149,11 @@ func (folder *Folder) ReadObject(objectRelativePath string) (io.ReadCloser, erro
 		}
 		return nil, errors.Wrapf(err, "failed to read object: '%s' from S3", objectPath)
 	}
-
 	reader := object.Body
 	if folder.config.RangeBatchEnabled {
 		reader = NewRangeReader(object.Body, objectPath, folder.config.RangeMaxRetries, folder)
 	}
-	return reader, nil
+	return NewContentLengthValidator(reader, aws.Int64Value(object.ContentLength), objectPath), nil
 }
 
 func (folder *Folder) GetSubFolder(subFolderRelativePath string) storage.Folder {


### PR DESCRIPTION
If s3 returns object with body that differs from Content-Length, the error is uninformative
`Extraction error in part_10.tar.br: extractOne: tar extract failed: openpgp: invalid data: parsing error`

Added wrapper that checks if actual length equals to Content-Length header