### PR TITLE
docker(ubuntu): clean debconf cache in base images

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -10,4 +10,4 @@ RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https:
     apt-get install --yes --no-install-recommends --no-install-suggests \
     git ca-certificates \
     liblzo2-2 && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* /var/cache/debconf/*

--- a/docker/ubuntu/Dockerfile_22_04
+++ b/docker/ubuntu/Dockerfile_22_04
@@ -12,4 +12,4 @@ RUN apt-get update && \
         wget curl \
         git \
         ca-certificates && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* /var/cache/debconf/*


### PR DESCRIPTION
reduce base images by 1Mb