### PR TITLE
ci: remove go caching from windows native build

### DIFF
--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
         id: go
 
       - name: Build dependencies


### PR DESCRIPTION
cache entry is 950MB, taking up much of our 10GB cache for little gain