### PR TITLE
Make local & sftp filesystem storage PutObject atomic and durable

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -217,6 +217,7 @@ To store backups on files system, WAL-G requires that these variables be set:
 (e.g. `/tmp/wal-g-test-data`)
 
 Please, keep in mind that by default storing backups on disk along with database is not safe. Do not use it as a disaster recovery plan.
+If this is used with nfs networked storage, the backend should provide standard file system semantics (no async).
 
 SSH
 -----------

--- a/pkg/storages/fs/folder.go
+++ b/pkg/storages/fs/folder.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -44,10 +46,15 @@ func (folder *Folder) ListFolder() (objects []storage.Object, subFolders []stora
 			// I do not use GetSubfolder() intentially
 			subPath := path.Join(folder.subPath, fileInfo.Name()) + "/"
 			subFolders = append(subFolders, NewFolder(folder.rootPath, subPath))
-		} else {
-			info, _ := fileInfo.Info()
-			objects = append(objects, storage.NewLocalObject(fileInfo.Name(), info.ModTime(), info.Size()))
+			continue
 		}
+
+		if storage.HasTimestampRandomTmpSuffix(fileInfo.Name()) {
+			continue // Do not list objects that have not been written yet, like S3.
+		}
+
+		info, _ := fileInfo.Info()
+		objects = append(objects, storage.NewLocalObject(fileInfo.Name(), info.ModTime(), info.Size()))
 	}
 	return
 }
@@ -101,9 +108,14 @@ func (folder *Folder) ReadObject(objectRelativePath string) (io.ReadCloser, erro
 func (folder *Folder) PutObject(name string, content io.Reader) error {
 	tracelog.DebugLogger.Printf("Put %v into %v\n", name, folder.subPath)
 	filePath := folder.GetFilePath(name)
-	file, err := OpenFileWithDir(filePath)
+	randomSuffix, err := storage.NewTimestampRandomTag()
 	if err != nil {
-		return fmt.Errorf("unable to open file %q: %w", filePath, err)
+		return fmt.Errorf("failed to generate random postfix: %w", err)
+	}
+	tmpFilePath := filePath + randomSuffix
+	file, err := OpenFileWithDir(tmpFilePath)
+	if err != nil {
+		return fmt.Errorf("unable to open file %q: %w", tmpFilePath, err)
 	}
 	_, err = io.Copy(file, content)
 	if err != nil {
@@ -111,11 +123,32 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 		if closerErr != nil {
 			tracelog.InfoLogger.Println("Error during closing failed upload ", closerErr)
 		}
-		return fmt.Errorf("unable to copy data to file %q: %w", filePath, err)
+		return fmt.Errorf("unable to copy data to file %q: %w", tmpFilePath, err)
+	}
+	if err := file.Sync(); err != nil {
+		closerErr := file.Close()
+		if closerErr != nil {
+			tracelog.InfoLogger.Println("Error during closing failed upload ", closerErr)
+		}
+		return fmt.Errorf("unable to flush file contents to disk %q: %w", tmpFilePath, err)
 	}
 	err = file.Close()
 	if err != nil {
-		return fmt.Errorf("unable to close file %q: %w", filePath, err)
+		return fmt.Errorf("unable to close file %q: %w", tmpFilePath, err)
+	}
+	if err := os.Rename(tmpFilePath, filePath); err != nil {
+		return fmt.Errorf("unable to rename tmp file %q to %q: %w", tmpFilePath, filePath, err)
+	}
+	if runtime.GOOS == "windows" {
+		return nil // Windows cannot guarantee that folder entries are durable
+	}
+	dir, err := os.Open(filepath.Dir(filePath))
+	if err != nil {
+		return fmt.Errorf("unable to open directory for fsync: %w", err)
+	}
+	defer dir.Close()
+	if err := dir.Sync(); err != nil {
+		return fmt.Errorf("unable to fsync directory: %w", err)
 	}
 	return nil
 }

--- a/pkg/storages/sh/folder.go
+++ b/pkg/storages/sh/folder.go
@@ -58,6 +58,10 @@ func (folder *Folder) ListFolder() (objects []storage.Object, subFolders []stora
 			continue
 		}
 
+		if storage.HasTimestampRandomTmpSuffix(fileInfo.Name()) {
+			continue // Do not list objects that have not been written yet, like S3.
+		}
+
 		object := storage.NewLocalObject(
 			fileInfo.Name(),
 			fileInfo.ModTime(),
@@ -155,30 +159,41 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 		return err
 	}
 
-	absolutePath := filepath.Join(folder.path, name)
+	randomSuffix, err := storage.NewTimestampRandomTag()
+	if err != nil {
+		return fmt.Errorf("error generating random postfix: %w", err)
+	}
 
+	absolutePath := filepath.Join(folder.path, name)
 	dirPath := filepath.Dir(absolutePath)
+	tmpFilePath := absolutePath + randomSuffix
 	err = client.MkdirAll(dirPath)
 	if err != nil {
 		return fmt.Errorf("create directory %q via SFTP: %w", dirPath, err)
 	}
 
-	file, err := client.Create(absolutePath)
+	file, err := client.Create(tmpFilePath)
 	if err != nil {
-		return fmt.Errorf("create file %q via SFTP: %w", absolutePath, err)
+		return fmt.Errorf("create file %q via SFTP: %w", tmpFilePath, err)
 	}
 
 	_, err = io.Copy(file, content)
 	if err != nil {
 		closerErr := file.Close()
 		if closerErr != nil {
-			tracelog.InfoLogger.Println("Error during closing failed upload ", closerErr)
+			tracelog.InfoLogger.Println("error during closing failed upload ", closerErr)
 		}
-		return fmt.Errorf("write data to file %q via SFTP: %w", absolutePath, err)
+		return fmt.Errorf("write data to file %q via SFTP: %w", tmpFilePath, err)
 	}
+
 	err = file.Close()
 	if err != nil {
-		return fmt.Errorf("close file %q opened via SFTP: %w", absolutePath, err)
+		return fmt.Errorf("close file %q opened via SFTP: %w", tmpFilePath, err)
+	}
+
+	err = renameSFTP(client, tmpFilePath, absolutePath)
+	if err != nil {
+		return fmt.Errorf("unable to rename tmp file %q to %q: %w", tmpFilePath, absolutePath, err)
 	}
 	return nil
 }

--- a/pkg/storages/sh/sftp_lazy.go
+++ b/pkg/storages/sh/sftp_lazy.go
@@ -1,8 +1,10 @@
 package sh
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/pkg/sftp"
@@ -15,6 +17,8 @@ type SFTPClient interface {
 	ReadDir(path string) ([]os.FileInfo, error)
 	Join(elem ...string) string
 	Remove(path string) error
+	Rename(oldname, newname string) error
+	PosixRename(oldname, newname string) error
 	Stat(p string) (os.FileInfo, error)
 	Open(path string) (*sftp.File, error)
 	Create(path string) (*sftp.File, error)
@@ -62,4 +66,27 @@ func connect(addr string, config *ssh.ClientConfig) (*sftp.Client, error) {
 	}
 
 	return sftpClient, nil
+}
+
+// This could be made cleaner using client.HasExtension in sftp 1.13
+func renameSFTP(client SFTPClient, oldpath, newpath string) error {
+	err := client.PosixRename(oldpath, newpath)
+	if err == nil {
+		return nil
+	}
+
+	if isUnsupportedPosixRename(err) {
+		return client.Rename(oldpath, newpath)
+	}
+
+	return err
+}
+
+func isUnsupportedPosixRename(err error) bool {
+	var statusErr *sftp.StatusError
+	if errors.As(err, &statusErr) && statusErr.FxCode() == sftp.ErrSSHFxOpUnsupported {
+		return true
+	}
+
+	return strings.HasPrefix(err.Error(), "sftp: unimplemented packet type")
 }

--- a/pkg/storages/storage/utils.go
+++ b/pkg/storages/storage/utils.go
@@ -1,8 +1,14 @@
 package storage
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"net/url"
+	"path/filepath"
+	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -48,4 +54,41 @@ func ParsePrefixAsURL(prefix string) (bucket, server string, err error) {
 	}
 
 	return storageURL.Host, storageURL.Path, nil
+}
+
+const (
+	tmpTagRandomBytes = 8 // 16 chars / 64 random bits
+	tmpTagTimeLayout  = "20060102T150405Z"
+)
+
+// NewTimestampRandomTag returns a timestamp-prefixed random tag.
+//
+// Example:
+//
+//	.tmp.20260428T113012Z-9f2c6a4b
+func NewTimestampRandomTag() (string, error) {
+	b := make([]byte, tmpTagRandomBytes)
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+
+	return ".tmp." + time.Now().UTC().Format(tmpTagTimeLayout) + "-" + hex.EncodeToString(b[:]), nil
+}
+
+var tmpSuffixRE = regexp.MustCompile(fmt.Sprintf(
+	`\.tmp\.`+
+		`\d{8}T\d{6}Z`+
+		`-`+
+		`[0-9a-f]{%d}`+
+		`$`,
+	tmpTagRandomBytes*2, // two hex chars per byte
+))
+
+// HasTimestampRandomTmpSuffix returns true iff path ends with:
+//
+//	.tmp.<UTC timestamp to seconds>-<8 lowercase hex chars>
+//
+// It checks only the path string suffix; it does not stat the file.
+func HasTimestampRandomTmpSuffix(path string) bool {
+	return tmpSuffixRE.MatchString(filepath.Base(path))
 }


### PR DESCRIPTION
The "local" filesystem storage option is occasionally used with mounted network shares, so it is worth making it correct so that wal files are always durably archived when the archive command returns successfully.

The sftp implementation is also common in a plain unix server setting. So while sftp limits the durability guarentees you can offer to "the server has acked it", using the atomic rename pattern should make it a bit harder to corrupt a wal file or leave it in an unfinished state, and the code changes are very similar so I did that too.

### Database name
All, this changes the storage layer only.

# Pull request description
This makes the PutObject implementation for fs and sftp atomic with a posix rename, after fsyncing the data in the fs case.

The "local" filesystem storage option is occasionally used with mounted network shares, so it is worth making it correct so that wal files are always durably archived when the archive command returns successfully.

The sftp implementation is also common in a plain unix server setting. So while sftp limits the durability guarentees you can offer to "the server has acked it", using the atomic rename pattern should make it a bit harder to corrupt a wal file or leave it in an unfinished state, and the code changes are very similar so I did that too.


### Describe what this PR fixes
The PutObject is not atomic.

### Please provide steps to reproduce (if it's a bug)
Creating a network partition during transfer, or using lazyfs.

