### PR TITLE
Add timeline switch check

### DIFF
--- a/internal/databases/postgres/wal_segment_runner.go
+++ b/internal/databases/postgres/wal_segment_runner.go
@@ -107,7 +107,7 @@ func (r *WalSegmentRunner) getNextSegment() WalSegmentDescription {
 		// for example after restoring cluster
 		// We will skip such records
 		if _, fileExists := r.walFolderSegments[nextSegment]; fileExists {
-			tracelog.WarningLogger.Printf("timeline switch at LSN %s is invalid. Skipping it\n", record.lsn.String())
+			tracelog.WarningLogger.Printf("timeline switch at LSN %s is not from our history. Skipping it\n", record.lsn.String())
 			return nextSegment
 		}
 		// switch timeline if current WAL segment number found in .history record


### PR DESCRIPTION
### Database name
Postgres

# Pull request description

In some cases (when cluster was restored) there are records in .history file, that are not actually present in cluster history.
Integrity check fails because it tries to switch timeline that was not actually switched.
The logic is: if wal file with current timeline is present on LSN before switch, then this switch was not actually present
