### PR TITLE
Convert PostgreSQL system_identifier to uint64 and add tests

### DIFF
--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -208,7 +208,12 @@ func (queryRunner *PgQueryRunner) getSystemIdentifier() (err error) {
 		return nil
 	}
 	conn := queryRunner.Connection
-	err = conn.QueryRow(context.TODO(), queryRunner.buildGetSystemIdentifier()).Scan(&queryRunner.SystemIdentifier)
+	var systemIdentifier int64
+	err = conn.QueryRow(context.TODO(), queryRunner.buildGetSystemIdentifier()).Scan(&systemIdentifier)
+	if err == nil {
+		converted := uint64(systemIdentifier)
+		queryRunner.SystemIdentifier = &converted
+	}
 	return errors.Wrap(err, "System Identifier: getting identifier of DB failed")
 }
 

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -211,6 +211,10 @@ func (queryRunner *PgQueryRunner) getSystemIdentifier() (err error) {
 	var systemIdentifier int64
 	err = conn.QueryRow(context.TODO(), queryRunner.buildGetSystemIdentifier()).Scan(&systemIdentifier)
 	if err == nil {
+		// Intentionally scan into int64 and then convert to uint64 so negative
+		// int64 values are reinterpreted via two's-complement wraparound. This
+		// preserves the system identifier representation expected by PostgreSQL
+		// tooling; do not replace this with a direct uint64 scan.
 		converted := uint64(systemIdentifier)
 		queryRunner.SystemIdentifier = &converted
 	}

--- a/internal/databases/postgres/query_runner_test.go
+++ b/internal/databases/postgres/query_runner_test.go
@@ -81,3 +81,39 @@ func TestIsTablespaceMapExists(t *testing.T) {
 		})
 	}
 }
+
+func TestSystemIdentifierToUint64Y2K38(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    int64
+		expected uint64
+	}{
+		{
+			name:     "negative_from_pg_control_system_after_y2k38",
+			input:    -9223371710917873611,
+			expected: 9223372362791678005,
+		},
+		{
+			name:     "regular_positive_value",
+			input:    9223371710917873611,
+			expected: 9223371710917873611,
+		},
+		{
+			name:     "minus_one_becomes_max_uint64",
+			input:    -1,
+			expected: ^uint64(0),
+		},
+		{
+			name:     "min_int64_becomes_1_shift_63",
+			input:    -1 << 63,
+			expected: 1 << 63,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := uint64(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
# Pull request description

### Describe what this PR fixes
This pull request improves the handling and testing of PostgreSQL system identifiers, particularly focusing on correct type conversion from `int64` to `uint64` to handle edge cases such as negative values and large integers. The main changes include updating the assignment logic in the query runner and adding comprehensive tests to ensure correct conversion behavior.

**Bug fix and type handling:**

* Updated `getSystemIdentifier` in `query_runner.go` to first scan the system identifier as an `int64`, then safely convert it to `uint64` before assignment, ensuring correct handling of negative values and large numbers.

**Testing improvements:**

* Added `TestSystemIdentifierToUint64Y2K38` in `query_runner_test.go` to verify that various edge-case `int64` values (including negative, large, and minimum values) are correctly converted to `uint64`, preventing potential bugs with system identifier interpretation.

### Please provide steps to reproduce (if it's a bug)
from #2097:
1. Set system time to later than 03:14:07 on 19 January 2038.
2. Perform a backup: wal-g backup-push "$PGDATA" --full
3. See error:
```
INFO: 2038/01/18 19:15:38.030390 Backup will be pushed to storage: default
WARNING: 2038/01/18 19:15:38.041779 Couldn't get system identifier because of error: 'System Identifier: getting identifier of DB failed: can't scan into dest[0]: -9223371710917873611 is less than zero for uint64'
ERROR: 2038/01/18 19:15:38.042630 System Identifier: getting identifier of DB failed: can't scan into dest[0]: -9223371710917873611 is less than zero for uint64
```
