### PR TITLE
ci: cache buildkit layers across commits via gha backend

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -66,6 +66,10 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
+      - name: Set up Docker Buildx
+        if: steps.cache-images.outputs.cache-hit != 'true'
+        uses: docker/setup-buildx-action@v4
+
       # build images
       - name: Build images
         if: steps.cache-images.outputs.cache-hit != 'true'
@@ -73,6 +77,9 @@ jobs:
     env:
       USE_BROTLI: 1
       USE_LZO: 1
+      # route docker compose build through buildx bake so per-service cache_from / cache_to in docker-compose.bake.yml take effect
+      COMPOSE_BAKE: "true"
+      COMPOSE_FILE: docker-compose.yml:docker-compose.bake.yml
 
   test:
     name: test

--- a/Makefile
+++ b/Makefile
@@ -61,17 +61,27 @@ pg_build: $(CMD_FILES) $(PKG_FILES)
 install_and_build_pg: deps pg_build
 
 pg10_build_image:
+ifeq ($(COMPOSE_BAKE),true)
+	# bake resolves DAG across services in one invocation via additional_contexts (see docker-compose.bake.yml).
+	docker compose build $(DOCKER_COMMON) pg10 pg10_tests_template
+else
 	# There are dependencies between container images.
 	# Running in one command leads to using outdated images and fails on clean system.
 	# It can not be fixed with depends_on in compose file. https://github.com/docker/compose/issues/6332
 	docker compose build $(DOCKER_COMMON)
 	docker compose build pg10
 	docker compose build pg10_tests_template
+endif
 
 pg18_build_image:
+ifeq ($(COMPOSE_BAKE),true)
+	# bake resolves DAG across services in one invocation via additional_contexts (see docker-compose.bake.yml).
+	docker compose build $(DOCKER_COMMON) pg18 pg18_tests_template
+else
 	docker compose build $(DOCKER_COMMON)
 	docker compose build pg18
 	docker compose build pg18_tests_template
+endif
 
 pg_save_image: install_and_build_pg pg10_build_image pg18_build_image
 	mkdir -p ${CACHE_FOLDER}

--- a/docker-compose.bake.yml
+++ b/docker-compose.bake.yml
@@ -1,0 +1,79 @@
+# Build cache overrides for CI, layered onto docker-compose.yml via COMPOSE_FILE
+# Persists BuildKit layer cache for slow base images across commits using GitHub
+# Actions cache backend, so apt-get doesn't refetch from EOL bionic mirrors on
+# every push. Requires a docker-container builder (setup-buildx-action) and
+# COMPOSE_BAKE=true. cache_to=gha is a no-op outside Actions
+services:
+  golang:
+    build:
+      cache_from:
+        - type=gha,scope=walg-golang
+      cache_to:
+        - type=gha,mode=max,scope=walg-golang
+
+  ubuntu:
+    build:
+      cache_from:
+        - type=gha,scope=walg-ubuntu-bionic
+      cache_to:
+        - type=gha,mode=max,scope=walg-ubuntu-bionic
+
+  ubuntu_22_04:
+    build:
+      cache_from:
+        - type=gha,scope=walg-ubuntu-2204
+      cache_to:
+        - type=gha,mode=max,scope=walg-ubuntu-2204
+
+  # additional_contexts wires FROM references to sibling bake targets. The
+  # docker-container builder's content store is digest-addressed and does not
+  # resolve image names like the local docker daemon does, so without this
+  # FROM wal-g/ubuntu:18.04 falls through to docker.io and fails authorization.
+  # Keys must omit :latest, buildx strips the tag from FROM identifiers before
+  # matching against the contexts map and a literal :latest key never hits
+  pg10:
+    build:
+      additional_contexts:
+        wal-g/ubuntu:18.04: service:ubuntu
+      cache_from:
+        - type=gha,scope=walg-pg10
+        - type=gha,scope=walg-ubuntu-bionic
+      cache_to:
+        - type=gha,mode=max,scope=walg-pg10
+
+  pg10_tests_template:
+    build:
+      additional_contexts:
+        wal-g/golang: service:golang
+        wal-g/pg10: service:pg10
+      cache_from:
+        - type=gha,scope=walg-pg10-tests
+        - type=gha,scope=walg-pg10
+        - type=gha,scope=walg-golang
+        - type=gha,scope=walg-ubuntu-bionic
+      cache_to:
+        - type=gha,mode=max,scope=walg-pg10-tests
+
+  # pg18 builds on ubuntu 22.04, not bionic (UBUNTU_TAG=22.04, see docker-compose.yml)
+  pg18:
+    build:
+      additional_contexts:
+        wal-g/ubuntu:22.04: service:ubuntu_22_04
+      cache_from:
+        - type=gha,scope=walg-pg18
+        - type=gha,scope=walg-ubuntu-2204
+      cache_to:
+        - type=gha,mode=max,scope=walg-pg18
+
+  pg18_tests_template:
+    build:
+      additional_contexts:
+        wal-g/golang: service:golang
+        wal-g/pg18: service:pg18
+      cache_from:
+        - type=gha,scope=walg-pg18-tests
+        - type=gha,scope=walg-pg18
+        - type=gha,scope=walg-golang
+        - type=gha,scope=walg-ubuntu-2204
+      cache_to:
+        - type=gha,mode=max,scope=walg-pg18-tests

--- a/docker/golang/Dockerfile
+++ b/docker/golang/Dockerfile
@@ -5,7 +5,10 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=xterm-256color
 
-RUN apt-get update && \
+# bionic is EOL, archive.ubuntu.com mirrors are flaky; retry & lengthen timeouts
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+        > /etc/apt/apt.conf.d/80-retries && \
+    apt-get update && \
     apt-get -y install \
         build-essential cmake \
         iputils-ping \

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -3,7 +3,10 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=xterm-256color
 
-RUN apt-get update && \
+# bionic is EOL, archive.ubuntu.com mirrors are flaky; retry & lengthen timeouts
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+        > /etc/apt/apt.conf.d/80-retries && \
+    apt-get update && \
     apt-get install --yes --no-install-recommends --no-install-suggests \
     git ca-certificates \
     liblzo2-2 && \


### PR DESCRIPTION
trying to reduce apt flakiness by caching that layer better