### PR TITLE
fix: close pipe handles on Encrypt error path

### DIFF
--- a/internal/storagetools/copy_object_handler.go
+++ b/internal/storagetools/copy_object_handler.go
@@ -23,6 +23,8 @@ func Encrypt(source io.Reader, crypter crypto.Crypter) (io.Reader, error) {
 	writeCloser, err := crypter.Encrypt(dstWriter)
 
 	if err != nil {
+		_ = cryptReader.Close()
+		_ = dstWriter.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Closes the `io.Pipe` reader and writer when `crypter.Encrypt()` fails. Without this, both handles leak on the error path.

## Why this matters

Static analysis (Svace) flagged `cryptReader` and `dstWriter` as leaked handles at `copy_object_handler.go:21-27`. The `io.Pipe()` call on line 21 creates both, but if `crypter.Encrypt(dstWriter)` errors on line 23, the function returns `nil` without closing either.

## Changes

- `internal/storagetools/copy_object_handler.go`: Close `cryptReader` and `dstWriter` before returning on encrypt error.

## Testing

- Verified Go compilation passes for `./internal/storagetools/...`

Fixes #1988

This contribution was developed with AI assistance (Claude Code).