### PR TITLE
CI: Run github workflows once

### DIFF
--- a/.github/workflows/dockertests-par.yml
+++ b/.github/workflows/dockertests-par.yml
@@ -1,6 +1,10 @@
 name: Docker tests
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  push:
+    branches: master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   parallel:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,9 @@
 name: golangci-lint
-on: [ push, pull_request ]
+
+on:
+  push:
+    branches: master
+  pull_request:
 
 env:
   GO_VERSION: "1.25"

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,11 @@
 name: Unit tests
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  push:
+    branches: master
+  pull_request:
+  workflow_dispatch:
+
 
 env:
   GO_VERSION: "1.25"

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -1,6 +1,10 @@
 name: windows native build
 
-on: [ push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: master
+  pull_request:
+  workflow_dispatch:
 
 env:
   GO_VERSION: "1.25"


### PR DESCRIPTION
Partially reverts #2083

`on: pull_request`
> By default, ... `pull_request` event's activity type is `opened`, `synchronize`, or `reopened`.

Where `synchronize` is
> A pull request's head branch was updated. For example, the head branch was updated from the base branch or new commits were pushed to the head branch.