### PR TITLE
Retry S3 requests on connection timeout and i/o timeout errors

### DIFF
--- a/pkg/storages/s3/retryer.go
+++ b/pkg/storages/s3/retryer.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/wal-g/tracelog"
 )
 
 func NewConnResetRetryer(baseRetryer request.Retryer) *ConnResetRetryer {
@@ -18,8 +19,12 @@ type ConnResetRetryer struct {
 
 func (r ConnResetRetryer) ShouldRetry(req *request.Request) bool {
 	if req.Error != nil {
-		if strings.Contains(req.Error.Error(), "connection reset by peer") ||
-			strings.Contains(req.Error.Error(), "connection refused") {
+		errMsg := req.Error.Error()
+		if strings.Contains(errMsg, "connection reset by peer") ||
+			strings.Contains(errMsg, "connection refused") ||
+			strings.Contains(errMsg, "connection timed out") ||
+			strings.Contains(errMsg, "i/o timeout") {
+			tracelog.InfoLogger.Printf("Retrying S3 request due to transient network error: %v", req.Error)
 			return true
 		}
 	}


### PR DESCRIPTION
## Problem

During large multipart backup uploads over unstable networks, the OS can return `write: connection timed out` or `read: connection timed out`, causing the **entire backup to fail** without any retry attempt.

`ConnResetRetryer` already retried `connection reset by peer` and `connection refused` errors, but did not handle TCP timeout errors.

### Error log (before fix)

```
INFO: 2026/03/19 02:38:06.619025 Starting part 5 ...
ERROR: 2026/03/19 02:38:29.189731 failed to upload 'cluster-psql-qwe/18/basebackups_005/base_000000020000010E000000D7/tar_partitions/part_005.tar.br' to bucket 'wal-g': MultipartUpload: upload multipart failed
        upload id: 8051de8028fd7af6a5d0022282716edb
caused by: RequestError: send request failed
caused by: Put "https://s3.ru-1.storage.selcloud.ru/wal-g/cluster-psql-qwe/18/basebackups_005/base_000000020000010E000000D7/tar_partitions/part_005.tar.br?partNumber=9&uploadId=8051de8028fd7af6a5d0022282716edb": write tcp 10.10.10.10:37610->92.53.68.16:443: write: connection timed out
ERROR: 2026/03/19 02:38:29.189826 upload: could not upload 'base_000000020000010E000000D7/tar_partitions/part_005.tar.br'
ERROR: 2026/03/19 02:38:29.189832 failed to upload 'cluster-psql-qwe/18/basebackups_005/base_000000020000010E000000D7/tar_partitions/part_005.tar.br' to bucket 'wal-g': MultipartUpload: upload multipart failed
        upload id: 8051de8028fd7af6a5d0022282716edb
caused by: RequestError: send request failed
caused by: Put "https://s3.ru-1.storage.selcloud.ru/wal-g/cluster-psql-qwe/18/basebackups_005/base_000000020000010E000000D7/tar_partitions/part_005.tar.br?partNumber=9&uploadId=8051de8028fd7af6a5d0022282716edb": write tcp 10.10.10.10:37610->92.53.68.16:443: write: connection timed out
ERROR: 2026/03/19 02:38:29.189856 Unable to continue the backup process because of the loss of a part 5.
```

The backup fails completely — no retry is attempted.

## Fix

Added `connection timed out` and `i/o timeout` to the list of transient network errors in `ConnResetRetryer.ShouldRetry()`. Also added logging on each retry so operators can observe what is happening.

## Retry chain in production (after fix)

After deploying the fix, the same type of network error was handled gracefully:

```
INFO: 2026/03/22 03:19:40.057146 Starting part 3 ...
INFO: 2026/03/22 03:19:43.852070 Retrying S3 request due to transient network error: RequestError: send request failed
caused by: Post "https://s3.ru-1.storage.selcloud.ru/wal-g/cluster-psql-qwe/18/basebackups_005/base_00000002000004DA00000043/tar_partitions/part_003.tar.br?uploads=": read tcp 10.10.10.10:55722->92.53.68.16:443: read: connection timed out
INFO: 2026/03/22 03:19:43.852076 Retrying S3 request due to transient network error: RequestError: send request failed
caused by: Put "https://s3.ru-1.storage.selcloud.ru/wal-g/cluster-psql-qwe/18/basebackups_005/base_00000002000004DA00000043/tar_partitions/part_002.tar.br?partNumber=23&uploadId=ab01bcaa5371a27d2d34c37d2ae1be77": read tcp 10.10.10.10:55722->92.53.68.16:443: read: connection timed out
INFO: 2026/03/22 03:19:44.003516 S3 returned HTTP 409 (OperationAborted), retrying request
INFO: 2026/03/22 03:19:44.129601 S3 returned HTTP 409 (OperationAborted), retrying request
INFO: 2026/03/22 03:19:44.383524 S3 returned HTTP 409 (OperationAborted), retrying request
INFO: 2026/03/22 03:19:44.770169 S3 returned HTTP 409 (OperationAborted), retrying request
INFO: 2026/03/22 03:19:45.689891 S3 returned HTTP 409 (OperationAborted), retrying request
INFO: 2026/03/22 03:19:47.496305 S3 returned HTTP 409 (OperationAborted), retrying request
INFO: 2026/03/22 03:19:51.043355 S3 returned HTTP 409 (OperationAborted), retrying request
INFO: 2026/03/22 03:19:58.314506 S3 returned HTTP 409 (OperationAborted), retrying request
INFO: 2026/03/22 03:20:02.312392 Files will be uploaded to storage: default
INFO: 2026/03/22 03:20:03.823381 FILE PATH: 00000002000004DA00000044.br
INFO: 2026/03/22 03:20:27.274536 Finished writing part 3.
```

### What happens in the retry chain

1. **Connection timeout** — the client does not receive a response from S3, but the data may have already been received by the server. The retry logic catches this and resends the request.
2. **HTTP 409 OperationAborted** — when the retry hits S3, the original request may still be processing on the server side. S3 detects a concurrent operation on the same object/uploadId and responds with 409.
3. **Exponential backoff** — the 409 retries use exponential backoff (notice timestamps: 44.0s → 44.1s → 44.4s → 44.8s → 45.7s → 47.5s → 51.0s → 58.3s). After ~14 seconds the original server-side operation completes and the next retry succeeds.
4. **Backup completes** — `Finished writing part 3` confirms the backup completed successfully.

### Verification

The resulting backup was successfully restored and verified on a test server — all data intact, PostgreSQL started normally.

## Changes

- `pkg/storages/s3/retryer.go`: Added `connection timed out` and `i/o timeout` to retryable error patterns, added retry logging via tracelog
