### PR TITLE
fs: remove empty parent dirs after DeleteObjects

### DIFF
--- a/pkg/storages/fs/folder.go
+++ b/pkg/storages/fs/folder.go
@@ -53,16 +53,34 @@ func (folder *Folder) ListFolder() (objects []storage.Object, subFolders []stora
 }
 
 func (folder *Folder) DeleteObjects(objectsWithRelativePaths []storage.Object) error {
+	baseDir := path.Join(folder.rootPath, folder.subPath)
 	for _, object := range objectsWithRelativePaths {
-		err := os.RemoveAll(folder.GetFilePath(object.GetName()))
+		filePath := folder.GetFilePath(object.GetName())
+		err := os.RemoveAll(filePath)
 		if os.IsNotExist(err) {
 			continue
 		}
 		if err != nil {
 			return fmt.Errorf("unable to delete file %q: %w", object.GetName(), err)
 		}
+		removeEmptyParentDirs(path.Dir(filePath), baseDir)
 	}
 	return nil
+}
+
+// removeEmptyParentDirs removes empty parent directories up to (but not including) stopDir.
+// os.Remove only succeeds on empty directories, so non-empty dirs are left untouched.
+func removeEmptyParentDirs(dir, stopDir string) {
+	for dir != stopDir {
+		if err := os.Remove(dir); err != nil {
+			return
+		}
+		parent := path.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
 }
 
 func (folder *Folder) Exists(objectRelativePath string) (bool, error) {

--- a/pkg/storages/fs/folder_test.go
+++ b/pkg/storages/fs/folder_test.go
@@ -3,7 +3,9 @@ package fs
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -18,6 +20,77 @@ func TestFSFolder(t *testing.T) {
 	assert.NoError(t, err)
 
 	storage.RunFolderTest(st.RootFolder(), t)
+}
+
+func TestDeleteObjectsRemovesEmptyDirs(t *testing.T) {
+	tmpDir := setupTmpDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	st, err := ConfigureStorage(tmpDir, nil)
+	assert.NoError(t, err)
+	root := st.RootFolder()
+
+	// Simulate a real backup layout:
+	//   backup_001.json.lz4          — sentinel at root level
+	//   backup_001/pg_data/global/pg_control
+	//   backup_001/pg_data/base/1/1259
+	err = root.PutObject("backup_001.json.lz4", strings.NewReader("{}"))
+	assert.NoError(t, err)
+	err = root.PutObject("backup_001/pg_data/global/pg_control", strings.NewReader("data"))
+	assert.NoError(t, err)
+	err = root.PutObject("backup_001/pg_data/base/1/1259", strings.NewReader("data"))
+	assert.NoError(t, err)
+
+	// Delete sentinel + all data files, same as DeleteBackups does.
+	err = root.DeleteObjects([]storage.Object{
+		storage.NewLocalObject("backup_001.json.lz4", time.Time{}, 0),
+		storage.NewLocalObject("backup_001/pg_data/global/pg_control", time.Time{}, 0),
+		storage.NewLocalObject("backup_001/pg_data/base/1/1259", time.Time{}, 0),
+	})
+	assert.NoError(t, err)
+
+	// The backup directory itself and all nested dirs must be gone.
+	for _, dir := range []string{
+		"backup_001/pg_data/global",
+		"backup_001/pg_data/base/1",
+		"backup_001/pg_data/base",
+		"backup_001/pg_data",
+		"backup_001",
+	} {
+		_, statErr := os.Stat(filepath.Join(tmpDir, dir))
+		assert.True(t, os.IsNotExist(statErr), "expected directory to be removed: %s", dir)
+	}
+}
+
+func TestDeleteObjectsKeepsNonEmptyDirs(t *testing.T) {
+	tmpDir := setupTmpDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	st, err := ConfigureStorage(tmpDir, nil)
+	assert.NoError(t, err)
+	root := st.RootFolder()
+
+	// Two backups share a common parent layout but are independent.
+	err = root.PutObject("backup_001/pg_data/file_a", strings.NewReader("data"))
+	assert.NoError(t, err)
+	err = root.PutObject("backup_002/pg_data/file_b", strings.NewReader("data"))
+	assert.NoError(t, err)
+
+	// Delete only backup_001's file.
+	err = root.DeleteObjects([]storage.Object{
+		storage.NewLocalObject("backup_001/pg_data/file_a", time.Time{}, 0),
+	})
+	assert.NoError(t, err)
+
+	// backup_001 subtree must be gone.
+	for _, dir := range []string{"backup_001/pg_data", "backup_001"} {
+		_, statErr := os.Stat(filepath.Join(tmpDir, dir))
+		assert.True(t, os.IsNotExist(statErr), "expected directory to be removed: %s", dir)
+	}
+
+	// backup_002 subtree must still be intact.
+	_, statErr := os.Stat(filepath.Join(tmpDir, "backup_002/pg_data"))
+	assert.NoError(t, statErr, "backup_002/pg_data should still exist")
 }
 
 func setupTmpDir(t *testing.T) string {


### PR DESCRIPTION
FS storage leaves empty folders. This looks ugly, let's fix it.