### PR TITLE
docs: document delete retain ordering after PG timeline reset (#2284)

### DIFF
--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -563,6 +563,20 @@ Flags:
 - `-t, --to string` Storage config to where should copy backup
 - `-w, --with-history` If set - copy WALs older than backup finish_lsn. If not - copy only WALs from start_lsn to finish_lsn
 
+### Delete retention ordering and ``--use-sentinel-time``
+
+For PostgreSQL, ``wal-g delete retain`` and ``wal-g delete before`` sort backups using the **timeline** and WAL **segment number** parsed from the backup name (``base_<timeline>...``) unless you change that behavior.
+
+After a **major version upgrade** (for example ``pg_upgrade``) or a new data directory, the cluster timeline often **starts again at a low value** while backups from the old cluster remain in the same bucket or prefix. Then name-based order is **not** the same as real-world time: ``retain`` may keep old backups and delete **new** ones even when you meant to keep the latest *N* backups. See [issue #636](https://github.com/wal-g/wal-g/issues/636).
+
+Use the ``--use-sentinel-time`` flag on ``wal-g delete`` so WAL-G orders backups by **start time** from each backup's sentinel/metadata (when metadata is present for backups in storage). If metadata cannot be read for some backups, WAL-G **falls back** to timeline and segment ordering.
+
+**Mitigations:** prefer a **separate storage path or bucket** per major PostgreSQL version so pre- and post-upgrade backups are not mixed; always run without ``--confirm`` first to dry-run.
+
+```bash
+wal-g delete retain FULL 5 --use-sentinel-time --confirm
+```
+
 ### ``delete garbage``
 
 Deletes outdated WAL archives and backups leftover files from storage, e.g. unsuccessfully backups or partially deleted ones. Will remove all non-permanent objects before the earliest non-permanent backup. This command is useful when backups are being deleted by the `delete target` command.

--- a/docs/README.md
+++ b/docs/README.md
@@ -201,6 +201,8 @@ Lists names and creation time of available backups.
 
 Is used to delete backups and WALs before them. By default, ``delete`` will perform a dry run. If you want to execute deletion, you have to add ``--confirm`` flag at the end of the command. Backups marked as permanent will not be deleted.
 
+For **PostgreSQL**, ``delete retain`` and ``delete before`` order backups using the timeline and WAL segment embedded in each backup name by default. After a **major upgrade** (e.g. ``pg_upgrade``) the timeline often resets while older backups stay in the same storage, so that order may **not** be chronological and ``retain`` can remove **new** backups by mistake. Pass the global flag ``--use-sentinel-time`` on ``delete`` to order by backup start time from sentinel/metadata when it is available; see [PostgreSQL.md](PostgreSQL.md#delete-retention-ordering-and-use-sentinel-time).
+
 ``delete`` can operate in four modes: ``retain``, ``before``, ``everything`` and ``target``.
 
 ``retain`` [FULL|FIND_FULL] %number% [--after %name|time%]
@@ -231,6 +233,8 @@ If `FIND_FULL` is specified, WAL-G will calculate minimum backup needed to keep 
 ``retain FIND_FULL 5`` will find necessary full for 5th and keep everything after it
 
 ``retain 5 --after 2019-12-12T12:12:12`` keep 5 most recent backups and backups made after 2019-12-12 12:12:12
+
+``retain FULL 5 --use-sentinel-time`` (PostgreSQL) same as ``retain FULL 5`` but order backups by sentinel start time—use when mixing backups across a timeline reset (e.g. after major upgrade); still add ``--confirm`` to run deletion
 
 ``before base_000010000123123123`` will fail if `base_000010000123123123` is delta
 


### PR DESCRIPTION
### Database name
Postgresql

# Pull request description

This adds user-facing documentation for the PostgreSQL pitfall where delete retain / delete before order backups by timeline and WAL segment in the backup name. After a major upgrade (or timeline reset), that order can diverge from real time and retain may delete newer backups (see [#636](https://github.com/wal-g/wal-g/issues/636)).

The docs describe the --use-sentinel-time flag, fallback when metadata is missing, and operational mitigations (e.g. separate storage per major version). Changes are in docs/README.md and docs/PostgreSQL.md.