### PR TITLE
feat(s3): add S3_REQUEST_TIMEOUT to bound response-header wait

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -103,6 +103,10 @@ By default, WAL-G checks whether versioning is enabled on the bucket. When the u
 
 Sets batch size for object deletion. By default is set to 1000.
 
+* `S3_REQUEST_TIMEOUT`
+
+Sets the maximum number of seconds WAL-G will wait for the S3 server to send response headers for any request. Once headers arrive, body transfer is not constrained -- multi-GB uploads and downloads still complete. This protects against unresponsive endpoints (wrong host, network black hole, dead Minio, etc.) where commands would otherwise hang indefinitely. The default is `0`, which disables the timeout and preserves prior behavior.
+
 GCS
 -----------
 To store backups in Google Cloud Storage, WAL-G requires that this variable be set:

--- a/pkg/storages/s3/configure.go
+++ b/pkg/storages/s3/configure.go
@@ -48,6 +48,13 @@ const (
 	disable100ContinueSetting      = "S3_DISABLE_100_CONTINUE"
 	enableVersioningSetting        = "S3_ENABLE_VERSIONING"
 	deleteBatchSizeSetting         = "S3_DELETE_BATCH_SIZE"
+	// requestTimeoutSetting bounds how long WAL-G will wait for the S3 server
+	// to send response headers. Once headers arrive, body transfer is not
+	// constrained by this timeout, so large uploads/downloads still succeed.
+	// Default 0 disables the timeout, preserving prior behavior; this avoids
+	// silently changing the contract for existing users on flaky-but-eventually-
+	// responsive endpoints.
+	requestTimeoutSetting = "S3_REQUEST_TIMEOUT"
 )
 
 var SettingList = []string{
@@ -86,6 +93,7 @@ var SettingList = []string{
 	disable100ContinueSetting,
 	enableVersioningSetting,
 	deleteBatchSizeSetting,
+	requestTimeoutSetting,
 }
 
 const (
@@ -104,6 +112,9 @@ const (
 	defaultDisabledRetentionPeriod = -1
 	defaultDisable100Continue      = false
 	defaultDeleteBatchSize         = 1000
+	// defaultRequestTimeoutSeconds = 0 means no response-header timeout. Existing
+	// users see no behavior change unless they opt in by setting S3_REQUEST_TIMEOUT.
+	defaultRequestTimeoutSeconds = 0
 )
 
 // TODO: Unit tests
@@ -185,6 +196,11 @@ func ConfigureStorage(
 		return nil, err
 	}
 
+	requestTimeoutSeconds, err := setting.IntOptional(settings, requestTimeoutSetting, defaultRequestTimeoutSeconds)
+	if err != nil {
+		return nil, err
+	}
+
 	config := &Config{
 		Secrets: &Secrets{
 			SecretKey: strings.TrimSpace(setting.FirstDefined(settings, secretAccessKeySetting, secretKeySetting)),
@@ -225,6 +241,7 @@ func ConfigureStorage(
 		Disable100Continue:      disable100Continue,
 		EnableVersioning:        settings[enableVersioningSetting],
 		DeleteBatchSize:         deleteBatchSize,
+		RequestTimeout:          time.Duration(requestTimeoutSeconds) * time.Second,
 	}
 
 	st, err := NewStorage(config, rootWraps...)

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -105,6 +106,7 @@ func configureSession(sess *session.Session, config *Config) error {
 			MaxThrottleDelay: config.MaxThrottlingRetryDelay,
 		}))
 
+	applyRequestTimeout(awsConfig.HTTPClient, config.RequestTimeout)
 	awsConfig.HTTPClient.Transport = NewRoundTripperWithLogging(awsConfig.HTTPClient.Transport)
 	accessKey := config.AccessKey
 	secretKey := config.Secrets.SecretKey
@@ -180,6 +182,28 @@ func configureSession(sess *session.Session, config *Config) error {
 
 	sess.Config = awsConfig
 	return nil
+}
+
+// applyRequestTimeout sets ResponseHeaderTimeout on the AWS SDK's HTTP client
+// when the user has opted in via S3_REQUEST_TIMEOUT. Bounding header receipt
+// (not body transfer) is what lets large uploads still complete while still
+// catching dead/wrong endpoints that would otherwise hang indefinitely.
+//
+// We clone the underlying transport rather than mutating it in place so we
+// don't touch http.DefaultTransport (a process-wide singleton) or any
+// user-supplied transport that may be shared across other clients.
+func applyRequestTimeout(client *http.Client, timeout time.Duration) {
+	if timeout <= 0 {
+		return
+	}
+	var base *http.Transport
+	if existing, ok := client.Transport.(*http.Transport); ok && existing != nil {
+		base = existing.Clone()
+	} else {
+		base = http.DefaultTransport.(*http.Transport).Clone()
+	}
+	base.ResponseHeaderTimeout = timeout
+	client.Transport = base
 }
 
 func detectAWSRegion(bucket string, awsConfig *aws.Config) (string, error) {

--- a/pkg/storages/s3/storage.go
+++ b/pkg/storages/s3/storage.go
@@ -44,7 +44,12 @@ type Config struct {
 	Disable100Continue       bool
 	EnableVersioning         string
 	DeleteBatchSize          int
-	showAllVersions          bool // When true, include deleted objects in listing (for st ls --all-versions)
+	// RequestTimeout, when > 0, becomes the http.Transport.ResponseHeaderTimeout
+	// on the AWS SDK's HTTP client. The S3 server has this long to send headers
+	// for any request before the connection is aborted; body streaming is not
+	// constrained, so multi-GB uploads/downloads still complete.
+	RequestTimeout  time.Duration
+	showAllVersions bool // When true, include deleted objects in listing (for st ls --all-versions)
 }
 
 type Secrets struct {

--- a/pkg/storages/s3/storage_test.go
+++ b/pkg/storages/s3/storage_test.go
@@ -1,9 +1,12 @@
 package s3
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 )
 
@@ -45,6 +48,99 @@ func TestS3FolderCreatesWithAdditionalHeadersYAML(t *testing.T) {
 		})
 
 	assert.NoError(t, err)
+}
+
+func TestS3FolderRequestTimeoutDefaultIsDisabled(t *testing.T) {
+	waleS3Prefix := "s3://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(waleS3Prefix,
+		map[string]string{
+			endpointSetting:          "HTTP://s3.kek.lol.net/",
+			skipValidationSetting:    "true",
+			uploadConcurrencySetting: "1",
+		})
+
+	assert.NoError(t, err)
+}
+
+func TestS3FolderRequestTimeoutAcceptsValue(t *testing.T) {
+	waleS3Prefix := "s3://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(waleS3Prefix,
+		map[string]string{
+			endpointSetting:          "HTTP://s3.kek.lol.net/",
+			skipValidationSetting:    "true",
+			uploadConcurrencySetting: "1",
+			requestTimeoutSetting:    "45",
+		})
+
+	assert.NoError(t, err)
+}
+
+func TestS3FolderRequestTimeoutRejectsNonInteger(t *testing.T) {
+	waleS3Prefix := "s3://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(waleS3Prefix,
+		map[string]string{
+			endpointSetting:          "HTTP://s3.kek.lol.net/",
+			skipValidationSetting:    "true",
+			uploadConcurrencySetting: "1",
+			requestTimeoutSetting:    "not-a-number",
+		})
+
+	assert.Error(t, err)
+}
+
+// TestConfigureSessionAppliesRequestTimeout verifies that a Config with
+// RequestTimeout > 0 produces an HTTP transport whose ResponseHeaderTimeout
+// matches. This is the actual contract S3_REQUEST_TIMEOUT advertises -- the
+// configure-time tests above only confirm the setting parses; this one
+// confirms it threads through to net/http where it takes effect.
+func TestConfigureSessionAppliesRequestTimeout(t *testing.T) {
+	cfg := &Config{
+		Secrets:                 &Secrets{},
+		Region:                  "us-east-1",
+		Endpoint:                "http://s3.kek.lol.net",
+		Bucket:                  "test-bucket",
+		MaxRetries:              defaultMaxRetries,
+		MinThrottlingRetryDelay: time.Duration(defaultMinThrottlingRetryDelay) * time.Millisecond,
+		MaxThrottlingRetryDelay: time.Duration(defaultMaxThrottlingRetryDelay) * time.Millisecond,
+		Uploader:                &UploaderConfig{UploadConcurrency: 1, MaxPartSize: defaultMaxPartSize, StorageClass: defaultStorageClass},
+		RequestTimeout:          30 * time.Second,
+	}
+
+	sess, err := createSession(cfg)
+	require.NoError(t, err)
+
+	// configureSession wraps the underlying transport in a loggingTransport,
+	// so we have to peel that layer off before checking ResponseHeaderTimeout.
+	wrapped, ok := sess.Config.HTTPClient.Transport.(*loggingTransport)
+	require.True(t, ok, "expected loggingTransport wrapper")
+	transport, ok := wrapped.underlying.(*http.Transport)
+	require.True(t, ok, "expected underlying *http.Transport")
+	assert.Equal(t, 30*time.Second, transport.ResponseHeaderTimeout)
+}
+
+func TestConfigureSessionLeavesTimeoutZeroWhenUnset(t *testing.T) {
+	cfg := &Config{
+		Secrets:                 &Secrets{},
+		Region:                  "us-east-1",
+		Endpoint:                "http://s3.kek.lol.net",
+		Bucket:                  "test-bucket",
+		MaxRetries:              defaultMaxRetries,
+		MinThrottlingRetryDelay: time.Duration(defaultMinThrottlingRetryDelay) * time.Millisecond,
+		MaxThrottlingRetryDelay: time.Duration(defaultMaxThrottlingRetryDelay) * time.Millisecond,
+		Uploader:                &UploaderConfig{UploadConcurrency: 1, MaxPartSize: defaultMaxPartSize, StorageClass: defaultStorageClass},
+		// RequestTimeout deliberately left as zero value
+	}
+
+	sess, err := createSession(cfg)
+	require.NoError(t, err)
+
+	wrapped, ok := sess.Config.HTTPClient.Transport.(*loggingTransport)
+	require.True(t, ok, "expected loggingTransport wrapper")
+	if transport, ok := wrapped.underlying.(*http.Transport); ok {
+		assert.Equal(t, time.Duration(0), transport.ResponseHeaderTimeout, "expected no header timeout when setting is unset")
+	}
+	// If the underlying isn't a *http.Transport, no timeout was set; that's
+	// also valid -- the contract is "no behavior change when unset."
 }
 
 func TestS3Folder(t *testing.T) {


### PR DESCRIPTION
## Summary

Refs #1949, #1362.

The S3 storage backend currently relies entirely on aws-sdk-go's default HTTP
client, which sets no timeout on response headers. When the configured
endpoint is wrong, unreachable, or temporarily black-holing connections,
wal-g commands hang indefinitely instead of failing fast. From issue #1949:

```
$ time wal-g wal-push testfile --config config.env
INFO: 2025/03/26 11:39:38.930549 Files will be uploaded to storage: default
ERROR: 2025/03/26 11:39:38.931827 Error of parallel upload: open archive_status: no such file or directory
^C
real	11m46,349s
```

```
$ wal-g backup-list --config config.env
INFO: 2025/03/26 13:34:47.112480 List backups from storages: [default]
^C # Stopped after multiple minutes.
```

This adds an opt-in `S3_REQUEST_TIMEOUT` (in seconds) that bounds how long
the SDK will wait for response headers from the S3 server. Once headers
arrive, body transfer is not constrained -- so multi-GB uploads and
downloads still complete normally.

## Why ResponseHeaderTimeout (not Client.Timeout)

`net/http` exposes several semantically distinct timeouts:

| Timeout | What it bounds | Risk for wal-g |
| --- | --- | --- |
| `http.Client.Timeout` | end-to-end including body transfer | aborts large PUT/GET mid-stream |
| `http.Transport.ResponseHeaderTimeout` | server has N seconds to start responding with headers | none for body transfer |
| `http.Transport.DialContext` timeout | TCP/TLS handshake only | doesn't catch hangs after connect |

`ResponseHeaderTimeout` is the right knob for this issue. The reproducer
(invalid endpoint) hangs at the response-header phase; legitimate large
uploads/downloads complete header negotiation in milliseconds and then
spend the rest of their wallclock streaming bytes -- which we don't want
to cut off.

This matches the pattern of `GCS_CONTEXT_TIMEOUT` in the GCS backend
(opt-in setting bounding a timeout dimension that wouldn't truncate normal
operations) so users who run multi-storage configs see consistent behavior.

## Implementation

| File | Change |
| --- | --- |
| `pkg/storages/s3/configure.go` | New `S3_REQUEST_TIMEOUT` setting, registered in `SettingList`, parsed via existing `setting.IntOptional`; default `0` (disabled). |
| `pkg/storages/s3/storage.go` | New `RequestTimeout time.Duration` field on `Config`. |
| `pkg/storages/s3/session.go` | New `applyRequestTimeout` helper called from `configureSession` before the logging-transport wrapping. Helper extracted to keep `configureSession`'s cyclomatic complexity within the project's `gocyclo=15` budget. |
| `pkg/storages/s3/storage_test.go` | Five tests: setting parses, omission produces zero default, non-integer values error, configured value reaches the underlying `*http.Transport`, omission leaves `ResponseHeaderTimeout` at zero. |
| `docs/STORAGES.md` | Documentation in the S3 "Optional variables" section. |

The `applyRequestTimeout` helper clones the underlying transport rather
than mutating it in place, so we never touch `http.DefaultTransport` (a
process-wide singleton) or any user-supplied transport that may be shared
with other clients.

## Behavior change

`S3_REQUEST_TIMEOUT` is opt-in. The default is `0`, which disables the
header timeout and preserves the existing wal-g behavior exactly. Users
who want the safety net set the env variable to e.g. `30` for thirty
seconds.

## Verification

```
GOEXPERIMENT=jsonv2 go build ./pkg/storages/s3/...
GOEXPERIMENT=jsonv2 go test ./pkg/storages/s3/ -run "TestS3Folder|TestConfigureSession" -v

=== RUN   TestS3FolderRequestTimeoutDefaultIsDisabled       --- PASS (0.00s)
=== RUN   TestS3FolderRequestTimeoutAcceptsValue            --- PASS (0.00s)
=== RUN   TestS3FolderRequestTimeoutRejectsNonInteger       --- PASS (0.00s)
=== RUN   TestConfigureSessionAppliesRequestTimeout         --- PASS (0.00s)
=== RUN   TestConfigureSessionLeavesTimeoutZeroWhenUnset    --- PASS (0.00s)
PASS

GOEXPERIMENT=jsonv2 go vet ./pkg/storages/s3/        # clean
GOEXPERIMENT=jsonv2 golangci-lint run ./pkg/storages/s3/...
0 issues.
gofmt -l pkg/storages/s3/                            # clean
```

(`GOEXPERIMENT=jsonv2` is required because the project's go.mod targets
1.25 and one transitive import uses `encoding/json/v2`. Not related to
this change.)

## Notes / out of scope

- This PR only addresses the response-header hang. Issue #1949 also
  surfaces a related concern about `//TODO`s around connect/retry
  behavior in `pkg/storages/s3/folder.go`. Those touch the deeper
  retry policy and feel like a separate change to me; happy to follow
  up if there's appetite for it.

- I did not change any default. Picking the right default header
  timeout for S3 is a policy decision (AWS itself can take seconds
  to start responding under load), and shipping a default could
  silently change behavior for users with high-latency endpoints.
  Opt-in is the safe step here.

- `S3_REQUEST_TIMEOUT` is parsed as integer seconds via the existing
  `setting.IntOptional` helper, matching the convention used by other
  numeric S3 settings like `S3_MAX_RETRIES`. Happy to switch to a
  duration string (e.g. `"30s"`) if the maintainers prefer.

