### PR TITLE
Only invoke pg_relation_filepath for mapped catalogs (relfilenode=0)

### DIFF
--- a/internal/databases/postgres/query_runner.go
+++ b/internal/databases/postgres/query_runner.go
@@ -580,11 +580,15 @@ func (queryRunner *PgQueryRunner) GetLockingPID() (int, error) {
 // Returns:
 // - string: SQL query
 // - error: An error if faces problems, otherwise nil.
-func (queryRunner *PgQueryRunner) BuildGetTablesQuery() (string, error) {
+func (queryRunner *PgQueryRunner) buildGetTablesQuery() (string, error) {
 	switch {
 	case queryRunner.Version >= 90000:
-		query := "SELECT c.relfilenode, c.oid, pg_relation_filepath(c.oid), c.relname, pg_namespace.nspname, " +
-			"c.relkind, parent.relname AS parent_name " +
+		// Only invoke pg_relation_filepath for mapped catalogs (relfilenode=0)
+		// Over millions of relations exhausts backend RELOID syscache, OOMing query
+		// Path only used by processTables when relfilenode=0
+		query := "SELECT c.relfilenode, c.oid, " +
+			"CASE WHEN c.relfilenode = 0 THEN pg_relation_filepath(c.oid) END, " +
+			"c.relname, pg_namespace.nspname, c.relkind, parent.relname AS parent_name " +
 			"FROM pg_class c JOIN pg_namespace ON c.relnamespace = pg_namespace.oid " +
 			"LEFT JOIN pg_inherits i ON c.oid = i.inhrelid LEFT JOIN pg_class parent ON i.inhparent = parent.oid;"
 		return query, nil
@@ -602,7 +606,7 @@ func (queryRunner *PgQueryRunner) getTables() (map[string]TableInfo, error) {
 	tables := make(map[string]TableInfo, 0)
 	parentTables := make([]string, 0)
 
-	getTablesQuery, err := queryRunner.BuildGetTablesQuery()
+	getTablesQuery, err := queryRunner.buildGetTablesQuery()
 	if err != nil {
 		return nil, errors.Wrap(err, "QueryRunner GetTables: Building query failed")
 	}


### PR DESCRIPTION
Over millions of relations exhausts backend RELOID syscache, OOMing query
Path only used by processTables when relfilenode=0

Mapped catalogs are bootstrap catalogs: pg_class, pg_attribute, pg_proc, pg_type) plus shared catalogs (pg_database, pg_authid, ...) & indexes/toasts, physical filename can't live in pg_class.relfilenode since pg_class is one of them. Their filenumbers come from separate pg_filenode.map; see postgres src/backend/utils/cache/relmapper.c:
"Mapped catalogs have zero in their pg_class.relfilenode entries."
Cap is 64 per database (MAX_MAPPINGS)

Fixes #2234