### PR TITLE
fix: skip checksum validation for torn pages covered by WAL  (FPI)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -361,6 +361,11 @@ services:
     container_name: wal-g_pg_delete_retain_after_test
     command: /tmp/tests/delete_retain_after_test.sh
 
+  pg_checksum_corruption_test:
+    <<: *pg_test_common
+    container_name: wal-g_pg_checksum_corruption_test
+    command: /tmp/tests/checksum_corruption_test.sh
+
   pg_full_backup_test:
     <<: *pg_test_common
     container_name: wal-g_pg_full_backup_test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -400,6 +400,11 @@ services:
     container_name: wal-g_pg${PG_MAJOR}_delete_retain_after_test
     command: /tmp/tests/delete_retain_after_test.sh
 
+  pg_checksum_corruption_test:
+    <<: *pg_test_common
+    container_name: wal-g_pg${PG_MAJOR}_checksum_corruption_test
+    command: /tmp/tests/checksum_corruption_test.sh
+
   pg_full_backup_test_compression_none_encryption_test:
     <<: *pg_test_common
     container_name: wal-g_pg${PG_MAJOR}_full_backup_test_compression_none_encryption_test

--- a/docker/pg_tests/scripts/configs/checksum_corruption_test_config.json
+++ b/docker/pg_tests/scripts/configs/checksum_corruption_test_config.json
@@ -1,0 +1,1 @@
+"WALE_S3_PREFIX": "s3://fullbucket"

--- a/docker/pg_tests/scripts/tests/checksum_corruption_test.sh
+++ b/docker/pg_tests/scripts/tests/checksum_corruption_test.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -e -x
+
+. /tmp/tests/test_functions/prepare_config.sh
+prepare_config "/tmp/configs/checksum_corruption_test_config.json"
+
+# Init cluster with data checksums enabled
+initdb --data-checksums ${PGDATA}
+
+echo "full_page_writes = on" >> ${PGDATA}/postgresql.conf
+echo "archive_mode = on" >> ${PGDATA}/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 wal-g --config=${TMP_CONFIG} wal-push %p'" >> ${PGDATA}/postgresql.conf
+
+pg_ctl -D ${PGDATA} -w start
+
+wal-g --config=${TMP_CONFIG} st rm / --target=all || true
+
+pgbench -i -s 1 postgres
+psql -c "CHECKPOINT" postgres
+
+# Target pgbench_accounts — the large table we just created (scale=1 → ~13MB).
+# pg_relation_filepath returns the path relative to PGDATA, e.g. "base/16384/16385".
+DATA_FILE="${PGDATA}/$(psql -t -A -c "SELECT pg_relation_filepath('pgbench_accounts')" postgres)"
+
+# Keep a clean copy so test 2 starts from a valid state
+cp "${DATA_FILE}" "/tmp/clean_data_file_backup"
+
+pg_ctl -D ${PGDATA} -w stop
+
+# ── Test 1: replace bytes (conv=notrunc) → file size unchanged, checksum breaks ──
+# Equivalent to: dd if=/dev/urandom of=<file> bs=1 count=4 seek=6000 conv=notrunc
+dd if=/dev/urandom of="${DATA_FILE}" bs=1 count=4 seek=6000 conv=notrunc
+
+pg_ctl -D ${PGDATA} -w start
+
+BACKUP_LOG_1="/tmp/checksum_test1.log"
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --verify > "${BACKUP_LOG_1}" 2>&1 || true
+
+if ! grep -q "Corruption found" "${BACKUP_LOG_1}"; then
+    echo "TEST 1 FAILED: Expected 'Corruption found' warning for replaced bytes"
+    cat "${BACKUP_LOG_1}"
+    exit 1
+fi
+echo "TEST 1 PASSED: byte replacement detected as checksum corruption"
+
+pg_ctl -D ${PGDATA} -w stop
+
+# Restore the clean file before test 2
+cp "/tmp/clean_data_file_backup" "${DATA_FILE}"
+
+# ── Test 2: append bytes → file size grows by 4 (not a multiple of page size) ──
+# Equivalent to: dd if=/dev/urandom bs=1 count=4 >> <file>
+dd if=/dev/urandom bs=1 count=4 >> "${DATA_FILE}"
+
+pg_ctl -D ${PGDATA} -w start
+
+BACKUP_LOG_2="/tmp/checksum_test2.log"
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --verify > "${BACKUP_LOG_2}" 2>&1 || true
+
+if ! grep -q "invalid file size" "${BACKUP_LOG_2}"; then
+    echo "TEST 2 FAILED: Expected 'invalid file size' warning for appended bytes"
+    cat "${BACKUP_LOG_2}"
+    exit 1
+fi
+if grep -q "Corruption found" "${BACKUP_LOG_2}"; then
+    echo "TEST 2 FAILED: Got 'Corruption found' but size mismatch must take a different code path"
+    cat "${BACKUP_LOG_2}"
+    exit 1
+fi
+echo "TEST 2 PASSED: byte insertion hits size-guard, not checksum path"
+
+/tmp/scripts/drop_pg.sh
+rm ${TMP_CONFIG}
+echo "checksum_corruption_test completed"

--- a/docker/pg_tests/scripts/tests/checksum_corruption_test.sh
+++ b/docker/pg_tests/scripts/tests/checksum_corruption_test.sh
@@ -2,7 +2,24 @@
 set -e -x
 
 . /tmp/tests/test_functions/prepare_config.sh
+. /tmp/tests/test_functions/pg_compat.sh
 prepare_config "/tmp/configs/checksum_corruption_test_config.json"
+
+# pg_checksums confirms the damage independently of wal-g. It appeared in PG 12
+# (pg_verify_checksums in 11), so on PG 10 we only have wal-g's own report.
+expect_pg_checksums_failure() {
+    if ! pg_version_ge 12; then
+        echo "pg_checksums is not available before PG 12, skipping the independent check"
+        return 0
+    fi
+    if pg_checksums --check -D "${PGDATA}" >/tmp/pg_checksums.log 2>&1; then
+        echo "FAILED: pg_checksums found no problem, but the file was corrupted"
+        cat /tmp/pg_checksums.log
+        exit 1
+    fi
+    echo "pg_checksums reports a problem too:"
+    cat /tmp/pg_checksums.log
+}
 
 # Init cluster with data checksums enabled
 initdb --data-checksums ${PGDATA}
@@ -31,6 +48,8 @@ pg_ctl -D ${PGDATA} -w stop
 # Equivalent to: dd if=/dev/urandom of=<file> bs=1 count=4 seek=6000 conv=notrunc
 dd if=/dev/urandom of="${DATA_FILE}" bs=1 count=4 seek=6000 conv=notrunc
 
+expect_pg_checksums_failure
+
 pg_ctl -D ${PGDATA} -w start
 
 BACKUP_LOG_1="/tmp/checksum_test1.log"
@@ -51,6 +70,8 @@ cp "/tmp/clean_data_file_backup" "${DATA_FILE}"
 # ── Test 2: append bytes → file size grows by 4 (not a multiple of page size) ──
 # Equivalent to: dd if=/dev/urandom bs=1 count=4 >> <file>
 dd if=/dev/urandom bs=1 count=4 >> "${DATA_FILE}"
+
+expect_pg_checksums_failure
 
 pg_ctl -D ${PGDATA} -w start
 

--- a/internal/databases/greenplum/tar_ball_composer.go
+++ b/internal/databases/greenplum/tar_ball_composer.go
@@ -44,7 +44,7 @@ func NewGpTarBallComposerMaker(relStorageMap AoRelFileStorageMap, uploader inter
 func (maker *GpTarBallComposerMaker) Make(bundle *postgres.Bundle) (internal.TarBallComposer, error) {
 	// checksums verification is not supported in Greenplum (yet)
 	// TODO: Add support for checksum verification
-	filePackerOptions := postgres.NewTarBallFilePackerOptions(false, false)
+	filePackerOptions := postgres.NewTarBallFilePackerOptions(false, false, false, postgres.LSN(0))
 
 	baseFiles, err := maker.loadBaseFiles(bundle.IncrementFromName)
 	if err != nil {

--- a/internal/databases/greenplum/tar_ball_composer.go
+++ b/internal/databases/greenplum/tar_ball_composer.go
@@ -46,7 +46,7 @@ func NewGpTarBallComposerMaker(relStorageMap AoRelFileStorageMap, paxRelStorageM
 func (maker *GpTarBallComposerMaker) Make(ctx context.Context, bundle *postgres.Bundle) (internal.TarBallComposer, error) {
 	// checksums verification is not supported in Greenplum (yet)
 	// TODO: Add support for checksum verification
-	filePackerOptions := postgres.NewTarBallFilePackerOptions(false, false)
+	filePackerOptions := postgres.NewTarBallFilePackerOptions(false, false, false, postgres.LSN(0))
 
 	baseFiles, err := maker.loadBaseFiles(ctx, bundle.IncrementFromName)
 	if err != nil {

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -81,6 +81,7 @@ type CurBackupInfo struct {
 	dataCatalogSize  int64
 	incrementCount   int
 	StartChkpNum     *uint32
+	fullPageWrites   bool
 }
 
 func NewPrevBackupInfo(name string, sentinel BackupSentinelDto, filesMeta FilesMetadataDto) PrevBackupInfo {
@@ -319,7 +320,8 @@ func (bh *BackupHandler) SetComposerInitFunc(initFunc func(handler *BackupHandle
 func configureTarBallComposer(bh *BackupHandler, tarBallComposerType TarBallComposerType) error {
 	maker, err := NewTarBallComposerMaker(tarBallComposerType, bh.Workers.QueryRunner,
 		bh.Arguments.Uploader, bh.CurBackupInfo.Name,
-		NewTarBallFilePackerOptions(bh.Arguments.verifyPageChecksums, bh.Arguments.storeAllCorruptBlocks),
+		NewTarBallFilePackerOptions(bh.Arguments.verifyPageChecksums, bh.Arguments.storeAllCorruptBlocks,
+			bh.CurBackupInfo.fullPageWrites, bh.CurBackupInfo.startLSN),
 		bh.Arguments.withoutFilesMetadata)
 	if err != nil {
 		return err
@@ -681,6 +683,15 @@ func (bh *BackupHandler) checkDataChecksums() error {
 			bh.Arguments.verifyPageChecksums = false
 		} else {
 			tracelog.InfoLogger.Println("data_checksums is enabled in DB.")
+			fullPageWrites, err := bh.Workers.QueryRunner.GetFullPageWrites()
+			if err != nil {
+				return err
+			}
+			bh.CurBackupInfo.fullPageWrites = fullPageWrites
+			if fullPageWrites {
+				tracelog.InfoLogger.Println(
+					"full_page_writes is enabled. Pages modified after backup start will skip checksum validation.")
+			}
 		}
 	} else {
 		tracelog.DebugLogger.Println(

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -722,7 +722,7 @@ func (bh *BackupHandler) checkDataChecksums(ctx context.Context) error {
 			bh.Arguments.verifyPageChecksums = false
 		} else {
 			tracelog.InfoLogger.Println("data_checksums is enabled in DB.")
-			fullPageWrites, err := bh.Workers.QueryRunner.GetFullPageWrites()
+			fullPageWrites, err := bh.Workers.QueryRunner.GetFullPageWrites(ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -78,6 +78,7 @@ type CurBackupInfo struct {
 	dataCatalogSize  int64
 	incrementCount   int
 	StartChkpNum     *uint32
+	fullPageWrites   bool
 }
 
 func NewPrevBackupInfo(name string, sentinel BackupSentinelDto, filesMeta FilesMetadataDto) PrevBackupInfo {
@@ -318,7 +319,8 @@ func (bh *BackupHandler) SetComposerInitFunc(initFunc func(ctx context.Context, 
 func configureTarBallComposer(ctx context.Context, bh *BackupHandler, tarBallComposerType TarBallComposerType) error {
 	maker, err := NewTarBallComposerMaker(ctx, tarBallComposerType, bh.Workers.QueryRunner,
 		bh.Arguments.Uploader, bh.CurBackupInfo.Name,
-		NewTarBallFilePackerOptions(bh.Arguments.verifyPageChecksums, bh.Arguments.storeAllCorruptBlocks),
+		NewTarBallFilePackerOptions(bh.Arguments.verifyPageChecksums, bh.Arguments.storeAllCorruptBlocks,
+			bh.CurBackupInfo.fullPageWrites, bh.CurBackupInfo.startLSN),
 		bh.Arguments.withoutFilesMetadata)
 	if err != nil {
 		return err
@@ -720,6 +722,15 @@ func (bh *BackupHandler) checkDataChecksums(ctx context.Context) error {
 			bh.Arguments.verifyPageChecksums = false
 		} else {
 			tracelog.InfoLogger.Println("data_checksums is enabled in DB.")
+			fullPageWrites, err := bh.Workers.QueryRunner.GetFullPageWrites()
+			if err != nil {
+				return err
+			}
+			bh.CurBackupInfo.fullPageWrites = fullPageWrites
+			if fullPageWrites {
+				tracelog.InfoLogger.Println(
+					"full_page_writes is enabled. Pages modified after backup start will skip checksum validation.")
+			}
 		}
 	} else {
 		tracelog.DebugLogger.Println(

--- a/internal/databases/postgres/paged_file_verifier.go
+++ b/internal/databases/postgres/paged_file_verifier.go
@@ -188,7 +188,9 @@ func isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage, fullPage
 }
 
 // VerifyPagedFileIncrement verifies pages of an increment
-func VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Reader, fullPageWrites bool, backupStartLSN LSN) ([]uint32, error) {
+func VerifyPagedFileIncrement(
+	path string, fileInfo os.FileInfo, increment io.Reader, fullPageWrites bool, backupStartLSN LSN,
+) ([]uint32, error) {
 	_, diffBlockCount, diffMap, err := GetIncrementHeaderFields(increment)
 	if err != nil {
 		return nil, err
@@ -202,7 +204,9 @@ func VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Re
 }
 
 // VerifyPagedFileBase verifies pages of a standard paged file
-func VerifyPagedFileBase(path string, fileInfo os.FileInfo, pagedFile io.Reader, fullPageWrites bool, backupStartLSN LSN) ([]uint32, error) {
+func VerifyPagedFileBase(
+	path string, fileInfo os.FileInfo, pagedFile io.Reader, fullPageWrites bool, backupStartLSN LSN,
+) ([]uint32, error) {
 	size := fileInfo.Size()
 	filePageCount := uint32((size + DatabasePageSize - 1) / DatabasePageSize)
 	blockNumbers := make([]uint32, 0, filePageCount)

--- a/internal/databases/postgres/paged_file_verifier.go
+++ b/internal/databases/postgres/paged_file_verifier.go
@@ -118,16 +118,28 @@ func pgChecksumBlock(page *PgDatabasePage) uint32 {
 	return result
 }
 
+// pageVerifier holds backup-level context for page checksum validation.
+// fullPageWrites and backupStartLSN are invariant across all pages in a single backup,
+// so they live in the struct rather than being threaded through every call.
+type pageVerifier struct {
+	fullPageWrites bool
+	backupStartLSN LSN
+}
+
+func newPageVerifier(fullPageWrites bool, backupStartLSN LSN) *pageVerifier {
+	return &pageVerifier{fullPageWrites: fullPageWrites, backupStartLSN: backupStartLSN}
+}
+
 // This function is an adaptation of is_page_corrupted() from
 // https://github.com/google/pg_page_verification/blob/master/pg_page_verification.c
 
-// Function checks a page header checksum value against the current
+// isPageCorrupted checks a page header checksum value against the current
 // checksum value of a page.  NewPage checksums will be zero until they
 // are set.  There is a similar function PageIsVerified responsible for
 // checking pages before they are loaded into buffer pool.
 //
 // see:  src/backend/storage/page/bufpage.info
-func isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage) (bool, error) {
+func (v *pageVerifier) isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage) (bool, error) {
 	pageHeader, err := parsePostgresPageHeader(bytes.NewReader(page[:]))
 	if err != nil {
 		return false, err
@@ -149,6 +161,16 @@ func isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage) (bool, e
 	if pageHeader.pdChecksum == 0 {
 		// Zero value means that there is no checksum calculated for this page.
 		// Probably checksums are disabled in the cluster
+		return false, nil
+	}
+
+	// Skip validation for pages modified after backup start when full_page_writes is on.
+	// Such pages will be recovered via Full Page Images in WAL during restore,
+	// so torn pages or transient corruption cannot cause data loss.
+	if v.fullPageWrites && pageHeader.lsn() > v.backupStartLSN {
+		tracelog.DebugLogger.Printf(
+			"isPageCorrupted: skipping %s/[%d], page LSN %s > backupStartLSN %s (full_page_writes on)",
+			path, blockNo, pageHeader.lsn(), v.backupStartLSN)
 		return false, nil
 	}
 
@@ -178,7 +200,7 @@ func isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage) (bool, e
 }
 
 // VerifyPagedFileIncrement verifies pages of an increment
-func VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Reader) ([]uint32, error) {
+func (v *pageVerifier) VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Reader) ([]uint32, error) {
 	_, diffBlockCount, diffMap, err := GetIncrementHeaderFields(increment)
 	if err != nil {
 		return nil, err
@@ -188,29 +210,29 @@ func VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Re
 		blockNo := binary.LittleEndian.Uint32(diffMap[i*sizeofInt32 : (i+1)*sizeofInt32])
 		blockNumbers = append(blockNumbers, blockNo)
 	}
-	return verifyPageBlocks(path, fileInfo, increment, blockNumbers)
+	return v.verifyPageBlocks(path, fileInfo, increment, blockNumbers)
 }
 
 // VerifyPagedFileBase verifies pages of a standard paged file
-func VerifyPagedFileBase(path string, fileInfo os.FileInfo, pagedFile io.Reader) ([]uint32, error) {
+func (v *pageVerifier) VerifyPagedFileBase(path string, fileInfo os.FileInfo, pagedFile io.Reader) ([]uint32, error) {
 	size := fileInfo.Size()
 	filePageCount := uint32((size + DatabasePageSize - 1) / DatabasePageSize)
 	blockNumbers := make([]uint32, 0, filePageCount)
 	for i := uint32(0); i < filePageCount; i++ {
 		blockNumbers = append(blockNumbers, i)
 	}
-	return verifyPageBlocks(path, fileInfo, pagedFile, blockNumbers)
+	return v.verifyPageBlocks(path, fileInfo, pagedFile, blockNumbers)
 }
 
 // verifyPageBlocks verifies provided page blocks from the pagedBlocks reader
-func verifyPageBlocks(path string, fileInfo os.FileInfo, pageBlocks io.Reader,
+func (v *pageVerifier) verifyPageBlocks(path string, fileInfo os.FileInfo, pageBlocks io.Reader,
 	blockNumbers []uint32) (corruptBlockNumbers []uint32, err error) {
 	if _, ignored := ignoredFileNames[fileInfo.Name()]; ignored || !isChecksumValidatableFile(fileInfo, path) {
 		_, err = io.Copy(io.Discard, pageBlocks)
 		return nil, err
 	}
 	for _, blockNo := range blockNumbers {
-		corrupted, err := verifySinglePage(path, blockNo, pageBlocks)
+		corrupted, err := v.verifySinglePage(path, blockNo, pageBlocks)
 		if corrupted {
 			corruptBlockNumbers = append(corruptBlockNumbers, blockNo)
 		}
@@ -236,11 +258,11 @@ func verifyPageBlocks(path string, fileInfo os.FileInfo, pageBlocks io.Reader,
 }
 
 // verifySinglePage reads and verifies single paged file block
-func verifySinglePage(path string, blockNo uint32, pageBlocks io.Reader) (bool, error) {
+func (v *pageVerifier) verifySinglePage(path string, blockNo uint32, pageBlocks io.Reader) (bool, error) {
 	page := PgDatabasePage{}
 	_, err := io.ReadFull(pageBlocks, page[:DatabasePageSize])
 	if err != nil {
 		return false, err
 	}
-	return isPageCorrupted(path, blockNo, &page)
+	return v.isPageCorrupted(path, blockNo, &page)
 }

--- a/internal/databases/postgres/paged_file_verifier.go
+++ b/internal/databases/postgres/paged_file_verifier.go
@@ -118,18 +118,6 @@ func pgChecksumBlock(page *PgDatabasePage) uint32 {
 	return result
 }
 
-// pageVerifier holds backup-level context for page checksum validation.
-// fullPageWrites and backupStartLSN are invariant across all pages in a single backup,
-// so they live in the struct rather than being threaded through every call.
-type pageVerifier struct {
-	fullPageWrites bool
-	backupStartLSN LSN
-}
-
-func newPageVerifier(fullPageWrites bool, backupStartLSN LSN) *pageVerifier {
-	return &pageVerifier{fullPageWrites: fullPageWrites, backupStartLSN: backupStartLSN}
-}
-
 // This function is an adaptation of is_page_corrupted() from
 // https://github.com/google/pg_page_verification/blob/master/pg_page_verification.c
 
@@ -139,7 +127,7 @@ func newPageVerifier(fullPageWrites bool, backupStartLSN LSN) *pageVerifier {
 // checking pages before they are loaded into buffer pool.
 //
 // see:  src/backend/storage/page/bufpage.info
-func (v *pageVerifier) isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage) (bool, error) {
+func isPageCorrupted(path string, blockNo uint32, page *PgDatabasePage, fullPageWrites bool, backupStartLSN LSN) (bool, error) {
 	pageHeader, err := parsePostgresPageHeader(bytes.NewReader(page[:]))
 	if err != nil {
 		return false, err
@@ -165,12 +153,12 @@ func (v *pageVerifier) isPageCorrupted(path string, blockNo uint32, page *PgData
 	}
 
 	// Skip validation for pages modified after backup start when full_page_writes is on.
-	// Such pages will be recovered via Full Page Images in WAL during restore,
+	// Such pages will be recovered via Full Page Images (FPI) in WAL during restore,
 	// so torn pages or transient corruption cannot cause data loss.
-	if v.fullPageWrites && pageHeader.lsn() > v.backupStartLSN {
+	if fullPageWrites && pageHeader.lsn() > backupStartLSN {
 		tracelog.DebugLogger.Printf(
 			"isPageCorrupted: skipping %s/[%d], page LSN %s > backupStartLSN %s (full_page_writes on)",
-			path, blockNo, pageHeader.lsn(), v.backupStartLSN)
+			path, blockNo, pageHeader.lsn(), backupStartLSN)
 		return false, nil
 	}
 
@@ -200,7 +188,7 @@ func (v *pageVerifier) isPageCorrupted(path string, blockNo uint32, page *PgData
 }
 
 // VerifyPagedFileIncrement verifies pages of an increment
-func (v *pageVerifier) VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Reader) ([]uint32, error) {
+func VerifyPagedFileIncrement(path string, fileInfo os.FileInfo, increment io.Reader, fullPageWrites bool, backupStartLSN LSN) ([]uint32, error) {
 	_, diffBlockCount, diffMap, err := GetIncrementHeaderFields(increment)
 	if err != nil {
 		return nil, err
@@ -210,29 +198,29 @@ func (v *pageVerifier) VerifyPagedFileIncrement(path string, fileInfo os.FileInf
 		blockNo := binary.LittleEndian.Uint32(diffMap[i*sizeofInt32 : (i+1)*sizeofInt32])
 		blockNumbers = append(blockNumbers, blockNo)
 	}
-	return v.verifyPageBlocks(path, fileInfo, increment, blockNumbers)
+	return verifyPageBlocks(path, fileInfo, increment, blockNumbers, fullPageWrites, backupStartLSN)
 }
 
 // VerifyPagedFileBase verifies pages of a standard paged file
-func (v *pageVerifier) VerifyPagedFileBase(path string, fileInfo os.FileInfo, pagedFile io.Reader) ([]uint32, error) {
+func VerifyPagedFileBase(path string, fileInfo os.FileInfo, pagedFile io.Reader, fullPageWrites bool, backupStartLSN LSN) ([]uint32, error) {
 	size := fileInfo.Size()
 	filePageCount := uint32((size + DatabasePageSize - 1) / DatabasePageSize)
 	blockNumbers := make([]uint32, 0, filePageCount)
 	for i := uint32(0); i < filePageCount; i++ {
 		blockNumbers = append(blockNumbers, i)
 	}
-	return v.verifyPageBlocks(path, fileInfo, pagedFile, blockNumbers)
+	return verifyPageBlocks(path, fileInfo, pagedFile, blockNumbers, fullPageWrites, backupStartLSN)
 }
 
 // verifyPageBlocks verifies provided page blocks from the pagedBlocks reader
-func (v *pageVerifier) verifyPageBlocks(path string, fileInfo os.FileInfo, pageBlocks io.Reader,
-	blockNumbers []uint32) (corruptBlockNumbers []uint32, err error) {
+func verifyPageBlocks(path string, fileInfo os.FileInfo, pageBlocks io.Reader,
+	blockNumbers []uint32, fullPageWrites bool, backupStartLSN LSN) (corruptBlockNumbers []uint32, err error) {
 	if _, ignored := ignoredFileNames[fileInfo.Name()]; ignored || !isChecksumValidatableFile(fileInfo, path) {
 		_, err = io.Copy(io.Discard, pageBlocks)
 		return nil, err
 	}
 	for _, blockNo := range blockNumbers {
-		corrupted, err := v.verifySinglePage(path, blockNo, pageBlocks)
+		corrupted, err := verifySinglePage(path, blockNo, pageBlocks, fullPageWrites, backupStartLSN)
 		if corrupted {
 			corruptBlockNumbers = append(corruptBlockNumbers, blockNo)
 		}
@@ -258,11 +246,11 @@ func (v *pageVerifier) verifyPageBlocks(path string, fileInfo os.FileInfo, pageB
 }
 
 // verifySinglePage reads and verifies single paged file block
-func (v *pageVerifier) verifySinglePage(path string, blockNo uint32, pageBlocks io.Reader) (bool, error) {
+func verifySinglePage(path string, blockNo uint32, pageBlocks io.Reader, fullPageWrites bool, backupStartLSN LSN) (bool, error) {
 	page := PgDatabasePage{}
 	_, err := io.ReadFull(pageBlocks, page[:DatabasePageSize])
 	if err != nil {
 		return false, err
 	}
-	return v.isPageCorrupted(path, blockNo, &page)
+	return isPageCorrupted(path, blockNo, &page, fullPageWrites, backupStartLSN)
 }

--- a/internal/databases/postgres/paged_file_verifier_test.go
+++ b/internal/databases/postgres/paged_file_verifier_test.go
@@ -37,8 +37,7 @@ func TestPageVerifier_DetectsReplacement(t *testing.T) {
 
 	copy(page[6000:6004], []byte{0xDE, 0xAD, 0xBE, 0xEF})
 
-	v := newPageVerifier(false /* fullPageWrites */, LSN(0))
-	corrupted, err := v.isPageCorrupted("base/1/16384", 0, &page)
+	corrupted, err := isPageCorrupted("base/1/16384", 0, &page, false /* fullPageWrites */, LSN(0))
 	require.NoError(t, err)
 	require.True(t, corrupted)
 }
@@ -63,8 +62,7 @@ func TestPageVerifier_InvalidSizeOnInsertion(t *testing.T) {
 	require.NoError(t, err)
 	defer f.Close()
 
-	v := newPageVerifier(false, LSN(0))
-	corruptBlocks, err := v.verifyFile(filePath, fileInfo, f, false)
+	corruptBlocks, err := verifyFile(filePath, fileInfo, f, false, false, LSN(0))
 	require.NoError(t, err)
 	require.Empty(t, corruptBlocks)
 }
@@ -76,8 +74,7 @@ func TestPageVerifier_SkipsTornPage(t *testing.T) {
 	page := buildValidChecksummedPage(t, 0, "base/1/16384")
 	copy(page[6000:6004], []byte{0xDE, 0xAD, 0xBE, 0xEF})
 
-	v := newPageVerifier(true, LSN(1))
-	corrupted, err := v.isPageCorrupted("base/1/16384", 0, &page)
+	corrupted, err := isPageCorrupted("base/1/16384", 0, &page, true, LSN(1))
 	require.NoError(t, err)
 	require.False(t, corrupted)
 }
@@ -89,8 +86,7 @@ func TestPageVerifier_DetectsCorruptionWhenLSNBeforeBackup(t *testing.T) {
 	copy(page[6000:6004], []byte{0xDE, 0xAD, 0xBE, 0xEF})
 
 	// Page LSN = 100, backupStartLSN = 200 → lsn() < backupStartLSN.
-	v := newPageVerifier(true, LSN(200))
-	corrupted, err := v.isPageCorrupted("base/1/16384", 0, &page)
+	corrupted, err := isPageCorrupted("base/1/16384", 0, &page, true, LSN(200))
 	require.NoError(t, err)
 	require.True(t, corrupted)
 }

--- a/internal/databases/postgres/paged_file_verifier_test.go
+++ b/internal/databases/postgres/paged_file_verifier_test.go
@@ -1,0 +1,96 @@
+package postgres
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildValidChecksummedPage returns an 8KB page with a valid header and correct checksum.
+// pdLsnH=0, pdLsnL=100 → LSN = 100 (non-zero, satisfies isNew/isValid).
+func buildValidChecksummedPage(t *testing.T, blockNo uint32, path string) PgDatabasePage {
+	t.Helper()
+	var page PgDatabasePage
+
+	binary.LittleEndian.PutUint32(page[0:], 0)       // pdLsnH
+	binary.LittleEndian.PutUint32(page[4:], 100)     // pdLsnL → LSN = 100
+	binary.LittleEndian.PutUint16(page[10:], 0)      // pdFlags
+	binary.LittleEndian.PutUint16(page[12:], 28)     // pdLower
+	binary.LittleEndian.PutUint16(page[14:], 8000)   // pdUpper
+	binary.LittleEndian.PutUint16(page[16:], 8192)   // pdSpecial
+	binary.LittleEndian.PutUint16(page[18:], 0x2005) // pdPageSizeVersion (size=8192, version=5)
+
+	relFileID, err := GetRelFileIDFrom(path)
+	require.NoError(t, err)
+	checksum := pgChecksumPage(uint32(relFileID*BlocksInRelFile)+blockNo, &page)
+	binary.LittleEndian.PutUint16(page[8:], checksum) // pdChecksum
+	return page
+}
+
+// TestPageVerifier_DetectsReplacement: overwrites 4 bytes (dd conv=notrunc, size stays 8192)
+// → checksum mismatch → must be reported as corrupt.
+func TestPageVerifier_DetectsReplacement(t *testing.T) {
+	page := buildValidChecksummedPage(t, 0, "base/1/16384")
+
+	copy(page[6000:6004], []byte{0xDE, 0xAD, 0xBE, 0xEF})
+
+	v := newPageVerifier(false /* fullPageWrites */, LSN(0))
+	corrupted, err := v.isPageCorrupted("base/1/16384", 0, &page)
+	require.NoError(t, err)
+	require.True(t, corrupted)
+}
+
+// TestPageVerifier_InvalidSizeOnInsertion: appending bytes (dd without conv=notrunc) makes
+// the file size a non-multiple of the page size — hits the size-guard, not the checksum path.
+func TestPageVerifier_InvalidSizeOnInsertion(t *testing.T) {
+	page := buildValidChecksummedPage(t, 0, "base/1/16384")
+
+	data := make([]byte, DatabasePageSize+4)
+	copy(data, page[:DatabasePageSize])
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "base", "1", "16384")
+	require.NoError(t, os.MkdirAll(filepath.Dir(filePath), 0o755))
+	require.NoError(t, os.WriteFile(filePath, data, 0o644))
+
+	fileInfo, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	f, err := os.Open(filePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	v := newPageVerifier(false, LSN(0))
+	corruptBlocks, err := v.verifyFile(filePath, fileInfo, f, false)
+	require.NoError(t, err)
+	require.Empty(t, corruptBlocks)
+}
+
+// TestPageVerifier_SkipsTornPage: a page with a bad checksum whose LSN > backupStartLSN
+// must NOT be reported as corrupt when full_page_writes is on — it will be recovered via WAL FPI.
+func TestPageVerifier_SkipsTornPage(t *testing.T) {
+	// Page LSN = 100, backupStartLSN = 1 → lsn() > backupStartLSN.
+	page := buildValidChecksummedPage(t, 0, "base/1/16384")
+	copy(page[6000:6004], []byte{0xDE, 0xAD, 0xBE, 0xEF})
+
+	v := newPageVerifier(true, LSN(1))
+	corrupted, err := v.isPageCorrupted("base/1/16384", 0, &page)
+	require.NoError(t, err)
+	require.False(t, corrupted)
+}
+
+// TestPageVerifier_DetectsCorruptionWhenLSNBeforeBackup: full_page_writes=on does NOT protect
+// pages written before the backup started — lsn() <= backupStartLSN → no FPI → must detect.
+func TestPageVerifier_DetectsCorruptionWhenLSNBeforeBackup(t *testing.T) {
+	page := buildValidChecksummedPage(t, 0, "base/1/16384")
+	copy(page[6000:6004], []byte{0xDE, 0xAD, 0xBE, 0xEF})
+
+	// Page LSN = 100, backupStartLSN = 200 → lsn() < backupStartLSN.
+	v := newPageVerifier(true, LSN(200))
+	corrupted, err := v.isPageCorrupted("base/1/16384", 0, &page)
+	require.NoError(t, err)
+	require.True(t, corrupted)
+}

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -727,6 +727,15 @@ func (queryRunner *PgQueryRunner) GetDataChecksums() (string, error) {
 	return dataChecksums, nil
 }
 
+// GetFullPageWrites retrieves the full_page_writes PostgreSQL setting.
+func (queryRunner *PgQueryRunner) GetFullPageWrites() (bool, error) {
+	value, err := queryRunner.GetParameter("full_page_writes")
+	if err != nil {
+		return false, errors.Wrap(err, "GetFullPageWrites: failed to retrieve full_page_writes")
+	}
+	return value == "on", nil
+}
+
 // GetArchiveMode retrieves the current archive_mode setting.
 func (queryRunner *PgQueryRunner) GetArchiveMode() (string, error) {
 	queryRunner.Mu.Lock()

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -746,8 +746,8 @@ func (queryRunner *PgQueryRunner) GetDataChecksums(ctx context.Context) (string,
 }
 
 // GetFullPageWrites retrieves the full_page_writes PostgreSQL setting.
-func (queryRunner *PgQueryRunner) GetFullPageWrites() (bool, error) {
-	value, err := queryRunner.GetParameter("full_page_writes")
+func (queryRunner *PgQueryRunner) GetFullPageWrites(ctx context.Context) (bool, error) {
+	value, err := queryRunner.GetParameter(ctx, "full_page_writes")
 	if err != nil {
 		return false, errors.Wrap(err, "GetFullPageWrites: failed to retrieve full_page_writes")
 	}

--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -745,6 +745,15 @@ func (queryRunner *PgQueryRunner) GetDataChecksums(ctx context.Context) (string,
 	return dataChecksums, nil
 }
 
+// GetFullPageWrites retrieves the full_page_writes PostgreSQL setting.
+func (queryRunner *PgQueryRunner) GetFullPageWrites() (bool, error) {
+	value, err := queryRunner.GetParameter("full_page_writes")
+	if err != nil {
+		return false, errors.Wrap(err, "GetFullPageWrites: failed to retrieve full_page_writes")
+	}
+	return value == "on", nil
+}
+
 // GetArchiveMode retrieves the current archive_mode setting.
 func (queryRunner *PgQueryRunner) GetArchiveMode(ctx context.Context) (string, error) {
 	queryRunner.Mu.Lock()

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -102,7 +102,9 @@ func (p *TarBallFilePackerImpl) PackFileIntoTar(cfi *internal.ComposeFileInfo, t
 		// fileReadCloser is needed for PackFileTo, secondReadCloser is for the page verification
 		fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
 		errorGroup.Go(func() (err error) {
-			corruptBlocks, err := verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented, p.options.fullPageWrites, p.options.backupStartLSN)
+			corruptBlocks, err := verifyFile(
+				cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented,
+				p.options.fullPageWrites, p.options.backupStartLSN)
 			if err != nil {
 				return err
 			}
@@ -176,7 +178,9 @@ func (p *TarBallFilePackerImpl) createFileReadCloser(cfi *internal.ComposeFileIn
 	return fileReadCloser, nil
 }
 
-func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool, fullPageWrites bool, backupStartLSN LSN) ([]uint32, error) {
+func verifyFile(
+	path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool, fullPageWrites bool, backupStartLSN LSN,
+) ([]uint32, error) {
 	if !isChecksumValidatableFile(fileInfo, path) {
 		tracelog.DebugLogger.Printf(
 			"verifyFile: %s does not meet the criteria for checksum validation. "+

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -54,7 +54,6 @@ type TarBallFilePackerImpl struct {
 	files                internal.BundleFiles
 	options              TarBallFilePackerOptions
 	IncrementFromChkpNum *uint32
-	pageVerifier         *pageVerifier
 }
 
 func NewTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *LSN, files internal.BundleFiles,
@@ -64,7 +63,6 @@ func NewTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *LSN, fil
 		incrementFromLsn: incrementFromLsn,
 		files:            files,
 		options:          options,
-		pageVerifier:     newPageVerifier(options.fullPageWrites, options.backupStartLSN),
 	}
 }
 
@@ -104,7 +102,7 @@ func (p *TarBallFilePackerImpl) PackFileIntoTar(cfi *internal.ComposeFileInfo, t
 		// fileReadCloser is needed for PackFileTo, secondReadCloser is for the page verification
 		fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
 		errorGroup.Go(func() (err error) {
-			corruptBlocks, err := p.pageVerifier.verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented)
+			corruptBlocks, err := verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented, p.options.fullPageWrites, p.options.backupStartLSN)
 			if err != nil {
 				return err
 			}
@@ -178,7 +176,7 @@ func (p *TarBallFilePackerImpl) createFileReadCloser(cfi *internal.ComposeFileIn
 	return fileReadCloser, nil
 }
 
-func (v *pageVerifier) verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool) ([]uint32, error) {
+func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool, fullPageWrites bool, backupStartLSN LSN) ([]uint32, error) {
 	if !isChecksumValidatableFile(fileInfo, path) {
 		tracelog.DebugLogger.Printf(
 			"verifyFile: %s does not meet the criteria for checksum validation. "+
@@ -200,9 +198,9 @@ func (v *pageVerifier) verifyFile(path string, fileInfo os.FileInfo, fileReader 
 	}
 
 	if isIncremented {
-		return v.VerifyPagedFileIncrement(path, fileInfo, fileReader)
+		return VerifyPagedFileIncrement(path, fileInfo, fileReader, fullPageWrites, backupStartLSN)
 	}
-	return v.VerifyPagedFileBase(path, fileInfo, fileReader)
+	return VerifyPagedFileBase(path, fileInfo, fileReader, fullPageWrites, backupStartLSN)
 }
 
 // TeeReadCloser creates two io.ReadClosers from one

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -33,12 +33,17 @@ func (err SkippedFileError) Error() string {
 type TarBallFilePackerOptions struct {
 	verifyPageChecksums   bool
 	storeAllCorruptBlocks bool
+	fullPageWrites        bool
+	backupStartLSN        LSN
 }
 
-func NewTarBallFilePackerOptions(verifyPageChecksums, storeAllCorruptBlocks bool) TarBallFilePackerOptions {
+func NewTarBallFilePackerOptions(verifyPageChecksums, storeAllCorruptBlocks, fullPageWrites bool,
+	backupStartLSN LSN) TarBallFilePackerOptions {
 	return TarBallFilePackerOptions{
 		verifyPageChecksums:   verifyPageChecksums,
 		storeAllCorruptBlocks: storeAllCorruptBlocks,
+		fullPageWrites:        fullPageWrites,
+		backupStartLSN:        backupStartLSN,
 	}
 }
 
@@ -49,6 +54,7 @@ type TarBallFilePackerImpl struct {
 	files                internal.BundleFiles
 	options              TarBallFilePackerOptions
 	IncrementFromChkpNum *uint32
+	pageVerifier         *pageVerifier
 }
 
 func NewTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *LSN, files internal.BundleFiles,
@@ -58,6 +64,7 @@ func NewTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *LSN, fil
 		incrementFromLsn: incrementFromLsn,
 		files:            files,
 		options:          options,
+		pageVerifier:     newPageVerifier(options.fullPageWrites, options.backupStartLSN),
 	}
 }
 
@@ -97,7 +104,7 @@ func (p *TarBallFilePackerImpl) PackFileIntoTar(cfi *internal.ComposeFileInfo, t
 		// fileReadCloser is needed for PackFileTo, secondReadCloser is for the page verification
 		fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
 		errorGroup.Go(func() (err error) {
-			corruptBlocks, err := verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented)
+			corruptBlocks, err := p.pageVerifier.verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented)
 			if err != nil {
 				return err
 			}
@@ -171,7 +178,7 @@ func (p *TarBallFilePackerImpl) createFileReadCloser(cfi *internal.ComposeFileIn
 	return fileReadCloser, nil
 }
 
-func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool) ([]uint32, error) {
+func (v *pageVerifier) verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool) ([]uint32, error) {
 	if !isChecksumValidatableFile(fileInfo, path) {
 		tracelog.DebugLogger.Printf(
 			"verifyFile: %s does not meet the criteria for checksum validation. "+
@@ -193,9 +200,9 @@ func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncre
 	}
 
 	if isIncremented {
-		return VerifyPagedFileIncrement(path, fileInfo, fileReader)
+		return v.VerifyPagedFileIncrement(path, fileInfo, fileReader)
 	}
-	return VerifyPagedFileBase(path, fileInfo, fileReader)
+	return v.VerifyPagedFileBase(path, fileInfo, fileReader)
 }
 
 // TeeReadCloser creates two io.ReadClosers from one

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -57,7 +57,6 @@ type TarBallFilePackerImpl struct {
 	files                internal.BundleFiles
 	options              TarBallFilePackerOptions
 	IncrementFromChkpNum *uint32
-	pageVerifier         *pageVerifier
 }
 
 func NewTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *LSN, files internal.BundleFiles,
@@ -67,7 +66,6 @@ func NewTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *LSN, fil
 		incrementFromLsn: incrementFromLsn,
 		files:            files,
 		options:          options,
-		pageVerifier:     newPageVerifier(options.fullPageWrites, options.backupStartLSN),
 	}
 }
 
@@ -111,7 +109,7 @@ func (p *TarBallFilePackerImpl) PackFileIntoTar(ctx context.Context, cfi *intern
 			fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
 		}
 		errorGroup.Go(func() (err error) {
-			corruptBlocks, err := p.pageVerifier.verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented)
+			corruptBlocks, err := verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented, p.options.fullPageWrites, p.options.backupStartLSN)
 			if err != nil {
 				return err
 			}
@@ -185,7 +183,7 @@ func (p *TarBallFilePackerImpl) createFileReadCloser(ctx context.Context, cfi *i
 	return fileReadCloser, nil
 }
 
-func (v *pageVerifier) verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool) ([]uint32, error) {
+func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool, fullPageWrites bool, backupStartLSN LSN) ([]uint32, error) {
 	if !isChecksumValidatableFile(fileInfo, path) {
 		tracelog.DebugLogger.Printf(
 			"verifyFile: %s does not meet the criteria for checksum validation. "+
@@ -207,9 +205,9 @@ func (v *pageVerifier) verifyFile(path string, fileInfo os.FileInfo, fileReader 
 	}
 
 	if isIncremented {
-		return v.VerifyPagedFileIncrement(path, fileInfo, fileReader)
+		return VerifyPagedFileIncrement(path, fileInfo, fileReader, fullPageWrites, backupStartLSN)
 	}
-	return v.VerifyPagedFileBase(path, fileInfo, fileReader)
+	return VerifyPagedFileBase(path, fileInfo, fileReader, fullPageWrites, backupStartLSN)
 }
 
 // newTeeReadCloser creates two io.ReadClosers from one. Writes to the second consumer

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -36,12 +36,17 @@ func (err SkippedFileError) Error() string {
 type TarBallFilePackerOptions struct {
 	verifyPageChecksums   bool
 	storeAllCorruptBlocks bool
+	fullPageWrites        bool
+	backupStartLSN        LSN
 }
 
-func NewTarBallFilePackerOptions(verifyPageChecksums, storeAllCorruptBlocks bool) TarBallFilePackerOptions {
+func NewTarBallFilePackerOptions(verifyPageChecksums, storeAllCorruptBlocks, fullPageWrites bool,
+	backupStartLSN LSN) TarBallFilePackerOptions {
 	return TarBallFilePackerOptions{
 		verifyPageChecksums:   verifyPageChecksums,
 		storeAllCorruptBlocks: storeAllCorruptBlocks,
+		fullPageWrites:        fullPageWrites,
+		backupStartLSN:        backupStartLSN,
 	}
 }
 
@@ -52,6 +57,7 @@ type TarBallFilePackerImpl struct {
 	files                internal.BundleFiles
 	options              TarBallFilePackerOptions
 	IncrementFromChkpNum *uint32
+	pageVerifier         *pageVerifier
 }
 
 func NewTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *LSN, files internal.BundleFiles,
@@ -61,6 +67,7 @@ func NewTarBallFilePacker(deltaMap PagedFileDeltaMap, incrementFromLsn *LSN, fil
 		incrementFromLsn: incrementFromLsn,
 		files:            files,
 		options:          options,
+		pageVerifier:     newPageVerifier(options.fullPageWrites, options.backupStartLSN),
 	}
 }
 
@@ -104,7 +111,7 @@ func (p *TarBallFilePackerImpl) PackFileIntoTar(ctx context.Context, cfi *intern
 			fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
 		}
 		errorGroup.Go(func() (err error) {
-			corruptBlocks, err := verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented)
+			corruptBlocks, err := p.pageVerifier.verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented)
 			if err != nil {
 				return err
 			}
@@ -178,7 +185,7 @@ func (p *TarBallFilePackerImpl) createFileReadCloser(ctx context.Context, cfi *i
 	return fileReadCloser, nil
 }
 
-func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool) ([]uint32, error) {
+func (v *pageVerifier) verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool) ([]uint32, error) {
 	if !isChecksumValidatableFile(fileInfo, path) {
 		tracelog.DebugLogger.Printf(
 			"verifyFile: %s does not meet the criteria for checksum validation. "+
@@ -200,9 +207,9 @@ func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncre
 	}
 
 	if isIncremented {
-		return VerifyPagedFileIncrement(path, fileInfo, fileReader)
+		return v.VerifyPagedFileIncrement(path, fileInfo, fileReader)
 	}
-	return VerifyPagedFileBase(path, fileInfo, fileReader)
+	return v.VerifyPagedFileBase(path, fileInfo, fileReader)
 }
 
 // newTeeReadCloser creates two io.ReadClosers from one. Writes to the second consumer

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -109,7 +109,9 @@ func (p *TarBallFilePackerImpl) PackFileIntoTar(ctx context.Context, cfi *intern
 			fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
 		}
 		errorGroup.Go(func() (err error) {
-			corruptBlocks, err := verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented, p.options.fullPageWrites, p.options.backupStartLSN)
+			corruptBlocks, err := verifyFile(
+				cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented,
+				p.options.fullPageWrites, p.options.backupStartLSN)
 			if err != nil {
 				return err
 			}
@@ -183,7 +185,9 @@ func (p *TarBallFilePackerImpl) createFileReadCloser(ctx context.Context, cfi *i
 	return fileReadCloser, nil
 }
 
-func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool, fullPageWrites bool, backupStartLSN LSN) ([]uint32, error) {
+func verifyFile(
+	path string, fileInfo os.FileInfo, fileReader io.Reader, isIncremented bool, fullPageWrites bool, backupStartLSN LSN,
+) ([]uint32, error) {
 	if !isChecksumValidatableFile(fileInfo, path) {
 		tracelog.DebugLogger.Printf(
 			"verifyFile: %s does not meet the criteria for checksum validation. "+

--- a/internal/databases/postgres/walk_test.go
+++ b/internal/databases/postgres/walk_test.go
@@ -442,7 +442,7 @@ func testWalk(t *testing.T, composer postgres.TarBallComposerType, withoutFilesM
 }
 
 func setupTestTarBallComposerMaker(composer postgres.TarBallComposerType, withoutFilesMetadata bool) postgres.TarBallComposerMaker {
-	filePackOptions := postgres.NewTarBallFilePackerOptions(false, false)
+	filePackOptions := postgres.NewTarBallFilePackerOptions(false, false, false, postgres.LSN(0))
 	switch composer {
 	case postgres.RegularComposer:
 		if withoutFilesMetadata {


### PR DESCRIPTION
### Database name
PostgreSQL

### Pull request description

During `backup-push`, WAL-G validates page checksums as it reads data files. When PostgreSQL writes an 8KB page, the OS may split the write into two 4KB operations. If WAL-G reads the page between those two writes (a "torn page"), the checksum will not match — this is reported as corruption, but it could be a false positive.

With `full_page_writes=on`, PostgreSQL writes a Full Page Image (FPI) into WAL for the first modification of every page after a checkpoint. `pg_backup_start` forces a checkpoint, so any page whose LSN > `backupStartLSN` was modified after that checkpoint and therefore has an FPI in WAL. Even if that page is torn or genuinely corrupted at backup time, recovery will restore it from the WAL FPI. Reporting these pages as corrupt has no value and causes false alarms.

### Describe what this PR fixes
In `isPageCorrupted`: if `full_page_writes` is enabled AND `page.LSN > backupStartLSN`, skip the checksum check and return `false`.
Pages written before the backup started (`LSN <= backupStartLSN`) are still fully validated — no FPI guarantee exists for them.

### Testing:
- Unit and integration tests were written with Claude's assistance; I have reviewed and verified each one manually twice.
- The Docker integration test completes in ~15 seconds on an ancient MacBook (Intel chip)) and will not meaningfully increase the overall test suite runtime.


### P.S. 
The full_page_writes check is intentional and important. On Copy-on-Write filesystems (ZFS, btrfs, etc.) torn pages cannot occur, so administrators may disable full_page_writes for performance. In that case — regardless of page LSN — a checksum mismatch is genuine corruption, and WAL-G must always emit a WARNING. The fix correctly gates the skip on full_page_writes=on, so COW users are fully protected.