### PR TITLE
Daemon crash fix

### DIFF
--- a/internal/daemon/common.go
+++ b/internal/daemon/common.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	ErrCorruptedMessageBody = fmt.Errorf("corrapted message body")
+	ErrCorruptedMessageBody = fmt.Errorf("corrupted message body")
 )
 
 func (msg SocketMessageType) ToBytes() []byte {

--- a/internal/daemon/common.go
+++ b/internal/daemon/common.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	ErrCorruptedCorruptedMessageBody = fmt.Errorf("currepted message body")
+	ErrCorruptedMessageBody = fmt.Errorf("corrapted message body")
 )
 
 func (msg SocketMessageType) ToBytes() []byte {
@@ -50,23 +50,26 @@ func ArgsToBytes(args ...string) ([]byte, error) {
 }
 
 func BytesToArgs(body []byte) ([]string, error) {
+	if len(body) == 0 {
+		return nil, ErrCorruptedMessageBody
+	}
 	argsCount := int(body[0])
 	res := make([]string, 0, argsCount)
 	idx := 1
 	for i := 0; i < argsCount; i++ {
-		if idx+2 >= len(body) {
-			return nil, ErrCorruptedCorruptedMessageBody
+		if idx+2 > len(body) {
+			return nil, ErrCorruptedMessageBody
 		}
 		l := int(binary.BigEndian.Uint16(body[idx : idx+2]))
 		idx += 2
 		if idx+l > len(body) {
-			return nil, ErrCorruptedCorruptedMessageBody
+			return nil, ErrCorruptedMessageBody
 		}
 		res = append(res, string(body[idx:idx+l]))
 		idx += l
 	}
 	if len(body) != idx {
-		return nil, ErrCorruptedCorruptedMessageBody
+		return nil, ErrCorruptedMessageBody
 	}
 	return res, nil
 }

--- a/internal/databases/postgres/daemon_handler.go
+++ b/internal/databases/postgres/daemon_handler.go
@@ -225,11 +225,11 @@ func HandleDaemon(options DaemonOptions) {
 	SetupSignalListener()
 
 	multiSt, err := internal.ConfigureMultiStorage(true)
-	defer utility.LoggedClose(multiSt, "close multi-storage")
 	if err != nil {
 		tracelog.ErrorLogger.Fatal("configure multi-storage: %w", err)
 		return
 	}
+	defer utility.LoggedClose(multiSt, "close multi-storage")
 
 	for {
 		fd, err := l.Accept()

--- a/internal/databases/postgres/daemon_handler.go
+++ b/internal/databases/postgres/daemon_handler.go
@@ -194,6 +194,9 @@ func (r SocketMessageReader) Next() (messageType daemon.SocketMessageType, messa
 	if err != nil {
 		return daemon.ErrorType, nil, fmt.Errorf("fail to read message len: %w", err)
 	}
+	if messageLength < 3 {
+		return daemon.ErrorType, nil, fmt.Errorf("message too short: %d", messageLength)
+	}
 	messageBody = make([]byte, messageLength-3)
 	_, err = io.ReadFull(r.c, messageBody)
 	if err != nil {


### PR DESCRIPTION
### Database name
Postgres

# Pull request description
While running wal-g daemon, i rarely receive an error
```bash
...
runtime: g 1: unexpected return pc for runtime.memclrNoHeapPointersChunked called from 0xc000a87a88
...
```
As far as i understood, the problem must be in daemon_handler, and might be connected to unsafe code.
In this pr I want to refactor all possible reasons

List of changes:
- Daemon message length check
- Calling defer after nil check
- Addressing after length check
- Fix possible skip of empty arg

Some of this situations seem to be impossible, but better safe than sorry