### PR TITLE
Feat/retain only one restore point in Greenplum

### DIFF
--- a/cmd/gp/delete.go
+++ b/cmd/gp/delete.go
@@ -3,7 +3,6 @@ package gp
 import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
-
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"

--- a/cmd/gp/delete.go
+++ b/cmd/gp/delete.go
@@ -3,6 +3,7 @@ package gp
 import (
 	"github.com/spf13/cobra"
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"
@@ -130,10 +131,11 @@ func runDeleteTrimWal(cmd *cobra.Command, args []string) {
 	rootFolder, err := getMultistorageRootFolder(true, policies.UniteAllStorages)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, greenplum.DeleteArgs{Confirmed: confirmed})
+	delArgs := greenplum.DeleteArgs{Confirmed: confirmed}
+	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, delArgs)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	err = deleteHandler.HandleDeleteTrimWal(args[0], confirmed)
+	err = deleteHandler.HandleDeleteTrimWal(args[0])
 	tracelog.ErrorLogger.FatalOnError(err)
 }
 

--- a/cmd/gp/delete.go
+++ b/cmd/gp/delete.go
@@ -134,7 +134,7 @@ func runDeleteTrimWal(cmd *cobra.Command, args []string) {
 	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, delArgs)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	err = deleteHandler.HandleDeleteTrimWal(args[0])
+	err = deleteHandler.HandleDeleteTrimWal(cmd.Context(), args[0])
 	tracelog.ErrorLogger.FatalOnError(err)
 }
 

--- a/cmd/gp/delete.go
+++ b/cmd/gp/delete.go
@@ -16,6 +16,10 @@ var deleteTargetUserData = ""
 const DeleteGarbageExamples = `  garbage           Deletes outdated WAL archives and leftover backups files from storage`
 const DeleteGarbageUse = "garbage"
 
+const DeleteTrimWalUse = "trim-wal"
+const DeleteTrimWalShortDescription = "Delete WAL files accumulated after the given backup's restore point"
+const DeleteTrimWalExamples = "  trim-wal base_000000010000000000000001\n  trim-wal LATEST"
+
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
@@ -56,6 +60,14 @@ var deleteGarbageCmd = &cobra.Command{
 	Example: DeleteGarbageExamples,
 	Args:    cobra.NoArgs,
 	Run:     runDeleteGarbage,
+}
+
+var deleteTrimWalCmd = &cobra.Command{
+	Use:     DeleteTrimWalUse + " BACKUP_NAME|LATEST",
+	Short:   DeleteTrimWalShortDescription,
+	Example: DeleteTrimWalExamples,
+	Args:    cobra.ExactArgs(1),
+	Run:     runDeleteTrimWal,
 }
 
 func runDeleteBefore(cmd *cobra.Command, args []string) {
@@ -114,6 +126,17 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 	deleteHandler.HandleDeleteTarget(targetBackupSelector)
 }
 
+func runDeleteTrimWal(cmd *cobra.Command, args []string) {
+	rootFolder, err := getMultistorageRootFolder(true, policies.UniteAllStorages)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	deleteHandler, err := greenplum.NewDeleteHandler(rootFolder, greenplum.DeleteArgs{Confirmed: confirmed})
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	err = deleteHandler.HandleDeleteTrimWal(args[0], confirmed)
+	tracelog.ErrorLogger.FatalOnError(err)
+}
+
 func runDeleteGarbage(cmd *cobra.Command, args []string) {
 	rootFolder, err := getMultistorageRootFolder(true, policies.UniteAllStorages)
 	tracelog.ErrorLogger.FatalOnError(err)
@@ -132,7 +155,7 @@ func init() {
 	deleteTargetCmd.Flags().StringVar(
 		&deleteTargetUserData, internal.DeleteTargetUserDataFlag, "", internal.DeleteTargetUserDataDescription)
 
-	deleteCmd.AddCommand(deleteRetainCmd, deleteBeforeCmd, deleteEverythingCmd, deleteTargetCmd, deleteGarbageCmd)
+	deleteCmd.AddCommand(deleteRetainCmd, deleteBeforeCmd, deleteEverythingCmd, deleteTargetCmd, deleteGarbageCmd, deleteTrimWalCmd)
 	deleteCmd.PersistentFlags().BoolVar(&confirmed, internal.ConfirmFlag, false, "Confirms backup deletion")
 	deleteCmd.PersistentFlags().BoolVar(&forceDelete, "force-delete", false, "Force delete")
 	_ = deleteCmd.PersistentFlags().MarkHidden("force-delete")

--- a/docs/Greenplum.md
+++ b/docs/Greenplum.md
@@ -280,9 +280,9 @@ wal-g check-ao-aocs-length --check-backup --backup-name=backup_name
 
 ### ``delete trim-wal``
 
-Deletes WAL files accumulated after the given backup's restore point LSN on every segment. This frees storage space when WAL files are no longer needed for point-in-time recovery from that backup.
+Deletes WAL files accumulated after the given backup's restore point LSN on every segment, within the same timeline as the restore point. This frees storage space when WAL files are no longer needed for point-in-time recovery from that backup. WAL files from other timelines are not affected.
 
-Also removes all `*_restore_point.json` metadata files except the one associated with the specified backup.
+Also removes `*_restore_point.json` metadata files created after the specified backup's restore point, while retaining the target restore point and any older ones.
 
 Usage:
 ```bash

--- a/docs/Greenplum.md
+++ b/docs/Greenplum.md
@@ -277,3 +277,14 @@ If you want to secect special backup for check, you can add it`s name:
 ```bash
 wal-g check-ao-aocs-length --check-backup --backup-name=backup_name
 ```
+
+### ``delete trim-wal``
+
+Deletes WAL files accumulated after the given backup's restore point LSN on every segment. This frees storage space when WAL files are no longer needed for point-in-time recovery from that backup.
+
+Also removes all `*_restore_point.json` metadata files except the one associated with the specified backup.
+
+Usage:
+```bash
+wal-g delete trim-wal BACKUP_NAME|LATEST [--confirm]
+```

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -6,15 +6,18 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
-	"golang.org/x/sync/errgroup"
 )
 
 type DeleteArgs struct {
@@ -245,18 +248,36 @@ func (h *DeleteHandler) HandleDeleteTrimWal(ctx context.Context, backupName stri
 	}
 
 	if sentinel.RestorePoint != nil {
-		return h.deleteRestorePointsExcept(*sentinel.RestorePoint, h.args.Confirmed, baseBackupFolder)
+		return h.deleteRestorePointsAfter(*sentinel.RestorePoint, h.args.Confirmed, baseBackupFolder)
 	}
 	return nil
 }
 
-func (h *DeleteHandler) deleteRestorePointsExcept(targetRestorePoint string, confirm bool, baseBackupFolder storage.Folder) error {
-	_, err := FetchAllRestorePoints(h.Folder)
+func (h *DeleteHandler) deleteRestorePointsAfter(targetRestorePoint string, confirm bool, baseBackupFolder storage.Folder) error {
+	allRestorePoints, err := FetchAllRestorePoints(h.Folder)
 	if err != nil {
 		if _, ok := err.(NoRestorePointsFoundError); ok {
 			return nil
 		}
 		return err
+	}
+
+	var cutoffTime time.Time
+	for _, restorePoint := range allRestorePoints {
+		if restorePoint.Name == targetRestorePoint {
+			cutoffTime = restorePoint.FinishTime
+			break
+		}
+	}
+	if cutoffTime.IsZero() {
+		return nil
+	}
+
+	toDelete := make(map[string]struct{}, len(allRestorePoints))
+	for _, restorePoint := range allRestorePoints {
+		if restorePoint.FinishTime.After(cutoffTime) {
+			toDelete[restorePoint.Name] = struct{}{}
+		}
 	}
 
 	folderFilter := func(string) bool { return true }
@@ -265,7 +286,8 @@ func (h *DeleteHandler) deleteRestorePointsExcept(targetRestorePoint string, con
 		if !strings.HasSuffix(name, RestorePointSuffix) {
 			return false
 		}
-		return StripRightmostRestorePointName(name) != targetRestorePoint
+		_, ok := toDelete[StripRightmostRestorePointName(name)]
+		return ok
 	}, folderFilter)
 }
 

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -7,16 +7,14 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/wal-g/tracelog"
-
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
+	"golang.org/x/sync/errgroup"
 )
 
 type DeleteArgs struct {

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -201,7 +201,7 @@ func (h *DeleteHandler) dispatchDeleteCmd(target internal.BackupObject, delType 
 }
 
 // HandleDeleteTrimWal deletes WAL files accumulated after each segment's RestorePointLSN.
-func (h *DeleteHandler) HandleDeleteTrimWal(backupName string) error {
+func (h *DeleteHandler) HandleDeleteTrimWal(ctx context.Context, backupName string) error {
 	baseBackupFolder := h.Folder.GetSubFolder(utility.BaseBackupPath)
 	backupName, err := internal.UnwrapLatestModifier(backupName, baseBackupFolder)
 	if err != nil {
@@ -231,7 +231,7 @@ func (h *DeleteHandler) HandleDeleteTrimWal(backupName string) error {
 		tracelog.WarningLogger.Printf("config error: %v", err)
 	}
 
-	errorGroup, _ := errgroup.WithContext(context.Background())
+	errorGroup, _ := errgroup.WithContext(ctx)
 	errorGroup.SetLimit(deleteConcurrency)
 	for i := range sentinel.Segments {
 		meta := sentinel.Segments[i]

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -229,6 +229,15 @@ func (h *DeleteHandler) HandleDeleteTrimWal(ctx context.Context, backupName stri
 		return err
 	}
 
+	var cutoffTimeline uint32
+	if sentinel.RestorePoint != nil {
+		rpMeta, err := FetchRestorePointMetadata(h.Folder, *sentinel.RestorePoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch restore point metadata: %w", err)
+		}
+		cutoffTimeline = rpMeta.TimeLine
+	}
+
 	deleteConcurrency, err := conf.GetMaxConcurrency(conf.GPDeleteConcurrency)
 	if err != nil {
 		tracelog.WarningLogger.Printf("config error: %v", err)
@@ -239,7 +248,7 @@ func (h *DeleteHandler) HandleDeleteTrimWal(ctx context.Context, backupName stri
 	for i := range sentinel.Segments {
 		meta := sentinel.Segments[i]
 		errorGroup.Go(func() error {
-			return h.trimSegmentWal(meta, h.args.Confirmed)
+			return h.trimSegmentWal(meta, cutoffTimeline, h.args.Confirmed)
 		})
 	}
 
@@ -291,7 +300,7 @@ func (h *DeleteHandler) deleteRestorePointsAfter(targetRestorePoint string, conf
 	}, folderFilter)
 }
 
-func (h *DeleteHandler) trimSegmentWal(meta SegmentMetadata, confirm bool) error {
+func (h *DeleteHandler) trimSegmentWal(meta SegmentMetadata, cutoffTimeline uint32, confirm bool) error {
 	lsn, err := postgres.ParseLSN(meta.RestorePointLSN)
 	if err != nil {
 		return fmt.Errorf("failed to parse RestorePointLSN for segment %d: %w", meta.ContentID, err)
@@ -314,8 +323,11 @@ func (h *DeleteHandler) trimSegmentWal(meta SegmentMetadata, confirm bool) error
 		if !strings.HasPrefix(name, utility.WalPath) {
 			return false
 		}
-		_, segNo, ok := postgres.TryFetchTimelineAndLogSegNo(name)
+		timeline, segNo, ok := postgres.TryFetchTimelineAndLogSegNo(name)
 		if !ok {
+			return false
+		}
+		if cutoffTimeline != 0 && timeline != cutoffTimeline {
 			return false
 		}
 		return postgres.WalSegmentNo(segNo) > cutoffSegNo

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sync/errgroup"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
@@ -16,6 +15,7 @@ import (
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
+	"golang.org/x/sync/errgroup"
 )
 
 type DeleteArgs struct {

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
-
 	"github.com/wal-g/tracelog"
-
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
@@ -272,9 +270,9 @@ func (h *DeleteHandler) deleteRestorePointsAfter(targetRestorePoint string, conf
 	}
 
 	var cutoffTime time.Time
-	for _, restorePoint := range allRestorePoints {
-		if restorePoint.Name == targetRestorePoint {
-			cutoffTime = restorePoint.FinishTime
+	for i := range allRestorePoints {
+		if allRestorePoints[i].Name == targetRestorePoint {
+			cutoffTime = allRestorePoints[i].FinishTime
 			break
 		}
 	}
@@ -283,9 +281,9 @@ func (h *DeleteHandler) deleteRestorePointsAfter(targetRestorePoint string, conf
 	}
 
 	toDelete := make(map[string]struct{}, len(allRestorePoints))
-	for _, restorePoint := range allRestorePoints {
-		if restorePoint.FinishTime.After(cutoffTime) {
-			toDelete[restorePoint.Name] = struct{}{}
+	for i := range allRestorePoints {
+		if allRestorePoints[i].FinishTime.After(cutoffTime) {
+			toDelete[allRestorePoints[i].Name] = struct{}{}
 		}
 	}
 

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -203,7 +203,7 @@ func (h *DeleteHandler) dispatchDeleteCmd(target internal.BackupObject, delType 
 }
 
 // HandleDeleteTrimWal deletes WAL files accumulated after each segment's RestorePointLSN.
-func (h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) error {
+func (h *DeleteHandler) HandleDeleteTrimWal(backupName string) error {
 	baseBackupFolder := h.Folder.GetSubFolder(utility.BaseBackupPath)
 	backupName, err := internal.UnwrapLatestModifier(backupName, baseBackupFolder)
 	if err != nil {
@@ -238,7 +238,7 @@ func (h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) err
 	for i := range sentinel.Segments {
 		meta := sentinel.Segments[i]
 		errorGroup.Go(func() error {
-			return h.trimSegmentWal(meta, confirm)
+			return h.trimSegmentWal(meta, h.args.Confirmed)
 		})
 	}
 
@@ -247,7 +247,7 @@ func (h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) err
 	}
 
 	if sentinel.RestorePoint != nil {
-		return h.deleteRestorePointsExcept(*sentinel.RestorePoint, confirm, baseBackupFolder)
+		return h.deleteRestorePointsExcept(*sentinel.RestorePoint, h.args.Confirmed, baseBackupFolder)
 	}
 	return nil
 }

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -7,14 +7,16 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/wal-g/tracelog"
+
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
-	"golang.org/x/sync/errgroup"
 )
 
 type DeleteArgs struct {
@@ -200,6 +202,81 @@ func (h *DeleteHandler) dispatchDeleteCmd(target internal.BackupObject, delType 
 	return errorGroup.Wait()
 }
 
+// HandleDeleteTrimWal deletes WAL files accumulated after each segment's RestorePointLSN.
+func (h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) error {
+	folder := h.Folder.GetSubFolder(utility.BaseBackupPath)
+	backupName, err := internal.UnwrapLatestModifier(backupName, folder)
+	if err != nil {
+		return err
+	}
+
+	target, err := h.FindTargetByName(backupName)
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		return fmt.Errorf("backup '%s' not found", backupName)
+	}
+
+	backup, err := NewBackupInStorage(h.Folder, target.GetBackupName(), multistorage.GetStorage(target))
+	if err != nil {
+		return err
+	}
+
+	sentinel, err := backup.GetSentinel()
+	if err != nil {
+		return err
+	}
+
+	deleteConcurrency, err := conf.GetMaxConcurrency(conf.GPDeleteConcurrency)
+	if err != nil {
+		tracelog.WarningLogger.Printf("config error: %v", err)
+	}
+
+	errorGroup, _ := errgroup.WithContext(context.Background())
+	errorGroup.SetLimit(deleteConcurrency)
+
+	for i := range sentinel.Segments {
+		meta := sentinel.Segments[i]
+		errorGroup.Go(func() error {
+			return h.trimSegmentWal(meta, confirm)
+		})
+	}
+
+	return errorGroup.Wait()
+}
+
+func (h *DeleteHandler) trimSegmentWal(meta SegmentMetadata, confirm bool) error {
+	lsn, err := postgres.ParseLSN(meta.RestorePointLSN)
+	if err != nil {
+		return fmt.Errorf("failed to parse RestorePointLSN for segment %d: %w", meta.ContentID, err)
+	}
+
+	cutoffSegNo := postgres.NewWalSegmentNo(lsn)
+	segFolder := h.Folder.GetSubFolder(FormatSegmentStoragePrefix(meta.ContentID))
+	permanentBackups, permanentWals := GetPermanentBackupsAndWals(h.Folder, meta.ContentID)
+
+	segDeleteHandler, err := postgres.NewDeleteHandler(segFolder, permanentBackups, permanentWals, false)
+	if err != nil {
+		return err
+	}
+
+	tracelog.InfoLogger.Printf("Trimming WAL for segment %d (cutoff segment: %d)", meta.ContentID, cutoffSegNo)
+
+	folderFilter := func(string) bool { return true }
+	return segDeleteHandler.DeleteObjectsWhereWithPermanentCheck(confirm, func(object storage.Object) bool {
+		name := object.GetName()
+		if !strings.HasPrefix(name, utility.WalPath) {
+			return false
+		}
+		_, segNo, ok := postgres.TryFetchTimelineAndLogSegNo(name)
+		if !ok {
+			return false
+		}
+		return postgres.WalSegmentNo(segNo) > cutoffSegNo
+	}, folderFilter)
+}
+
 // HandleDeleteGarbage delete outdated WAL archives and leftover backup files
 func (h *DeleteHandler) HandleDeleteGarbage(args []string) error {
 	predicate := postgres.ExtractDeleteGarbagePredicate(args)
@@ -227,4 +304,9 @@ func (h *DeleteHandler) HandleDeleteGarbage(args []string) error {
 
 	folderFilter := func(name string) bool { return strings.HasPrefix(name, utility.BaseBackupPath) }
 	return h.DeleteBeforeTargetWhere(target, h.args.Confirmed, predicate, folderFilter)
+}
+
+func(h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) error {
+	backupName, err := internal.UnWrapLatestModifier(backupName, h.Folder.GetSubFolder(utility.BaseBackupPath))
+	if err != 
 }

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -204,8 +204,8 @@ func (h *DeleteHandler) dispatchDeleteCmd(target internal.BackupObject, delType 
 
 // HandleDeleteTrimWal deletes WAL files accumulated after each segment's RestorePointLSN.
 func (h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) error {
-	folder := h.Folder.GetSubFolder(utility.BaseBackupPath)
-	backupName, err := internal.UnwrapLatestModifier(backupName, folder)
+	baseBackupFolder := h.Folder.GetSubFolder(utility.BaseBackupPath)
+	backupName, err := internal.UnwrapLatestModifier(backupName, baseBackupFolder)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,6 @@ func (h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) err
 
 	errorGroup, _ := errgroup.WithContext(context.Background())
 	errorGroup.SetLimit(deleteConcurrency)
-
 	for i := range sentinel.Segments {
 		meta := sentinel.Segments[i]
 		errorGroup.Go(func() error {
@@ -243,7 +242,33 @@ func (h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) err
 		})
 	}
 
-	return errorGroup.Wait()
+	if err := errorGroup.Wait(); err != nil {
+		return err
+	}
+
+	if sentinel.RestorePoint != nil {
+		return h.deleteRestorePointsExcept(*sentinel.RestorePoint, confirm, baseBackupFolder)
+	}
+	return nil
+}
+
+func (h *DeleteHandler) deleteRestorePointsExcept(targetRestorePoint string, confirm bool, baseBackupFolder storage.Folder) error {
+	_, err := FetchAllRestorePoints(h.Folder)
+	if err != nil {
+		if _, ok := err.(NoRestorePointsFoundError); ok {
+			return nil
+		}
+		return err
+	}
+
+	folderFilter := func(string) bool { return true }
+	return internal.DeleteObjectsWhere(baseBackupFolder, confirm, func(object storage.Object) bool {
+		name := object.GetName()
+		if !strings.HasSuffix(name, RestorePointSuffix) {
+			return false
+		}
+		return StripRightmostRestorePointName(name) != targetRestorePoint
+	}, folderFilter)
 }
 
 func (h *DeleteHandler) trimSegmentWal(meta SegmentMetadata, confirm bool) error {
@@ -304,9 +329,4 @@ func (h *DeleteHandler) HandleDeleteGarbage(args []string) error {
 
 	folderFilter := func(name string) bool { return strings.HasPrefix(name, utility.BaseBackupPath) }
 	return h.DeleteBeforeTargetWhere(target, h.args.Confirmed, predicate, folderFilter)
-}
-
-func(h *DeleteHandler) HandleDeleteTrimWal(backupName string, confirm bool) error {
-	backupName, err := internal.UnWrapLatestModifier(backupName, h.Folder.GetSubFolder(utility.BaseBackupPath))
-	if err != 
 }

--- a/internal/databases/greenplum/delete_handler_test.go
+++ b/internal/databases/greenplum/delete_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,13 @@ import (
 	"github.com/wal-g/wal-g/testtools"
 	"github.com/wal-g/wal-g/utility"
 )
+
+type testRestorePoint struct {
+	name       string
+	finishTime time.Time
+}
+
+var baseFinishTime = time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
 
 const walTimeline = uint32(1)
 
@@ -37,7 +45,7 @@ func makeTrimWalFolder(
 	backupRestorePoint string,
 	segments []greenplum.SegmentMetadata,
 	walSegNosByContentID map[int][]uint64,
-	storedRestorePoints []string,
+	storedRestorePoints []testRestorePoint,
 ) storage.Folder {
 	folder := testtools.MakeDefaultInMemoryStorageFolder()
 	baseBackupFolder := folder.GetSubFolder(utility.BaseBackupPath)
@@ -69,15 +77,15 @@ func makeTrimWalFolder(
 		}
 	}
 
-	for _, restorePointName := range storedRestorePoints {
+	for _, rp := range storedRestorePoints {
 		restorePointData := map[string]interface{}{
-			"name":        restorePointName,
-			"start_time":  "2026-01-01T00:00:00Z",
-			"finish_time": "2026-01-01T00:00:01Z",
+			"name":        rp.name,
+			"start_time":  rp.finishTime.Add(-time.Second).Format(time.RFC3339),
+			"finish_time": rp.finishTime.Format(time.RFC3339),
 		}
 		restorePointBytes, err := json.Marshal(restorePointData)
 		require.NoError(t, err)
-		err = baseBackupFolder.PutObject(restorePointName+greenplum.RestorePointSuffix, bytes.NewReader(restorePointBytes))
+		err = baseBackupFolder.PutObject(rp.name+greenplum.RestorePointSuffix, bytes.NewReader(restorePointBytes))
 		require.NoError(t, err)
 	}
 
@@ -104,7 +112,7 @@ func TestHandleDeleteTrimWal_DeletesWalAfterCutoff(t *testing.T) {
 		},
 	}
 	walSegNosByContentID := map[int][]uint64{0: {1, 2, 3, 4}}
-	storedRestorePoints := []string{restorePoint}
+	storedRestorePoints := []testRestorePoint{{restorePoint, baseFinishTime}}
 	folder := makeTrimWalFolder(
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
 	)
@@ -134,7 +142,10 @@ func TestHandleDeleteTrimWal_WithoutConfirm_NothingDeleted(t *testing.T) {
 	}
 	walSegNos := []uint64{1, 2, 3, 4}
 	walSegNosByContentID := map[int][]uint64{0: walSegNos}
-	storedRestorePoints := []string{restorePoint, "old_restore_point"}
+	storedRestorePoints := []testRestorePoint{
+		{restorePoint, baseFinishTime},
+		{"later_restore_point", baseFinishTime.Add(time.Minute)},
+	}
 
 	folder := makeTrimWalFolder(
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
@@ -151,12 +162,12 @@ func TestHandleDeleteTrimWal_WithoutConfirm_NothingDeleted(t *testing.T) {
 	for _, segNo := range walSegNos {
 		assert.Contains(t, objectPaths, walObjectPath(0, segNo), "dry run must not delete WAL segNo %d", segNo)
 	}
-	// Old restore point must still be present
-	oldRestorePointFilePath := path.Join(utility.BaseBackupPath, "old_restore_point"+greenplum.RestorePointSuffix)
-	assert.Contains(t, objectPaths, oldRestorePointFilePath, "dry run must not delete restore point files")
+	// later_restore_point would be deleted in confirmed mode, but dry run must keep it
+	laterRestorePointFilePath := path.Join(utility.BaseBackupPath, "later_restore_point"+greenplum.RestorePointSuffix)
+	assert.Contains(t, objectPaths, laterRestorePointFilePath, "dry run must not delete restore point files")
 }
 
-func TestHandleDeleteTrimWal_DeletesRestorePointsExceptTarget(t *testing.T) {
+func TestHandleDeleteTrimWal_DeletesRestorePointsAfterTarget(t *testing.T) {
 	backupName := "backup_20260101T000000Z"
 	restorePoint := "test_restore_point"
 	segments := []greenplum.SegmentMetadata{
@@ -167,7 +178,11 @@ func TestHandleDeleteTrimWal_DeletesRestorePointsExceptTarget(t *testing.T) {
 	}
 	walSegNos := []uint64{1}
 	walSegNosByContentID := map[int][]uint64{0: walSegNos}
-	storedRestorePoints := []string{restorePoint, "old_restore_point_1", "old_restore_point_2"}
+	storedRestorePoints := []testRestorePoint{
+		{restorePoint, baseFinishTime},
+		{"before_restore_point", baseFinishTime.Add(-time.Minute)},
+		{"after_restore_point", baseFinishTime.Add(time.Minute)},
+	}
 	folder := makeTrimWalFolder(
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
 	)
@@ -180,13 +195,14 @@ func TestHandleDeleteTrimWal_DeletesRestorePointsExceptTarget(t *testing.T) {
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
-	restorePointFile := path.Join(utility.BaseBackupPath, restorePoint+greenplum.RestorePointSuffix)
-	assert.Contains(t, objectPaths, restorePointFile, "target restore point must be kept")
+	targetFile := path.Join(utility.BaseBackupPath, restorePoint+greenplum.RestorePointSuffix)
+	assert.Contains(t, objectPaths, targetFile, "target restore point must be kept")
 
-	restorePointFile1 := path.Join(utility.BaseBackupPath, "old_restore_point_1"+greenplum.RestorePointSuffix)
-	restorePointFile2 := path.Join(utility.BaseBackupPath, "old_restore_point_2"+greenplum.RestorePointSuffix)
-	assert.NotContains(t, objectPaths, restorePointFile1, "old restore point 1 must be deleted")
-	assert.NotContains(t, objectPaths, restorePointFile2, "old restore point 2 must be deleted")
+	beforeFile := path.Join(utility.BaseBackupPath, "before_restore_point"+greenplum.RestorePointSuffix)
+	assert.Contains(t, objectPaths, beforeFile, "restore point before target must be kept")
+
+	afterFile := path.Join(utility.BaseBackupPath, "after_restore_point"+greenplum.RestorePointSuffix)
+	assert.NotContains(t, objectPaths, afterFile, "restore point after target must be deleted")
 }
 
 func TestHandleDeleteTrimWal_NoRestorePoint(t *testing.T) {
@@ -227,7 +243,7 @@ func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
 		-1: {1, 2, 3},
 		0:  {1, 2, 3},
 	}
-	storedRestorePoints := []string{restorePoint}
+	storedRestorePoints := []testRestorePoint{{restorePoint, baseFinishTime}}
 	folder := makeTrimWalFolder(
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
 	)

--- a/internal/databases/greenplum/delete_handler_test.go
+++ b/internal/databases/greenplum/delete_handler_test.go
@@ -21,18 +21,19 @@ import (
 type testRestorePoint struct {
 	name       string
 	finishTime time.Time
+	timeLine   uint32
 }
 
 var baseFinishTime = time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
 
-const walTimeline = uint32(1)
+const baseWalTimeLine = uint32(1)
 
-func walSegFilename(segNo uint64) string {
-	return postgres.WalSegmentNo(segNo).GetFilename(walTimeline)
+func walSegFilename(segNo uint64, walTimeLine uint32) string {
+	return postgres.WalSegmentNo(segNo).GetFilename(walTimeLine)
 }
 
-func walObjectPath(contentID int, segNo uint64) string {
-	return path.Join(greenplum.FormatSegmentWalPath(contentID), walSegFilename(segNo))
+func walObjectPath(contentID int, segNo uint64, walTimeLine uint32) string {
+	return path.Join(greenplum.FormatSegmentWalPath(contentID), walSegFilename(segNo, walTimeLine))
 }
 
 func walCutoffLSN(cutoffSegNo uint64) string {
@@ -71,7 +72,7 @@ func makeTrimWalFolder(
 	for contentID, segNos := range walSegNosByContentID {
 		segFolder := folder.GetSubFolder(greenplum.FormatSegmentStoragePrefix(contentID))
 		for _, segNo := range segNos {
-			walFilePath := path.Join(utility.WalPath, walSegFilename(segNo))
+			walFilePath := path.Join(utility.WalPath, walSegFilename(segNo, baseWalTimeLine))
 			err = segFolder.PutObject(walFilePath, &bytes.Buffer{})
 			require.NoError(t, err)
 		}
@@ -82,6 +83,7 @@ func makeTrimWalFolder(
 			"name":        rp.name,
 			"start_time":  rp.finishTime.Add(-time.Second).Format(time.RFC3339),
 			"finish_time": rp.finishTime.Format(time.RFC3339),
+			"time_line":   rp.timeLine,
 		}
 		restorePointBytes, err := json.Marshal(restorePointData)
 		require.NoError(t, err)
@@ -106,13 +108,10 @@ func TestHandleDeleteTrimWal_DeletesWalAfterCutoff(t *testing.T) {
 	backupName := "backup_20260101T000000Z"
 	restorePoint := "test_restore_point"
 	segments := []greenplum.SegmentMetadata{
-		{
-			ContentID:       0,
-			RestorePointLSN: walCutoffLSN(2),
-		},
+		{ContentID: 0, RestorePointLSN: walCutoffLSN(2)},
 	}
 	walSegNosByContentID := map[int][]uint64{0: {1, 2, 3, 4}}
-	storedRestorePoints := []testRestorePoint{{restorePoint, baseFinishTime}}
+	storedRestorePoints := []testRestorePoint{{restorePoint, baseFinishTime, baseWalTimeLine}}
 	folder := makeTrimWalFolder(
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
 	)
@@ -125,26 +124,24 @@ func TestHandleDeleteTrimWal_DeletesWalAfterCutoff(t *testing.T) {
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
-	assert.Contains(t, objectPaths, walObjectPath(0, 1), "WAL at cutoff-1 must be retained")
-	assert.Contains(t, objectPaths, walObjectPath(0, 2), "WAL at cutoff must be retained")
-	assert.NotContains(t, objectPaths, walObjectPath(0, 3), "WAL past cutoff must be deleted")
-	assert.NotContains(t, objectPaths, walObjectPath(0, 4), "WAL past cutoff must be deleted")
+	assert.Contains(t, objectPaths, walObjectPath(0, 1, baseWalTimeLine), "WAL at cutoff-1 must be retained")
+	assert.Contains(t, objectPaths, walObjectPath(0, 2, baseWalTimeLine), "WAL at cutoff must be retained")
+	assert.NotContains(t, objectPaths, walObjectPath(0, 3, baseWalTimeLine), "WAL past cutoff must be deleted")
+	assert.NotContains(t, objectPaths, walObjectPath(0, 4, baseWalTimeLine), "WAL past cutoff must be deleted")
 }
 
 func TestHandleDeleteTrimWal_WithoutConfirm_NothingDeleted(t *testing.T) {
 	backupName := "backup_20260101T000000Z"
 	restorePoint := "test_restore_point"
+	laterRestorePoint := "later_restore_point"
 	segments := []greenplum.SegmentMetadata{
-		{
-			ContentID:       0,
-			RestorePointLSN: walCutoffLSN(2),
-		},
+		{ContentID: 0, RestorePointLSN: walCutoffLSN(2)},
 	}
 	walSegNos := []uint64{1, 2, 3, 4}
 	walSegNosByContentID := map[int][]uint64{0: walSegNos}
 	storedRestorePoints := []testRestorePoint{
-		{restorePoint, baseFinishTime},
-		{"later_restore_point", baseFinishTime.Add(time.Minute)},
+		{restorePoint, baseFinishTime, baseWalTimeLine},
+		{laterRestorePoint, baseFinishTime.Add(time.Minute), baseWalTimeLine},
 	}
 
 	folder := makeTrimWalFolder(
@@ -160,28 +157,27 @@ func TestHandleDeleteTrimWal_WithoutConfirm_NothingDeleted(t *testing.T) {
 
 	objectPaths := getStorageObjectsPaths(t, folder)
 	for _, segNo := range walSegNos {
-		assert.Contains(t, objectPaths, walObjectPath(0, segNo), "dry run must not delete WAL segNo %d", segNo)
+		assert.Contains(t, objectPaths, walObjectPath(0, segNo, baseWalTimeLine), "dry run must not delete WAL segNo %d", segNo)
 	}
 	// later_restore_point would be deleted in confirmed mode, but dry run must keep it
-	laterRestorePointFilePath := path.Join(utility.BaseBackupPath, "later_restore_point"+greenplum.RestorePointSuffix)
+	laterRestorePointFilePath := path.Join(utility.BaseBackupPath, laterRestorePoint+greenplum.RestorePointSuffix)
 	assert.Contains(t, objectPaths, laterRestorePointFilePath, "dry run must not delete restore point files")
 }
 
 func TestHandleDeleteTrimWal_DeletesRestorePointsAfterTarget(t *testing.T) {
 	backupName := "backup_20260101T000000Z"
 	restorePoint := "test_restore_point"
+	beforeRestorePoint := "before_restore_point"
+	afterRestorePoint := "after_restore_point"
 	segments := []greenplum.SegmentMetadata{
-		{
-			ContentID:       0,
-			RestorePointLSN: walCutoffLSN(2),
-		},
+		{ContentID: 0, RestorePointLSN: walCutoffLSN(2)},
 	}
 	walSegNos := []uint64{1}
 	walSegNosByContentID := map[int][]uint64{0: walSegNos}
 	storedRestorePoints := []testRestorePoint{
-		{restorePoint, baseFinishTime},
-		{"before_restore_point", baseFinishTime.Add(-time.Minute)},
-		{"after_restore_point", baseFinishTime.Add(time.Minute)},
+		{restorePoint, baseFinishTime, baseWalTimeLine},
+		{beforeRestorePoint, baseFinishTime.Add(-time.Minute), baseWalTimeLine},
+		{afterRestorePoint, baseFinishTime.Add(time.Minute), baseWalTimeLine},
 	}
 	folder := makeTrimWalFolder(
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
@@ -198,10 +194,10 @@ func TestHandleDeleteTrimWal_DeletesRestorePointsAfterTarget(t *testing.T) {
 	targetFile := path.Join(utility.BaseBackupPath, restorePoint+greenplum.RestorePointSuffix)
 	assert.Contains(t, objectPaths, targetFile, "target restore point must be kept")
 
-	beforeFile := path.Join(utility.BaseBackupPath, "before_restore_point"+greenplum.RestorePointSuffix)
+	beforeFile := path.Join(utility.BaseBackupPath, beforeRestorePoint+greenplum.RestorePointSuffix)
 	assert.Contains(t, objectPaths, beforeFile, "restore point before target must be kept")
 
-	afterFile := path.Join(utility.BaseBackupPath, "after_restore_point"+greenplum.RestorePointSuffix)
+	afterFile := path.Join(utility.BaseBackupPath, afterRestorePoint+greenplum.RestorePointSuffix)
 	assert.NotContains(t, objectPaths, afterFile, "restore point after target must be deleted")
 }
 
@@ -209,10 +205,7 @@ func TestHandleDeleteTrimWal_NoRestorePoint(t *testing.T) {
 	backupName := "backup_20260101T000000Z"
 	restorePoint := ""
 	segments := []greenplum.SegmentMetadata{
-		{
-			ContentID:       0,
-			RestorePointLSN: walCutoffLSN(2),
-		},
+		{ContentID: 0, RestorePointLSN: walCutoffLSN(2)},
 	}
 	walSegNos := []uint64{1, 3}
 	walSegNosByContentID := map[int][]uint64{0: walSegNos}
@@ -223,13 +216,12 @@ func TestHandleDeleteTrimWal_NoRestorePoint(t *testing.T) {
 	delArgs := greenplum.DeleteArgs{Confirmed: true}
 	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
-
 	err = handler.HandleDeleteTrimWal(context.Background(), backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
-	assert.Contains(t, objectPaths, walObjectPath(0, 1), "WAL at or before cutoff must be kept")
-	assert.NotContains(t, objectPaths, walObjectPath(0, 3), "WAL past cutoff must be deleted")
+	assert.Contains(t, objectPaths, walObjectPath(0, 1, baseWalTimeLine), "WAL at or before cutoff must be kept")
+	assert.NotContains(t, objectPaths, walObjectPath(0, 3, baseWalTimeLine), "WAL past cutoff must be deleted")
 }
 
 func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
@@ -243,7 +235,9 @@ func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
 		-1: {1, 2, 3},
 		0:  {1, 2, 3},
 	}
-	storedRestorePoints := []testRestorePoint{{restorePoint, baseFinishTime}}
+	storedRestorePoints := []testRestorePoint{
+		{restorePoint, baseFinishTime, baseWalTimeLine},
+	}
 	folder := makeTrimWalFolder(
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
 	)
@@ -256,14 +250,49 @@ func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
+	assert.Contains(t, objectPaths, walObjectPath(-1, 1, baseWalTimeLine))
+	assert.NotContains(t, objectPaths, walObjectPath(-1, 2, baseWalTimeLine))
+	assert.NotContains(t, objectPaths, walObjectPath(-1, 3, baseWalTimeLine))
 
-	assert.Contains(t, objectPaths, walObjectPath(-1, 1))
-	assert.NotContains(t, objectPaths, walObjectPath(-1, 2))
-	assert.NotContains(t, objectPaths, walObjectPath(-1, 3))
+	assert.Contains(t, objectPaths, walObjectPath(0, 1, baseWalTimeLine))
+	assert.Contains(t, objectPaths, walObjectPath(0, 2, baseWalTimeLine))
+	assert.NotContains(t, objectPaths, walObjectPath(0, 3, baseWalTimeLine))
+}
 
-	assert.Contains(t, objectPaths, walObjectPath(0, 1))
-	assert.Contains(t, objectPaths, walObjectPath(0, 2))
-	assert.NotContains(t, objectPaths, walObjectPath(0, 3))
+func TestHandleDeleteTrimWal_SkipsWalFromOtherTimeline(t *testing.T) {
+	backupName := "backup_20260101T000000Z"
+	restorePoint := "test_restore_point"
+	segments := []greenplum.SegmentMetadata{
+		{ContentID: 0, RestorePointLSN: walCutoffLSN(2)},
+	}
+	walSegNosByContentID := map[int][]uint64{0: {1, 2, 3, 4}}
+	storedRestorePoints := []testRestorePoint{
+		{restorePoint, baseFinishTime, baseWalTimeLine},
+	}
+	folder := makeTrimWalFolder(
+		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
+	)
+
+	const otherTimeline = uint32(2)
+	segNosAfterCutoffOnOtherTimeline := []uint64{3, 4}
+	for _, segNo := range segNosAfterCutoffOnOtherTimeline {
+		err := folder.PutObject(walObjectPath(0, segNo, otherTimeline), &bytes.Buffer{})
+		require.NoError(t, err)
+	}
+
+	delArgs := greenplum.DeleteArgs{Confirmed: true}
+	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
+	require.NoError(t, err)
+
+	err = handler.HandleDeleteTrimWal(context.Background(), backupName)
+	require.NoError(t, err)
+
+	objectPaths := getStorageObjectsPaths(t, folder)
+	assert.NotContains(t, objectPaths, walObjectPath(0, 3, baseWalTimeLine), "WAL on cutoff timeline past cutoff must be deleted")
+	assert.NotContains(t, objectPaths, walObjectPath(0, 4, baseWalTimeLine), "WAL on cutoff timeline past cutoff must be deleted")
+
+	assert.Contains(t, objectPaths, walObjectPath(0, 3, otherTimeline), "WAL on other timeline must be kept")
+	assert.Contains(t, objectPaths, walObjectPath(0, 4, otherTimeline), "WAL on other timeline must be kept")
 }
 
 func TestHandleDeleteTrimWal_BackupNotFound(t *testing.T) {

--- a/internal/databases/greenplum/delete_handler_test.go
+++ b/internal/databases/greenplum/delete_handler_test.go
@@ -106,12 +106,14 @@ func TestHandleDeleteTrimWal_DeletesWalAfterCutoff(t *testing.T) {
 	walSegNosByContentID := map[int][]uint64{0: {1, 2, 3, 4}}
 	storedRestorePoints := []string{restorePoint}
 	folder := makeTrimWalFolder(
-		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints)
+		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
+	)
 
-	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	delArgs := greenplum.DeleteArgs{Confirmed: true}
+	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName, true)
+	err = handler.HandleDeleteTrimWal(backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -138,10 +140,11 @@ func TestHandleDeleteTrimWal_WithoutConfirm_NothingDeleted(t *testing.T) {
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
 	)
 
-	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	delArgs := greenplum.DeleteArgs{Confirmed: false}
+	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName, false)
+	err = handler.HandleDeleteTrimWal(backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -169,10 +172,11 @@ func TestHandleDeleteTrimWal_DeletesRestorePointsExceptTarget(t *testing.T) {
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
 	)
 
-	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	delArgs := greenplum.DeleteArgs{Confirmed: true}
+	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName, true)
+	err = handler.HandleDeleteTrimWal(backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -200,10 +204,11 @@ func TestHandleDeleteTrimWal_NoRestorePoint(t *testing.T) {
 		t, backupName, restorePoint, segments, walSegNosByContentID, nil,
 	)
 
-	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	delArgs := greenplum.DeleteArgs{Confirmed: true}
+	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName, true)
+	err = handler.HandleDeleteTrimWal(backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -227,10 +232,11 @@ func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
 		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
 	)
 
-	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	delArgs := greenplum.DeleteArgs{Confirmed: true}
+	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName, true)
+	err = handler.HandleDeleteTrimWal(backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -247,9 +253,10 @@ func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
 func TestHandleDeleteTrimWal_BackupNotFound(t *testing.T) {
 	folder := makeTrimWalFolder(t, "backup_20260101T000000Z", "", nil, nil, nil)
 
-	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	delArgs := greenplum.DeleteArgs{Confirmed: true}
+	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal("backup_nonexistent", true)
+	err = handler.HandleDeleteTrimWal("backup_nonexistent")
 	assert.Error(t, err)
 }

--- a/internal/databases/greenplum/delete_handler_test.go
+++ b/internal/databases/greenplum/delete_handler_test.go
@@ -3,7 +3,6 @@ package greenplum_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"path"
 	"testing"
 
@@ -11,24 +10,24 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
+	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/testtools"
 	"github.com/wal-g/wal-g/utility"
 )
 
-const (
-	timeline         = uint32(1)
-	segmentsPerGroup = uint64(0x100)
-)
+const walTimeline = uint32(1)
 
 func walSegFilename(segNo uint64) string {
-	hi := segNo / segmentsPerGroup
-	lo := segNo % segmentsPerGroup
-	return fmt.Sprintf("%08X%08X%08X", timeline, hi, lo)
+	return postgres.WalSegmentNo(segNo).GetFilename(walTimeline)
 }
 
 func walObjectPath(contentID int, segNo uint64) string {
-	return path.Join(greenplum.FormatSegmentStoragePrefix(contentID), utility.WalPath, walSegFilename(segNo))
+	return path.Join(greenplum.FormatSegmentWalPath(contentID), walSegFilename(segNo))
+}
+
+func walCutoffLSN(cutoffSegNo uint64) string {
+	return postgres.LSN(cutoffSegNo * postgres.WalSegmentSize).String()
 }
 
 func makeTrimWalFolder(
@@ -100,7 +99,7 @@ func TestHandleDeleteTrimWal_DeletesWalAfterCutoff(t *testing.T) {
 	segments := []greenplum.SegmentMetadata{
 		{
 			ContentID:       0,
-			RestorePointLSN: "0/02000000",
+			RestorePointLSN: walCutoffLSN(2),
 		},
 	}
 	walSegNosByContentID := map[int][]uint64{0: {1, 2, 3, 4}}
@@ -129,7 +128,7 @@ func TestHandleDeleteTrimWal_WithoutConfirm_NothingDeleted(t *testing.T) {
 	segments := []greenplum.SegmentMetadata{
 		{
 			ContentID:       0,
-			RestorePointLSN: "0/02000000",
+			RestorePointLSN: walCutoffLSN(2),
 		},
 	}
 	walSegNos := []uint64{1, 2, 3, 4}
@@ -162,7 +161,7 @@ func TestHandleDeleteTrimWal_DeletesRestorePointsExceptTarget(t *testing.T) {
 	segments := []greenplum.SegmentMetadata{
 		{
 			ContentID:       0,
-			RestorePointLSN: "0/02000000",
+			RestorePointLSN: walCutoffLSN(2),
 		},
 	}
 	walSegNos := []uint64{1}
@@ -195,7 +194,7 @@ func TestHandleDeleteTrimWal_NoRestorePoint(t *testing.T) {
 	segments := []greenplum.SegmentMetadata{
 		{
 			ContentID:       0,
-			RestorePointLSN: "0/02000000",
+			RestorePointLSN: walCutoffLSN(2),
 		},
 	}
 	walSegNos := []uint64{1, 3}
@@ -220,8 +219,8 @@ func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
 	backupName := "backup_20260101T000000Z"
 	restorePoint := "test_restore_point"
 	segments := []greenplum.SegmentMetadata{
-		{ContentID: -1, RestorePointLSN: "0/01000000"},
-		{ContentID: 0, RestorePointLSN: "0/02000000"},
+		{ContentID: -1, RestorePointLSN: walCutoffLSN(1)},
+		{ContentID: 0, RestorePointLSN: walCutoffLSN(2)},
 	}
 	walSegNosByContentID := map[int][]uint64{
 		-1: {1, 2, 3},

--- a/internal/databases/greenplum/delete_handler_test.go
+++ b/internal/databases/greenplum/delete_handler_test.go
@@ -2,6 +2,7 @@ package greenplum_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"path"
 	"testing"
@@ -112,7 +113,7 @@ func TestHandleDeleteTrimWal_DeletesWalAfterCutoff(t *testing.T) {
 	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName)
+	err = handler.HandleDeleteTrimWal(context.Background(), backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -143,7 +144,7 @@ func TestHandleDeleteTrimWal_WithoutConfirm_NothingDeleted(t *testing.T) {
 	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName)
+	err = handler.HandleDeleteTrimWal(context.Background(), backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -175,7 +176,7 @@ func TestHandleDeleteTrimWal_DeletesRestorePointsExceptTarget(t *testing.T) {
 	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName)
+	err = handler.HandleDeleteTrimWal(context.Background(), backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -207,7 +208,7 @@ func TestHandleDeleteTrimWal_NoRestorePoint(t *testing.T) {
 	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName)
+	err = handler.HandleDeleteTrimWal(context.Background(), backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -235,7 +236,7 @@ func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
 	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal(backupName)
+	err = handler.HandleDeleteTrimWal(context.Background(), backupName)
 	require.NoError(t, err)
 
 	objectPaths := getStorageObjectsPaths(t, folder)
@@ -256,6 +257,6 @@ func TestHandleDeleteTrimWal_BackupNotFound(t *testing.T) {
 	handler, err := greenplum.NewDeleteHandler(folder, delArgs)
 	require.NoError(t, err)
 
-	err = handler.HandleDeleteTrimWal("backup_nonexistent")
+	err = handler.HandleDeleteTrimWal(context.Background(), "backup_nonexistent")
 	assert.Error(t, err)
 }

--- a/internal/databases/greenplum/delete_handler_test.go
+++ b/internal/databases/greenplum/delete_handler_test.go
@@ -1,0 +1,255 @@
+package greenplum_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/testtools"
+	"github.com/wal-g/wal-g/utility"
+)
+
+const (
+	timeline         = uint32(1)
+	segmentsPerGroup = uint64(0x100)
+)
+
+func walSegFilename(segNo uint64) string {
+	hi := segNo / segmentsPerGroup
+	lo := segNo % segmentsPerGroup
+	return fmt.Sprintf("%08X%08X%08X", timeline, hi, lo)
+}
+
+func walObjectPath(contentID int, segNo uint64) string {
+	return path.Join(greenplum.FormatSegmentStoragePrefix(contentID), utility.WalPath, walSegFilename(segNo))
+}
+
+func makeTrimWalFolder(
+	t *testing.T,
+	backupName string,
+	backupRestorePoint string,
+	segments []greenplum.SegmentMetadata,
+	walSegNosByContentID map[int][]uint64,
+	storedRestorePoints []string,
+) storage.Folder {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	baseBackupFolder := folder.GetSubFolder(utility.BaseBackupPath)
+
+	sentinelData := map[string]interface{}{
+		"segments":    segments,
+		"start_time":  "2026-01-01T00:00:00Z",
+		"finish_time": "2026-01-01T00:01:00Z",
+		"hostname":    "testhost",
+		"gp_version":  "6.0.0",
+		"gp_flavor":   "greenplum",
+	}
+	if backupRestorePoint != "" {
+		sentinelData["restore_point"] = backupRestorePoint
+	}
+	sentinelBytes, err := json.Marshal(sentinelData)
+	require.NoError(t, err)
+
+	sentinelFile := backupName + utility.SentinelSuffix
+	err = baseBackupFolder.PutObject(sentinelFile, bytes.NewReader(sentinelBytes))
+	require.NoError(t, err)
+
+	for contentID, segNos := range walSegNosByContentID {
+		segFolder := folder.GetSubFolder(greenplum.FormatSegmentStoragePrefix(contentID))
+		for _, segNo := range segNos {
+			walFilePath := path.Join(utility.WalPath, walSegFilename(segNo))
+			err = segFolder.PutObject(walFilePath, &bytes.Buffer{})
+			require.NoError(t, err)
+		}
+	}
+
+	for _, restorePointName := range storedRestorePoints {
+		restorePointData := map[string]interface{}{
+			"name":        restorePointName,
+			"start_time":  "2026-01-01T00:00:00Z",
+			"finish_time": "2026-01-01T00:00:01Z",
+		}
+		restorePointBytes, err := json.Marshal(restorePointData)
+		require.NoError(t, err)
+		err = baseBackupFolder.PutObject(restorePointName+greenplum.RestorePointSuffix, bytes.NewReader(restorePointBytes))
+		require.NoError(t, err)
+	}
+
+	return folder
+}
+
+func getStorageObjectsPaths(t *testing.T, folder storage.Folder) []string {
+	objects, err := storage.ListFolderRecursively(folder)
+	require.NoError(t, err)
+	names := make([]string, len(objects))
+	for i, o := range objects {
+		names[i] = o.GetName()
+	}
+	return names
+}
+
+func TestHandleDeleteTrimWal_DeletesWalAfterCutoff(t *testing.T) {
+	backupName := "backup_20260101T000000Z"
+	restorePoint := "test_restore_point"
+	segments := []greenplum.SegmentMetadata{
+		{
+			ContentID:       0,
+			RestorePointLSN: "0/02000000",
+		},
+	}
+	walSegNosByContentID := map[int][]uint64{0: {1, 2, 3, 4}}
+	storedRestorePoints := []string{restorePoint}
+	folder := makeTrimWalFolder(
+		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints)
+
+	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	require.NoError(t, err)
+
+	err = handler.HandleDeleteTrimWal(backupName, true)
+	require.NoError(t, err)
+
+	objectPaths := getStorageObjectsPaths(t, folder)
+	assert.Contains(t, objectPaths, walObjectPath(0, 1), "WAL at cutoff-1 must be retained")
+	assert.Contains(t, objectPaths, walObjectPath(0, 2), "WAL at cutoff must be retained")
+	assert.NotContains(t, objectPaths, walObjectPath(0, 3), "WAL past cutoff must be deleted")
+	assert.NotContains(t, objectPaths, walObjectPath(0, 4), "WAL past cutoff must be deleted")
+}
+
+func TestHandleDeleteTrimWal_WithoutConfirm_NothingDeleted(t *testing.T) {
+	backupName := "backup_20260101T000000Z"
+	restorePoint := "test_restore_point"
+	segments := []greenplum.SegmentMetadata{
+		{
+			ContentID:       0,
+			RestorePointLSN: "0/02000000",
+		},
+	}
+	walSegNos := []uint64{1, 2, 3, 4}
+	walSegNosByContentID := map[int][]uint64{0: walSegNos}
+	storedRestorePoints := []string{restorePoint, "old_restore_point"}
+
+	folder := makeTrimWalFolder(
+		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
+	)
+
+	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	require.NoError(t, err)
+
+	err = handler.HandleDeleteTrimWal(backupName, false)
+	require.NoError(t, err)
+
+	objectPaths := getStorageObjectsPaths(t, folder)
+	for _, segNo := range walSegNos {
+		assert.Contains(t, objectPaths, walObjectPath(0, segNo), "dry run must not delete WAL segNo %d", segNo)
+	}
+	// Old restore point must still be present
+	oldRestorePointFilePath := path.Join(utility.BaseBackupPath, "old_restore_point"+greenplum.RestorePointSuffix)
+	assert.Contains(t, objectPaths, oldRestorePointFilePath, "dry run must not delete restore point files")
+}
+
+func TestHandleDeleteTrimWal_DeletesRestorePointsExceptTarget(t *testing.T) {
+	backupName := "backup_20260101T000000Z"
+	restorePoint := "test_restore_point"
+	segments := []greenplum.SegmentMetadata{
+		{
+			ContentID:       0,
+			RestorePointLSN: "0/02000000",
+		},
+	}
+	walSegNos := []uint64{1}
+	walSegNosByContentID := map[int][]uint64{0: walSegNos}
+	storedRestorePoints := []string{restorePoint, "old_restore_point_1", "old_restore_point_2"}
+	folder := makeTrimWalFolder(
+		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
+	)
+
+	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	require.NoError(t, err)
+
+	err = handler.HandleDeleteTrimWal(backupName, true)
+	require.NoError(t, err)
+
+	objectPaths := getStorageObjectsPaths(t, folder)
+	restorePointFile := path.Join(utility.BaseBackupPath, restorePoint+greenplum.RestorePointSuffix)
+	assert.Contains(t, objectPaths, restorePointFile, "target restore point must be kept")
+
+	restorePointFile1 := path.Join(utility.BaseBackupPath, "old_restore_point_1"+greenplum.RestorePointSuffix)
+	restorePointFile2 := path.Join(utility.BaseBackupPath, "old_restore_point_2"+greenplum.RestorePointSuffix)
+	assert.NotContains(t, objectPaths, restorePointFile1, "old restore point 1 must be deleted")
+	assert.NotContains(t, objectPaths, restorePointFile2, "old restore point 2 must be deleted")
+}
+
+func TestHandleDeleteTrimWal_NoRestorePoint(t *testing.T) {
+	backupName := "backup_20260101T000000Z"
+	restorePoint := ""
+	segments := []greenplum.SegmentMetadata{
+		{
+			ContentID:       0,
+			RestorePointLSN: "0/02000000",
+		},
+	}
+	walSegNos := []uint64{1, 3}
+	walSegNosByContentID := map[int][]uint64{0: walSegNos}
+	folder := makeTrimWalFolder(
+		t, backupName, restorePoint, segments, walSegNosByContentID, nil,
+	)
+
+	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	require.NoError(t, err)
+
+	err = handler.HandleDeleteTrimWal(backupName, true)
+	require.NoError(t, err)
+
+	objectPaths := getStorageObjectsPaths(t, folder)
+	assert.Contains(t, objectPaths, walObjectPath(0, 1), "WAL at or before cutoff must be kept")
+	assert.NotContains(t, objectPaths, walObjectPath(0, 3), "WAL past cutoff must be deleted")
+}
+
+func TestHandleDeleteTrimWal_MultipleSegments(t *testing.T) {
+	backupName := "backup_20260101T000000Z"
+	restorePoint := "test_restore_point"
+	segments := []greenplum.SegmentMetadata{
+		{ContentID: -1, RestorePointLSN: "0/01000000"},
+		{ContentID: 0, RestorePointLSN: "0/02000000"},
+	}
+	walSegNosByContentID := map[int][]uint64{
+		-1: {1, 2, 3},
+		0:  {1, 2, 3},
+	}
+	storedRestorePoints := []string{restorePoint}
+	folder := makeTrimWalFolder(
+		t, backupName, restorePoint, segments, walSegNosByContentID, storedRestorePoints,
+	)
+
+	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	require.NoError(t, err)
+
+	err = handler.HandleDeleteTrimWal(backupName, true)
+	require.NoError(t, err)
+
+	objectPaths := getStorageObjectsPaths(t, folder)
+
+	assert.Contains(t, objectPaths, walObjectPath(-1, 1))
+	assert.NotContains(t, objectPaths, walObjectPath(-1, 2))
+	assert.NotContains(t, objectPaths, walObjectPath(-1, 3))
+
+	assert.Contains(t, objectPaths, walObjectPath(0, 1))
+	assert.Contains(t, objectPaths, walObjectPath(0, 2))
+	assert.NotContains(t, objectPaths, walObjectPath(0, 3))
+}
+
+func TestHandleDeleteTrimWal_BackupNotFound(t *testing.T) {
+	folder := makeTrimWalFolder(t, "backup_20260101T000000Z", "", nil, nil, nil)
+
+	handler, err := greenplum.NewDeleteHandler(folder, greenplum.DeleteArgs{})
+	require.NoError(t, err)
+
+	err = handler.HandleDeleteTrimWal("backup_nonexistent", true)
+	assert.Error(t, err)
+}

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -504,6 +504,16 @@ func DeleteObjectsWhere(
 	return nil
 }
 
+func (h *DeleteHandler) DeleteObjectsWhereWithPermanentCheck(
+	confirm bool,
+	objFilter func(object storage.Object) bool,
+	folderFilter func(name string) bool,
+) error {
+	return DeleteObjectsWhere(h.Folder, confirm, func(object storage.Object) bool {
+		return objFilter(object) && !h.isPermanent(object)
+	}, folderFilter)
+}
+
 func findTarget(objects []BackupObject,
 	compare func(object1, object2 storage.Object) bool,
 	isTarget func(object BackupObject) bool) (BackupObject, error) {


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

greenplum

# Pull request description
Implements delete trim-wal command for Greenplum (issue #2261).  Closes #2261
Over time, WAL files accumulate after a backup's restore point and consume significant storage space. There was no way to remove them without deleting the backup itself.

This PR adds the `delete trim-wal BACKUP_NAME|LATEST` command that:

Deletes WAL files past the RestorePointLSN cutoff for every Greenplum segment independently
Removes all `*_restore_point.json` metadata files except the one tied to the specified backup
Supports `--confirm` flag (dry-run by default)
Supports `LATEST` as a backup name
