### PR TITLE
mongo: export container logs as artifacts

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -122,6 +122,38 @@ jobs:
 
       - name: Run test
         run: ${{ matrix.command }}
+
+      - name: Collect container logs
+        if: always()
+        run: |
+          set +e
+          mkdir -p container-logs
+          # wal-g_* covers pg/mysql/etcd/etc; *.test_net_* covers mongo/redis
+          containers=$(docker ps -a --filter 'name=wal-g_' --filter 'name=test_net_' --format '{{.Names}}')
+          for c in $containers; do
+            mkdir -p "container-logs/$c"
+            docker logs "$c" >"container-logs/$c/stdout.log" 2>"container-logs/$c/stderr.log"
+            docker cp "$c:/var/log" "container-logs/$c/var-log" 2>/dev/null
+          done
+          ls -R container-logs || true
+
+      - name: Sanitize artifact name
+        if: always()
+        id: artifact
+        env:
+          COMMAND: ${{ matrix.command }}
+        run: |
+          slug=$(printf '%s' "$COMMAND" | tr -c 'A-Za-z0-9._-' '_')
+          echo "slug=$slug" >>"$GITHUB_OUTPUT"
+
+      - name: Upload container logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: logs-${{ steps.artifact.outputs.slug }}
+          path: container-logs
+          if-no-files-found: ignore
+          retention-days: 14
     env:
       USE_BROTLI: 1
       USE_LIBSODIUM: 1

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ mongo_install: mongo_build
 mongo_features:
 	set -e
 	make go_deps
-	cd tests_func/ && MONGO_VERSION=$(MONGO_VERSION) MONGO_PACKAGE=$(MONGO_PACKAGE) MONGO_REPO=$(MONGO_REPO) MONGO_TEST_TYPE=$(MONGO_TEST_TYPE) go test -v -count=1 -timeout 45m  --tf.test=true --tf.debug=true --tf.clean=true --tf.stop=true --tf.database=mongodb
+	cd tests_func/ && MONGO_VERSION=$(MONGO_VERSION) MONGO_PACKAGE=$(MONGO_PACKAGE) MONGO_REPO=$(MONGO_REPO) MONGO_TEST_TYPE=$(MONGO_TEST_TYPE) go test -v -count=1 -timeout 45m  --tf.test=true --tf.debug=true --tf.clean=false --tf.stop=false --tf.database=mongodb
 
 mongo_binary_features:
 	MONGO_TEST_TYPE="binary" $(MAKE) mongo_features

--- a/internal/databases/mongo/binary/oplog_reply.go
+++ b/internal/databases/mongo/binary/oplog_reply.go
@@ -75,7 +75,10 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 	}
 
 	dbApplier := oplog.NewDBApplier(mongoClient, oplog.DBApplierArgs{
-		PreserveUUID:   false,
+		// Catch-up replays onto an existing replica synced from master, so collection
+		// UUIDs already match. Preserving 'ui' keeps them aligned through replay so
+		// the replica can rejoin replSet without NamespaceNotFound on master's UUIDs
+		PreserveUUID:   replayArgs.WithCatchUpReconfig,
 		Partial:        replayArgs.Partial,
 		InitMongo:      initMongo,
 		Reconfig:       replayArgs.WithCatchUpReconfig,

--- a/tests_func/helpers/mongo.go
+++ b/tests_func/helpers/mongo.go
@@ -601,12 +601,10 @@ func (mc *MongoCtl) GetLogs() error {
 }
 
 func (mc *MongoCtl) PurgeDatadir() error {
-	err := mc.StopMongod()
-	if err != nil {
+	if err := mc.StopMongod(); err != nil {
 		return err
 	}
-	_, err = mc.runCmd("bash", "-c", "rm -rf /var/lib/mongodb/*")
-	if err != nil {
+	if _, err := mc.runCmd("bash", "-c", "rm -rf /var/lib/mongodb/*"); err != nil {
 		return err
 	}
 
@@ -619,23 +617,20 @@ func (mc *MongoCtl) ChownDBPath() error {
 }
 
 func (mc *MongoCtl) ChangeReplSet(rs string) error {
-	_, err := mc.runCmd("bash", "-c",
+	if _, err := mc.runCmd("bash", "-c",
 		fmt.Sprintf("sed -i 's/--replSet [^ ]*/--replSet %s/' /etc/supervisor/conf.d/mongodb.conf", rs),
-	)
-	if err != nil {
+	); err != nil {
 		return err
 	}
-	_, err = mc.runCmd("supervisorctl", "reread")
-	if err != nil {
+	if _, err := mc.runCmd("supervisorctl", "reread"); err != nil {
 		return err
 	}
-	_, err = mc.runCmd("supervisorctl", "update")
-	if err != nil {
+	if _, err := mc.runCmd("supervisorctl", "update"); err != nil {
 		return err
 	}
-	err = mc.StopMongod()
-	if err != nil {
+	if err := mc.StopMongod(); err != nil {
 		return err
 	}
 	return mc.StartMongod()
 }
+

--- a/tests_func/images/mongodb/config/supervisor/conf.d/mongodb.conf
+++ b/tests_func/images/mongodb/config/supervisor/conf.d/mongodb.conf
@@ -3,6 +3,7 @@ command=/usr/bin/mongod --config /config/%(ENV_MONGO_CONF_FILE)s --replSet %(hos
 process_name=%(program_name)s
 autostart=true
 autorestart=true
+startsecs=5
 stopsignal=TERM
 user=mongodb
 stdout_logfile=/dev/stderr

--- a/tests_func/mongo_steps.go
+++ b/tests_func/mongo_steps.go
@@ -425,7 +425,7 @@ func (tctx *TestContext) addPartiallyData(host string) error {
 		return err
 	}
 
-	// we wait for wt checkpoint, which wt does every 60 secs
+	// wait for wt checkpoint, which wt does every 60 secs
 	time.Sleep(time.Minute)
 
 	return nil
@@ -533,7 +533,7 @@ func (tctx *TestContext) FillOplog(host string) error {
 		if err != nil {
 			return err
 		}
-		if time.Now().Sub(start).Seconds()-oplogTimeDiff > 60 {
+		if time.Since(start).Seconds()-oplogTimeDiff > 60 {
 			break
 		}
 	}


### PR DESCRIPTION
also increase startsecs from 1s to 5s since CI environments yield for long durations

this revealed issue where catching up should preserve UUIDs