### PR TITLE
Refactor log messages for consistency and clarity

### DIFF
--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -482,10 +482,10 @@ func DeleteObjectsWhere(
 	tracelog.InfoLogger.Println("Evaluating objects for deletion...")
 	for _, object := range relativePathObjects {
 		if objFilter(object) {
-			tracelog.InfoLogger.Printf("Object marked for deletion: %s (Storage: %s)\n", object.GetName(), multistorage.GetStorage(object))
+			tracelog.InfoLogger.Printf("Object marked for deletion: %s storage=%s\n", object.GetName(), multistorage.GetStorage(object))
 			markedForDeletion = append(markedForDeletion, object)
 		} else {
-			tracelog.DebugLogger.Printf("Object skipped: %s (Storage: %s)\n", object.GetName(), multistorage.GetStorage(object))
+			tracelog.DebugLogger.Printf("Object skipped: %s storage=%s\n", object.GetName(), multistorage.GetStorage(object))
 		}
 	}
 	deletionCount := len(markedForDeletion)
@@ -496,11 +496,11 @@ func DeleteObjectsWhere(
 	if confirm {
 		err := folder.DeleteObjects(markedForDeletion)
 		if err == nil {
-			tracelog.InfoLogger.Printf("Objects deleted successfully: %d.\n", deletionCount)
+			tracelog.InfoLogger.Printf("Objects deleted successfully: count=%d\n", deletionCount)
 		}
 		return err
 	}
-	tracelog.InfoLogger.Printf("Dry run: %d objects would be deleted. Run with --confirm to execute.\n", deletionCount)
+	tracelog.InfoLogger.Printf("Dry run: objects would be deleted count=%d, Run with --confirm to execute\n", deletionCount)
 	return nil
 }
 


### PR DESCRIPTION
### Database name
All

# Pull request description
Improve log message on deletion.

```bash
wal-g delete target base_000000010000000000000002

INFO: 2026/03/27 17:31:37.164564 Backup to delete will be searched in storages: [default]
INFO: 2026/03/27 17:31:37.164623 retrieving permanent objects
INFO: 2026/03/27 17:31:37.276503 Selecting the backup with name base_000000010000000000000002...
INFO: 2026/03/27 17:31:37.740202 Evaluating objects for deletion...
INFO: 2026/03/27 17:31:37.740225 Object marked for deletion: base_000000010000000000000002_backup_stop_sentinel.json storage=default
INFO: 2026/03/27 17:31:37.740231 Object marked for deletion: base_000000010000000000000002/files_metadata.json storage=default
INFO: 2026/03/27 17:31:37.740250 Object marked for deletion: base_000000010000000000000002/metadata.json storage=default
INFO: 2026/03/27 17:31:37.740262 Object marked for deletion: base_000000010000000000000002/tar_partitions/backup_label.tar.zst storage=default
INFO: 2026/03/27 17:31:37.740267 Object marked for deletion: base_000000010000000000000002/tar_partitions/part_001.tar.zst storage=default
INFO: 2026/03/27 17:31:37.740268 Object marked for deletion: base_000000010000000000000002/tar_partitions/pg_control.tar.zst storage=default
INFO: 2026/03/27 17:31:37.740307 Dry run: objects would be deleted count=6 Run with --confirm to execute
```

```bash
wal-g delete garbage --confirm

INFO: 2026/03/27 17:32:53.088130 Backup to delete will be searched in storages: [default]
INFO: 2026/03/27 17:32:53.088180 retrieving permanent objects
INFO: 2026/03/27 17:32:53.241638 Running in default mode. Will remove outdated WAL files and leftover backup files.
INFO: 2026/03/27 17:32:53.320198 Start delete
INFO: 2026/03/27 17:32:55.331485 Evaluating objects for deletion...
INFO: 2026/03/27 17:32:55.331581 Object marked for deletion: wal_005/000000010000000000000002.00000028.backup.zst storage=default
INFO: 2026/03/27 17:32:55.331596 Object marked for deletion: wal_005/000000010000000000000002.zst storage=default
INFO: 2026/03/27 17:32:55.331599 Object marked for deletion: wal_005/000000010000000000000003.zst storage=default
INFO: 2026/03/27 17:32:55.346038 Objects deleted successfully: count=3
```