### PR TITLE
migrate from gp-common-go-libs to cloudberry-go-libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.2.3
 	github.com/aliyun/credentials-go v1.4.5
 	github.com/apache/cloudberry-go-libs v1.0.12-0.20250910014224-fc376e8a1056
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/cactus/go-statsd-client/v5 v5.0.0
 	github.com/google/brotli/go/cbrotli v1.1.0
 	github.com/klauspost/compress v1.18.5
@@ -83,6 +82,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/alibabacloud-go/debug v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
-	github.com/greenplum-db/gp-common-go-libs v1.0.22
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pglogrepl v0.0.0-20260401131349-e37c41485510
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
@@ -52,6 +51,7 @@ require (
 	github.com/RoaringBitmap/roaring/v2 v2.18.0
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.2.3
 	github.com/aliyun/credentials-go v1.4.5
+	github.com/apache/cloudberry-go-libs v1.0.12-0.20250910014224-fc376e8a1056
 	github.com/cactus/go-statsd-client/v5 v5.0.0
 	github.com/google/brotli/go/cbrotli v1.1.0
 	github.com/klauspost/compress v1.18.5

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.2.3
 	github.com/aliyun/credentials-go v1.4.5
 	github.com/apache/cloudberry-go-libs v1.0.12-0.20250910014224-fc376e8a1056
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/cactus/go-statsd-client/v5 v5.0.0
 	github.com/google/brotli/go/cbrotli v1.1.0
 	github.com/klauspost/compress v1.18.5
@@ -82,7 +83,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/alibabacloud-go/debug v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.2.3/go.mod h1:FTzydeQVmR24FI0D6X
 github.com/aliyun/credentials-go v1.4.5 h1:O76WYKgdy1oQYYiJkERjlA2dxGuvLRrzuO2ScrtGWSk=
 github.com/aliyun/credentials-go v1.4.5/go.mod h1:Jm6d+xIgwJVLVWT561vy67ZRP4lPTQxMbEYRuT2Ti1U=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apache/cloudberry-go-libs v1.0.12-0.20250910014224-fc376e8a1056 h1:ycrFztmYATpidbSAU1rw60XuhuDxgBHtLD3Sueu947c=
+github.com/apache/cloudberry-go-libs v1.0.12-0.20250910014224-fc376e8a1056/go.mod h1:lfHWkNYsno/lV+Nee0OoCmlOlBz5yvT6EW8WQEOUI5c=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -347,8 +349,6 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/greenplum-db/gp-common-go-libs v1.0.22 h1:+dgQBBLRHEZoBHwjU+XHO4oIgVPQoWiIODo/gON9L50=
-github.com/greenplum-db/gp-common-go-libs v1.0.22/go.mod h1:03Vvqi9U/KP7GivSUf4GY2EDjWpfvlnkprU+muFd/pY=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/internal/databases/greenplum/ao_check_length_handler.go
+++ b/internal/databases/greenplum/ao_check_length_handler.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/wal-g/tracelog"
-
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"

--- a/internal/databases/greenplum/ao_check_length_handler.go
+++ b/internal/databases/greenplum/ao_check_length_handler.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
-	"github.com/hashicorp/go-version"
+	"github.com/apache/cloudberry-go-libs/dbconn"
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
@@ -217,11 +218,15 @@ func (fh *FetchHandler) createRecoveryConfigs() error {
 	pathToRecoveryConf := viper.GetString(conf.GPRelativeRecoveryConfPath)
 	pathToPostgresqlConf := viper.GetString(conf.GPRelativePostgresqlConfPath)
 
-	semVer, err := version.NewVersion(fh.sentinel.GpVersion)
+	semVer, err := semver.Make(fh.sentinel.GpVersion)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("failed to parse GP version: %s,  %s", fh.sentinel.GpVersion, err)
 	}
-	pgVersion := NewVersion(semVer, fh.sentinel.GpFlavor).EstimatePostgreSQLVersion()
+	gpdbVersion := dbconn.GPDBVersion{
+		SemVer: semVer,
+		Type:   fh.sentinel.GpFlavor.ToDBType(),
+	}
+	pgVersion := EstimatePostgreSQLVersion(gpdbVersion)
 	if pgVersion > 120000 && pathToRecoveryConf == "recovery.conf" {
 		// Starting from PostgreSQL 12.0 - the server will not start if a recovery.conf exists.
 		tracelog.ErrorLogger.Print(

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
-	"github.com/apache/cloudberry-go-libs/dbconn"
-	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
@@ -218,15 +216,7 @@ func (fh *FetchHandler) createRecoveryConfigs() error {
 	pathToRecoveryConf := viper.GetString(conf.GPRelativeRecoveryConfPath)
 	pathToPostgresqlConf := viper.GetString(conf.GPRelativePostgresqlConfPath)
 
-	semVer, err := semver.Make(fh.sentinel.GpVersion)
-	if err != nil {
-		tracelog.ErrorLogger.Printf("failed to parse GP version: %s,  %s", fh.sentinel.GpVersion, err)
-	}
-	gpdbVersion := dbconn.GPDBVersion{
-		SemVer: semVer,
-		Type:   fh.sentinel.GpFlavor.ToDBType(),
-	}
-	pgVersion := EstimatePostgreSQLVersion(gpdbVersion)
+	pgVersion := EstimatePostgreSQLVersion(fh.sentinel.GpFlavor, fh.sentinel.GpVersion)
 	if pgVersion > 120000 && pathToRecoveryConf == "recovery.conf" {
 		// Starting from PostgreSQL 12.0 - the server will not start if a recovery.conf exists.
 		tracelog.ErrorLogger.Print(

--- a/internal/databases/greenplum/backup_fetch_handler_test.go
+++ b/internal/databases/greenplum/backup_fetch_handler_test.go
@@ -5,8 +5,9 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/config"
 )

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/apache/cloudberry-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/gplog"
 	"github.com/google/uuid"
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/jackc/pgx/v5"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
-	"github.com/apache/cloudberry-go-libs/dbconn"
 	"github.com/apache/cloudberry-go-libs/gplog"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -89,7 +88,7 @@ type CurrBackupInfo struct {
 	startTime            time.Time
 	finishTime           time.Time
 	systemIdentifier     *uint64
-	gpVersion            dbconn.GPDBVersion
+	gpVersion            Version
 	segmentsMetadata     map[string]PgSegmentSentinelDto
 	backupPidByContentID map[int]int
 	incrementCount       int
@@ -245,8 +244,8 @@ func (bh *BackupHandler) uploadRestorePointMetadata(ctx context.Context, restore
 		StartTime:        bh.currBackupInfo.startTime,
 		FinishTime:       bh.currBackupInfo.finishTime,
 		Hostname:         hostname,
-		GpVersion:        bh.currBackupInfo.gpVersion.SemVer.String(),
-		GpFlavor:         NewFlavor(bh.currBackupInfo.gpVersion.Type),
+		GpVersion:        bh.currBackupInfo.gpVersion.String(),
+		GpFlavor:         bh.currBackupInfo.gpVersion.Flavor.String(),
 		SystemIdentifier: bh.currBackupInfo.systemIdentifier,
 		LsnBySegment:     restoreLSNs,
 	}
@@ -384,8 +383,8 @@ func (bh *BackupHandler) checkPrerequisites(ctx context.Context) (err error) {
 	tracelog.InfoLogger.Println("Checking backup prerequisites")
 
 	version := bh.currBackupInfo.gpVersion
-	if version.Type == dbconn.CBDB ||
-		(version.Type == dbconn.GPDB && version.SemVer.Major >= 7) {
+	if version.Flavor == Cloudberry ||
+		(version.Flavor == Greenplum && version.Major >= 7) {
 		// CB & GP7+ allows the non-exclusive backups
 		tracelog.InfoLogger.Println("Checking backup prerequisites: SKIP - non-exclusive backups used")
 		return nil
@@ -505,22 +504,25 @@ func CheckArchiveCommand(ctx context.Context, conn *pgx.Conn) error {
 }
 
 func getGpClusterInfo(ctx context.Context, conn *pgx.Conn) (
-	globalCluster *cluster.Cluster, version dbconn.GPDBVersion, systemIdentifier *uint64, err error) {
+	globalCluster *cluster.Cluster, version Version, systemIdentifier *uint64, err error) {
 	queryRunner, err := NewGpQueryRunner(ctx, conn)
 	if err != nil {
-		return globalCluster, dbconn.GPDBVersion{}, nil, err
+		return globalCluster, Version{}, nil, err
 	}
 
 	versionStr, err := queryRunner.GetGreenplumVersion(ctx)
 	if err != nil {
-		return globalCluster, dbconn.GPDBVersion{}, nil, err
+		return globalCluster, Version{}, nil, err
 	}
 	tracelog.InfoLogger.Printf("Greenplum version: %s", versionStr)
-	version = ParseVersionInfo(versionStr)
+	version, err = parseGreenplumVersion(versionStr)
+	if err != nil {
+		return globalCluster, Version{}, nil, err
+	}
 
 	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo(ctx)
 	if err != nil {
-		return globalCluster, dbconn.GPDBVersion{}, nil, err
+		return globalCluster, Version{}, nil, err
 	}
 	globalCluster = cluster.NewCluster(segConfigs)
 
@@ -659,8 +661,8 @@ func (bh *BackupHandler) terminateRunningBackups(ctx context.Context) error {
 	// Abort the non-finished exclusive backups on the segments.
 	// WAL-G in CB&GP7+ uses the non-exclusive backups, that are terminated on connection close, so this is unnecessary.
 	version := bh.currBackupInfo.gpVersion
-	if version.Type == dbconn.CBDB ||
-		(version.Type == dbconn.GPDB && version.SemVer.Major >= 7) {
+	if version.Flavor == Cloudberry ||
+		(version.Flavor == Greenplum && version.Major >= 7) {
 		return nil
 	}
 

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -518,7 +518,7 @@ func getGpClusterInfo(ctx context.Context, conn *pgx.Conn) (
 	tracelog.InfoLogger.Printf("Greenplum version: %s", versionStr)
 	version = ParseVersionInfo(versionStr)
 
-	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo(ctx, version)
+	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo(ctx)
 	if err != nil {
 		return globalCluster, dbconn.GPDBVersion{}, nil, err
 	}

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/dbconn"
 	"github.com/apache/cloudberry-go-libs/gplog"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -88,7 +89,7 @@ type CurrBackupInfo struct {
 	startTime            time.Time
 	finishTime           time.Time
 	systemIdentifier     *uint64
-	gpVersion            Version
+	gpVersion            dbconn.GPDBVersion
 	segmentsMetadata     map[string]PgSegmentSentinelDto
 	backupPidByContentID map[int]int
 	incrementCount       int
@@ -244,8 +245,8 @@ func (bh *BackupHandler) uploadRestorePointMetadata(ctx context.Context, restore
 		StartTime:        bh.currBackupInfo.startTime,
 		FinishTime:       bh.currBackupInfo.finishTime,
 		Hostname:         hostname,
-		GpVersion:        bh.currBackupInfo.gpVersion.String(),
-		GpFlavor:         bh.currBackupInfo.gpVersion.Flavor.String(),
+		GpVersion:        bh.currBackupInfo.gpVersion.SemVer.String(),
+		GpFlavor:         NewFlavor(bh.currBackupInfo.gpVersion.Type),
 		SystemIdentifier: bh.currBackupInfo.systemIdentifier,
 		LsnBySegment:     restoreLSNs,
 	}
@@ -383,8 +384,8 @@ func (bh *BackupHandler) checkPrerequisites(ctx context.Context) (err error) {
 	tracelog.InfoLogger.Println("Checking backup prerequisites")
 
 	version := bh.currBackupInfo.gpVersion
-	if version.Flavor == Cloudberry ||
-		(version.Flavor == Greenplum && version.Major >= 7) {
+	if version.Type == dbconn.CBDB ||
+		(version.Type == dbconn.GPDB && version.SemVer.Major >= 7) {
 		// CB & GP7+ allows the non-exclusive backups
 		tracelog.InfoLogger.Println("Checking backup prerequisites: SKIP - non-exclusive backups used")
 		return nil
@@ -504,24 +505,22 @@ func CheckArchiveCommand(ctx context.Context, conn *pgx.Conn) error {
 }
 
 func getGpClusterInfo(ctx context.Context, conn *pgx.Conn) (
-	globalCluster *cluster.Cluster, version Version, systemIdentifier *uint64, err error) {
+	globalCluster *cluster.Cluster, version dbconn.GPDBVersion, systemIdentifier *uint64, err error) {
 	queryRunner, err := NewGpQueryRunner(ctx, conn)
 	if err != nil {
-		return globalCluster, Version{}, nil, err
+		return globalCluster, dbconn.GPDBVersion{}, nil, err
 	}
 
 	versionStr, err := queryRunner.GetGreenplumVersion(ctx)
 	if err != nil {
-		return globalCluster, Version{}, nil, err
+		return globalCluster, dbconn.GPDBVersion{}, nil, err
 	}
 	tracelog.InfoLogger.Printf("Greenplum version: %s", versionStr)
-	version, err = parseGreenplumVersion(versionStr)
+	version = ParseVersionInfo(versionStr)
+
+	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo(ctx, version)
 	if err != nil {
-		return globalCluster, Version{}, nil, err
-	}
-	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo(ctx)
-	if err != nil {
-		return globalCluster, Version{}, nil, err
+		return globalCluster, dbconn.GPDBVersion{}, nil, err
 	}
 	globalCluster = cluster.NewCluster(segConfigs)
 
@@ -660,8 +659,8 @@ func (bh *BackupHandler) terminateRunningBackups(ctx context.Context) error {
 	// Abort the non-finished exclusive backups on the segments.
 	// WAL-G in CB&GP7+ uses the non-exclusive backups, that are terminated on connection close, so this is unnecessary.
 	version := bh.currBackupInfo.gpVersion
-	if version.Flavor == Cloudberry ||
-		(version.Flavor == Greenplum && version.Major >= 7) {
+	if version.Type == dbconn.CBDB ||
+		(version.Type == dbconn.GPDB && version.SemVer.Major >= 7) {
 		return nil
 	}
 

--- a/internal/databases/greenplum/backup_push_handler_test.go
+++ b/internal/databases/greenplum/backup_push_handler_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/google/uuid"
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+
 	"github.com/wal-g/wal-g/internal/config"
 )
 

--- a/internal/databases/greenplum/backup_push_handler_test.go
+++ b/internal/databases/greenplum/backup_push_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/dbconn"
 	"github.com/google/uuid"
 
 	"github.com/wal-g/wal-g/internal/config"
@@ -71,7 +72,7 @@ func TestBuildBackupPushCommand(t *testing.T) {
 					startTime:            currentTime.UTC(),
 					finishTime:           currentTime.Add(10 * time.Second).UTC(),
 					systemIdentifier:     nil,
-					gpVersion:            Version{},
+					gpVersion:            dbconn.GPDBVersion{},
 					segmentsMetadata:     nil,
 					backupPidByContentID: nil,
 					incrementCount:       0,
@@ -129,7 +130,7 @@ func TestBuildBackupPushCommand(t *testing.T) {
 					startTime:            currentTime.UTC(),
 					finishTime:           currentTime.Add(10 * time.Second).UTC(),
 					systemIdentifier:     nil,
-					gpVersion:            Version{},
+					gpVersion:            dbconn.GPDBVersion{},
 					segmentsMetadata:     nil,
 					backupPidByContentID: nil,
 					incrementCount:       0,
@@ -187,7 +188,7 @@ func TestBuildBackupPushCommand(t *testing.T) {
 					startTime:            currentTime.UTC(),
 					finishTime:           currentTime.Add(10 * time.Second).UTC(),
 					systemIdentifier:     nil,
-					gpVersion:            Version{},
+					gpVersion:            dbconn.GPDBVersion{},
 					segmentsMetadata:     nil,
 					backupPidByContentID: nil,
 					incrementCount:       0,

--- a/internal/databases/greenplum/backup_push_handler_test.go
+++ b/internal/databases/greenplum/backup_push_handler_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
-	"github.com/apache/cloudberry-go-libs/dbconn"
 	"github.com/google/uuid"
 
 	"github.com/wal-g/wal-g/internal/config"
@@ -72,7 +71,7 @@ func TestBuildBackupPushCommand(t *testing.T) {
 					startTime:            currentTime.UTC(),
 					finishTime:           currentTime.Add(10 * time.Second).UTC(),
 					systemIdentifier:     nil,
-					gpVersion:            dbconn.GPDBVersion{},
+					gpVersion:            Version{},
 					segmentsMetadata:     nil,
 					backupPidByContentID: nil,
 					incrementCount:       0,
@@ -130,7 +129,7 @@ func TestBuildBackupPushCommand(t *testing.T) {
 					startTime:            currentTime.UTC(),
 					finishTime:           currentTime.Add(10 * time.Second).UTC(),
 					systemIdentifier:     nil,
-					gpVersion:            dbconn.GPDBVersion{},
+					gpVersion:            Version{},
 					segmentsMetadata:     nil,
 					backupPidByContentID: nil,
 					incrementCount:       0,
@@ -188,7 +187,7 @@ func TestBuildBackupPushCommand(t *testing.T) {
 					startTime:            currentTime.UTC(),
 					finishTime:           currentTime.Add(10 * time.Second).UTC(),
 					systemIdentifier:     nil,
-					gpVersion:            dbconn.GPDBVersion{},
+					gpVersion:            Version{},
 					segmentsMetadata:     nil,
 					backupPidByContentID: nil,
 					incrementCount:       0,

--- a/internal/databases/greenplum/backup_sentinel_dto.go
+++ b/internal/databases/greenplum/backup_sentinel_dto.go
@@ -111,8 +111,8 @@ func NewBackupSentinelDto(currBackupInfo *CurrBackupInfo, prevBackupInfo *PrevBa
 		FinishTime:       currBackupInfo.finishTime,
 		DatetimeFormat:   MetadataDatetimeFormat,
 		Hostname:         hostname,
-		GpVersion:        currBackupInfo.gpVersion.String(),
-		GpFlavor:         currBackupInfo.gpVersion.Flavor,
+		GpVersion:        currBackupInfo.gpVersion.SemVer.String(),
+		GpFlavor:         NewFlavor(currBackupInfo.gpVersion.Type),
 		IsPermanent:      isPermanent,
 		SystemIdentifier: currBackupInfo.systemIdentifier,
 	}

--- a/internal/databases/greenplum/backup_sentinel_dto.go
+++ b/internal/databases/greenplum/backup_sentinel_dto.go
@@ -111,8 +111,8 @@ func NewBackupSentinelDto(currBackupInfo *CurrBackupInfo, prevBackupInfo *PrevBa
 		FinishTime:       currBackupInfo.finishTime,
 		DatetimeFormat:   MetadataDatetimeFormat,
 		Hostname:         hostname,
-		GpVersion:        currBackupInfo.gpVersion.SemVer.String(),
-		GpFlavor:         NewFlavor(currBackupInfo.gpVersion.Type),
+		GpVersion:        currBackupInfo.gpVersion.String(),
+		GpFlavor:         currBackupInfo.gpVersion.Flavor,
 		IsPermanent:      isPermanent,
 		SystemIdentifier: currBackupInfo.systemIdentifier,
 	}

--- a/internal/databases/greenplum/backup_sentinel_dto.go
+++ b/internal/databases/greenplum/backup_sentinel_dto.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )

--- a/internal/databases/greenplum/configure.go
+++ b/internal/databases/greenplum/configure.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/apache/cloudberry-go-libs/gplog"
 	"github.com/spf13/viper"
+
 	conf "github.com/wal-g/wal-g/internal/config"
 )
 

--- a/internal/databases/greenplum/configure.go
+++ b/internal/databases/greenplum/configure.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/apache/cloudberry-go-libs/gplog"
 	"github.com/spf13/viper"
-
 	conf "github.com/wal-g/wal-g/internal/config"
 )
 

--- a/internal/databases/greenplum/follow_primary_handler.go
+++ b/internal/databases/greenplum/follow_primary_handler.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	conf "github.com/wal-g/wal-g/internal/config"

--- a/internal/databases/greenplum/pax_relfile_storage_map.go
+++ b/internal/databases/greenplum/pax_relfile_storage_map.go
@@ -21,9 +21,12 @@ func NewPaxRelFileStorageMap(ctx context.Context, queryRunner *GpQueryRunner) (p
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query greenplum version")
 	}
-	version := ParseVersionInfo(versionStr)
-	if !version.IsCBDB() {
-		tracelog.DebugLogger.Printf("Skipping PAX storage map: flavor=%s does not support PAX", NewFlavor(version.Type))
+	version, err := parseGreenplumVersion(versionStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse greenplum version")
+	}
+	if version.Flavor != Cloudberry {
+		tracelog.DebugLogger.Printf("Skipping PAX storage map: flavor=%s does not support PAX", version.Flavor)
 		return pax.RelFileStorageMap{}, nil
 	}
 

--- a/internal/databases/greenplum/pax_relfile_storage_map.go
+++ b/internal/databases/greenplum/pax_relfile_storage_map.go
@@ -21,12 +21,9 @@ func NewPaxRelFileStorageMap(ctx context.Context, queryRunner *GpQueryRunner) (p
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query greenplum version")
 	}
-	version, err := parseGreenplumVersion(versionStr)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse greenplum version")
-	}
-	if version.Flavor != Cloudberry {
-		tracelog.DebugLogger.Printf("Skipping PAX storage map: flavor=%s does not support PAX", version.Flavor)
+	version := ParseVersionInfo(versionStr)
+	if !version.IsCBDB() {
+		tracelog.DebugLogger.Printf("Skipping PAX storage map: flavor=%s does not support PAX", NewFlavor(version.Type))
 		return pax.RelFileStorageMap{}, nil
 	}
 

--- a/internal/databases/greenplum/pg_hba_cfg_maker.go
+++ b/internal/databases/greenplum/pg_hba_cfg_maker.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 )
 
 const PgHbaTemplate = `# TYPE  DATABASE        USER            ADDRESS                 METHOD

--- a/internal/databases/greenplum/pg_hba_cfg_maker_test.go
+++ b/internal/databases/greenplum/pg_hba_cfg_maker_test.go
@@ -3,8 +3,9 @@ package greenplum_test
 import (
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 )
 

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -94,9 +94,9 @@ SELECT
 	s.hostname,
 	e.fselocation
 FROM gp_segment_configuration s
-JOIN pg_filespace_entry e ON s.dbid = e.fsedbid
-JOIN pg_filespace f ON e.fsefsoid = f.oid
-WHERE s.role = 'p' AND f.fsname = 'pg_system'
+JOIN pg_filespace_entry e ON s.dbid OPERATOR(pg_catalog.=) e.fsedbid
+JOIN pg_filespace f ON e.fsefsoid OPERATOR(pg_catalog.=) f.oid
+WHERE s.role OPERATOR(pg_catalog.=) 'p' AND f.fsname OPERATOR(pg_catalog.=) 'pg_system'
 ORDER BY s.content, s.role DESC;`
 	}
 	return `

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/dbconn"
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
@@ -80,7 +81,26 @@ func (queryRunner *GpQueryRunner) CreateGreenplumRestorePoint(ctx context.Contex
 	return restoreLSNs, nil
 }
 
-const getGreenplumSegmentsInfoQuery = `SELECT
+// BuildGetGreenplumSegmentsInfo formats a query to retrieve information about segments
+func (queryRunner *GpQueryRunner) buildGetGreenplumSegmentsInfo(version dbconn.GPDBVersion) string {
+	validRange := version.StringToSemVerRange("<6")
+	if version.IsGPDB() && validRange(version.SemVer) {
+		return `
+SELECT
+	s.dbid,
+	s.content,
+	s.role::text,
+	s.port,
+	s.hostname,
+	e.fselocation
+FROM gp_segment_configuration s
+JOIN pg_filespace_entry e ON s.dbid = e.fsedbid
+JOIN pg_filespace f ON e.fsefsoid = f.oid
+WHERE s.role = 'p' AND f.fsname = 'pg_system'
+ORDER BY s.content, s.role DESC;`
+	}
+	return `
+SELECT
 	dbid,
 	content,
 	role::text,
@@ -90,11 +110,12 @@ const getGreenplumSegmentsInfoQuery = `SELECT
 FROM pg_catalog.gp_segment_configuration
 WHERE role OPERATOR(pg_catalog.=) 'p'
 ORDER BY content, role DESC;`
+}
 
 // GetGreenplumSegmentsInfo returns the information about segments
-func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(ctx context.Context) (segments []cluster.SegConfig, err error) {
+func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(ctx context.Context, version dbconn.GPDBVersion) (segments []cluster.SegConfig, err error) {
 	conn := queryRunner.Connection
-	rows, err := conn.Query(ctx, getGreenplumSegmentsInfoQuery)
+	rows, err := conn.Query(ctx, queryRunner.buildGetGreenplumSegmentsInfo(version))
 	if err != nil {
 		return nil, err
 	}
@@ -412,13 +433,10 @@ func (queryRunner *GpQueryRunner) buildAORelPgClassQuery(ctx context.Context) (s
 	if err != nil {
 		return "", err
 	}
-	version, err := parseGreenplumVersion(versionStr)
-	if err != nil {
-		return "", err
-	}
+	version := ParseVersionInfo(versionStr)
 
-	switch version.Flavor {
-	case Greenplum:
+	switch version.Type {
+	case dbconn.GPDB:
 		{
 			switch {
 			case queryRunner.Version >= 120000:
@@ -431,10 +449,10 @@ func (queryRunner *GpQueryRunner) buildAORelPgClassQuery(ctx context.Context) (s
 				return "", postgres.NewUnsupportedPostgresVersionError(queryRunner.Version)
 			}
 		}
-	case Cloudberry:
+	case dbconn.CBDB:
 		return cbAoRelationPgClassQuery, nil
 	default:
-		return "", fmt.Errorf("unsupported greenplum flavor: %s", version.Flavor.String())
+		return "", fmt.Errorf("unsupported greenplum flavor: %s", version.VersionString)
 	}
 }
 

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
-	"github.com/apache/cloudberry-go-libs/dbconn"
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
@@ -410,10 +409,13 @@ func (queryRunner *GpQueryRunner) buildAORelPgClassQuery(ctx context.Context) (s
 	if err != nil {
 		return "", err
 	}
-	version := ParseVersionInfo(versionStr)
+	version, err := parseGreenplumVersion(versionStr)
+	if err != nil {
+		return "", err
+	}
 
-	switch version.Type {
-	case dbconn.GPDB:
+	switch version.Flavor {
+	case Greenplum:
 		{
 			switch {
 			case queryRunner.Version >= 120000:
@@ -426,10 +428,10 @@ func (queryRunner *GpQueryRunner) buildAORelPgClassQuery(ctx context.Context) (s
 				return "", postgres.NewUnsupportedPostgresVersionError(queryRunner.Version)
 			}
 		}
-	case dbconn.CBDB:
+	case Cloudberry:
 		return cbAoRelationPgClassQuery, nil
 	default:
-		return "", fmt.Errorf("unsupported greenplum flavor: %s", version.VersionString)
+		return "", fmt.Errorf("unsupported greenplum flavor: %s", version.Flavor.String())
 	}
 }
 

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -113,14 +113,14 @@ ORDER BY content, role DESC;`
 }
 
 // GetGreenplumSegmentsInfo returns the information about segments
-func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(ctx context.Context, version dbconn.GPDBVersion) (segments []cluster.SegConfig, err error) {
+func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(ctx context.Context, version dbconn.GPDBVersion) ([]cluster.SegConfig, error) {
 	conn := queryRunner.Connection
 	rows, err := conn.Query(ctx, queryRunner.buildGetGreenplumSegmentsInfo(version))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	segments = make([]cluster.SegConfig, 0)
+	segments := make([]cluster.SegConfig, 0)
 	for rows.Next() {
 		var dbID int
 		var contentID int
@@ -142,10 +142,7 @@ func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(ctx context.Context, 
 		segments = append(segments, segment)
 	}
 
-	if rows.Err() != nil {
-		return nil, rows.Err()
-	}
-	return segments, nil
+	return segments, rows.Err()
 }
 
 // GetGreenplumVersion returns version

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -81,26 +81,7 @@ func (queryRunner *GpQueryRunner) CreateGreenplumRestorePoint(ctx context.Contex
 	return restoreLSNs, nil
 }
 
-// BuildGetGreenplumSegmentsInfo formats a query to retrieve information about segments
-func (queryRunner *GpQueryRunner) buildGetGreenplumSegmentsInfo(version dbconn.GPDBVersion) string {
-	validRange := version.StringToSemVerRange("<6")
-	if version.IsGPDB() && validRange(version.SemVer) {
-		return `
-SELECT
-	s.dbid,
-	s.content,
-	s.role::text,
-	s.port,
-	s.hostname,
-	e.fselocation
-FROM gp_segment_configuration s
-JOIN pg_filespace_entry e ON s.dbid OPERATOR(pg_catalog.=) e.fsedbid
-JOIN pg_filespace f ON e.fsefsoid OPERATOR(pg_catalog.=) f.oid
-WHERE s.role OPERATOR(pg_catalog.=) 'p' AND f.fsname OPERATOR(pg_catalog.=) 'pg_system'
-ORDER BY s.content, s.role DESC;`
-	}
-	return `
-SELECT
+const getGreenplumSegmentsInfoQuery = `SELECT
 	dbid,
 	content,
 	role::text,
@@ -110,12 +91,11 @@ SELECT
 FROM pg_catalog.gp_segment_configuration
 WHERE role OPERATOR(pg_catalog.=) 'p'
 ORDER BY content, role DESC;`
-}
 
 // GetGreenplumSegmentsInfo returns the information about segments
-func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(ctx context.Context, version dbconn.GPDBVersion) ([]cluster.SegConfig, error) {
+func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(ctx context.Context) ([]cluster.SegConfig, error) {
 	conn := queryRunner.Connection
-	rows, err := conn.Query(ctx, queryRunner.buildGetGreenplumSegmentsInfo(version))
+	rows, err := conn.Query(ctx, getGreenplumSegmentsInfoQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/greenplum/recovery_action.go
+++ b/internal/databases/greenplum/recovery_action.go
@@ -7,7 +7,6 @@ import (
 	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
-
 	conf "github.com/wal-g/wal-g/internal/config"
 )
 

--- a/internal/databases/greenplum/recovery_action.go
+++ b/internal/databases/greenplum/recovery_action.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
+
 	conf "github.com/wal-g/wal-g/internal/config"
 )
 

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/dbconn"
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
@@ -30,7 +31,7 @@ type RestorePointMetadata struct {
 	FinishTime       time.Time      `json:"finish_time"`
 	Hostname         string         `json:"hostname"`
 	GpVersion        string         `json:"gp_version"`
-	GpFlavor         string         `json:"gp_flavor"`
+	GpFlavor         Flavor         `json:"gp_flavor"`
 	SystemIdentifier *uint64        `json:"system_identifier"`
 	LsnBySegment     map[int]string `json:"lsn_by_segment"`
 	StorageName      string         `json:"storage_name"`
@@ -90,7 +91,7 @@ type RestorePointCreator struct {
 	pointName        string
 	startTime        time.Time
 	systemIdentifier *uint64
-	gpVersion        Version
+	gpVersion        dbconn.GPDBVersion
 
 	Uploader internal.Uploader
 	Conn     *pgx.Conn
@@ -175,7 +176,7 @@ func createRestorePoint(ctx context.Context, conn *pgx.Conn, restorePointName st
 					seg, ok := globalCluster.ByContent[contentID]
 					if ok {
 						var pgOptions, switchFunction string
-						if gpVersion.Flavor == Greenplum && gpVersion.Major == 6 {
+						if gpVersion.IsGPDB() && gpVersion.SemVer.Major == 6 {
 							pgOptions = "-c gp_session_role=utility"
 							switchFunction = "pg_switch_xlog()"
 						} else {
@@ -219,8 +220,8 @@ func (rpc *RestorePointCreator) uploadMetadata(ctx context.Context, restoreLSNs 
 		StartTime:        rpc.startTime,
 		FinishTime:       utility.TimeNowCrossPlatformUTC(),
 		Hostname:         hostname,
-		GpVersion:        rpc.gpVersion.String(),
-		GpFlavor:         rpc.gpVersion.Flavor.String(),
+		GpVersion:        rpc.gpVersion.SemVer.String(),
+		GpFlavor:         NewFlavor(rpc.gpVersion.Type),
 		SystemIdentifier: rpc.systemIdentifier,
 		LsnBySegment:     restoreLSNs,
 		TimeLine:         timeLine,

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
-	"github.com/apache/cloudberry-go-libs/dbconn"
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
@@ -31,7 +30,7 @@ type RestorePointMetadata struct {
 	FinishTime       time.Time      `json:"finish_time"`
 	Hostname         string         `json:"hostname"`
 	GpVersion        string         `json:"gp_version"`
-	GpFlavor         Flavor         `json:"gp_flavor"`
+	GpFlavor         string         `json:"gp_flavor"`
 	SystemIdentifier *uint64        `json:"system_identifier"`
 	LsnBySegment     map[int]string `json:"lsn_by_segment"`
 	StorageName      string         `json:"storage_name"`
@@ -91,7 +90,7 @@ type RestorePointCreator struct {
 	pointName        string
 	startTime        time.Time
 	systemIdentifier *uint64
-	gpVersion        dbconn.GPDBVersion
+	gpVersion        Version
 
 	Uploader internal.Uploader
 	Conn     *pgx.Conn
@@ -176,7 +175,7 @@ func createRestorePoint(ctx context.Context, conn *pgx.Conn, restorePointName st
 					seg, ok := globalCluster.ByContent[contentID]
 					if ok {
 						var pgOptions, switchFunction string
-						if gpVersion.IsGPDB() && gpVersion.SemVer.Major == 6 {
+						if gpVersion.Flavor == Greenplum && gpVersion.Major == 6 {
 							pgOptions = "-c gp_session_role=utility"
 							switchFunction = "pg_switch_xlog()"
 						} else {
@@ -220,8 +219,8 @@ func (rpc *RestorePointCreator) uploadMetadata(ctx context.Context, restoreLSNs 
 		StartTime:        rpc.startTime,
 		FinishTime:       utility.TimeNowCrossPlatformUTC(),
 		Hostname:         hostname,
-		GpVersion:        rpc.gpVersion.SemVer.String(),
-		GpFlavor:         NewFlavor(rpc.gpVersion.Type),
+		GpVersion:        rpc.gpVersion.String(),
+		GpFlavor:         rpc.gpVersion.Flavor.String(),
 		SystemIdentifier: rpc.systemIdentifier,
 		LsnBySegment:     restoreLSNs,
 		TimeLine:         timeLine,

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"

--- a/internal/databases/greenplum/segment_config_maker.go
+++ b/internal/databases/greenplum/segment_config_maker.go
@@ -6,7 +6,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/apache/cloudberry-go-libs/cluster"
+
 	"github.com/wal-g/wal-g/utility"
 )
 

--- a/internal/databases/greenplum/segment_config_maker.go
+++ b/internal/databases/greenplum/segment_config_maker.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/apache/cloudberry-go-libs/cluster"
-
 	"github.com/wal-g/wal-g/utility"
 )
 

--- a/internal/databases/greenplum/version.go
+++ b/internal/databases/greenplum/version.go
@@ -1,36 +1,26 @@
 package greenplum
 
 import (
-	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/apache/cloudberry-go-libs/dbconn"
-	"github.com/blang/semver"
 )
 
-// cloudberry-go-libs dbconn matches only "Greenplum Database" & "Apache Cloudberry".
-// Greengage is Greenplum-compatible (wal-g PR #2324); legacy releases report "Cloudberry Database X.Y.Z"
-var (
-	greengagePattern  = regexp.MustCompile(`\(Greengage Database ([0-9]+\.[0-9]+\.[0-9]+)[^)]*\)`)
-	cbdbLegacyPattern = regexp.MustCompile(`\(Cloudberry Database ([0-9]+\.[0-9]+\.[0-9]+)[^)]*\)`)
+// dbconn parser matches only "Greenplum Database" & "Apache Cloudberry".
+// Remap those product strings so dbconn fills SemVer & Type
+var productRemap = strings.NewReplacer(
+	"Greengage Database", "Greenplum Database",
+	"Cloudberry Database", "Apache Cloudberry",
 )
 
 // ParseVersionInfo augments dbconn parser with Greengage & legacy "Cloudberry Database" product strings
 func ParseVersionInfo(versionString string) dbconn.GPDBVersion {
 	var v dbconn.GPDBVersion
 	v.ParseVersionInfo(versionString)
-	if v.Type != dbconn.Unknown {
-		return v
-	}
-	if m := greengagePattern.FindStringSubmatch(versionString); m != nil {
-		if ver, err := semver.Make(m[1]); err == nil {
-			v.Type = dbconn.GPDB
-			v.SemVer = ver
-		}
-	} else if m := cbdbLegacyPattern.FindStringSubmatch(versionString); m != nil {
-		if ver, err := semver.Make(m[1]); err == nil {
-			v.Type = dbconn.CBDB
-			v.SemVer = ver
-		}
+	if v.Type == dbconn.Unknown {
+		v.ParseVersionInfo(productRemap.Replace(versionString))
+		v.VersionString = versionString
 	}
 	return v
 }
@@ -69,14 +59,16 @@ const (
 	Unknown    Flavor = "unknown"
 )
 
-func EstimatePostgreSQLVersion(v dbconn.GPDBVersion) int {
-	if v.IsCBDB() {
+func EstimatePostgreSQLVersion(flavor Flavor, gpVersion string) int {
+	if flavor == Cloudberry {
 		return 140000
 	}
-	if v.SemVer.Major == 7 {
+	majorStr, _, _ := strings.Cut(gpVersion, ".")
+	major, _ := strconv.Atoi(majorStr)
+	switch major {
+	case 7:
 		return 120000
-	}
-	if v.SemVer.Major == 6 {
+	case 6:
 		return 90400
 	}
 	return 0

--- a/internal/databases/greenplum/version.go
+++ b/internal/databases/greenplum/version.go
@@ -1,63 +1,66 @@
 package greenplum
 
 import (
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/apache/cloudberry-go-libs/dbconn"
+	"github.com/hashicorp/go-version"
 )
-
-// dbconn parser matches only "Greenplum Database" & "Apache Cloudberry".
-// Remap those product strings so dbconn fills SemVer & Type
-var productRemap = strings.NewReplacer(
-	"Greengage Database", "Greenplum Database",
-	"Cloudberry Database", "Apache Cloudberry",
-)
-
-// ParseVersionInfo augments dbconn parser with Greengage & legacy "Cloudberry Database" product strings
-func ParseVersionInfo(versionString string) dbconn.GPDBVersion {
-	var v dbconn.GPDBVersion
-	v.ParseVersionInfo(versionString)
-	if v.Type == dbconn.Unknown {
-		v.ParseVersionInfo(productRemap.Replace(versionString))
-		v.VersionString = versionString
-	}
-	return v
-}
 
 type Flavor string
-
-func NewFlavor(t dbconn.DBType) Flavor {
-	switch t {
-	case dbconn.GPDB:
-		return Greenplum
-	case dbconn.CBDB:
-		return Cloudberry
-	default:
-		return Unknown
-	}
-}
 
 func (f Flavor) String() string {
 	return string(f)
 }
 
-func (f Flavor) ToDBType() dbconn.DBType {
-	switch f {
-	case Greenplum:
-		return dbconn.GPDB
-	case Cloudberry:
-		return dbconn.CBDB
-	default:
-		return dbconn.Unknown
-	}
-}
-
 const (
 	Greenplum  Flavor = "greenplum"
 	Cloudberry Flavor = "cloudberry"
-	Unknown    Flavor = "unknown"
 )
+
+type Version struct {
+	*version.Version
+	Major  int
+	Flavor Flavor // Note: can be '' for old backups
+}
+
+func NewVersion(v *version.Version, flavor Flavor) Version {
+	return Version{
+		Version: v,
+		Major:   v.Segments()[0],
+		Flavor:  flavor,
+	}
+}
+
+func parseGreenplumVersion(versionStr string) (Version, error) {
+	pattern := regexp.MustCompile(`(Greenplum Database|Greengage Database|Cloudberry Database|Apache Cloudberry) (\d+\.\d+\.\d+)`)
+	groups := pattern.FindStringSubmatch(versionStr)
+	if groups == nil {
+		return Version{}, fmt.Errorf("unknown flavor: %s", versionStr)
+	}
+	semVer, err := version.NewVersion(groups[2])
+	if err != nil {
+		return Version{}, err
+	}
+
+	var flavor Flavor
+	switch groups[1] {
+	case "Greenplum Database":
+		flavor = Greenplum
+	case "Greengage Database":
+		flavor = Greenplum
+	case "Cloudberry Database":
+		flavor = Cloudberry
+	case "Apache Cloudberry":
+		flavor = Cloudberry
+	default:
+		return Version{}, fmt.Errorf("unknown flavor: %s", groups[1])
+	}
+
+	return NewVersion(semVer, flavor), nil
+}
 
 func EstimatePostgreSQLVersion(flavor Flavor, gpVersion string) int {
 	if flavor == Cloudberry {

--- a/internal/databases/greenplum/version.go
+++ b/internal/databases/greenplum/version.go
@@ -1,73 +1,82 @@
 package greenplum
 
 import (
-	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/go-version"
+	"github.com/apache/cloudberry-go-libs/dbconn"
+	"github.com/blang/semver"
 )
 
+// cloudberry-go-libs dbconn matches only "Greenplum Database" & "Apache Cloudberry".
+// Greengage is Greenplum-compatible (wal-g PR #2324); legacy releases report "Cloudberry Database X.Y.Z"
+var (
+	greengagePattern  = regexp.MustCompile(`\(Greengage Database ([0-9]+\.[0-9]+\.[0-9]+)[^)]*\)`)
+	cbdbLegacyPattern = regexp.MustCompile(`\(Cloudberry Database ([0-9]+\.[0-9]+\.[0-9]+)[^)]*\)`)
+)
+
+// ParseVersionInfo augments dbconn parser with Greengage & legacy "Cloudberry Database" product strings
+func ParseVersionInfo(versionString string) dbconn.GPDBVersion {
+	var v dbconn.GPDBVersion
+	v.ParseVersionInfo(versionString)
+	if v.Type != dbconn.Unknown {
+		return v
+	}
+	if m := greengagePattern.FindStringSubmatch(versionString); m != nil {
+		if ver, err := semver.Make(m[1]); err == nil {
+			v.Type = dbconn.GPDB
+			v.SemVer = ver
+		}
+	} else if m := cbdbLegacyPattern.FindStringSubmatch(versionString); m != nil {
+		if ver, err := semver.Make(m[1]); err == nil {
+			v.Type = dbconn.CBDB
+			v.SemVer = ver
+		}
+	}
+	return v
+}
+
 type Flavor string
+
+func NewFlavor(t dbconn.DBType) Flavor {
+	switch t {
+	case dbconn.GPDB:
+		return Greenplum
+	case dbconn.CBDB:
+		return Cloudberry
+	default:
+		return Unknown
+	}
+}
 
 func (f Flavor) String() string {
 	return string(f)
 }
 
+func (f Flavor) ToDBType() dbconn.DBType {
+	switch f {
+	case Greenplum:
+		return dbconn.GPDB
+	case Cloudberry:
+		return dbconn.CBDB
+	default:
+		return dbconn.Unknown
+	}
+}
+
 const (
 	Greenplum  Flavor = "greenplum"
 	Cloudberry Flavor = "cloudberry"
+	Unknown    Flavor = "unknown"
 )
 
-type Version struct {
-	*version.Version
-	Major  int
-	Flavor Flavor // Note: can be '' for old backups
-}
-
-func NewVersion(v *version.Version, flavor Flavor) Version {
-	return Version{
-		Version: v,
-		Major:   v.Segments()[0],
-		Flavor:  flavor,
-	}
-}
-
-func parseGreenplumVersion(versionStr string) (Version, error) {
-	pattern := regexp.MustCompile(`(Greenplum Database|Greengage Database|Cloudberry Database|Apache Cloudberry) (\d+\.\d+\.\d+)`)
-	groups := pattern.FindStringSubmatch(versionStr)
-	if groups == nil {
-		return Version{}, fmt.Errorf("unknown flavor: %s", versionStr)
-	}
-	semVer, err := version.NewVersion(groups[2])
-	if err != nil {
-		return Version{}, err
-	}
-
-	var flavor Flavor
-	switch groups[1] {
-	case "Greenplum Database":
-		flavor = Greenplum
-	case "Greengage Database":
-		flavor = Greenplum
-	case "Cloudberry Database":
-		flavor = Cloudberry
-	case "Apache Cloudberry":
-		flavor = Cloudberry
-	default:
-		return Version{}, fmt.Errorf("unknown flavor: %s", groups[1])
-	}
-
-	return NewVersion(semVer, flavor), nil
-}
-
-func (v Version) EstimatePostgreSQLVersion() int {
-	if v.Flavor == Cloudberry {
+func EstimatePostgreSQLVersion(v dbconn.GPDBVersion) int {
+	if v.IsCBDB() {
 		return 140000
 	}
-	if v.Major == 7 {
+	if v.SemVer.Major == 7 {
 		return 120000
 	}
-	if v.Major == 6 {
+	if v.SemVer.Major == 6 {
 		return 90400
 	}
 	return 0

--- a/internal/databases/greenplum/version_test.go
+++ b/internal/databases/greenplum/version_test.go
@@ -3,7 +3,8 @@ package greenplum
 import (
 	"testing"
 
-	"github.com/hashicorp/go-version"
+	"github.com/apache/cloudberry-go-libs/dbconn"
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,29 +12,34 @@ func TestParseGreenplumVersion(t *testing.T) {
 	var tests = []struct {
 		name   string
 		input  string
-		result Version
+		result dbconn.GPDBVersion
 	}{
 		{
 			name:   "greenplum 6.25 instance",
 			input:  "PostgreSQL 9.4.26 (Greenplum Database 6.25.3-mdb+yezzey+yagpcc-r+dev.40.gf0f10f9335 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Jul 24 2024 13:29:56",
-			result: NewVersion(version.Must(version.NewVersion("6.25.3")), Greenplum),
+			result: dbconn.GPDBVersion{SemVer: semver.MustParse("6.25.3"), Type: dbconn.GPDB},
+		},
+		{
+			name:   "greengage 6.27 instance",
+			input:  "PostgreSQL 9.4.26 (Greengage Database 6.27.0 build commit:0123456789abcdef) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit",
+			result: dbconn.GPDBVersion{SemVer: semver.MustParse("6.27.0"), Type: dbconn.GPDB},
 		},
 		{
 			name:   "cloudberry 1.6.0",
 			input:  "PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Sep 13 2024 07:33:38",
-			result: NewVersion(version.Must(version.NewVersion("1.6.0")), Cloudberry),
+			result: dbconn.GPDBVersion{SemVer: semver.MustParse("1.6.0"), Type: dbconn.CBDB},
 		},
 		{
 			name:   "apache cloudberry dev",
 			input:  "PostgreSQL 14.4 (Apache Cloudberry 1.0.0+00da831 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit compiled on Feb 25 2025 10:24:41",
-			result: NewVersion(version.Must(version.NewVersion("1.0.0")), Cloudberry),
+			result: dbconn.GPDBVersion{SemVer: semver.MustParse("1.0.0"), Type: dbconn.CBDB},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			version, err := parseGreenplumVersion(tt.input)
-			assert.NoError(t, err)
-			assert.Equalf(t, tt.result, version, tt.name)
+			v := ParseVersionInfo(tt.input)
+			assert.Equalf(t, tt.result.SemVer, v.SemVer, tt.name)
+			assert.Equalf(t, tt.result.Type, v.Type, tt.name)
 		})
 	}
 }

--- a/internal/databases/greenplum/version_test.go
+++ b/internal/databases/greenplum/version_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/apache/cloudberry-go-libs/dbconn"
-	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,34 +11,39 @@ func TestParseGreenplumVersion(t *testing.T) {
 	var tests = []struct {
 		name   string
 		input  string
-		result dbconn.GPDBVersion
+		semVer string
+		dbType dbconn.DBType
 	}{
 		{
 			name:   "greenplum 6.25 instance",
 			input:  "PostgreSQL 9.4.26 (Greenplum Database 6.25.3-mdb+yezzey+yagpcc-r+dev.40.gf0f10f9335 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Jul 24 2024 13:29:56",
-			result: dbconn.GPDBVersion{SemVer: semver.MustParse("6.25.3"), Type: dbconn.GPDB},
+			semVer: "6.25.3",
+			dbType: dbconn.GPDB,
 		},
 		{
 			name:   "greengage 6.27 instance",
 			input:  "PostgreSQL 9.4.26 (Greengage Database 6.27.0 build commit:0123456789abcdef) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit",
-			result: dbconn.GPDBVersion{SemVer: semver.MustParse("6.27.0"), Type: dbconn.GPDB},
+			semVer: "6.27.0",
+			dbType: dbconn.GPDB,
 		},
 		{
 			name:   "cloudberry 1.6.0",
 			input:  "PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Sep 13 2024 07:33:38",
-			result: dbconn.GPDBVersion{SemVer: semver.MustParse("1.6.0"), Type: dbconn.CBDB},
+			semVer: "1.6.0",
+			dbType: dbconn.CBDB,
 		},
 		{
 			name:   "apache cloudberry dev",
 			input:  "PostgreSQL 14.4 (Apache Cloudberry 1.0.0+00da831 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit compiled on Feb 25 2025 10:24:41",
-			result: dbconn.GPDBVersion{SemVer: semver.MustParse("1.0.0"), Type: dbconn.CBDB},
+			semVer: "1.0.0",
+			dbType: dbconn.CBDB,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := ParseVersionInfo(tt.input)
-			assert.Equalf(t, tt.result.SemVer, v.SemVer, tt.name)
-			assert.Equalf(t, tt.result.Type, v.Type, tt.name)
+			assert.Equalf(t, tt.semVer, v.SemVer.String(), tt.name)
+			assert.Equalf(t, tt.dbType, v.Type, tt.name)
 		})
 	}
 }

--- a/internal/databases/greenplum/version_test.go
+++ b/internal/databases/greenplum/version_test.go
@@ -3,7 +3,7 @@ package greenplum
 import (
 	"testing"
 
-	"github.com/apache/cloudberry-go-libs/dbconn"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,39 +11,34 @@ func TestParseGreenplumVersion(t *testing.T) {
 	var tests = []struct {
 		name   string
 		input  string
-		semVer string
-		dbType dbconn.DBType
+		result Version
 	}{
 		{
 			name:   "greenplum 6.25 instance",
 			input:  "PostgreSQL 9.4.26 (Greenplum Database 6.25.3-mdb+yezzey+yagpcc-r+dev.40.gf0f10f9335 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Jul 24 2024 13:29:56",
-			semVer: "6.25.3",
-			dbType: dbconn.GPDB,
+			result: NewVersion(version.Must(version.NewVersion("6.25.3")), Greenplum),
 		},
 		{
 			name:   "greengage 6.27 instance",
 			input:  "PostgreSQL 9.4.26 (Greengage Database 6.27.0 build commit:0123456789abcdef) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit",
-			semVer: "6.27.0",
-			dbType: dbconn.GPDB,
+			result: NewVersion(version.Must(version.NewVersion("6.27.0")), Greenplum),
 		},
 		{
 			name:   "cloudberry 1.6.0",
 			input:  "PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Sep 13 2024 07:33:38",
-			semVer: "1.6.0",
-			dbType: dbconn.CBDB,
+			result: NewVersion(version.Must(version.NewVersion("1.6.0")), Cloudberry),
 		},
 		{
 			name:   "apache cloudberry dev",
 			input:  "PostgreSQL 14.4 (Apache Cloudberry 1.0.0+00da831 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit compiled on Feb 25 2025 10:24:41",
-			semVer: "1.0.0",
-			dbType: dbconn.CBDB,
+			result: NewVersion(version.Must(version.NewVersion("1.0.0")), Cloudberry),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := ParseVersionInfo(tt.input)
-			assert.Equalf(t, tt.semVer, v.SemVer.String(), tt.name)
-			assert.Equalf(t, tt.dbType, v.Type, tt.name)
+			version, err := parseGreenplumVersion(tt.input)
+			assert.NoError(t, err)
+			assert.Equalf(t, tt.result, version, tt.name)
 		})
 	}
 }


### PR DESCRIPTION
`greenplum-db/gp-common-go-libs` archived and doesn't evolve. It also has vulnerable transitive dependencies #2211.

We should check difference between `greenplum-db/gp-common-go-libs` and `apache/cloudberry-go-libs`. And use apache version because it is supported.