### PR TITLE
remove direct dependency on blang/semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1
 	github.com/aws/aws-sdk-go v1.55.7
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cucumber/godog v0.15.1
 	github.com/cyberdelia/lzo v1.0.0
@@ -73,6 +72,7 @@ require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/alibabacloud-go/debug v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/internal/databases/greenplum/backup_fetch_handler.go
+++ b/internal/databases/greenplum/backup_fetch_handler.go
@@ -5,8 +5,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
@@ -216,7 +216,7 @@ func (fh *FetchHandler) createRecoveryConfigs() error {
 	pathToRecoveryConf := viper.GetString(conf.GPRelativeRecoveryConfPath)
 	pathToPostgresqlConf := viper.GetString(conf.GPRelativePostgresqlConfPath)
 
-	semVer, err := semver.Make(fh.sentinel.GpVersion)
+	semVer, err := version.NewVersion(fh.sentinel.GpVersion)
 	if err != nil {
 		tracelog.ErrorLogger.Printf("failed to parse GP version: %s,  %s", fh.sentinel.GpVersion, err)
 	}

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -518,7 +518,7 @@ func getGpClusterInfo(conn *pgx.Conn) (globalCluster *cluster.Cluster, version V
 	if err != nil {
 		return globalCluster, Version{}, nil, err
 	}
-	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo(version)
+	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo()
 	if err != nil {
 		return globalCluster, Version{}, nil, err
 	}

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -79,25 +79,7 @@ func (queryRunner *GpQueryRunner) CreateGreenplumRestorePoint(restorePointName s
 	return restoreLSNs, nil
 }
 
-// BuildGetGreenplumSegmentsInfo formats a query to retrieve information about segments
-func (queryRunner *GpQueryRunner) buildGetGreenplumSegmentsInfo(version Version) string {
-	if version.Flavor == Greenplum && version.Major < 6 {
-		return `
-SELECT
-	s.dbid,
-	s.content,
-	s.role::text,
-	s.port,
-	s.hostname,
-	e.fselocation
-FROM gp_segment_configuration s
-JOIN pg_filespace_entry e ON s.dbid = e.fsedbid
-JOIN pg_filespace f ON e.fsefsoid = f.oid
-WHERE s.role = 'p' AND f.fsname = 'pg_system'
-ORDER BY s.content, s.role DESC;`
-	}
-	return `
-SELECT
+const getGreenplumSegmentsInfoQuery = `SELECT
 	dbid,
 	content,
 	role::text,
@@ -107,12 +89,11 @@ SELECT
 FROM gp_segment_configuration
 WHERE role = 'p'
 ORDER BY content, role DESC;`
-}
 
 // GetGreenplumSegmentsInfo returns the information about segments
-func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(version Version) (segments []cluster.SegConfig, err error) {
+func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo() (segments []cluster.SegConfig, err error) {
 	conn := queryRunner.Connection
-	rows, err := conn.Query(context.TODO(), queryRunner.buildGetGreenplumSegmentsInfo(version))
+	rows, err := conn.Query(context.TODO(), getGreenplumSegmentsInfoQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
-	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
@@ -82,8 +81,7 @@ func (queryRunner *GpQueryRunner) CreateGreenplumRestorePoint(restorePointName s
 
 // BuildGetGreenplumSegmentsInfo formats a query to retrieve information about segments
 func (queryRunner *GpQueryRunner) buildGetGreenplumSegmentsInfo(version Version) string {
-	validRange := dbconn.StringToSemVerRange("<6")
-	if version.Flavor == Greenplum && validRange(version.Version) {
+	if version.Flavor == Greenplum && version.Major < 6 {
 		return `
 SELECT
 	s.dbid,

--- a/internal/databases/greenplum/version.go
+++ b/internal/databases/greenplum/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/blang/semver"
+	"github.com/hashicorp/go-version"
 )
 
 type Flavor string
@@ -19,24 +19,26 @@ const (
 )
 
 type Version struct {
-	semver.Version
+	*version.Version
+	Major  int
 	Flavor Flavor // Note: can be '' for old backups
 }
 
-func NewVersion(version semver.Version, flavor Flavor) Version {
+func NewVersion(v *version.Version, flavor Flavor) Version {
 	return Version{
-		Version: version,
+		Version: v,
+		Major:   v.Segments()[0],
 		Flavor:  flavor,
 	}
 }
 
-func parseGreenplumVersion(version string) (Version, error) {
+func parseGreenplumVersion(versionStr string) (Version, error) {
 	pattern := regexp.MustCompile(`(Greenplum Database|Cloudberry Database|Apache Cloudberry) (\d+\.\d+\.\d+)`)
-	groups := pattern.FindStringSubmatch(version)
+	groups := pattern.FindStringSubmatch(versionStr)
 	if groups == nil {
-		return Version{}, fmt.Errorf("unknown flavor: %s", version)
+		return Version{}, fmt.Errorf("unknown flavor: %s", versionStr)
 	}
-	semVer, err := semver.Make(groups[2])
+	semVer, err := version.NewVersion(groups[2])
 	if err != nil {
 		return Version{}, err
 	}

--- a/internal/databases/greenplum/version_test.go
+++ b/internal/databases/greenplum/version_test.go
@@ -3,7 +3,7 @@ package greenplum
 import (
 	"testing"
 
-	"github.com/blang/semver"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,17 +16,17 @@ func TestParseGreenplumVersion(t *testing.T) {
 		{
 			name:   "greenplum 6.25 instance",
 			input:  "PostgreSQL 9.4.26 (Greenplum Database 6.25.3-mdb+yezzey+yagpcc-r+dev.40.gf0f10f9335 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Jul 24 2024 13:29:56",
-			result: NewVersion(semver.MustParse("6.25.3"), Greenplum),
+			result: NewVersion(version.Must(version.NewVersion("6.25.3")), Greenplum),
 		},
 		{
 			name:   "cloudberry 1.6.0",
 			input:  "PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Sep 13 2024 07:33:38",
-			result: NewVersion(semver.MustParse("1.6.0"), Cloudberry),
+			result: NewVersion(version.Must(version.NewVersion("1.6.0")), Cloudberry),
 		},
 		{
 			name:   "apache cloudberry dev",
 			input:  "PostgreSQL 14.4 (Apache Cloudberry 1.0.0+00da831 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit compiled on Feb 25 2025 10:24:41",
-			result: NewVersion(semver.MustParse("1.0.0"), Cloudberry),
+			result: NewVersion(version.Must(version.NewVersion("1.0.0")), Cloudberry),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
hashicorp/go-version matches what we use on redis, we don't use semver logic with greenplum