### PR TITLE
ci: cache mongo base images, drop noop mongo_test matrix entry

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -36,6 +36,7 @@ jobs:
             ${{ env.CACHE_FILE_UBUNTU_18_04 }}
             ${{ env.CACHE_FILE_UBUNTU_22_04 }}
             ${{ env.CACHE_FILE_GOLANG }}
+            ${{ env.CACHE_FOLDER }}/wal-g_mongo-base-*.tar
           key: ${{ env.IMAGES_CACHE_KEY }}
 
       - name: Cleanup space on runner
@@ -72,7 +73,7 @@ jobs:
       # build images
       - name: Build images
         if: steps.cache-images.outputs.cache-hit != 'true'
-        run: make pg_save_image
+        run: make pg_save_image mongo_save_images
     env:
       USE_BROTLI: 1
       USE_LZO: 1
@@ -117,6 +118,7 @@ jobs:
             ${{ env.CACHE_FILE_UBUNTU_18_04 }}
             ${{ env.CACHE_FILE_UBUNTU_22_04 }}
             ${{ env.CACHE_FILE_GOLANG }}
+            ${{ env.CACHE_FOLDER }}/wal-g_mongo-base-*.tar
           key: ${{ env.IMAGES_CACHE_KEY }}
 
       - name: Fail if no cached images

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,41 @@ mongo_build: $(CMD_FILES) $(PKG_FILES)
 mongo_install: mongo_build
 	mv $(MAIN_MONGO_PATH)/wal-g $(GOBIN)/wal-g
 
-mongo_features:
+# variants are pkg:version:repo, four entries cover the matrix
+MONGO_BASE_VARIANTS := \
+	mongodb-org:8.0.3:repo.mongodb.org \
+	mongodb-enterprise:8.0.3:repo.mongodb.com \
+	mongodb-org:7.0.15:repo.mongodb.org \
+	mongodb-enterprise:7.0.15:repo.mongodb.com
+
+mongo_save_images:
+	mkdir -p ${CACHE_FOLDER}
+	@for v in $(MONGO_BASE_VARIANTS); do \
+		pkg=$${v%%:*}; rest=$${v#*:}; ver=$${rest%%:*}; repo=$${rest#*:}; \
+		tag=$$pkg-$$ver; \
+		echo "Building wal-g/mongo-base:$$tag"; \
+		docker build -f tests_func/Dockerfile.mongodb-base \
+			--build-arg MONGO_VERSION=$$ver \
+			--build-arg MONGO_PACKAGE=$$pkg \
+			--build-arg MONGO_REPO=$$repo \
+			-t wal-g/mongo-base:$$tag \
+			tests_func/ || exit 1; \
+		docker save wal-g/mongo-base:$$tag > ${CACHE_FOLDER}/wal-g_mongo-base-$$tag.tar || exit 1; \
+	done
+
+mongo_load_base:
+	@if [ -n "${CACHE_FOLDER}" ] && [ -f ${CACHE_FOLDER}/wal-g_mongo-base-$(MONGO_PACKAGE)-$(MONGO_VERSION).tar ]; then \
+		docker load -i ${CACHE_FOLDER}/wal-g_mongo-base-$(MONGO_PACKAGE)-$(MONGO_VERSION).tar; \
+	else \
+		docker build -f tests_func/Dockerfile.mongodb-base \
+			--build-arg MONGO_VERSION=$(MONGO_VERSION) \
+			--build-arg MONGO_PACKAGE=$(MONGO_PACKAGE) \
+			--build-arg MONGO_REPO=$(MONGO_REPO) \
+			-t wal-g/mongo-base:$(MONGO_PACKAGE)-$(MONGO_VERSION) \
+			tests_func/; \
+	fi
+
+mongo_features: mongo_load_base
 	set -e
 	make go_deps
 	cd tests_func/ && MONGO_VERSION=$(MONGO_VERSION) MONGO_PACKAGE=$(MONGO_PACKAGE) MONGO_REPO=$(MONGO_REPO) MONGO_TEST_TYPE=$(MONGO_TEST_TYPE) go test -v -count=1 -timeout 45m  --tf.test=true --tf.debug=true --tf.clean=false --tf.stop=false --tf.database=mongodb

--- a/tests_func/Dockerfile.mongodb
+++ b/tests_func/Dockerfile.mongodb
@@ -1,4 +1,7 @@
 # vim:set ft=dockerfile:
+ARG MONGO_PACKAGE=mongodb-org
+ARG MONGO_VERSION=
+
 FROM walg-func-test-base AS build
 
 ARG WALG_REPO=${GOPATH}/src/github.com/wal-g/wal-g
@@ -13,50 +16,6 @@ RUN make ENABLE_RACE_DETECTION=1 link_external_deps mongo_build
 
 ###
 
-FROM ubuntu:focal
+FROM wal-g/mongo-base:${MONGO_PACKAGE}-${MONGO_VERSION}
 
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mongo/wal-g /usr/bin/wal-g
-
-ENV DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
-
-ARG MONGO_PACKAGE=mongodb-org
-ARG MONGO_REPO=repo.mongodb.org
-ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
-ARG MONGO_VERSION=
-
-ENV TMP_DIR=/var/tmp/wal-g
-ENV WALG_CONF_DIR=/etc/wal-g/
-
-ENV MONGO_MAJOR=${MONGO_VERSION%.*}
-
-RUN apt-get update -q && \
-    apt-get install --yes --no-install-recommends --no-install-suggests \
-    supervisor ca-certificates libsasl2-modules-gssapi-mit snmp wget gnupg curl tzdata && \
-    echo "deb http://$MONGO_REPO/apt/ubuntu focal/${MONGO_PACKAGE}/${MONGO_MAJOR} multiverse" | tee "/etc/apt/sources.list.d/mongodb_${MONGO_MAJOR}.list" && \
-    wget -qO - https://www.mongodb.org/static/pgp/server-${MONGO_MAJOR}.asc | apt-key add - && \
-    apt-get update -q && \
-    apt-get download --allow-unauthenticated ${MONGO_PACKAGE}-server=$MONGO_VERSION && \
-    dpkg --unpack ${MONGO_PACKAGE}-server*.deb && \
-    sed -i 's/systemctl daemon-reload/echo "SKIPPED: systemctl daemon-reload"/' /var/lib/dpkg/info/${MONGO_PACKAGE}-server.postinst && \
-    dpkg --configure ${MONGO_PACKAGE}-server && \
-    apt-get install -yf && \
-    apt-get install --allow-unauthenticated -y mongodb-database-tools && \
-    apt-get install -y mongodb-mongosh && \
-    rm -rf /var/lib/apt/lists/* /var/cache/debconf /var/lib/mongodb/* && \
-    apt-get clean
-
-COPY images/base/config/supervisor /etc/supervisor
-COPY images/mongodb/config /config
-COPY images/mongodb/config/mongodb.keyfile /etc/mongodb/
-
-RUN chmod 700 /etc/mongodb/mongodb.keyfile && chown mongodb -R /etc/mongodb && \
-    mkdir -p /home/mongodb /var/log/wal-g/ ${TMP_DIR} && \
-    chown mongodb:mongodb /home/mongodb /var/log/wal-g/ && \
-    ln --force -s /config/supervisor/conf.d/mongodb.conf /etc/supervisor/conf.d/mongodb.conf && \
-    mkdir -p ${WALG_REPO} ${WALG_CONF_DIR} && \
-    mkdir -p /home/mongodb/.gnupg && touch /home/mongodb/.gnupg/gpg.conf && \
-    chmod -R 700 /home/mongodb/.gnupg && chown mongodb:mongodb -R /home/mongodb/.gnupg && \
-    ln --force -s /config/wal-g-${MONGO_MAJOR}.json ${WALG_CONF_DIR}/wal-g.json && \
-    ln --force -s /config/gpg-key.armor ${WALG_CONF_DIR}/gpg-key.armor
-
-CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/tests_func/Dockerfile.mongodb-base
+++ b/tests_func/Dockerfile.mongodb-base
@@ -1,0 +1,46 @@
+# vim:set ft=dockerfile:
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
+
+ARG MONGO_PACKAGE=mongodb-org
+ARG MONGO_REPO=repo.mongodb.org
+ENV MONGO_PACKAGE=${MONGO_PACKAGE} MONGO_REPO=${MONGO_REPO}
+ARG MONGO_VERSION=
+
+ENV TMP_DIR=/var/tmp/wal-g
+ENV WALG_CONF_DIR=/etc/wal-g/
+
+ENV MONGO_MAJOR=${MONGO_VERSION%.*}
+
+RUN apt-get update -q && \
+    apt-get install --yes --no-install-recommends --no-install-suggests \
+    supervisor ca-certificates libsasl2-modules-gssapi-mit snmp gnupg curl tzdata && \
+    echo "deb http://$MONGO_REPO/apt/debian bookworm/${MONGO_PACKAGE}/${MONGO_MAJOR} main" | tee "/etc/apt/sources.list.d/mongodb_${MONGO_MAJOR}.list" && \
+    curl -fsSL https://www.mongodb.org/static/pgp/server-${MONGO_MAJOR}.asc | apt-key add - && \
+    apt-get update -q && \
+    apt-get download --allow-unauthenticated ${MONGO_PACKAGE}-server=$MONGO_VERSION && \
+    dpkg --unpack ${MONGO_PACKAGE}-server*.deb && \
+    sed -i 's/systemctl daemon-reload/echo "SKIPPED: systemctl daemon-reload"/' /var/lib/dpkg/info/${MONGO_PACKAGE}-server.postinst && \
+    dpkg --configure ${MONGO_PACKAGE}-server && \
+    apt-get install -yf && \
+    apt-get install --allow-unauthenticated -y mongodb-database-tools && \
+    apt-get install -y mongodb-mongosh && \
+    rm -rf /var/lib/apt/lists/* /var/cache/debconf /var/lib/mongodb/* && \
+    apt-get clean
+
+COPY images/base/config/supervisor /etc/supervisor
+COPY images/mongodb/config /config
+COPY images/mongodb/config/mongodb.keyfile /etc/mongodb/
+
+RUN chmod 700 /etc/mongodb/mongodb.keyfile && chown mongodb -R /etc/mongodb && \
+    mkdir -p /home/mongodb /var/log/wal-g/ ${TMP_DIR} && \
+    chown mongodb:mongodb /home/mongodb /var/log/wal-g/ && \
+    ln --force -s /config/supervisor/conf.d/mongodb.conf /etc/supervisor/conf.d/mongodb.conf && \
+    mkdir -p ${WALG_CONF_DIR} && \
+    mkdir -p /home/mongodb/.gnupg && touch /home/mongodb/.gnupg/gpg.conf && \
+    chmod -R 700 /home/mongodb/.gnupg && chown mongodb:mongodb -R /home/mongodb/.gnupg && \
+    ln --force -s /config/wal-g-${MONGO_MAJOR}.json ${WALG_CONF_DIR}/wal-g.json && \
+    ln --force -s /config/gpg-key.armor ${WALG_CONF_DIR}/gpg-key.armor
+
+CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/tests_func/mongodb-docker-compose.yml
+++ b/tests_func/mongodb-docker-compose.yml
@@ -22,7 +22,6 @@ services:
             args:
                 - MONGO_VERSION=${MONGO_VERSION}
                 - MONGO_PACKAGE=${MONGO_PACKAGE}
-                - MONGO_REPO=${MONGO_REPO}
         depends_on:
           - minio01
         container_name: mongodb01.test_net_${TEST_ID}
@@ -45,7 +44,6 @@ services:
             args:
                 - MONGO_VERSION=${MONGO_VERSION}
                 - MONGO_PACKAGE=${MONGO_PACKAGE}
-                - MONGO_REPO=${MONGO_REPO}
         depends_on:
           - minio01
         container_name: mongodb02.test_net_${TEST_ID}


### PR DESCRIPTION
Split tests_func/Dockerfile.mongodb into two stages stored separately:
- Dockerfile.mongodb-base: ubuntu+mongo apt install + supervisor/configs, parameterized only by MONGO_VERSION/PACKAGE/REPO
- Dockerfile.mongodb: install wal-g over wal-g/mongo-base

Image building job now runs `make mongo_save_images` alongside pg_save_image

No longer re-downloads mongodb-{org,enterprise} from repo.mongodb.{org,com} for each variant

Also drop `make mongo_test` matrix entry: target only runs `mongo_build`, which every other mongo matrix entry already exercises inside its docker image