### PR TITLE
Replace go-sql-driver with go-mysql-org

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/cucumber/godog v0.15.1
 	github.com/cyberdelia/lzo v1.0.0
 	github.com/go-mysql-org/go-mysql v1.14.1-0.20260227075927-498f8104b8ff
-	github.com/go-sql-driver/mysql v1.10.0
 	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -245,9 +245,6 @@ github.com/go-openapi/errors v0.19.3 h1:7MGZI1ibQDLasvAz8HuhvYk9eNJbJkCOXWsSjjMS
 github.com/go-openapi/errors v0.19.3/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
 github.com/go-openapi/strfmt v0.19.4 h1:eRvaqAhpL0IL6Trh5fDsGnGhiXndzHFuA05w6sXH6/g=
 github.com/go-openapi/strfmt v0.19.4/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
-github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
-github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
-github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=

--- a/internal/databases/mysql/backup_push_handler.go
+++ b/internal/databases/mysql/backup_push_handler.go
@@ -32,20 +32,20 @@ func HandleBackupPush(
 		tracelog.WarningLogger.Printf("Failed to obtain the OS hostname")
 	}
 
-	db, err := getMySQLConnection()
+	conn, err := getMySQLConnection(ctx)
 	tracelog.ErrorLogger.FatalOnError(err)
-	defer utility.LoggedClose(db, "")
+	defer utility.LoggedClose(conn, "")
 
-	version, err := getMySQLVersion(db)
-	tracelog.ErrorLogger.FatalOnError(err)
-
-	flavor, err := getMySQLFlavor(db)
+	version, err := getMySQLVersion(conn)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	serverUUID, err := getServerUUID(db, flavor)
+	flavor, err := getMySQLFlavor(conn)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	gtidStart, err := getMySQLGTIDExecuted(db, flavor)
+	serverUUID, err := getServerUUID(conn, flavor)
+	tracelog.ErrorLogger.FatalOnError(err)
+
+	gtidStart, err := getMySQLGTIDExecuted(conn, flavor)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	binlogStart, err := getLastUploadedBinlogBeforeGTID(ctx, folder, gtidStart, flavor)

--- a/internal/databases/mysql/binlog_find_handler.go
+++ b/internal/databases/mysql/binlog_find_handler.go
@@ -10,14 +10,14 @@ import (
 )
 
 func HandleBinlogFind(ctx context.Context, folder storage.Folder, gtid string) {
-	db, err := getMySQLConnection()
+	conn, err := getMySQLConnection(ctx)
 	tracelog.ErrorLogger.FatalOnError(err)
-	defer utility.LoggedClose(db, "")
-	flavor, err := getMySQLFlavor(db)
+	defer utility.LoggedClose(conn, "")
+	flavor, err := getMySQLFlavor(conn)
 	tracelog.ErrorLogger.FatalOnError(err)
 	var gtidSet gomysql.GTIDSet
 	if gtid == "" {
-		gtidSet, err = getMySQLGTIDExecuted(db, flavor)
+		gtidSet, err = getMySQLGTIDExecuted(conn, flavor)
 		tracelog.ErrorLogger.FatalOnError(err)
 	} else {
 		gtidSet, err = gomysql.ParseGTIDSet(flavor, gtid)

--- a/internal/databases/mysql/binlog_push_handler.go
+++ b/internal/databases/mysql/binlog_push_handler.go
@@ -3,7 +3,6 @@ package mysql
 import (
 	"bufio"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
@@ -30,14 +30,14 @@ func HandleBinlogPush(ctx context.Context, uploader internal.Uploader, untilBinl
 	rootFolder := uploader.Folder()
 	uploader.ChangeDirectory(BinlogPath)
 
-	db, err := getMySQLConnection()
+	conn, err := getMySQLConnection(ctx)
 	tracelog.ErrorLogger.FatalOnError(err)
-	defer utility.LoggedClose(db, "")
+	defer utility.LoggedClose(conn, "")
 
-	binlogsFolder, err := getMySQLBinlogsFolder(db)
+	binlogsFolder, err := getMySQLBinlogsFolder(conn)
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	binlogs, err := getMySQLBinlogs(db)
+	binlogs, err := getMySQLBinlogs(conn)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	lastBinlog := lastOrDefault(binlogs, "")
@@ -62,7 +62,7 @@ func HandleBinlogPush(ctx context.Context, uploader internal.Uploader, untilBinl
 
 	var filter gtidFilter
 	if checkGTIDs {
-		flavor, err := getMySQLFlavor(db)
+		flavor, err := getMySQLFlavor(conn)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		switch flavor {
@@ -138,13 +138,16 @@ func HandleBinlogPush(ctx context.Context, uploader internal.Uploader, untilBinl
 	putCache(cache)
 }
 
-func getMySQLBinlogs(db *sql.DB) ([]string, error) {
+func getMySQLBinlogs(conn *client.Conn) ([]string, error) {
 	var result []string
 	// SHOW BINARY LOGS acquire binlog mutex and may hang while mysql is committing huge transactions
 	// so we read binlog index from the disk with no locking
-	row := db.QueryRow("SELECT @@log_bin_index")
-	var binlogIndex string
-	err := row.Scan(&binlogIndex)
+	r, err := conn.Execute("SELECT @@log_bin_index")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query mysql variable: %w", err)
+	}
+	defer r.Close()
+	binlogIndex, err := r.GetString(0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query mysql variable: %w", err)
 	}
@@ -161,10 +164,13 @@ func getMySQLBinlogs(db *sql.DB) ([]string, error) {
 	return result, nil
 }
 
-func getMySQLBinlogsFolder(db *sql.DB) (string, error) {
-	row := db.QueryRow("SHOW VARIABLES LIKE 'log_bin_basename'")
-	var nonce, logBinBasename string
-	err := row.Scan(&nonce, &logBinBasename)
+func getMySQLBinlogsFolder(conn *client.Conn) (string, error) {
+	r, err := conn.Execute("SHOW VARIABLES LIKE 'log_bin_basename'")
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	logBinBasename, err := r.GetString(0, 1)
 	if err != nil {
 		return "", err
 	}

--- a/internal/databases/mysql/binlog_server_handler.go
+++ b/internal/databases/mysql/binlog_server_handler.go
@@ -2,7 +2,6 @@ package mysql
 
 import (
 	"context"
-	"database/sql"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -13,10 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/go-mysql-org/go-mysql/server"
-	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
@@ -128,11 +127,17 @@ func (h *Handler) waitReplicationIsDoneSafe() {
 
 	tracelog.InfoLogger.Printf("All S3 binlogs processed. Waiting for replica to catch up to GTID: %s", h.sentGTIDs.String())
 
-	db, err := sql.Open("mysql", h.replicaSource)
+	dsn, err := parseMySQLDatasource(h.replicaSource)
 	if err != nil {
-		tracelog.ErrorLogger.Fatalf("Failed to connect to replica SQL port: %v", err)
+		tracelog.ErrorLogger.Fatalf("Failed to parse replica datasource: %v", err)
 	}
-	defer db.Close()
+	var conn *client.Conn
+	connCount := 0
+	defer func() {
+		if conn != nil {
+			conn.Close()
+		}
+	}()
 
 	for {
 		if h.ctx.Err() != nil {
@@ -140,16 +145,31 @@ func (h *Handler) waitReplicationIsDoneSafe() {
 			return
 		}
 
-		var executedStr string
-		err := db.QueryRowContext(h.ctx, "SELECT @@global.gtid_executed").Scan(&executedStr)
-		if err == nil {
-			replicaSet, _ := mysql.ParseGTIDSet("mysql", executedStr)
-			if replicaSet != nil && replicaSet.Contain(h.sentGTIDs) {
-				tracelog.InfoLogger.Println("Replica has successfully caught up! We are safely done.")
-				os.Exit(0)
+		if conn == nil {
+			if conn, err = connectMySQL(h.ctx, dsn, ""); err != nil {
+				connCount++
+				tracelog.WarningLogger.Printf("Failed to connect to replica SQL (times: %d) port: %v", connCount, err)
+				time.Sleep(1 * time.Second)
+				continue
 			}
-		} else {
+			connCount = 0
+		}
+
+		r, err := conn.Execute("SELECT @@global.gtid_executed")
+		if err != nil {
 			tracelog.WarningLogger.Printf("Failed to query replica GTID state: %v", err)
+			conn.Close()
+			conn = nil
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		executedStr, _ := r.GetString(0, 0)
+		r.Close()
+
+		replicaSet, _ := mysql.ParseGTIDSet("mysql", executedStr)
+		if replicaSet != nil && replicaSet.Contain(h.sentGTIDs) {
+			tracelog.InfoLogger.Println("Replica has successfully caught up! We are safely done.")
+			os.Exit(0)
 		}
 
 		time.Sleep(1 * time.Second)
@@ -353,7 +373,7 @@ func HandleBinlogServer(ctx context.Context, since string, until string) {
 	// validate WALG_MYSQL_BINLOG_SERVER_REPLICA_SOURCE
 	replicaSource, err := conf.GetRequiredSetting(conf.MysqlBinlogServerReplicaSource)
 	tracelog.ErrorLogger.FatalOnError(err)
-	_, err = mysqldriver.ParseDSN(replicaSource)
+	_, err = parseMySQLDatasource(replicaSource)
 	tracelog.ErrorLogger.FatalOnError(err)
 
 	dstDir, err := internal.GetLogsDstSettings(conf.MysqlBinlogDstSetting)

--- a/internal/databases/mysql/binlog_server_handler.go
+++ b/internal/databases/mysql/binlog_server_handler.go
@@ -148,7 +148,13 @@ func (h *Handler) waitReplicationIsDoneSafe() {
 		if conn == nil {
 			if conn, err = connectMySQL(h.ctx, dsn, ""); err != nil {
 				connCount++
-				tracelog.WarningLogger.Printf("Failed to connect to replica SQL (times: %d) port: %v", connCount, err)
+				if connCount >= 10 {
+					tracelog.ErrorLogger.Fatalf("Failed to connect to replica SQL 10 times, giving up: %v", err)
+				} else if connCount > 1 {
+					tracelog.WarningLogger.Printf("Failed to connect to replica SQL (times: %d): %v", connCount, err)
+				} else {
+					tracelog.WarningLogger.Printf("Failed to connect to replica SQL: %v", err)
+				}
 				time.Sleep(1 * time.Second)
 				continue
 			}

--- a/internal/databases/mysql/mysql.go
+++ b/internal/databases/mysql/mysql.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/go-mysql-org/go-mysql/client"
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
-	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/compression"
@@ -34,35 +36,34 @@ const (
 	WalgXtrabackupTool              BackupTool = "WALG_XTRABACKUP_TOOL"
 )
 
-func fetchMySQLVariable(db *sql.DB, variable string) (string, error) {
-	row := db.QueryRow("SELECT @@" + variable)
-	var value string
-	err := row.Scan(&value)
+func fetchMySQLVariable(conn *client.Conn, variable string) (string, error) {
+	r, err := conn.Execute("SELECT @@" + variable)
 	if err != nil {
 		return "", err
 	}
-	return value, nil
+	defer r.Close()
+	return r.GetString(0, 0)
 }
 
-func getMySQLVersion(db *sql.DB) (string, error) {
+func getMySQLVersion(conn *client.Conn) (string, error) {
 	// e.g. '8.0.35-27'
-	return fetchMySQLVariable(db, "version")
+	return fetchMySQLVariable(conn, "version")
 }
 
 //nolint:unused
-func getMySQLArchitecture(db *sql.DB) (string, error) {
+func getMySQLArchitecture(conn *client.Conn) (string, error) {
 	// e.g 'x86_64' / 'aarch64' / 'arm64'
-	return fetchMySQLVariable(db, "version_compile_machine")
+	return fetchMySQLVariable(conn, "version_compile_machine")
 }
 
 //nolint:unused
-func getMySQLOS(db *sql.DB) (string, error) {
+func getMySQLOS(conn *client.Conn) (string, error) {
 	// e.g. 'Linux' / 'macos14.2'
-	return fetchMySQLVariable(db, "version_compile_os")
+	return fetchMySQLVariable(conn, "version_compile_os")
 }
 
-func getMySQLFlavor(db *sql.DB) (string, error) {
-	version, err := getMySQLVersion(db)
+func getMySQLFlavor(conn *client.Conn) (string, error) {
+	version, err := getMySQLVersion(conn)
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +76,7 @@ func getMySQLFlavor(db *sql.DB) (string, error) {
 	return gomysql.MySQLFlavor, nil
 }
 
-func getMySQLGTIDExecuted(db *sql.DB, flavor string) (gomysql.GTIDSet, error) {
+func getMySQLGTIDExecuted(conn *client.Conn, flavor string) (gomysql.GTIDSet, error) {
 	query := ""
 	switch flavor {
 	case gomysql.MySQLFlavor:
@@ -86,9 +87,12 @@ func getMySQLGTIDExecuted(db *sql.DB, flavor string) (gomysql.GTIDSet, error) {
 		return nil, fmt.Errorf("unknown MySQL flavor: %s", flavor)
 	}
 
-	gtidStr := ""
-	row := db.QueryRow(query)
-	err := row.Scan(&gtidStr)
+	r, err := conn.Execute(query)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	gtidStr, err := r.GetString(0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +100,7 @@ func getMySQLGTIDExecuted(db *sql.DB, flavor string) (gomysql.GTIDSet, error) {
 	return gomysql.ParseGTIDSet(flavor, gtidStr)
 }
 
-func getServerUUID(db *sql.DB, flavor string) (string, error) {
+func getServerUUID(conn *client.Conn, flavor string) (string, error) {
 	query := ""
 	switch flavor {
 	case gomysql.MySQLFlavor:
@@ -108,13 +112,12 @@ func getServerUUID(db *sql.DB, flavor string) (string, error) {
 		return "", fmt.Errorf("unknown MySQL flavor: %s", flavor)
 	}
 
-	row := db.QueryRow(query)
-	var uuid string
-	err := row.Scan(&uuid)
+	r, err := conn.Execute(query)
 	if err != nil {
 		return "", err
 	}
-	return uuid, nil
+	defer r.Close()
+	return r.GetString(0, 0)
 }
 
 func getLastUploadedBinlog(ctx context.Context, folder storage.Folder) (string, error) {
@@ -161,76 +164,293 @@ func getLastUploadedBinlogBeforeGTID(ctx context.Context, folder storage.Folder,
 	return "", nil
 }
 
-func getMySQLConnection() (*sql.DB, error) {
+// mysqlDatasource holds the fields parsed from a go-sql-driver style DSN.
+type mysqlDatasource struct {
+	user     string
+	password string
+	network  string // tcp, tcp4, tcp6 or unix
+	addr     string // host:port for tcp, socket path for unix
+	dbName   string
+	params   url.Values
+}
+
+// parseMySQLDatasource parses a go-sql-driver style DSN, matching its address,
+// database-name and parameter normalization:
+//
+//	[user[:password]@][net[(addr)]]/dbname[?param=value&...]
+//
+// https://github.com/go-sql-driver/mysql#dsn-data-source-name
+// Errors avoid echoing the DSN since it commonly carries credentials.
+func parseMySQLDatasource(dsn string) (mysqlDatasource, error) {
+	var d mysqlDatasource
+
+	slash := strings.LastIndex(dsn, "/")
+	if slash < 0 {
+		return d, errors.New("invalid mysql datasource: missing '/' before database name")
+	}
+	endpoint, dbAndParams := dsn[:slash], dsn[slash+1:]
+
+	if at := strings.LastIndex(endpoint, "@"); at >= 0 {
+		credentials := endpoint[:at]
+		if colon := strings.IndexByte(credentials, ':'); colon >= 0 {
+			d.user, d.password = credentials[:colon], credentials[colon+1:]
+		} else {
+			d.user = credentials
+		}
+		endpoint = endpoint[at+1:]
+	}
+
+	if open := strings.IndexByte(endpoint, '('); open >= 0 {
+		if !strings.HasSuffix(endpoint, ")") {
+			return d, errors.New("invalid mysql datasource: network address not terminated (missing ')')")
+		}
+		d.network = endpoint[:open]
+		d.addr = endpoint[open+1 : len(endpoint)-1]
+	} else {
+		d.addr = endpoint
+	}
+
+	rawDBName := dbAndParams
+	if q := strings.IndexByte(dbAndParams, '?'); q >= 0 {
+		rawDBName = dbAndParams[:q]
+		params, err := url.ParseQuery(dbAndParams[q+1:])
+		if err != nil {
+			return d, errors.New("invalid mysql datasource parameters")
+		}
+		d.params = params
+	} else {
+		d.params = url.Values{}
+	}
+	dbName, err := url.PathUnescape(rawDBName)
+	if err != nil {
+		return d, fmt.Errorf("invalid mysql dbname %q: %w", rawDBName, err)
+	}
+	d.dbName = dbName
+
+	d.network, d.addr, err = defaultMySQLAddr(d.network, d.addr)
+	return d, err
+}
+
+// defaultMySQLAddr applies go-sql-driver's network/address defaults: empty net
+// becomes tcp, an empty addr resolves to 127.0.0.1:3306 (tcp) or /tmp/mysql.sock
+// (unix), and a tcp addr without a port gets :3306. go-mysql fills in none of these.
+func defaultMySQLAddr(network, addr string) (string, string, error) {
+	if network == "" {
+		network = "tcp"
+	}
+	if addr == "" {
+		switch network {
+		case "tcp":
+			return network, "127.0.0.1:3306", nil
+		case "unix":
+			return network, "/tmp/mysql.sock", nil
+		default:
+			return network, "", fmt.Errorf("default addr for mysql network %q unknown", network)
+		}
+	}
+	if network == "tcp" {
+		if _, _, err := net.SplitHostPort(addr); err != nil {
+			addr = net.JoinHostPort(addr, "3306")
+		}
+	}
+	return network, addr, nil
+}
+
+// getMySQLConnection connects using WALG_MYSQL_DATASOURCE_NAME, falling back to
+// localhost when the configured host is unreachable.
+func getMySQLConnection(ctx context.Context) (*client.Conn, error) {
 	datasourceName, err := conf.GetRequiredSetting(conf.MysqlDatasourceNameSetting)
 	if err != nil {
 		return nil, err
 	}
-	db, err := getMySQLConnectionFromDatasource(datasourceName)
-	if err != nil {
-		fallbackDatasourceName := replaceHostInDatasourceName(datasourceName, "localhost")
-		if fallbackDatasourceName != datasourceName {
-			tracelog.ErrorLogger.Println(err.Error())
-			tracelog.ErrorLogger.Println("Failed to connect using provided host, trying localhost")
-
-			db, err = getMySQLConnectionFromDatasource(datasourceName)
-		}
-	}
-	return db, err
-}
-
-func getMySQLConnectionFromDatasource(datasourceName string) (*sql.DB, error) {
-	if caFile, ok := conf.GetSetting(conf.MysqlSslCaSetting); ok {
-		rootCertPool := x509.NewCertPool()
-		pem, err := os.ReadFile(caFile)
-		if err != nil {
-			return nil, err
-		}
-		if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
-			return nil, fmt.Errorf("failed to load certificate from %s", caFile)
-		}
-		err = mysqldriver.RegisterTLSConfig("custom", &tls.Config{
-			RootCAs: rootCertPool,
-		})
-		if err != nil {
-			return nil, err
-		}
-		if strings.Contains(datasourceName, "?tls=") || strings.Contains(datasourceName, "&tls=") {
-			return nil,
-				fmt.Errorf("mySQL datasource string contains tls option. It can't be used with %v option",
-					conf.MysqlSslCaSetting)
-		}
-		if strings.Contains(datasourceName, "?") {
-			datasourceName += "&tls=custom"
-		} else {
-			datasourceName += "?tls=custom"
-		}
-	}
-	_, err := mysqldriver.ParseDSN(datasourceName)
+	dsn, err := parseMySQLDatasource(datasourceName)
 	if err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("mysql", datasourceName)
-	return db, err
+
+	caFile, hasCA := conf.GetSetting(conf.MysqlSslCaSetting)
+	if hasCA && dsn.params.Has("tls") {
+		return nil, fmt.Errorf("mysql datasource contains tls option, it can't be used with %v option",
+			conf.MysqlSslCaSetting)
+	}
+
+	conn, err := connectMySQL(ctx, dsn, caFile)
+	if err != nil {
+		if fallback := replaceHost(dsn.addr, "localhost"); fallback != dsn.addr {
+			tracelog.ErrorLogger.Println(err.Error())
+			tracelog.ErrorLogger.Println("Failed to connect using provided host, trying localhost")
+			dsn.addr = fallback
+			conn, err = connectMySQL(ctx, dsn, caFile)
+		}
+	}
+	return conn, err
 }
 
-func replaceHostInDatasourceName(datasourceName string, newHost string) string {
-	var userData, dbNameAndParams string
-
-	splitName := strings.SplitN(datasourceName, "@", 2)
-	if len(splitName) == 2 {
-		userData = splitName[0]
-	} else {
-		userData = ""
-	}
-	splitName = strings.SplitN(datasourceName, "/", 2)
-	if len(splitName) == 2 {
-		dbNameAndParams = splitName[1]
-	} else {
-		dbNameAndParams = ""
+// connectMySQL opens a go-mysql client connection. When caFile is set a custom
+// CA is used; otherwise TLS follows the DSN 'tls' parameter.
+func connectMySQL(ctx context.Context, dsn mysqlDatasource, caFile string) (*client.Conn, error) {
+	host, _, err := net.SplitHostPort(dsn.addr)
+	if err != nil {
+		host = dsn.addr // unix socket or portless addr
 	}
 
-	return userData + "@" + newHost + "/" + dbNameAndParams
+	tlsConfig, allowFallback, err := dsn.resolveTLS(host, caFile)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := dsn.dial(ctx, tlsConfig)
+	// tls=preferred connects plaintext when the server lacks TLS support;
+	// go-mysql rejects a configured TLS against such a server (client/auth.go)
+	if err != nil && allowFallback && strings.Contains(err.Error(), "does not support TLS") {
+		conn, err = dsn.dial(ctx, nil)
+	}
+	return conn, err
+}
+
+func (d mysqlDatasource) dial(ctx context.Context, tlsConfig *tls.Config) (*client.Conn, error) {
+	options, timeout, err := d.connectParams()
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig != nil {
+		options = append(options, func(conn *client.Conn) error {
+			conn.SetTLSConfig(tlsConfig)
+			return nil
+		})
+	}
+	dialer := net.Dialer{Timeout: timeout}
+	return client.ConnectWithDialer(ctx, d.network, d.addr, d.user, d.password, d.dbName, dialer.DialContext, options...)
+}
+
+// connectParams maps the supported go-sql-driver DSN options to go-mysql client
+// settings plus the dial timeout (go-sql-driver default 0 = no timeout). tls is
+// handled by resolveTLS; database/sql-layer options (parseTime, loc, ...) are ignored.
+func (d mysqlDatasource) connectParams() ([]client.Option, time.Duration, error) {
+	var (
+		options []client.Option
+		timeout time.Duration
+	)
+	for key := range d.params {
+		value := d.params.Get(key)
+		switch key {
+		case "tls": // handled by resolveTLS
+		case "timeout":
+			dur, err := time.ParseDuration(value)
+			if err != nil {
+				return nil, 0, fmt.Errorf("invalid mysql timeout option: %w", err)
+			}
+			timeout = dur
+		case "readTimeout":
+			dur, err := time.ParseDuration(value)
+			if err != nil {
+				return nil, 0, fmt.Errorf("invalid mysql readTimeout option: %w", err)
+			}
+			options = append(options, func(c *client.Conn) error { c.ReadTimeout = dur; return nil })
+		case "writeTimeout":
+			dur, err := time.ParseDuration(value)
+			if err != nil {
+				return nil, 0, fmt.Errorf("invalid mysql writeTimeout option: %w", err)
+			}
+			options = append(options, func(c *client.Conn) error { c.WriteTimeout = dur; return nil })
+		case "collation":
+			collation := value
+			options = append(options, func(c *client.Conn) error { return c.SetCollation(collation) })
+		case "compress":
+			option, err := compressOption(value)
+			if err != nil {
+				return nil, 0, err
+			}
+			if option != nil {
+				options = append(options, option)
+			}
+		}
+	}
+	return options, timeout, nil
+}
+
+// compressOption maps the compress DSN value to a capability. It accepts
+// go-mysql algorithm names (zlib, zstd) and go-sql-driver booleans, where a
+// truthy value selects zlib. A nil option disables compression.
+func compressOption(value string) (client.Option, error) {
+	switch value {
+	case "zlib":
+		return capabilityOption(gomysql.CLIENT_COMPRESS), nil
+	case "zstd":
+		return capabilityOption(gomysql.CLIENT_ZSTD_COMPRESSION_ALGORITHM), nil
+	}
+	on, ok := readBool(value)
+	if !ok {
+		return nil, fmt.Errorf("invalid mysql compress option %q (want zlib, zstd, true or false)", value)
+	}
+	if on {
+		return capabilityOption(gomysql.CLIENT_COMPRESS), nil
+	}
+	return nil, nil
+}
+
+func capabilityOption(capability uint32) client.Option {
+	return func(c *client.Conn) error {
+		return c.SetCapability(capability)
+	}
+}
+
+// resolveTLS mirrors go-sql-driver's 'tls' parameter semantics; a non-empty
+// caFile (WALG_MYSQL_SSL_CA) takes precedence as a custom verified CA.
+func (d mysqlDatasource) resolveTLS(host, caFile string) (config *tls.Config, allowFallback bool, err error) {
+	if caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, false, err
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, false, fmt.Errorf("failed to load certificate from %s", caFile)
+		}
+		return &tls.Config{RootCAs: pool, ServerName: host}, false, nil
+	}
+
+	switch mode := tlsConfigName(d.params.Get("tls")); mode {
+	case "", "false":
+		return nil, false, nil
+	case "true":
+		return &tls.Config{ServerName: host}, false, nil
+	case "skip-verify":
+		return &tls.Config{InsecureSkipVerify: true}, false, nil
+	case "preferred":
+		return &tls.Config{InsecureSkipVerify: true}, true, nil
+	default:
+		return nil, false, fmt.Errorf("unknown mysql tls config name %q", mode)
+	}
+}
+
+// tlsConfigName maps a DSN 'tls' value to go-sql-driver's canonical form,
+// accepting its boolean aliases (1/true/TRUE/True, 0/false/FALSE/False).
+func tlsConfigName(value string) string {
+	if b, ok := readBool(value); ok {
+		if b {
+			return "true"
+		}
+		return "false"
+	}
+	return strings.ToLower(value)
+}
+
+func readBool(input string) (value, valid bool) {
+	switch input {
+	case "1", "true", "TRUE", "True":
+		return true, true
+	case "0", "false", "FALSE", "False":
+		return false, true
+	}
+	return false, false
+}
+
+func replaceHost(addr, newHost string) string {
+	if _, port, err := net.SplitHostPort(addr); err == nil {
+		return net.JoinHostPort(newHost, port)
+	}
+	return addr
 }
 
 type StreamSentinelDto struct {

--- a/internal/databases/mysql/mysql_test.go
+++ b/internal/databases/mysql/mysql_test.go
@@ -1,0 +1,201 @@
+package mysql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/client"
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMySQLDatasource(t *testing.T) {
+	tests := []struct {
+		name     string
+		dsn      string
+		user     string
+		password string
+		network  string
+		addr     string
+		dbName   string
+	}{
+		{
+			// form used by docker/mysql, docker/mariadb export_common.sh
+			name:    "empty tcp addr defaults to 127.0.0.1:3306",
+			dsn:     "sbtest:@/sbtest",
+			user:    "sbtest",
+			network: "tcp",
+			addr:    "127.0.0.1:3306",
+			dbName:  "sbtest",
+		},
+		{
+			name:     "tcp with host and port",
+			dsn:      "user:pass@tcp(localhost:3306)/mysql",
+			user:     "user",
+			password: "pass",
+			network:  "tcp",
+			addr:     "localhost:3306",
+			dbName:   "mysql",
+		},
+		{
+			name:     "tcp host without port gets :3306",
+			dsn:      "user:pass@tcp(localhost)/mysql",
+			user:     "user",
+			password: "pass",
+			network:  "tcp",
+			addr:     "localhost:3306",
+			dbName:   "mysql",
+		},
+		{
+			name:    "unix socket",
+			dsn:     "user@unix(/var/run/mysqld/mysqld.sock)/db",
+			user:    "user",
+			network: "unix",
+			addr:    "/var/run/mysqld/mysqld.sock",
+			dbName:  "db",
+		},
+		{
+			name:    "empty unix addr defaults to /tmp/mysql.sock",
+			dsn:     "user@unix()/db",
+			user:    "user",
+			network: "unix",
+			addr:    "/tmp/mysql.sock",
+			dbName:  "db",
+		},
+		{
+			name:    "no credentials, empty addr",
+			dsn:     "/db",
+			network: "tcp",
+			addr:    "127.0.0.1:3306",
+			dbName:  "db",
+		},
+		{
+			name:    "percent-encoded database name is unescaped",
+			dsn:     "user@/foo%2Fbar",
+			user:    "user",
+			network: "tcp",
+			addr:    "127.0.0.1:3306",
+			dbName:  "foo/bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := parseMySQLDatasource(tt.dsn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.user, d.user)
+			assert.Equal(t, tt.password, d.password)
+			assert.Equal(t, tt.network, d.network)
+			assert.Equal(t, tt.addr, d.addr)
+			assert.Equal(t, tt.dbName, d.dbName)
+		})
+	}
+}
+
+func TestParseMySQLDatasource_Params(t *testing.T) {
+	d, err := parseMySQLDatasource("user:pass@tcp(host:3306)/db?tls=skip-verify&timeout=30s")
+	require.NoError(t, err)
+	assert.Equal(t, "skip-verify", d.params.Get("tls"))
+	assert.Equal(t, "30s", d.params.Get("timeout"))
+}
+
+func TestParseMySQLDatasource_Errors(t *testing.T) {
+	// errors must not echo the DSN (commonly carries credentials)
+	for _, dsn := range []string{"user:secret@tcp(host:3306)", "user:secret@tcp(host:3306/db"} {
+		_, err := parseMySQLDatasource(dsn)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "secret")
+	}
+}
+
+func TestTLSConfigName(t *testing.T) {
+	cases := map[string]string{
+		"1": "true", "true": "true", "TRUE": "true", "True": "true",
+		"0": "false", "false": "false", "FALSE": "false", "False": "false",
+		"skip-verify": "skip-verify",
+		"preferred":   "preferred",
+		"PREFERRED":   "preferred",
+		"":            "",
+		"custom":      "custom",
+	}
+	for value, want := range cases {
+		assert.Equalf(t, want, tlsConfigName(value), "tls=%q", value)
+	}
+}
+
+func TestResolveTLS(t *testing.T) {
+	mk := func(tls string) mysqlDatasource {
+		d, err := parseMySQLDatasource("u@tcp(host:3306)/db?tls=" + tls)
+		require.NoError(t, err)
+		return d
+	}
+
+	cfg, fallback, err := mk("true").resolveTLS("host", "")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "host", cfg.ServerName)
+	assert.False(t, cfg.InsecureSkipVerify)
+	assert.False(t, fallback)
+
+	cfg, fallback, err = mk("skip-verify").resolveTLS("host", "")
+	require.NoError(t, err)
+	assert.True(t, cfg.InsecureSkipVerify)
+	assert.False(t, fallback)
+
+	cfg, fallback, err = mk("preferred").resolveTLS("host", "")
+	require.NoError(t, err)
+	assert.True(t, cfg.InsecureSkipVerify)
+	assert.True(t, fallback)
+
+	cfg, _, err = mk("0").resolveTLS("host", "")
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+
+	_, _, err = mk("bogus").resolveTLS("host", "")
+	assert.Error(t, err)
+}
+
+func TestConnectParams(t *testing.T) {
+	mk := func(query string) mysqlDatasource {
+		d, err := parseMySQLDatasource("u@tcp(host:3306)/db?" + query)
+		require.NoError(t, err)
+		return d
+	}
+
+	opts, timeout, err := mk("timeout=30s&readTimeout=5s&writeTimeout=7s&collation=utf8mb4_general_ci&compress=true").connectParams()
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Second, timeout)
+	assert.Len(t, opts, 4) // readTimeout, writeTimeout, collation, compress (timeout is not an option)
+
+	_, timeout, err = mk("readTimeout=5s").connectParams()
+	require.NoError(t, err)
+	assert.Zero(t, timeout) // go-sql-driver default: no dial timeout
+
+	for _, bad := range []string{"timeout=xyz", "readTimeout=nope", "compress=bogus"} {
+		_, _, err := mk(bad).connectParams()
+		assert.Errorf(t, err, "expected error for %q", bad)
+	}
+}
+
+func TestConnectParams_Apply(t *testing.T) {
+	apply := func(query string) *client.Conn {
+		d, err := parseMySQLDatasource("u@tcp(host:3306)/db?" + query)
+		require.NoError(t, err)
+		opts, _, err := d.connectParams()
+		require.NoError(t, err)
+		c := &client.Conn{}
+		for _, opt := range opts {
+			require.NoError(t, opt(c))
+		}
+		return c
+	}
+
+	assert.Equal(t, 5*time.Second, apply("readTimeout=5s").ReadTimeout)
+	assert.Equal(t, 7*time.Second, apply("writeTimeout=7s").WriteTimeout)
+	assert.Equal(t, "utf8mb4_unicode_ci", apply("collation=utf8mb4_unicode_ci").GetCollation())
+	assert.True(t, apply("compress=true").HasCapability(gomysql.CLIENT_COMPRESS))
+	assert.True(t, apply("compress=zlib").HasCapability(gomysql.CLIENT_COMPRESS))
+	assert.True(t, apply("compress=zstd").HasCapability(gomysql.CLIENT_ZSTD_COMPRESSION_ALGORITHM))
+	assert.False(t, apply("compress=false").HasCapability(gomysql.CLIENT_COMPRESS))
+}


### PR DESCRIPTION
go-mysql-org already needed for binlog handling

DSN parsing designed to match go-sql-driver, but added support for explicit zlib or zstd compression