### PR TITLE
🧪 test: add unit tests for ConfigureStorage function

### DIFF
--- a/pkg/storages/fs/configure_test.go
+++ b/pkg/storages/fs/configure_test.go
@@ -1,0 +1,58 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+func TestConfigureStorageStripsWaleFileURLPrefix(t *testing.T) {
+	tmpDir := t.TempDir()
+	st, err := ConfigureStorage(waleFileURL+tmpDir, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	err = st.RootFolder().PutObject("prefix-check.txt", strings.NewReader(""))
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(tmpDir, "prefix-check.txt"))
+	assert.NoError(t, statErr)
+}
+
+func TestConfigureStorageReturnsWrappedErrorForMissingRoot(t *testing.T) {
+	missingDir := filepath.Join(t.TempDir(), "missing-root")
+
+	st, err := ConfigureStorage(missingDir, nil)
+
+	assert.Nil(t, st)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "create FS storage")
+	assert.ErrorContains(t, err, "FS storage root directory doesn't exist or is inaccessible")
+}
+
+func TestConfigureStorageAppliesRootWraps(t *testing.T) {
+	tmpDir := t.TempDir()
+	wrapCalled := false
+
+	wrap := func(prev storage.Folder) storage.Folder {
+		wrapCalled = true
+		return prev.GetSubFolder("wrapped")
+	}
+
+	st, err := ConfigureStorage(tmpDir, nil, wrap)
+	require.NoError(t, err)
+	assert.True(t, wrapCalled)
+	require.NotNil(t, st)
+
+	err = st.RootFolder().PutObject("wrapped-check.txt", strings.NewReader(""))
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(filepath.Join(tmpDir, "wrapped", "wrapped-check.txt"))
+	assert.NoError(t, statErr)
+}

--- a/pkg/storages/fs/configure_test.go
+++ b/pkg/storages/fs/configure_test.go
@@ -32,6 +32,7 @@ func TestConfigureStorageReturnsWrappedErrorForMissingRoot(t *testing.T) {
 
 	assert.Nil(t, st)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 	assert.ErrorContains(t, err, "create FS storage")
 	assert.ErrorContains(t, err, "FS storage root directory doesn't exist or is inaccessible")
 }

--- a/pkg/storages/fs/configure_test.go
+++ b/pkg/storages/fs/configure_test.go
@@ -48,7 +48,7 @@ func TestConfigureStorageAppliesRootWraps(t *testing.T) {
 
 	st, err := ConfigureStorage(tmpDir, nil, wrap)
 	require.NoError(t, err)
-	assert.True(t, wrapCalled)
+	require.True(t, wrapCalled)
 	require.NotNil(t, st)
 
 	err = st.RootFolder().PutObject("wrapped-check.txt", strings.NewReader(""))


### PR DESCRIPTION
# Pull request description

### Describe what this PR fixes
`ConfigureStorage` had `// TODO: Unit tests` and no direct coverage:
- WAL-E backward compatibility,
- error wrapping for invalid/missing FS root path,
- application of `rootWraps`