### PR TITLE
Fix for MongoDB binary-backup-push  --add-user-data flag 

### DIFF
--- a/cmd/mongo/binary_backup_push.go
+++ b/cmd/mongo/binary_backup_push.go
@@ -42,6 +42,7 @@ var binaryBackupPushCmd = &cobra.Command{
 			SkipMetadata:  skipMetadata,
 			AppName:       "wal-g-mongo " + binaryBackupPushCommandName,
 			CountJournals: countJournals,
+			UserDataRaw:   userDataRaw,
 		}
 		err := mongo.HandleBinaryBackupPush(ctx, pushArgs)
 		tracelog.ErrorLogger.FatalOnError(err)
@@ -53,7 +54,7 @@ func init() {
 	binaryBackupPushCmd.Flags().BoolVar(&skipMetadata, SkipMetadataFlag, false, "Skip metadata collecting for partial restore")
 	binaryBackupPushCmd.Flags().BoolVar(&countJournals, CountJournalsFlag, false,
 		"Count and store in S3 oplog sizes required to get replay data from a backup to the next one")
-	backupPushCmd.Flags().StringVar(&userDataRaw, AddUserDataFlag,
+	binaryBackupPushCmd.Flags().StringVar(&userDataRaw, AddUserDataFlag,
 		"", "Write the provided user data to the backup sentinel and metadata files.")
 	cmd.AddCommand(binaryBackupPushCmd)
 }

--- a/internal/databases/mongo/binary/backup.go
+++ b/internal/databases/mongo/binary/backup.go
@@ -304,9 +304,7 @@ func (backupService *BackupService) BackgroundMetadata(ctx context.Context, skip
 	}
 
 	return NewStorageMetadataCollector(bgMongoService, func(routes *models.BackupRoutesInfo) error {
-		tracelog.InfoLogger.Printf("ROUTES BEFORE DOWNLOADING: %v", routes)
 		err = internal.UploadMetadata(backupService.Uploader, routes, backupService.Sentinel.BackupName)
-		tracelog.InfoLogger.Printf("DOWNLOADED OR ERR: %v", err)
 		return err
 	}), nil
 }

--- a/internal/databases/mongo/binary/metadata_collector.go
+++ b/internal/databases/mongo/binary/metadata_collector.go
@@ -2,7 +2,6 @@ package binary
 
 import (
 	"container/heap"
-	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/databases/mongo/common"
 
 	"github.com/mongodb/mongo-tools/common/util"
@@ -64,7 +63,6 @@ func (smc *StorageMetadataCollector) GetStats() {
 			smc.ErrsChan <- err
 			return
 		}
-		tracelog.DebugLogger.Printf("NsInfo: %v", nsInfo)
 
 		smc.handleTop100Info(&nsInfo)
 		smc.pmc.HandleNsInfo(&nsInfo)


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
