### PR TITLE
ETCD: Calculate snapshot size

### DIFF
--- a/internal/databases/etcd/backup_push_handler.go
+++ b/internal/databases/etcd/backup_push_handler.go
@@ -13,6 +13,7 @@ import (
 type StreamSentinelDto struct {
 	StartLocalTime time.Time `json:"StartLocalTime,omitempty"`
 	IsPermanent    bool      `json:"IsPermanent"`
+	SnapshotSize   int64     `json:"SnapshotSize"`
 
 	UserData interface{} `json:"UserData,omitempty"`
 }
@@ -36,10 +37,14 @@ func HandleBackupPush(uploader internal.Uploader, backupCmd *exec.Cmd, permanent
 	userData, err := internal.UnmarshalSentinelUserData(userDataRaw)
 	tracelog.ErrorLogger.FatalfOnError("Failed to unmarshal the provided UserData: %s", err)
 
+	dataSize, err := internal.FolderSize(uploader.Folder(), fileName)
+	tracelog.ErrorLogger.FatalfOnError("can not get backup size: %+v", err)
+
 	sentinel := StreamSentinelDto{
 		StartLocalTime: timeStart,
 		IsPermanent:    permanent,
 		UserData:       userData,
+		SnapshotSize:   dataSize,
 	}
 
 	err = internal.UploadSentinel(uploader, &sentinel, fileName)


### PR DESCRIPTION
### Database name
ETCD

# Pull request description
Calculate snapshot size for etcd snapshot and put it in metadata
```
[QA]root ~ # wal-g-etcd --config /etc/wal-g/wal-g.yaml backup-push
WARNING: 2026/04/03 10:31:39.979635 WALG_ETCD_DATA_DIR is unknown
WARNING: 2026/04/03 10:31:39.979663 WALG_FAILOVER_STORAGES_CHECK_TIMEOUT is unknown
WARNING: 2026/04/03 10:31:39.979675 WALG_FAILOVER_STORAGES_CACHE_LIFETIME is unknown
WARNING: 2026/04/03 10:31:39.979679 We found that some variables in your config file detected as 'Unknown'. 
  If this is not right, please create issue https://github.com/wal-g/wal-g/issues/new
[QA]root ~ # wal-g-etcd --config /etc/wal-g/wal-g.yaml st cat basebackups_005/stream_20260403T103139Z_backup_stop_sentinel.json
WARNING: 2026/04/03 10:31:53.294865 WALG_FAILOVER_STORAGES_CHECK_TIMEOUT is unknown
WARNING: 2026/04/03 10:31:53.294927 WALG_ETCD_DATA_DIR is unknown
WARNING: 2026/04/03 10:31:53.294932 WALG_FAILOVER_STORAGES_CACHE_LIFETIME is unknown
WARNING: 2026/04/03 10:31:53.294937 We found that some variables in your config file detected as 'Unknown'. 
  If this is not right, please create issue https://github.com/wal-g/wal-g/issues/new
{"StartLocalTime":"2026-04-03T10:31:39.980756Z","IsPermanent":false,"SnapshotSize":2553}
```

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
