### PR TITLE
Fix tests failing when /tmp is tmpfs

### DIFF
--- a/internal/databases/postgres/tar_interpreter_test.go
+++ b/internal/databases/postgres/tar_interpreter_test.go
@@ -17,6 +17,9 @@ func testInterpret(t *testing.T,
 	dbDataDirectory, name string, typeflag byte,
 	create, delete func(string) error, assertFiles func(os.FileInfo, os.FileInfo)) {
 
+	// keep cwd on same FS as dbDataDirectory so os.Link doesn't hit EXDEV
+	t.Chdir(t.TempDir())
+
 	dbDataDirectory = filepath.ToSlash(dbDataDirectory)
 	tarInterpreter := &postgres.FileTarInterpreter{
 		DBDataDirectory: dbDataDirectory,


### PR DESCRIPTION
TestInterpretTypeLink failed when temp files were on different filesystem, run whole test on temp dir