### PR TITLE
Adds OCI Object Storage support as a WAL-G storage backend

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -1,6 +1,6 @@
 # WAL-G storage configuration
 
-WAL-G can store backups in S3, Google Cloud Storage, Azure, Alicloud, Swift, remote host (via SSH) or local file system. 
+WAL-G can store backups in S3, Google Cloud Storage, Azure, Alicloud, OCI Object Storage, Swift, remote host (via SSH) or local file system.
 
 S3
 -----------
@@ -199,6 +199,44 @@ Size of the part to upload when uploading large files to OSS. Alicloud OSS defau
 * `OSS_COPY_PART_SIZE`
 
 Size of the part to copy when copying large files within OSS. Default OSS is 67,108,864 bytes (64 MiB).
+
+OCI Object Storage
+-----------
+
+To connect to OCI Object Storage, WAL-G requires that this variable be set:
+
+* `WALG_OCI_PREFIX`
+  (e.g. `oci://bucket/path/to/folder`)
+
+WAL-G can authenticate either with a security token and private key pair, or with a standard OCI config file.
+
+**Security token authentication**
+
+Set these variables:
+
+* `OCI_REGION`
+* `OCI_TENANCY_OCID`
+* `OCI_SECURITY_TOKEN_FILE`
+* `OCI_PRIVATE_KEY_FILE`
+
+**OCI config file authentication**
+
+Set these variables:
+
+* `OCI_CONFIG_FILE`
+* `OCI_PROFILE`
+
+If `OCI_PROFILE` is omitted, WAL-G uses the `DEFAULT` profile.
+
+**Optional variables**
+
+* `WALG_OCI_CA_CERT_FILE`
+
+Path to a custom CA certificate file used for OCI Object Storage TLS connections.
+
+* `OCI_CONNECT_TIMEOUT`
+
+Connection timeout in seconds. Default is 30.
 
 Swift
 -----------

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/mongodb/mongo-tools v0.0.0-20240724183527-6d4f001be3fc
 	github.com/ncw/directio v1.0.5
 	github.com/ncw/swift/v2 v2.0.5
+	github.com/oracle/oci-go-sdk/v65 v65.112.0
 	github.com/pkg/profile v1.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
@@ -111,6 +112,7 @@ require (
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20260219190905-9b9281fa8d6d // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sony/gobreaker v0.5.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,8 @@ github.com/ncw/directio v1.0.5 h1:JSUBhdjEvVaJvOoyPAbcW0fnd0tvRXD76wEfZ1KcQz4=
 github.com/ncw/directio v1.0.5/go.mod h1:rX/pKEYkOXBGOggmcyJeJGloCkleSvphPx2eV3t6ROk=
 github.com/ncw/swift/v2 v2.0.5 h1:9o5Gsd7bInAFEqsGPcaUdsboMbqf8lnNtxqWKFT9iz8=
 github.com/ncw/swift/v2 v2.0.5/go.mod h1:cbAO76/ZwcFrFlHdXPjaqWZ9R7Hdar7HpjRXBfbjigk=
+github.com/oracle/oci-go-sdk/v65 v65.112.0 h1:L4O4SXAHq5T23qxbjaC/4NHikIKGHhrPtBKOtvGxk7Q=
+github.com/oracle/oci-go-sdk/v65 v65.112.0/go.mod h1:8ZzvzuEG/cFLFZhxg/Mg1w19KqyXBKO3c17QIc5PkGs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
@@ -517,6 +519,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
 github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
+github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/internal/storage_adapter.go
+++ b/internal/storage_adapter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/wal-g/wal-g/pkg/storages/azure"
 	"github.com/wal-g/wal-g/pkg/storages/fs"
 	"github.com/wal-g/wal-g/pkg/storages/gcs"
+	"github.com/wal-g/wal-g/pkg/storages/oci"
 	"github.com/wal-g/wal-g/pkg/storages/oss"
 	"github.com/wal-g/wal-g/pkg/storages/s3"
 	"github.com/wal-g/wal-g/pkg/storages/sh"
@@ -55,6 +56,7 @@ func (adapter *StorageAdapter) loadSettings(config *viper.Viper) map[string]stri
 }
 
 var StorageAdapters = []StorageAdapter{
+	{"OCI", oci.SettingList, oci.ConfigureStorage},
 	{"OSS", oss.SettingList, oss.ConfigureStorage},
 	{"S3", s3.SettingList, s3.ConfigureStorage},
 	{"FILE", nil, fs.ConfigureStorage},

--- a/pkg/storages/oci/client.go
+++ b/pkg/storages/oci/client.go
@@ -1,0 +1,317 @@
+package oci
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/objectstorage"
+)
+
+var errFileModifiedDuringRead = errors.New("file modified during read")
+
+// securityTokenConfigProvider implements OCI authentication using a security token from a file.
+// This is used when an external process (e.g., background service) manages token refresh.
+type securityTokenConfigProvider struct {
+	tenancyOCID      string
+	region           string
+	tokenFile        string
+	privateKeyFile   string
+	privateKey       *rsa.PrivateKey
+	cachedToken      string
+	cachedTokenMtime time.Time
+	mu               sync.RWMutex
+}
+
+func newSecurityTokenConfigProvider(config *Config) (*securityTokenConfigProvider, error) {
+	if config.TenancyOCID == "" {
+		return nil, fmt.Errorf("OCI_TENANCY_OCID is required")
+	}
+	if config.Region == "" {
+		return nil, fmt.Errorf("OCI_REGION is required")
+	}
+	if config.SecurityTokenFile == "" {
+		return nil, fmt.Errorf("OCI_SECURITY_TOKEN_FILE is required")
+	}
+	if config.PrivateKeyFile == "" {
+		return nil, fmt.Errorf("OCI_PRIVATE_KEY_FILE is required")
+	}
+
+	return &securityTokenConfigProvider{
+		tenancyOCID:    config.TenancyOCID,
+		region:         config.Region,
+		tokenFile:      config.SecurityTokenFile,
+		privateKeyFile: config.PrivateKeyFile,
+	}, nil
+}
+
+func (p *securityTokenConfigProvider) TenancyOCID() (string, error) {
+	return p.tenancyOCID, nil
+}
+
+func (p *securityTokenConfigProvider) UserOCID() (string, error) {
+	return "", nil
+}
+
+func (p *securityTokenConfigProvider) KeyFingerprint() (string, error) {
+	return "", nil
+}
+
+func (p *securityTokenConfigProvider) Region() (string, error) {
+	return p.region, nil
+}
+
+func (p *securityTokenConfigProvider) KeyID() (string, error) {
+	if err := p.loadIfStale(); err != nil {
+		return "", err
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return "ST$" + p.cachedToken, nil
+}
+
+func (p *securityTokenConfigProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	if err := p.loadIfStale(); err != nil {
+		return nil, err
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.privateKey, nil
+}
+
+// readFilesConsistently reads both files and verifies they weren't modified during the read.
+// Returns the file contents and the initial token file mtime, or an error if files were modified.
+func (p *securityTokenConfigProvider) readFilesConsistently() (tokenBytes []byte, keyBytes []byte, tokenMtime time.Time, err error) {
+	// Stat both files
+	tokenStatBefore, err := os.Stat(p.tokenFile)
+	if err != nil {
+		return nil, nil, time.Time{}, fmt.Errorf("stat token file %s: %w", p.tokenFile, err)
+	}
+	keyStatBefore, err := os.Stat(p.privateKeyFile)
+	if err != nil {
+		return nil, nil, time.Time{}, fmt.Errorf("stat private key file %s: %w", p.privateKeyFile, err)
+	}
+
+	// Read both files into memory
+	tokenBytes, err = os.ReadFile(p.tokenFile)
+	if err != nil {
+		return nil, nil, time.Time{}, fmt.Errorf("reading security token from %s: %w", p.tokenFile, err)
+	}
+	keyBytes, err = os.ReadFile(p.privateKeyFile)
+	if err != nil {
+		return nil, nil, time.Time{}, fmt.Errorf("reading private key from %s: %w", p.privateKeyFile, err)
+	}
+
+	// Stat both files again and compare
+	tokenStatAfter, err := os.Stat(p.tokenFile)
+	if err != nil {
+		return nil, nil, time.Time{}, fmt.Errorf("re-stat token file %s: %w", p.tokenFile, err)
+	}
+	keyStatAfter, err := os.Stat(p.privateKeyFile)
+	if err != nil {
+		return nil, nil, time.Time{}, fmt.Errorf("re-stat private key file %s: %w", p.privateKeyFile, err)
+	}
+
+	if !tokenStatBefore.ModTime().Equal(tokenStatAfter.ModTime()) {
+		return nil, nil, time.Time{}, fmt.Errorf("%w: token file", errFileModifiedDuringRead)
+	}
+	if !keyStatBefore.ModTime().Equal(keyStatAfter.ModTime()) {
+		return nil, nil, time.Time{}, fmt.Errorf("%w: private key file", errFileModifiedDuringRead)
+	}
+
+	return tokenBytes, keyBytes, tokenStatBefore.ModTime(), nil
+}
+
+// loadIfStale reloads both token and private key if the token file has been modified.
+// This ensures the private key stays in sync with the token when they're rotated together.
+func (p *securityTokenConfigProvider) loadIfStale() error {
+	tokenStat, err := os.Stat(p.tokenFile)
+	if err != nil {
+		return fmt.Errorf("stat token file %s: %w", p.tokenFile, err)
+	}
+
+	// Fast path: check if cache is fresh
+	p.mu.RLock()
+	fresh := p.privateKey != nil && tokenStat.ModTime().Equal(p.cachedTokenMtime)
+	p.mu.RUnlock()
+	if fresh {
+		return nil
+	}
+
+	// Slow path: reload both token and private key atomically
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if p.privateKey != nil && tokenStat.ModTime().Equal(p.cachedTokenMtime) {
+		return nil
+	}
+
+	// Retry reading files if they're modified during read (rotation race)
+	const maxAttempts = 3
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		tokenBytes, keyBytes, tokenMtime, err := p.readFilesConsistently()
+		if err != nil {
+			if errors.Is(err, errFileModifiedDuringRead) {
+				lastErr = err
+				continue
+			}
+			return err
+		}
+
+		// Parse token
+		token := strings.TrimSpace(string(tokenBytes))
+		if token == "" {
+			return fmt.Errorf("security token file %s is empty", p.tokenFile)
+		}
+
+		// Parse PEM-encoded private key
+		block, _ := pem.Decode(keyBytes)
+		if block == nil {
+			return fmt.Errorf("failed to decode PEM block from %s", p.privateKeyFile)
+		}
+		privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("parsing private key from %s: %w", p.privateKeyFile, err)
+		}
+
+		// Atomically update all cached values
+		p.cachedToken = token
+		p.privateKey = privateKey
+		p.cachedTokenMtime = tokenMtime
+		return nil
+	}
+
+	return fmt.Errorf("files kept rotating during reads after %d attempts: %w", maxAttempts, lastErr)
+}
+
+func (p *securityTokenConfigProvider) AuthType() (common.AuthConfig, error) {
+	return common.AuthConfig{
+		AuthType:         common.UserPrincipal,
+		IsFromConfigFile: false,
+	}, nil
+}
+
+type ociClient struct {
+	objectStorageClient *objectstorage.ObjectStorageClient
+	namespace           string
+	mu                  sync.RWMutex
+}
+
+// createTLSConfig creates a TLS configuration with custom CA certificates.
+func createTLSConfig(caCertFile string) (*tls.Config, error) {
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("loading system cert pool: %w", err)
+	}
+	if caCertPool == nil {
+		caCertPool = x509.NewCertPool()
+	}
+
+	caCert, err := os.ReadFile(caCertFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading CA certificate from %s: %w", caCertFile, err)
+	}
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA certificate from %s", caCertFile)
+	}
+
+	return &tls.Config{RootCAs: caCertPool}, nil
+}
+
+// configureClient creates an OCI object storage client using standard authentication methods.
+func configureClient(config *Config) (*ociClient, error) {
+	var configProvider common.ConfigurationProvider
+	var err error
+
+	// Try authentication methods in order of preference
+	if config.SecurityTokenFile != "" {
+		// Security token from file, for workload identity integrations.
+		configProvider, err = newSecurityTokenConfigProvider(config)
+		if err != nil {
+			return nil, fmt.Errorf("creating security token config provider: %w", err)
+		}
+	} else if config.ConfigFile != "" {
+		// Standard OCI config file (~/.oci/config)
+		profile := config.Profile
+		if profile == "" {
+			profile = "DEFAULT"
+		}
+		configProvider = common.CustomProfileConfigProvider(config.ConfigFile, profile)
+	} else {
+		return nil, fmt.Errorf("no authentication method configured: set OCI_SECURITY_TOKEN_FILE or OCI_CONFIG_FILE")
+	}
+
+	client, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		return nil, fmt.Errorf("creating OCI object storage client: %w", err)
+	}
+
+	client.SetRegion(config.Region)
+
+	// Configure HTTP client with custom transport
+	httpClient := &http.Client{}
+
+	// Clone DefaultTransport to preserve production-tuned defaults (connection pooling, etc.)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if config.ConnectTimeout > 0 {
+		transport.DialContext = (&net.Dialer{
+			Timeout: time.Duration(config.ConnectTimeout) * time.Second,
+		}).DialContext
+	}
+
+	if config.CACertFile != "" {
+		tlsConfig, err := createTLSConfig(config.CACertFile)
+		if err != nil {
+			return nil, fmt.Errorf("creating TLS config: %w", err)
+		}
+		transport.TLSClientConfig = tlsConfig
+	}
+
+	httpClient.Transport = transport
+	client.HTTPClient = httpClient
+
+	return &ociClient{
+		objectStorageClient: &client,
+	}, nil
+}
+
+// getNamespace returns the OCI namespace, fetching and caching it on first use.
+func (c *ociClient) getNamespace(ctx context.Context) (string, error) {
+	c.mu.RLock()
+	if c.namespace != "" {
+		ns := c.namespace
+		c.mu.RUnlock()
+		return ns, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.namespace != "" {
+		return c.namespace, nil
+	}
+
+	namespaceReq := objectstorage.GetNamespaceRequest{}
+	namespaceResp, err := c.objectStorageClient.GetNamespace(ctx, namespaceReq)
+	if err != nil {
+		return "", fmt.Errorf("getting OCI namespace: %w", err)
+	}
+
+	c.namespace = *namespaceResp.Value
+	return c.namespace, nil
+}

--- a/pkg/storages/oci/client_test.go
+++ b/pkg/storages/oci/client_test.go
@@ -1,0 +1,223 @@
+package oci
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestPrivateKey generates a valid RSA private key for testing
+func generateTestPrivateKey() ([]byte, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	})
+	return privateKeyPEM, nil
+}
+
+func TestSecurityTokenConfigProviderValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		expectError string
+	}{
+		{
+			name: "missing security token file",
+			config: &Config{
+				Region:            "us-phoenix-1",
+				TenancyOCID:       "ocid1.tenancy.oc1..test",
+				SecurityTokenFile: "",
+			},
+			expectError: "OCI_SECURITY_TOKEN_FILE is required",
+		},
+		{
+			name: "missing tenancy OCID",
+			config: &Config{
+				Region:            "us-phoenix-1",
+				TenancyOCID:       "",
+				SecurityTokenFile: "/tmp/token",
+			},
+			expectError: "OCI_TENANCY_OCID is required",
+		},
+		{
+			name: "missing region",
+			config: &Config{
+				Region:            "",
+				TenancyOCID:       "ocid1.tenancy.oc1..test",
+				SecurityTokenFile: "/tmp/token",
+			},
+			expectError: "OCI_REGION is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newSecurityTokenConfigProvider(tt.config)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+func TestSecurityTokenConfigProviderCreatesSuccessfully(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "token")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+	err := os.WriteFile(tokenPath, []byte("test-token"), 0600)
+	require.NoError(t, err)
+	testKey, err := generateTestPrivateKey()
+	require.NoError(t, err)
+	err = os.WriteFile(keyPath, testKey, 0600)
+	require.NoError(t, err)
+
+	config := &Config{
+		Region:            "us-phoenix-1",
+		TenancyOCID:       "ocid1.tenancy.oc1..test",
+		SecurityTokenFile: tokenPath,
+		PrivateKeyFile:    keyPath,
+	}
+
+	provider, err := newSecurityTokenConfigProvider(config)
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+	assert.Equal(t, "us-phoenix-1", provider.region)
+	assert.Equal(t, "ocid1.tenancy.oc1..test", provider.tenancyOCID)
+	assert.Equal(t, tokenPath, provider.tokenFile)
+	assert.Equal(t, keyPath, provider.privateKeyFile)
+}
+
+func TestSecurityTokenConfigProviderReadToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "token")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+	tokenContent := "test-oci-security-token"
+
+	err := os.WriteFile(tokenPath, []byte(tokenContent), 0600)
+	require.NoError(t, err)
+	testKey, err := generateTestPrivateKey()
+	require.NoError(t, err)
+	err = os.WriteFile(keyPath, testKey, 0600)
+	require.NoError(t, err)
+
+	config := &Config{
+		Region:            "us-phoenix-1",
+		TenancyOCID:       "ocid1.tenancy.oc1..test",
+		SecurityTokenFile: tokenPath,
+		PrivateKeyFile:    keyPath,
+	}
+
+	provider, err := newSecurityTokenConfigProvider(config)
+	require.NoError(t, err)
+
+	keyID, err := provider.KeyID()
+	require.NoError(t, err)
+	assert.Equal(t, "ST$"+tokenContent, keyID)
+}
+
+func TestSecurityTokenConfigProviderReadTokenTrimsWhitespace(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "token")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+	tokenContent := "  test-oci-security-token\n\t"
+
+	err := os.WriteFile(tokenPath, []byte(tokenContent), 0600)
+	require.NoError(t, err)
+	testKey, err := generateTestPrivateKey()
+	require.NoError(t, err)
+	err = os.WriteFile(keyPath, testKey, 0600)
+	require.NoError(t, err)
+
+	config := &Config{
+		Region:            "us-phoenix-1",
+		TenancyOCID:       "ocid1.tenancy.oc1..test",
+		SecurityTokenFile: tokenPath,
+		PrivateKeyFile:    keyPath,
+	}
+
+	provider, err := newSecurityTokenConfigProvider(config)
+	require.NoError(t, err)
+
+	keyID, err := provider.KeyID()
+	require.NoError(t, err)
+	assert.Equal(t, "ST$test-oci-security-token", keyID)
+}
+
+func TestSecurityTokenConfigProviderEmptyTokenFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "token")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+	err := os.WriteFile(tokenPath, []byte("   \n\t  "), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(keyPath, []byte("test-key"), 0600)
+	require.NoError(t, err)
+
+	config := &Config{
+		Region:            "us-phoenix-1",
+		TenancyOCID:       "ocid1.tenancy.oc1..test",
+		SecurityTokenFile: tokenPath,
+		PrivateKeyFile:    keyPath,
+	}
+
+	provider, err := newSecurityTokenConfigProvider(config)
+	require.NoError(t, err)
+
+	_, err = provider.KeyID()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is empty")
+}
+
+func TestSecurityTokenConfigProviderInterfaceMethods(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "token")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+	err := os.WriteFile(tokenPath, []byte("test-token"), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile(keyPath, []byte("test-key"), 0600)
+	require.NoError(t, err)
+
+	config := &Config{
+		Region:            "us-phoenix-1",
+		TenancyOCID:       "ocid1.tenancy.oc1..test",
+		SecurityTokenFile: tokenPath,
+		PrivateKeyFile:    keyPath,
+	}
+
+	provider, err := newSecurityTokenConfigProvider(config)
+	require.NoError(t, err)
+
+	tenancy, err := provider.TenancyOCID()
+	assert.NoError(t, err)
+	assert.Equal(t, "ocid1.tenancy.oc1..test", tenancy)
+
+	region, err := provider.Region()
+	assert.NoError(t, err)
+	assert.Equal(t, "us-phoenix-1", region)
+
+	userOCID, err := provider.UserOCID()
+	assert.NoError(t, err)
+	assert.Empty(t, userOCID)
+
+	fingerprint, err := provider.KeyFingerprint()
+	assert.NoError(t, err)
+	assert.Empty(t, fingerprint)
+
+	_, err = provider.PrivateRSAKey()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode PEM block")
+
+	authConfig, err := provider.AuthType()
+	assert.NoError(t, err)
+	assert.NotNil(t, authConfig)
+}

--- a/pkg/storages/oci/configure.go
+++ b/pkg/storages/oci/configure.go
@@ -1,0 +1,73 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/pkg/storages/storage/setting"
+)
+
+const (
+	regionSetting            = "OCI_REGION"
+	tenancyOCIDSetting       = "OCI_TENANCY_OCID"
+	securityTokenFileSetting = "OCI_SECURITY_TOKEN_FILE"
+	privateKeyFileSetting    = "OCI_PRIVATE_KEY_FILE"
+	configFileSetting        = "OCI_CONFIG_FILE"
+	profileSetting           = "OCI_PROFILE"
+	caCertFileSetting        = "WALG_OCI_CA_CERT_FILE"
+	connectTimeoutSetting    = "OCI_CONNECT_TIMEOUT"
+)
+
+var SettingList = []string{
+	regionSetting,
+	tenancyOCIDSetting,
+	securityTokenFileSetting,
+	privateKeyFileSetting,
+	configFileSetting,
+	profileSetting,
+	caCertFileSetting,
+	connectTimeoutSetting,
+}
+
+const (
+	defaultConnectTimeoutSeconds = 30
+)
+
+// ConfigureStorage creates OCI storage from configuration settings.
+func ConfigureStorage(
+	_ context.Context,
+	prefix string,
+	settings map[string]string,
+	rootWraps ...storage.WrapRootFolder,
+) (storage.HashableStorage, error) {
+	bucket, rootPath, err := storage.GetPathFromPrefix(prefix)
+	if err != nil {
+		return nil, fmt.Errorf("extract bucket and path from prefix %q: %w", prefix, err)
+	}
+
+	connectTimeout, err := setting.Int64Optional(settings, connectTimeoutSetting, defaultConnectTimeoutSeconds)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &Config{
+		Region:            strings.TrimSpace(settings[regionSetting]),
+		TenancyOCID:       strings.TrimSpace(settings[tenancyOCIDSetting]),
+		SecurityTokenFile: strings.TrimSpace(settings[securityTokenFileSetting]),
+		PrivateKeyFile:    strings.TrimSpace(settings[privateKeyFileSetting]),
+		ConfigFile:        strings.TrimSpace(settings[configFileSetting]),
+		Profile:           strings.TrimSpace(settings[profileSetting]),
+		CACertFile:        strings.TrimSpace(settings[caCertFileSetting]),
+		Bucket:            bucket,
+		RootPath:          rootPath,
+		ConnectTimeout:    connectTimeout,
+	}
+
+	st, err := NewStorage(config, rootWraps...)
+	if err != nil {
+		return nil, fmt.Errorf("create OCI storage: %w", err)
+	}
+	return st, nil
+}

--- a/pkg/storages/oci/folder.go
+++ b/pkg/storages/oci/folder.go
@@ -1,0 +1,348 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/objectstorage"
+	"github.com/oracle/oci-go-sdk/v65/objectstorage/transfer"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+var _ storage.Folder = &Folder{}
+
+// formatOCIError formats an OCI error with request ID for better debuggability.
+func formatOCIError(operation string, err error) error {
+	serviceErr, ok := common.IsServiceError(err)
+	if ok {
+		return fmt.Errorf("OCI %s failed: code=%s, status=%d, opc-request-id=%s, message=%s",
+			operation, serviceErr.GetCode(), serviceErr.GetHTTPStatusCode(),
+			serviceErr.GetOpcRequestID(), serviceErr.GetMessage())
+	}
+	return fmt.Errorf("%s: %w", operation, err)
+}
+
+// defaultRetryPolicy returns the default retry policy for OCI requests.
+func defaultRetryPolicy() *common.RetryPolicy {
+	policy := common.DefaultRetryPolicy()
+	return &policy
+}
+
+type Folder struct {
+	client *ociClient
+	bucket string
+	path   string
+	region string
+}
+
+// ctxReadCloser wraps an io.ReadCloser and cancels its context on Close.
+// This keeps the context alive for the lifetime of the reader, which is
+// owned by the caller and may outlive the function that created it.
+type ctxReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *ctxReadCloser) Close() error {
+	err := c.ReadCloser.Close()
+	c.cancel()
+	return err
+}
+
+// NewFolder creates a new folder instance for the given bucket and path.
+func NewFolder(client *ociClient, bucket string, path string, region string) *Folder {
+	// Ensure path has trailing slash for consistency
+	if path != "" && !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	return &Folder{
+		client: client,
+		bucket: bucket,
+		path:   path,
+		region: region,
+	}
+}
+
+// getNamespace retrieves the OCI namespace for this folder's operations.
+func (f *Folder) getNamespace(ctx context.Context) (string, error) {
+	if f.client == nil {
+		return "", fmt.Errorf("OCI client not initialized")
+	}
+	return f.client.getNamespace(ctx)
+}
+
+// GetPath returns the folder path with a trailing slash.
+func (f *Folder) GetPath() string {
+	return f.path
+}
+
+// ListFolder lists all objects and subfolders in this folder.
+func (f *Folder) ListFolder(ctx context.Context) (objects []storage.Object, subFolders []storage.Folder, err error) {
+	prefix := f.GetPath()
+	delimiter := "/"
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer cancel()
+	var nextStartWith *string
+
+	tracelog.DebugLogger.Printf("Listing OCI objects with prefix: %s", prefix)
+
+	namespace, err := f.getNamespace(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for {
+		req := objectstorage.ListObjectsRequest{
+			NamespaceName: common.String(namespace),
+			BucketName:    common.String(f.bucket),
+			Prefix:        common.String(prefix),
+			Delimiter:     common.String(delimiter),
+			Start:         nextStartWith,
+			Fields:        common.String("name,size,timeModified"),
+			RequestMetadata: common.RequestMetadata{
+				RetryPolicy: defaultRetryPolicy(),
+			},
+		}
+
+		resp, err := f.client.objectStorageClient.ListObjects(ctx, req)
+		if err != nil {
+			return nil, nil, formatOCIError("listing objects", err)
+		}
+
+		for _, commonPrefix := range resp.Prefixes {
+			subFolder := NewFolder(f.client, f.bucket, commonPrefix, f.region)
+			subFolders = append(subFolders, subFolder)
+		}
+
+		for _, object := range resp.Objects {
+			if *object.Name == prefix {
+				continue
+			}
+			objectRelativePath := strings.TrimPrefix(*object.Name, prefix)
+
+			// Size and TimeModified are explicitly requested via Fields parameter
+			// and should always be populated by OCI API
+			size := int64(0)
+			if object.Size != nil {
+				size = *object.Size
+			}
+
+			var modTime time.Time
+			if object.TimeModified != nil {
+				modTime = object.TimeModified.Time
+			}
+
+			objects = append(objects, storage.NewLocalObject(objectRelativePath, modTime, size))
+		}
+
+		if resp.NextStartWith == nil {
+			break
+		}
+		// Detect infinite loop if API returns same pagination token
+		if nextStartWith != nil && *nextStartWith == *resp.NextStartWith {
+			return nil, nil, fmt.Errorf("OCI returned identical pagination token, possible API bug")
+		}
+		nextStartWith = resp.NextStartWith
+	}
+
+	return objects, subFolders, nil
+}
+
+// DeleteObjects deletes multiple objects by their relative paths.
+func (f *Folder) DeleteObjects(ctx context.Context, objects []storage.Object) error {
+	timeout := time.Duration(len(objects)) * 30 * time.Second
+	if timeout < 5*time.Minute {
+		timeout = 5 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	namespace, err := f.getNamespace(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, object := range objects {
+		fullPath := f.GetPath() + object.GetName()
+		tracelog.DebugLogger.Printf("Deleting OCI object: %s", fullPath)
+
+		req := objectstorage.DeleteObjectRequest{
+			NamespaceName: common.String(namespace),
+			BucketName:    common.String(f.bucket),
+			ObjectName:    common.String(fullPath),
+			RequestMetadata: common.RequestMetadata{
+				RetryPolicy: defaultRetryPolicy(),
+			},
+		}
+
+		_, err := f.client.objectStorageClient.DeleteObject(ctx, req)
+		if err != nil {
+			return formatOCIError(fmt.Sprintf("deleting object %q", fullPath), err)
+		}
+	}
+
+	return nil
+}
+
+// Exists checks if an object exists at the given relative path.
+func (f *Folder) Exists(ctx context.Context, objectRelativePath string) (bool, error) {
+	objectPath := f.GetPath() + objectRelativePath
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	namespace, err := f.getNamespace(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	req := objectstorage.HeadObjectRequest{
+		NamespaceName: common.String(namespace),
+		BucketName:    common.String(f.bucket),
+		ObjectName:    common.String(objectPath),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: defaultRetryPolicy(),
+		},
+	}
+
+	_, err = f.client.objectStorageClient.HeadObject(ctx, req)
+	if err != nil {
+		serviceErr, ok := common.IsServiceError(err)
+		if ok && serviceErr.GetHTTPStatusCode() == 404 {
+			return false, nil
+		}
+		return false, formatOCIError(fmt.Sprintf("checking object %q existence", objectPath), err)
+	}
+
+	return true, nil
+}
+
+// GetSubFolder returns a folder instance for a subdirectory.
+func (f *Folder) GetSubFolder(subFolderRelativePath string) storage.Folder {
+	return NewFolder(f.client, f.bucket, storage.JoinPath(f.path, subFolderRelativePath), f.region)
+}
+
+// ReadObject downloads an object and returns its content as a reader.
+func (f *Folder) ReadObject(ctx context.Context, objectRelativePath string) (io.ReadCloser, error) {
+	objectPath := f.GetPath() + objectRelativePath
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+
+	tracelog.DebugLogger.Printf("Reading OCI object: %s", objectPath)
+
+	namespace, err := f.getNamespace(ctx)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	req := objectstorage.GetObjectRequest{
+		NamespaceName: common.String(namespace),
+		BucketName:    common.String(f.bucket),
+		ObjectName:    common.String(objectPath),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: defaultRetryPolicy(),
+		},
+	}
+
+	resp, err := f.client.objectStorageClient.GetObject(ctx, req)
+	if err != nil {
+		cancel()
+		serviceErr, ok := common.IsServiceError(err)
+		if ok && serviceErr.GetHTTPStatusCode() == 404 {
+			return nil, storage.NewObjectNotFoundError(objectPath)
+		}
+		return nil, formatOCIError(fmt.Sprintf("reading object %q", objectPath), err)
+	}
+
+	return &ctxReadCloser{ReadCloser: resp.Content, cancel: cancel}, nil
+}
+
+// PutObject uploads an object with context for cancellation.
+// Uses OCI's transfer.UploadManager to handle large objects without buffering in memory.
+func (f *Folder) PutObject(ctx context.Context, name string, content io.Reader) error {
+	objectPath := f.GetPath() + name
+
+	tracelog.DebugLogger.Printf("Putting OCI object: %s", objectPath)
+
+	namespace, err := f.getNamespace(ctx)
+	if err != nil {
+		return err
+	}
+
+	uploadManager := transfer.NewUploadManager()
+	req := transfer.UploadStreamRequest{
+		UploadRequest: transfer.UploadRequest{
+			NamespaceName:         common.String(namespace),
+			BucketName:            common.String(f.bucket),
+			ObjectName:            common.String(objectPath),
+			ObjectStorageClient:   f.client.objectStorageClient,
+			PartSize:              common.Int64(64 * 1024 * 1024), // 64MB parts
+			AllowMultipartUploads: common.Bool(true),
+		},
+		StreamReader: content,
+	}
+
+	_, err = uploadManager.UploadStream(ctx, req)
+	if err != nil {
+		return formatOCIError(fmt.Sprintf("putting object %q", objectPath), err)
+	}
+
+	return nil
+}
+
+// CopyObject copies an object from source to destination path within the bucket.
+func (f *Folder) CopyObject(ctx context.Context, srcPath string, dstPath string) error {
+	src := path.Join(f.GetPath(), srcPath)
+	dst := path.Join(f.GetPath(), dstPath)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	tracelog.DebugLogger.Printf("Copying OCI object from %s to %s", src, dst)
+
+	namespace, err := f.getNamespace(ctx)
+	if err != nil {
+		return err
+	}
+
+	req := objectstorage.CopyObjectRequest{
+		NamespaceName: common.String(namespace),
+		BucketName:    common.String(f.bucket),
+		CopyObjectDetails: objectstorage.CopyObjectDetails{
+			SourceObjectName:      common.String(src),
+			DestinationBucket:     common.String(f.bucket),
+			DestinationNamespace:  common.String(namespace),
+			DestinationObjectName: common.String(dst),
+			DestinationRegion:     common.String(f.region),
+		},
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: defaultRetryPolicy(),
+		},
+	}
+
+	_, err = f.client.objectStorageClient.CopyObject(ctx, req)
+	if err != nil {
+		if serviceErr, ok := common.IsServiceError(err); ok && serviceErr.GetHTTPStatusCode() == 404 {
+			return storage.NewObjectNotFoundError(srcPath)
+		}
+		return formatOCIError(fmt.Sprintf("copying object from %q to %q", src, dst), err)
+	}
+
+	return nil
+}
+
+func (f *Folder) Validate(ctx context.Context) error {
+	return nil
+}
+
+// SetVersioningEnabled is a no-op for OCI storage.
+func (f *Folder) SetVersioningEnabled(ctx context.Context, enable bool) {}
+
+// GetVersioningEnabled always returns false because OCI versioning is unsupported.
+func (f *Folder) GetVersioningEnabled(ctx context.Context) bool {
+	return false
+}

--- a/pkg/storages/oci/storage.go
+++ b/pkg/storages/oci/storage.go
@@ -1,0 +1,77 @@
+package oci
+
+import (
+	"fmt"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+var _ storage.HashableStorage = &Storage{}
+
+type Storage struct {
+	rootFolder storage.Folder
+	hash       string
+}
+
+type Config struct {
+	Region            string
+	TenancyOCID       string
+	SecurityTokenFile string
+	PrivateKeyFile    string
+	ConfigFile        string
+	Profile           string
+	CACertFile        string
+	Bucket            string
+	RootPath          string
+	ConnectTimeout    int64
+}
+
+// NewStorage creates a new OCI storage instance with the given configuration.
+func NewStorage(config *Config, rootWraps ...storage.WrapRootFolder) (*Storage, error) {
+	client, err := configureClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("configure OCI client: %w", err)
+	}
+
+	var folder storage.Folder = NewFolder(client, config.Bucket, config.RootPath, config.Region)
+
+	for _, wrap := range rootWraps {
+		folder = wrap(folder)
+	}
+
+	// Compute hash only from storage location identifiers, not credential paths
+	hashConfig := struct {
+		Region      string
+		TenancyOCID string
+		Bucket      string
+		RootPath    string
+	}{
+		Region:      config.Region,
+		TenancyOCID: config.TenancyOCID,
+		Bucket:      config.Bucket,
+		RootPath:    config.RootPath,
+	}
+
+	hash, err := storage.ComputeConfigHash("oci", hashConfig)
+	if err != nil {
+		return nil, fmt.Errorf("compute config hash: %w", err)
+	}
+
+	return &Storage{folder, hash}, nil
+}
+
+// RootFolder returns the root folder for this storage.
+func (s *Storage) RootFolder() storage.Folder {
+	return s.rootFolder
+}
+
+// ConfigHash returns a hash of the storage configuration.
+func (s *Storage) ConfigHash() string {
+	return s.hash
+}
+
+// Close is a no-op for OCI storage.
+// WAL-G spawns short-lived processes so connection cleanup is handled by process exit.
+func (s *Storage) Close() error {
+	return nil
+}

--- a/pkg/storages/oci/storage_test.go
+++ b/pkg/storages/oci/storage_test.go
@@ -1,0 +1,104 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOCIStorageConfigures(t *testing.T) {
+	t.Skip("Requires actual OCI credentials and token file")
+
+	ociPrefix := "oci://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(t.Context(), ociPrefix,
+		map[string]string{
+			regionSetting:            "us-phoenix-1",
+			tenancyOCIDSetting:       "ocid1.tenancy.oc1..test",
+			securityTokenFileSetting: "/tmp/test-token",
+		})
+
+	assert.NoError(t, err)
+}
+
+func TestOCIStorageConfiguresWithOptionalSettings(t *testing.T) {
+	t.Skip("Requires actual OCI credentials and token file")
+
+	ociPrefix := "oci://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(t.Context(), ociPrefix,
+		map[string]string{
+			regionSetting:            "us-phoenix-1",
+			tenancyOCIDSetting:       "ocid1.tenancy.oc1..test",
+			securityTokenFileSetting: "/tmp/test-token",
+			connectTimeoutSetting:    "60",
+		})
+
+	assert.NoError(t, err)
+}
+
+func TestOCIStorageRequiresRegion(t *testing.T) {
+	ociPrefix := "oci://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(t.Context(), ociPrefix,
+		map[string]string{
+			tenancyOCIDSetting:       "ocid1.tenancy.oc1..test",
+			securityTokenFileSetting: "/tmp/test-token",
+		})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "OCI_REGION is required")
+}
+
+func TestOCIStorageRequiresTenancyOCID(t *testing.T) {
+	ociPrefix := "oci://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(t.Context(), ociPrefix,
+		map[string]string{
+			regionSetting:            "us-phoenix-1",
+			securityTokenFileSetting: "/tmp/test-token",
+		})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "OCI_TENANCY_OCID is required")
+}
+
+func TestOCIStorageRequiresSecurityTokenFile(t *testing.T) {
+	ociPrefix := "oci://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(t.Context(), ociPrefix,
+		map[string]string{
+			regionSetting:      "us-phoenix-1",
+			tenancyOCIDSetting: "ocid1.tenancy.oc1..test",
+		})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no authentication method configured")
+}
+
+func TestOCIStorageWithConfigFile(t *testing.T) {
+	t.Skip("Requires OCI config file")
+
+	ociPrefix := "oci://test-bucket/wal-g-test-folder/Sub0"
+	_, err := ConfigureStorage(t.Context(), ociPrefix,
+		map[string]string{
+			regionSetting:      "us-phoenix-1",
+			tenancyOCIDSetting: "ocid1.tenancy.oc1..test",
+			configFileSetting:  "~/.oci/config",
+			profileSetting:     "DEFAULT",
+		})
+
+	assert.NoError(t, err)
+}
+
+func TestOCIFolder(t *testing.T) {
+	t.Skip("Credentials and OCI environment needed to run OCI tests")
+
+	ociPrefix := "oci://test-bucket/wal-g-test-folder/Sub0"
+	st, err := ConfigureStorage(t.Context(), ociPrefix,
+		map[string]string{
+			regionSetting:            "us-phoenix-1",
+			tenancyOCIDSetting:       "ocid1.tenancy.oc1..xxxxx",
+			securityTokenFileSetting: "/var/run/secrets/oci/token",
+		})
+	assert.NoError(t, err)
+
+	// This would run the standard folder test suite
+	// storage.RunFolderTest(st.RootFolder(), t)
+	_ = st
+}


### PR DESCRIPTION
 ### Database name

  Storage-layer change, not database-specific. Intended to work for all WAL-G-supported databases that use the common
  storage adapter path.

  # Pull request description

  ### Describe what this PR fixes

  Adds OCI Object Storage support as a WAL-G storage backend.

  This introduces an `oci://` storage adapter, configured via `WALG_OCI_PREFIX`, so WAL-G can store and retrieve
  backups/WAL archives from Oracle Cloud Infrastructure Object Storage.

  The new backend supports:

  - security token + private key file authentication
  - OCI config file + profile authentication
  - custom CA certificate configuration
  - configurable OCI connection timeout
  - object list/read/write/copy/delete/existence operations through the common storage interface

  Example configuration:

  ```bash
  WALG_OCI_PREFIX=oci://bucket/path/to/folder
  OCI_REGION=us-phoenix-1
  OCI_TENANCY_OCID=<tenancy-ocid>
  OCI_SECURITY_TOKEN_FILE=/path/to/token
  OCI_PRIVATE_KEY_FILE=/path/to/private-key.pem

  Alternatively, using an OCI config file:

  WALG_OCI_PREFIX=oci://bucket/path/to/folder
  OCI_CONFIG_FILE=/path/to/config
  OCI_PROFILE=DEFAULT