### PR TITLE
Include backup name in postgres backup-push progress logs

### DIFF
--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -243,7 +243,7 @@ func (bh *BackupHandler) startBackup(ctx context.Context) error {
 	}
 	bh.CurBackupInfo.startLSN = backupStartLSN
 	bh.CurBackupInfo.Name = backupName
-	tracelog.DebugLogger.Printf("Backup name: %s\nBackup start LSN: %s", backupName, backupStartLSN)
+	tracelog.InfoLogger.Printf("Started backup with name %s at LSN %s", backupName, backupStartLSN)
 	bh.initBackupTerminator()
 	return nil
 }

--- a/internal/storage_tar_ball.go
+++ b/internal/storage_tar_ball.go
@@ -61,7 +61,7 @@ func (tarBall *StorageTarBall) CloseTar() error {
 	if err != nil {
 		return errors.Wrap(err, "CloseTar: failed to close underlying writer")
 	}
-	tracelog.InfoLogger.Printf("Finished writing part %d.\n", tarBall.partNumber)
+	tracelog.InfoLogger.Printf("Finished writing part %d of backup %s.\n", tarBall.partNumber, tarBall.backupName)
 	return nil
 }
 
@@ -85,7 +85,7 @@ func (tarBall *StorageTarBall) startUpload(name string, crypter crypto.Crypter) 
 
 	path := GetBackupTarPath(tarBall.backupName, name)
 
-	tracelog.InfoLogger.Printf("Starting part %d ...\n", tarBall.partNumber)
+	tracelog.InfoLogger.Printf("Starting part %d of backup %s ...\n", tarBall.partNumber, tarBall.backupName)
 
 	go func() {
 		err := uploader.Upload(context.Background(), path, pipeReader)


### PR DESCRIPTION
### Database name
PostgreSQL.

# Pull request description

### Describe what this PR fixes

Per-part progress log lines emitted during `backup-push` do not include the in-progress backup name. Today they look like:

```
INFO: 2025/01/01 00:00:01.000000 Starting part 1 ...
INFO: 2025/01/01 00:00:02.000000 Finished writing part 1.
```

The backup name (`base_<TLI><LSN>`) is already on `StorageTarBall.backupName` at both log sites — set by `StorageTarBallMaker` from `bh.CurBackupInfo.Name` (`internal/databases/postgres/backup_push_handler.go:331`). It just isn't being printed.

This PR:

1. Includes the backup name in `Starting part N ...` and `Finished writing part N.` (`internal/storage_tar_ball.go`).
2. Promotes the existing DEBUG announcement of the backup name + start LSN to INFO so it appears once shortly after `pg_start_backup()` returns (`internal/databases/postgres/backup_push_handler.go`).

After this change a backup-push session looks like:

```
INFO: 2025/01/01 00:00:00.000000 Calling pg_start_backup()
INFO: 2025/01/01 00:00:00.500000 Started backup with name base_000000010000000A0000001E at LSN A/1E000000
INFO: 2025/01/01 00:00:01.000000 Starting part 1 of backup base_000000010000000A0000001E ...
INFO: 2025/01/01 00:00:02.000000 Finished writing part 1 of backup base_000000010000000A0000001E.
...
INFO: 2025/01/01 00:30:00.000000 Wrote backup with name base_000000010000000A0000001E
```

Motivation and precedent are in #2317. Same shape of change as #289.

### Please provide steps to reproduce (if it's a bug)

N/A — feature.

### Please add config and wal-g stdout/stderr logs for debug purpose

Before:

```
INFO: 2025/01/01 00:00:00.000000 Calling pg_start_backup()
INFO: 2025/01/01 00:00:01.000000 Starting part 1 ...
INFO: 2025/01/01 00:00:02.000000 Finished writing part 1.
INFO: 2025/01/01 00:30:00.000000 Wrote backup with name base_000000010000000A0000001E
```

After:

```
INFO: 2025/01/01 00:00:00.000000 Calling pg_start_backup()
INFO: 2025/01/01 00:00:00.500000 Started backup with name base_000000010000000A0000001E at LSN A/1E000000
INFO: 2025/01/01 00:00:01.000000 Starting part 1 of backup base_000000010000000A0000001E ...
INFO: 2025/01/01 00:00:02.000000 Finished writing part 1 of backup base_000000010000000A0000001E.
INFO: 2025/01/01 00:30:00.000000 Wrote backup with name base_000000010000000A0000001E
```
