### PR TITLE
Avoid temp files when parsing remote MySQL binlogs

### DIFF
--- a/internal/databases/mysql/mysql_binlog.go
+++ b/internal/databases/mysql/mysql_binlog.go
@@ -64,19 +64,42 @@ func UploadBinlogSentinel(ctx context.Context, folder storage.Folder, sentinelDt
 
 func GetBinlogPreviousGTIDs(filename string, flavor string) (mysql.GTIDSet, error) {
 	var result mysql.GTIDSet
+	fh, err := os.Open(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open binlog file '%s'", filename)
+	}
+	defer utility.LoggedClose(fh, "failed to close binlog")
 
+	err = parseBinlogPreviousGTIDs(fh, flavor, &result)
+	if err != nil && result == nil {
+		return nil, errors.Wrapf(err, "could not find GTIDs in binlog file '%s' \n", filename)
+	}
+
+	return result, nil
+}
+
+func parseBinlogPreviousGTIDs(reader io.Reader, flavor string, result *mysql.GTIDSet) error {
 	parser := replication.NewBinlogParser()
 	parser.SetFlavor(flavor)
 	parser.SetVerifyChecksum(false) // the faster, the better
 	parser.SetRawMode(true)         // choose events to parse manually
-	err := parser.ParseFile(filename, 0, func(event *replication.BinlogEvent) error {
+
+	header := make([]byte, len(replication.BinLogFileHeader))
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return err
+	}
+	if !bytes.Equal(header, replication.BinLogFileHeader) {
+		return fmt.Errorf("not a valid binlog file, head 4 bytes must fe'bin'")
+	}
+
+	return parser.ParseReader(reader, func(event *replication.BinlogEvent) error {
 		if event.Header.EventType == replication.PREVIOUS_GTIDS_EVENT && flavor == mysql.MySQLFlavor {
 			previousGTID := &replication.PreviousGTIDsEvent{}
 			err := previousGTID.Decode(event.RawData[replication.EventHeaderSize:])
 			if err != nil {
 				return err
 			}
-			result, err = mysql.ParseMysqlGTIDSet(previousGTID.GTIDSets)
+			*result, err = mysql.ParseMysqlGTIDSet(previousGTID.GTIDSets)
 			if err != nil {
 				return err
 			}
@@ -98,41 +121,26 @@ func GetBinlogPreviousGTIDs(filename string, flavor string) (mysql.GTIDSet, erro
 					return err
 				}
 			}
-			result = resultSet
+			*result = resultSet
 			return fmt.Errorf("shallow file read finished")
 		}
 		return nil
 	})
-
-	if err != nil && result == nil {
-		return nil, errors.Wrapf(err, "could not find GTIDs in binlog file '%s' \n", filename)
-	}
-
-	return result, nil
 }
 
 func GetBinlogPreviousGTIDsRemote(ctx context.Context, folder storage.Folder, filename string, flavor string) (mysql.GTIDSet, error) {
+	var result mysql.GTIDSet
 	binlogName := utility.TrimFileExtension(filename)
 	fh, err := internal.DownloadAndDecompressStorageFile(ctx, internal.NewFolderReader(folder), binlogName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read binlog %s: %w", binlogName, err)
 	}
 	defer utility.LoggedClose(fh, "failed to close binlog")
-	tmp, err := os.CreateTemp("", binlogName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
-	}
-	defer utility.LoggedClose(tmp, "failed to close temp file")
-	defer os.Remove(tmp.Name())
-	_, err = io.CopyN(tmp, fh, BinlogReadHeaderSize)
-	if err != nil && err != io.EOF {
-		return nil, fmt.Errorf("failed to read binlog beginning")
-	}
-	prevGtid, err := GetBinlogPreviousGTIDs(tmp.Name(), flavor)
-	if err != nil {
+	err = parseBinlogPreviousGTIDs(io.LimitReader(fh, BinlogReadHeaderSize), flavor, &result)
+	if err != nil && result == nil {
 		return nil, fmt.Errorf("failed to parse %s binlog %s: %w", flavor, binlogName, err)
 	}
-	return prevGtid, nil
+	return result, nil
 }
 
 func GetBinlogStartTimestamp(filename string, flavor string) (time.Time, error) {

--- a/internal/databases/mysql/mysql_binlog_test.go
+++ b/internal/databases/mysql/mysql_binlog_test.go
@@ -54,6 +54,7 @@ func TestGetBinlogPreviousGTIDsRemoteDoesNotRequireTempDir(t *testing.T) {
 	ctx := context.Background()
 	binlogData, err := os.ReadFile(testFilenameSmall)
 	require.NoError(t, err)
+	require.Less(t, len(binlogData), BinlogReadHeaderSize)
 
 	folder := memory.NewFolder("", memory.NewKVS())
 	binlogName := filepath.Base(testFilenameSmall)

--- a/internal/databases/mysql/mysql_binlog_test.go
+++ b/internal/databases/mysql/mysql_binlog_test.go
@@ -1,11 +1,17 @@
 package mysql
 
 import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/pkg/storages/memory"
 )
 
 const testFilenameSmall = "testdata/binlog_small_test"
@@ -42,4 +48,23 @@ func TestBinlogNum(t *testing.T) {
 	assert.Equal(t, 1, BinlogNum("foo.1"))
 	assert.Equal(t, 123456, BinlogNum("foo.123456"))
 	assert.Equal(t, 123456789, BinlogNum("foo.123456789"))
+}
+
+func TestGetBinlogPreviousGTIDsRemoteDoesNotRequireTempDir(t *testing.T) {
+	ctx := context.Background()
+	binlogData, err := os.ReadFile(testFilenameSmall)
+	require.NoError(t, err)
+
+	folder := memory.NewFolder("", memory.NewKVS())
+	binlogName := filepath.Base(testFilenameSmall)
+	require.NoError(t, folder.PutObject(ctx, binlogName, bytes.NewReader(binlogData)))
+
+	expectedGTIDSet, err := GetBinlogPreviousGTIDs(testFilenameSmall, mysql.MySQLFlavor)
+	require.NoError(t, err)
+
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "missing"))
+	actualGTIDSet, err := GetBinlogPreviousGTIDsRemote(ctx, folder, binlogName, mysql.MySQLFlavor)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedGTIDSet.String(), actualGTIDSet.String())
 }


### PR DESCRIPTION
### Database name
MySQL

# Pull request description

### Describe what this PR fixes
Fixes #2065.

`GetBinlogPreviousGTIDsRemote` downloaded the remote binlog prefix into a local temporary file before parsing previous GTIDs. This refactors the previous-GTID parser so the remote path can parse the limited storage reader in memory with `BinlogParser.ParseReader`, while keeping local file parsing on the same event-handling logic.

### Please provide steps to reproduce (if it's a bug)
The regression test stores a fixture binlog in memory storage, points `TMPDIR` at a missing directory, and verifies remote previous-GTID parsing still succeeds. The old temp-file path would fail while creating the temporary file in that setup.

Testing:

```bash
GOEXPERIMENT=jsonv2 go test ./internal/databases/mysql -run 'TestGetBinlogStartTimestamp|TestBinlogNum'
GOEXPERIMENT=jsonv2 go test ./internal/databases/mysql -run TestGetBinlogPreviousGTIDsRemoteDoesNotRequireTempDir -count=1
GOEXPERIMENT=jsonv2 go test ./internal/databases/mysql
```

### Please add config and wal-g stdout/stderr logs for debug purpose
N/A, covered by the unit test above.

<details><summary>If you can, provide logs</summary>
<p>

N/A

</p>
</details>