### PR TITLE
catchup: add parallel send/receive via WALG_UPLOAD_DISK_CONCURRENCY

### DIFF
--- a/internal/databases/postgres/catchup_send_recieve_handler.go
+++ b/internal/databases/postgres/catchup_send_recieve_handler.go
@@ -10,10 +10,12 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/compression"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres/errors"
 	"github.com/wal-g/wal-g/internal/ioextensions"
 	"github.com/wal-g/wal-g/utility"
@@ -27,10 +29,12 @@ func HandleCatchupSend(pgDataDirectory string, destination string) {
 		tracelog.ErrorLogger.Fatal("Our system lacks System Identifier, cannot proceed")
 	}
 	tracelog.ErrorLogger.FatalOnError(err)
-	writer, decoder, encoder := startSendConnection(destination)
+
+	// Coordinator connection (worker 0): handshake only.
+	writer0, decoder0, encoder0 := startSendConnection(destination)
 
 	var control PgControlData
-	err = decoder.Decode(&control)
+	err = decoder0.Decode(&control)
 	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.InfoLogger.Printf("Destination control file %v", control)
 	tracelog.InfoLogger.Printf("Our system id %v", *info.systemIdentifier)
@@ -42,9 +46,10 @@ func HandleCatchupSend(pgDataDirectory string, destination string) {
 			control.CurrentTimeline, info.Timeline)
 	}
 	var fileList internal.BackupFileList
-	err = decoder.Decode(&fileList)
+	err = decoder0.Decode(&fileList)
 	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.InfoLogger.Printf("Received file list of %v files", len(fileList))
+
 	_, lsnStr, _, err := runner.StartBackup("")
 	tracelog.ErrorLogger.FatalOnError(err)
 	lsn, err := ParseLSN(lsnStr)
@@ -54,29 +59,78 @@ func HandleCatchupSend(pgDataDirectory string, destination string) {
 			lsn, control.Checkpoint)
 	}
 
-	sendFileCommands(encoder, pgDataDirectory, fileList, control.Checkpoint)
+	numWorkers, err := conf.GetMaxUploadDiskConcurrency()
+	tracelog.ErrorLogger.FatalOnError(err)
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+	tracelog.InfoLogger.Printf("Sending with %v parallel workers", numWorkers)
+
+	// Tell receiver how many worker connections will follow.
+	err = encoder0.Encode(CatchupCommandDto{IsStart: true, NumWorkers: numWorkers})
+	tracelog.ErrorLogger.FatalOnError(err)
+	err = writer0.Flush()
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	// Open worker connections (worker 0 reuses the coordinator).
+	encoders := make([]*gob.Encoder, numWorkers)
+	writers := make([]ioextensions.WriteFlushCloser, numWorkers)
+	encoders[0] = encoder0
+	writers[0] = writer0
+	for i := 1; i < numWorkers; i++ {
+		w, _, enc := startSendConnection(destination)
+		encoders[i] = enc
+		writers[i] = w
+	}
+
+	// Walk the source tree in a goroutine; N workers consume from the channel.
+	fileChan := make(chan fileTask, numWorkers*10)
+	seenFiles := make(map[string]bool)
+	go func() {
+		walkIntoChannel(pgDataDirectory, fileList, control.Checkpoint, fileChan, seenFiles)
+		close(fileChan)
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func(enc *gob.Encoder) {
+			defer wg.Done()
+			for task := range fileChan {
+				sendOneFile(task.path, task.info, task.wasInBase, task.checkpoint, enc, task.fullFileName)
+			}
+		}(encoders[i])
+	}
+	// wg.Wait() also guarantees the walk goroutine has finished (fileChan is closed
+	// only after the full walk), so seenFiles is complete when we proceed.
+	wg.Wait()
+
+	sendDeletedFiles(encoder0, fileList, seenFiles)
 
 	label, offsetMap, _, err := runner.StopBackup()
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	err = encoder.Encode(
+	// Final binary files and IsDone always go through the coordinator (worker 0).
+	err = encoder0.Encode(
 		CatchupCommandDto{BinaryContents: []byte(label), FileName: BackupLabelFilename, IsBinContents: true})
 	tracelog.ErrorLogger.FatalOnError(err)
-	err = encoder.Encode(
+	err = encoder0.Encode(
 		CatchupCommandDto{BinaryContents: []byte(offsetMap), FileName: TablespaceMapFilename, IsBinContents: true})
 	tracelog.ErrorLogger.FatalOnError(err)
 	ourPgControl, err := os.ReadFile(path.Join(pgDataDirectory, PgControlPath))
 	tracelog.ErrorLogger.FatalOnError(err)
-	err = encoder.Encode(
+	err = encoder0.Encode(
 		CatchupCommandDto{
 			BinaryContents: ourPgControl, FileName: utility.SanitizePath(PgControlPath), IsBinContents: true,
 		})
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	err = encoder.Encode(CatchupCommandDto{IsDone: true})
-	tracelog.ErrorLogger.FatalOnError(err)
-	err = writer.Flush()
-	tracelog.ErrorLogger.FatalOnError(err)
+	for i := 0; i < numWorkers; i++ {
+		err = encoders[i].Encode(CatchupCommandDto{IsDone: true})
+		tracelog.ErrorLogger.FatalOnError(err)
+		err = writers[i].Flush()
+		tracelog.ErrorLogger.FatalOnError(err)
+	}
 	tracelog.InfoLogger.Printf("Send done")
 }
 
@@ -118,15 +172,23 @@ func chooseCompression() (compression.Compressor, compression.Decompressor) {
 	return c, d
 }
 
-func sendFileCommands(encoder *gob.Encoder, directory string, list internal.BackupFileList, checkpoint LSN) {
+type fileTask struct {
+	path         string
+	info         fs.FileInfo
+	wasInBase    bool
+	checkpoint   LSN
+	fullFileName string
+}
+
+func walkIntoChannel(directory string, list internal.BackupFileList, checkpoint LSN,
+	tasks chan<- fileTask, seenFiles map[string]bool) {
 	extendExcludedFiles()
-	seenFiles := make(map[string]bool)
-	err := filepath.Walk(directory, func(path string, info fs.FileInfo, err error) error {
-		fullFileName := utility.GetSubdirectoryRelativePath(path, directory)
+	err := filepath.Walk(directory, func(filePath string, info fs.FileInfo, err error) error {
+		fullFileName := utility.GetSubdirectoryRelativePath(filePath, directory)
 		seenFiles[fullFileName] = true
 		if err != nil {
 			if os.IsNotExist(err) {
-				tracelog.WarningLogger.Println(path, " deleted during filepath walk")
+				tracelog.WarningLogger.Println(filePath, " deleted during filepath walk")
 				return nil
 			}
 			return err
@@ -150,19 +212,22 @@ func sendFileCommands(encoder *gob.Encoder, directory string, list internal.Back
 		wasInBase := false
 		if fdto, ok := list[fullFileName]; ok {
 			if fdto.MTime.Equal(info.ModTime()) {
-				// No need to catchup
 				return nil
 			}
 			wasInBase = true
 		}
 
-		sendOneFile(path, info, wasInBase, checkpoint, encoder, fullFileName)
-
+		tasks <- fileTask{
+			path:         filePath,
+			info:         info,
+			wasInBase:    wasInBase,
+			checkpoint:   checkpoint,
+			fullFileName: fullFileName,
+		}
 		return nil
 	})
 	tracelog.ErrorLogger.FatalOnError(err)
 	tracelog.DebugLogger.Printf("Filepath walk done")
-	sendDeletedFiles(encoder, list, seenFiles)
 }
 
 func sendDeletedFiles(encoder *gob.Encoder, list internal.BackupFileList, seenFiles map[string]bool) {
@@ -239,47 +304,77 @@ func sendOneFile(path string, info fs.FileInfo, wasInBase bool, checkpoint LSN,
 	tracelog.ErrorLogger.FatalOnError(err)
 }
 
+func setupReceiverConn(conn net.Conn) (*gob.Encoder, *gob.Decoder, ioextensions.WriteFlushCloser) {
+	cmpr, decmpr := chooseCompression()
+	writer := cmpr.NewWriter(conn)
+	reader, err := decmpr.Decompress(conn)
+	tracelog.ErrorLogger.FatalOnError(err)
+	crypter := internal.ConfigureCrypter()
+	if crypter != nil {
+		decrypt, err := crypter.Decrypt(reader)
+		tracelog.ErrorLogger.FatalOnError(err)
+		encrypt, err := crypter.Encrypt(writer)
+		tracelog.ErrorLogger.FatalOnError(err)
+		return gob.NewEncoder(encrypt), gob.NewDecoder(decrypt), writer
+	}
+	return gob.NewEncoder(writer), gob.NewDecoder(reader), writer
+}
+
 func HandleCatchupReceive(pgDataDirectory string, port int) {
 	pgDataDirectory = utility.ResolveSymlink(pgDataDirectory)
 	tracelog.InfoLogger.Printf("Receiving %v on port %v\n", pgDataDirectory, port)
 	listen, err := net.Listen("tcp", fmt.Sprintf(":%v", port))
 	tracelog.ErrorLogger.FatalOnError(err)
-	conn, err := listen.Accept()
+
+	// Coordinator connection: handshake (send control + file list, read IsStart).
+	conn0, err := listen.Accept()
+	tracelog.ErrorLogger.FatalOnError(err)
+	encoder0, decoder0, writer0 := setupReceiverConn(conn0)
+
+	sendControlAndFileList(pgDataDirectory, encoder0)
+	err = writer0.Flush()
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	cmpr, decmpr := chooseCompression()
-
-	writer := cmpr.NewWriter(conn)
-	reader, err := decmpr.Decompress(conn)
+	var startCmd CatchupCommandDto
+	err = decoder0.Decode(&startCmd)
 	tracelog.ErrorLogger.FatalOnError(err)
-
-	crypter := internal.ConfigureCrypter()
-
-	var decoder *gob.Decoder
-	var encoder *gob.Encoder
-	if crypter != nil {
-		decrypt, err := crypter.Decrypt(reader)
-		tracelog.ErrorLogger.FatalOnError(err)
-		decoder = gob.NewDecoder(decrypt)
-		encrypt, err := crypter.Encrypt(writer)
-		tracelog.ErrorLogger.FatalOnError(err)
-		encoder = gob.NewEncoder(encrypt)
-	} else {
-		decoder = gob.NewDecoder(reader)
-		encoder = gob.NewEncoder(writer)
+	if !startCmd.IsStart {
+		tracelog.ErrorLogger.Fatal("Expected IsStart command from sender")
 	}
-	sendControlAndFileList(pgDataDirectory, encoder)
-	err = writer.Flush()
-	tracelog.ErrorLogger.FatalOnError(err)
-	for {
-		var cmd CatchupCommandDto
-		err := decoder.Decode(&cmd)
-		tracelog.ErrorLogger.FatalOnError(err)
-		if cmd.IsDone {
-			break
-		}
-		doRcvCommand(cmd, pgDataDirectory, decoder)
+	numWorkers := startCmd.NumWorkers
+	if numWorkers < 1 {
+		numWorkers = 1
 	}
+	tracelog.InfoLogger.Printf("Receiving with %v parallel workers", numWorkers)
+
+	// Accept the remaining worker connections on the same port.
+	decoders := make([]*gob.Decoder, numWorkers)
+	decoders[0] = decoder0
+	for i := 1; i < numWorkers; i++ {
+		conn, err := listen.Accept()
+		tracelog.ErrorLogger.FatalOnError(err)
+		_, dec, _ := setupReceiverConn(conn)
+		decoders[i] = dec
+	}
+	listen.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func(dec *gob.Decoder) {
+			defer wg.Done()
+			for {
+				var cmd CatchupCommandDto
+				err := dec.Decode(&cmd)
+				tracelog.ErrorLogger.FatalOnError(err)
+				if cmd.IsDone {
+					return
+				}
+				doRcvCommand(cmd, pgDataDirectory, dec)
+			}
+		}(decoders[i])
+	}
+	wg.Wait()
 	tracelog.InfoLogger.Printf("Receive done")
 }
 
@@ -352,6 +447,8 @@ func doRcvCommand(cmd CatchupCommandDto, directory string, decoder *gob.Decoder)
 }
 
 type CatchupCommandDto struct {
+	IsStart        bool
+	NumWorkers     int
 	IsDone         bool
 	IsIncremental  bool
 	IsFull         bool


### PR DESCRIPTION
After the initial handshake on the coordinator connection, the sender reads WALG_UPLOAD_DISK_CONCURRENCY (default 1, backward-compatible), announces the worker count via a new IsStart/NumWorkers message, and opens N TCP connections to the same port.  Each connection is served by a dedicated goroutine on both sides.

On the send side, filepath.Walk is now done in a separate goroutine that feeds a buffered channel; N worker goroutines pull file tasks from the channel and call sendOneFile concurrently.  sendDeletedFiles, StopBackup, and the final pg_control write always run on worker 0.

On the receive side, the listener stays open until all N workers have connected, then each worker processes its stream in a goroutine.

The old sendFileCommands function is replaced by walkIntoChannel + the channel/goroutine fan-out in HandleCatchupSend.

