### PR TITLE
tests_func: drop unused S3_PORT EXPOSE from MinIO image

### DIFF
--- a/tests_func/images/minio/Dockerfile
+++ b/tests_func/images/minio/Dockerfile
@@ -11,6 +11,4 @@ ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 HEALTHCHECK --interval=30s --timeout=5s \
     CMD /usr/bin/healthcheck.sh
 
-EXPOSE $S3_PORT
-
 CMD ["server", "/export"]


### PR DESCRIPTION
expose might be only constant.
while docker silently ignored it, podman on fedora linux decided it is an error.