### PR TITLE
Add "Greengage Database" to the list of valid version patterns

### DIFF
--- a/internal/databases/greenplum/version.go
+++ b/internal/databases/greenplum/version.go
@@ -33,7 +33,7 @@ func NewVersion(v *version.Version, flavor Flavor) Version {
 }
 
 func parseGreenplumVersion(versionStr string) (Version, error) {
-	pattern := regexp.MustCompile(`(Greenplum Database|Cloudberry Database|Apache Cloudberry) (\d+\.\d+\.\d+)`)
+	pattern := regexp.MustCompile(`(Greenplum Database|Greengage Database|Cloudberry Database|Apache Cloudberry) (\d+\.\d+\.\d+)`)
 	groups := pattern.FindStringSubmatch(versionStr)
 	if groups == nil {
 		return Version{}, fmt.Errorf("unknown flavor: %s", versionStr)
@@ -46,6 +46,8 @@ func parseGreenplumVersion(versionStr string) (Version, error) {
 	var flavor Flavor
 	switch groups[1] {
 	case "Greenplum Database":
+		flavor = Greenplum
+	case "Greengage Database":
 		flavor = Greenplum
 	case "Cloudberry Database":
 		flavor = Cloudberry


### PR DESCRIPTION
This commit eliminates ERROR message when trying to use wal-g with Greengage Database (https://github.com/GreengageDB/greengage). Other than that, the tool itself works fine, since Greengage is compatible with original Greenplum Database. 