### PR TITLE
Assorted fixes for catchup send\receive

### DIFF
--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -398,6 +398,9 @@ func receiveFileList(directory string) internal.BackupFileList {
 		if isDir && excluded {
 			return filepath.SkipDir
 		}
+		if isDir {
+			return nil
+		}
 		if excluded {
 			return nil
 		}

--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -244,6 +244,7 @@ func HandleCatchupReceive(pgDataDirectory string, port int) {
 	tracelog.InfoLogger.Printf("Receiving %v on port %v\n", pgDataDirectory, port)
 	listen, err := net.Listen("tcp", fmt.Sprintf(":%v", port))
 	tracelog.ErrorLogger.FatalOnError(err)
+	defer listen.Close()
 	conn, err := listen.Accept()
 	tracelog.ErrorLogger.FatalOnError(err)
 

--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -307,14 +307,20 @@ func (d *DecoderReader) Read(bytes []byte) (n int, err error) {
 func doRcvCommand(cmd CatchupCommandDto, directory string, decoder *gob.Decoder) {
 	if cmd.IsBinContents {
 		tracelog.InfoLogger.Printf("Writing file %v", cmd.FileName)
-		err := os.WriteFile(path.Join(directory, cmd.FileName), cmd.BinaryContents, 0666)
+		fullPath := path.Join(directory, cmd.FileName)
+		err := os.MkdirAll(filepath.Dir(fullPath), 0700)
+		tracelog.ErrorLogger.FatalOnError(err)
+		err = os.WriteFile(fullPath, cmd.BinaryContents, 0666)
 		tracelog.ErrorLogger.FatalOnError(err)
 		return
 	}
 
 	if cmd.IsFull {
 		tracelog.InfoLogger.Printf("Full file %v", cmd.FileName)
-		fd, err := os.Create(path.Join(directory, cmd.FileName))
+		fullPath := path.Join(directory, cmd.FileName)
+		err := os.MkdirAll(filepath.Dir(fullPath), 0700)
+		tracelog.ErrorLogger.FatalOnError(err)
+		fd, err := os.Create(fullPath)
 		tracelog.ErrorLogger.FatalOnError(err)
 		size := int64(cmd.FileSize)
 		for size != 0 {

--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -23,10 +23,10 @@ func HandleCatchupSend(pgDataDirectory string, destination string) {
 	pgDataDirectory = utility.ResolveSymlink(pgDataDirectory)
 	tracelog.InfoLogger.Printf("Sending %v to %v\n", pgDataDirectory, destination)
 	info, runner, err := GetPgServerInfo(true)
+	tracelog.ErrorLogger.FatalOnError(err)
 	if info.systemIdentifier == nil {
 		tracelog.ErrorLogger.Fatal("Our system lacks System Identifier, cannot proceed")
 	}
-	tracelog.ErrorLogger.FatalOnError(err)
 	writer, decoder, encoder := startSendConnection(destination)
 
 	var control PgControlData


### PR DESCRIPTION
## Describe what this PR fixes
Four bugs in the catchup-send / catchup-receive commands (internal/databases/postgres/catchup_send_recieve_handler.go):

Wrong error check order in HandleCatchupSend. info.systemIdentifier was dereferenced before the error returned by GetPgServerInfo was checked. When GetPgServerInfo fails the process would fatal with a misleading "lacks System Identifier" message instead of reporting the real error.

Missing parent-directory creation on the receiver side. os.Create and os.WriteFile in doRcvCommand do not create intermediate directories. If the sender has files inside a subdirectory that does not yet exist on the receiver (e.g. a new tablespace directory created after the base backup was taken), the write fails with no such file or directory.

Directories included in the receiver file list. receiveFileList did not skip directories, so they ended up in BackupFileList. When a directory was present on the receiver but absent on the sender, sendDeletedFiles would emit a delete command for it, and os.Remove would fail on any non-empty directory, aborting the transfer. The fix mirrors the guard that already existed in sendFileCommands.

Listening socket not closed after Accept. net.Listen in HandleCatchupReceive was never followed by a listen.Close(), leaking the file descriptor for the lifetime of the process.

## Please provide steps to reproduce (if it's a bug)
### Bug 2 (most likely to hit in practice):

Run catchup-receive on the standby.
On the primary, create a new table in a new schema / tablespace so that a subdirectory appears under PGDATA that does not exist on the standby.
Run catchup-send pointing at the standby.
Transfer aborts on the receiver with open <path>: no such file or directory.
### Bug 3:

Drop a tablespace on the primary after the standby's base backup was taken (so the corresponding directory is gone on the sender but still present on the receiver).
Run catchup-send / catchup-receive.
Transfer aborts on the receiver with remove <dir>: directory not empty.
## Please add config and wal-g stdout/stderr logs for debug purpose
### Bug 2 — receiver log

INFO: Receiving /var/lib/postgresql/data on port 1337
INFO: Writing file global/pg_control
FATAL: open /var/lib/postgresql/data/pg_tblspc/16384/PG_14_202107181/16385/1259: no such file or directory
### Bug 3 — receiver log

INFO: Receiving /var/lib/postgresql/data on port 1337
INFO: Deleting files [pg_tblspc/16384]
FATAL: remove /var/lib/postgresql/data/pg_tblspc/16384: directory not empty
