### PR TITLE
Add unit test for archive status manager

### DIFF
--- a/internal/configure.go
+++ b/internal/configure.go
@@ -208,7 +208,6 @@ func GetRelativeArchiveDataFolderPath() string {
 	return filepath.Join(getRelativeWalFolderPath(""), "walg_data", "walg_archive_status")
 }
 
-// TODO : unit tests
 func ConfigureArchiveStatusManager() (fsutil.DataFolder, error) {
 	return fsutil.NewDiskDataFolder(getArchiveDataFolderPath())
 }

--- a/internal/configure_test.go
+++ b/internal/configure_test.go
@@ -120,6 +120,31 @@ func TestGetDataFolderPath_WalIgnoreXlog(t *testing.T) {
 	resetToDefaults()
 }
 
+func TestConfigureArchiveStatusManager(t *testing.T) {
+	parentDir := prepareDataFolder(t, "pg_wal")
+	defer testtools.Cleanup(t, parentDir)
+	defer resetToDefaults()
+
+	viper.Set(config.PgDataSetting, parentDir)
+
+	manager, err := internal.ConfigureArchiveStatusManager()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, manager)
+
+	expectedDir := filepath.Join(parentDir, "pg_wal", "walg_data", "walg_archive_status")
+	info, err := os.Stat(expectedDir)
+
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	fileName := "test_status"
+	err = manager.CreateFile(fileName)
+
+	assert.NoError(t, err)
+	assert.True(t, manager.FileExists(fileName))
+}
+
 func TestConfigureCompressor_Lz4Method(t *testing.T) {
 	viper.Set(config.CompressionMethodSetting, "lz4")
 	compressor, err := internal.ConfigureCompressor()


### PR DESCRIPTION
## Database name

PostgreSQL

## Pull request description

This PR adds a unit test for `ConfigureArchiveStatusManager`.

The test verifies that:
- the archive status data folder is created under `pg_wal/walg_data/walg_archive_status`;
- the returned `DataFolder` can create and find a file.

The corresponding `// TODO : unit tests` comment was removed.

## Tests

```bash
GOEXPERIMENT=jsonv2 go test ./internal -run TestConfigureArchiveStatusManager -count=1 -v
GOEXPERIMENT=jsonv2 go test ./internal -count=1
