### PR TITLE
Direct IO backup-push IO size configuration to support high-throughput local NVMe disks

### DIFF
--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -27,6 +27,11 @@ To configure how many times failed file will be retried during ```backup-fetch``
 
 An experimental feature that allows you to perform direct_io reads during a ```backup-push``` without flushing the disk cache. To activate it, set the value of the environment variable to `true`.
 
+* `WALG_DIRECT_IO_BLOCK_COUNT`
+
+Set number of disk blocks read and processed in a single batch with direct_io during a ```backup-push```. Default 32 blocks is 32 * 4kb = 128kb
+single read. Larger reads up to 1024 blocks reduce syscall CPU costs and improve throughput at the expense of higher memory consumption.
+
 * `WALG_PREFETCH_DIR`
 
 By default WAL prefetch is storing prefetched data in pg_wal directory. This ensures that WAL can be easily moved from prefetch location to actual WAL consumption directory. But it may have negative consequences if you use it with pg_rewind in PostgreSQL 13.

--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -30,7 +30,7 @@ An experimental feature that allows you to perform direct_io reads during a ```b
 * `WALG_DIRECT_IO_BLOCK_COUNT`
 
 Set number of disk blocks read and processed in a single batch with direct_io during a ```backup-push```. Default 32 blocks is 32 * 4kb = 128kb
-single read. Larger reads up to 1024 blocks reduce syscall CPU costs and improve throughput at the expense of higher memory consumption.
+single read. Larger reads reduce syscall CPU costs and improve throughput at the expense of higher memory consumption.
 
 * `WALG_PREFETCH_DIR`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,7 @@ const (
 	PgpEnvelopeYcEndpointSetting  = "WALG_ENVELOPE_PGP_YC_ENDPOINT"
 	PgpEnvelopeCacheExpiration    = "WALG_ENVELOPE_CACHE_EXPIRATION"
 	DirectIO                      = "WALG_DIRECT_IO"
+	DirectIOBlockCountSetting     = "WALG_DIRECT_IO_BLOCK_COUNT"
 
 	PgDataSetting           = "PGDATA"
 	UserSetting             = "USER" // TODO : do something with it
@@ -283,6 +284,7 @@ var (
 		FailoverStorageCacheLifetime: "15m",
 		PgpEnvelopeCacheExpiration:   "0",
 		DirectIO:                     "false",
+		DirectIOBlockCountSetting:    "32",
 		LogLevelSetting:              "NORMAL",
 	}
 
@@ -386,6 +388,7 @@ var (
 		PgpEnvelopeYcSaKeyFileSetting: true,
 		PgpEnvelopeYcEndpointSetting:  true,
 		DirectIO:                      false,
+		DirectIOBlockCountSetting:     false,
 		LibsodiumKeySetting:           true,
 		LibsodiumKeyPathSetting:       true,
 		LibsodiumKeyTransform:         true,

--- a/internal/databases/postgres/tar_ball_file_packer.go
+++ b/internal/databases/postgres/tar_ball_file_packer.go
@@ -1,15 +1,19 @@
 package postgres
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/ncw/directio"
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	conf "github.com/wal-g/wal-g/internal/config"
 	pg_errors "github.com/wal-g/wal-g/internal/databases/postgres/errors"
 	"github.com/wal-g/wal-g/internal/databases/postgres/orioledb"
 	"github.com/wal-g/wal-g/internal/ioextensions"
@@ -94,7 +98,11 @@ func (p *TarBallFilePackerImpl) PackFileIntoTar(ctx context.Context, cfi *intern
 		var secondReadCloser io.ReadCloser
 		// newTeeReadCloser is used to provide the fileReadCloser to two consumers:
 		// fileReadCloser is needed for PackFileTo, secondReadCloser is for the page verification
-		fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
+		if viper.GetBool(conf.DirectIO) {
+			fileReadCloser, secondReadCloser = newTeeReadCloserDirectIO(fileReadCloser)
+		} else {
+			fileReadCloser, secondReadCloser = newTeeReadCloser(fileReadCloser)
+		}
 		errorGroup.Go(func() (err error) {
 			corruptBlocks, err := verifyFile(cfi.Path, cfi.FileInfo, secondReadCloser, cfi.IsIncremented)
 			if err != nil {
@@ -197,7 +205,8 @@ func verifyFile(path string, fileInfo os.FileInfo, fileReader io.Reader, isIncre
 	return VerifyPagedFileBase(path, fileInfo, fileReader)
 }
 
-// TeeReadCloser creates two io.ReadClosers from one
+// newTeeReadCloser creates two io.ReadClosers from one. Writes to the second consumer
+// (page verification) are streamed directly through an unbuffered pipe.
 func newTeeReadCloser(readCloser io.ReadCloser) (io.ReadCloser, io.ReadCloser) {
 	pipeReader, pipeWriter := io.Pipe()
 
@@ -207,3 +216,32 @@ func newTeeReadCloser(readCloser io.ReadCloser) (io.ReadCloser, io.ReadCloser) {
 	closer := ioextensions.NewMultiCloser([]io.Closer{readCloser, pipeWriter})
 	return &ioextensions.ReadCascadeCloser{Reader: teeReader, Closer: closer}, pipeReader
 }
+
+// newTeeReadCloserDirectIO is newTeeReadCloser for the DIRECT_IO read path: it buffers writes to
+// the second consumer (page verification) into WALG_DIRECT_IO_BLOCK_COUNT-sized blocks so the
+// verifier is woken once per O_DIRECT block instead of once per io.Copy chunk.
+func newTeeReadCloserDirectIO(readCloser io.ReadCloser) (io.ReadCloser, io.ReadCloser) {
+	pipeReader, pipeWriter := io.Pipe()
+
+	blockSize := viper.GetInt(conf.DirectIOBlockCountSetting) * directio.BlockSize
+	bufferedWriter := bufio.NewWriterSize(pipeWriter, blockSize)
+	teeReader := io.TeeReader(readCloser, bufferedWriter)
+
+	// Flush the bufferedWriter before the pipe writer is closed so the final
+	// partial block reaches the verifier.
+	closer := ioextensions.NewMultiCloser([]io.Closer{
+		readCloser,
+		closerFunc(func() error {
+			if err := bufferedWriter.Flush(); err != nil {
+				return err
+			}
+			return pipeWriter.Close()
+		}),
+	})
+	return &ioextensions.ReadCascadeCloser{Reader: teeReader, Closer: closer}, pipeReader
+}
+
+// closerFunc adapts a function to io.Closer.
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }

--- a/internal/fsutil/direct_io_reader.go
+++ b/internal/fsutil/direct_io_reader.go
@@ -13,14 +13,13 @@ import (
 	conf "github.com/wal-g/wal-g/internal/config"
 )
 
-const directIOBlockCount = 32
-
 type reader struct {
-	mu           *sync.Mutex
-	fd           *os.File
-	buff         []byte
-	buffOffset   int
-	alignedBlock []byte
+	mu               *sync.Mutex
+	fd               *os.File
+	buff             []byte
+	buffOffset       int
+	alignedBlockSize int
+	alignedBlock     []byte
 }
 
 // OpenReadOnlyMayBeDirectIO returns read-only io.ReadSeekCloser.
@@ -33,15 +32,21 @@ func OpenReadOnlyMayBeDirectIO(path string) (io.ReadSeekCloser, error) {
 
 // NewDirectIOReadSeekCloser returns io.ReadSeekCloser.
 func NewDirectIOReadSeekCloser(path string, flag int, perm os.FileMode) (io.ReadSeekCloser, error) {
+	blockCount := viper.GetInt(conf.DirectIOBlockCountSetting)
+	if blockCount <= 0 {
+		return nil, fmt.Errorf("%s is expected to be positive but is: %d", conf.DirectIOBlockCountSetting, blockCount)
+	}
 	in, errOpen := directio.OpenFile(path, flag, perm)
 	if errOpen != nil {
 		return nil, errOpen
 	}
+	alignedBlockSize := blockCount * directio.BlockSize
 	return &reader{
-		mu:           &sync.Mutex{},
-		fd:           in,
-		buff:         nil,
-		alignedBlock: directio.AlignedBlock(directIOBlockCount * directio.BlockSize),
+		mu:               &sync.Mutex{},
+		fd:               in,
+		buff:             nil,
+		alignedBlockSize: alignedBlockSize,
+		alignedBlock:     directio.AlignedBlock(alignedBlockSize),
 	}, nil
 }
 
@@ -73,7 +78,7 @@ func (r *reader) Seek(offset int64, whence int) (int64, error) {
 	defer r.mu.Unlock()
 	r.buffOffset = 0
 	r.buff = nil
-	r.alignedBlock = directio.AlignedBlock(directIOBlockCount * directio.BlockSize)
+	r.alignedBlock = directio.AlignedBlock(r.alignedBlockSize)
 	if whence != io.SeekStart {
 		panic(fmt.Errorf("this is programm bug, seek with whence %d currently is not supported by DirectIOReadSeekCloser",
 			whence))

--- a/internal/fsutil/direct_io_reader_test.go
+++ b/internal/fsutil/direct_io_reader_test.go
@@ -10,10 +10,18 @@ import (
 	"testing"
 
 	"github.com/ncw/directio"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/fsutil"
 )
+
+func TestMain(m *testing.M) {
+	// In production config.Configure() registers its default (32).
+	viper.Set(conf.DirectIOBlockCountSetting, 32)
+	os.Exit(m.Run())
+}
 
 func Test_NewDirectIOReadSeekCloser(t *testing.T) {
 	for _, testCaseSize := range []int64{
@@ -86,4 +94,37 @@ func getSHA256(t *testing.T, r io.ReadCloser) string {
 	_, err := io.Copy(h, r)
 	require.NoError(t, err)
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func Test_NewDirectIOReadSeekCloser_BlockCountOptions(t *testing.T) {
+	t.Cleanup(func() { viper.Set(conf.DirectIOBlockCountSetting, 32) })
+
+	// Iterate over common DirectIOBlockCountSetting options
+	for _, blockCount := range []int{1, 8, 32, 1024} {
+		viper.Set(conf.DirectIOBlockCountSetting, blockCount)
+
+		// Run 3 file size cases for each IOBlock size
+		t.Run(fmt.Sprintf("blockCount=%d/empty", blockCount), func(t *testing.T) {
+			directNewDirectIOReadSeekCloser(t, 0, 0)
+		})
+		t.Run(fmt.Sprintf("blockCount=%d/one_block", blockCount), func(t *testing.T) {
+			directNewDirectIOReadSeekCloser(t, directio.BlockSize, 0)
+		})
+		t.Run(fmt.Sprintf("blockCount=%d/blocks_plus_partial", blockCount), func(t *testing.T) {
+			directNewDirectIOReadSeekCloser(t, 32*directio.BlockSize+1, 0)
+		})
+	}
+}
+
+func Test_NewDirectIOReadSeekCloser_InvalidBlockCountError(t *testing.T) {
+	t.Cleanup(func() { viper.Set(conf.DirectIOBlockCountSetting, 32) })
+	fd, err := os.CreateTemp(os.TempDir(), "directio_invalid")
+	require.NoError(t, err)
+	require.NoError(t, fd.Close())
+	defer os.Remove(fd.Name())
+	for _, blockCount := range []int{0, -1} {
+		viper.Set(conf.DirectIOBlockCountSetting, blockCount)
+		_, err := fsutil.NewDirectIOReadSeekCloser(fd.Name(), syscall.O_RDONLY, 0)
+		assert.Error(t, err, "block count %d should be rejected", blockCount)
+	}
 }


### PR DESCRIPTION
## Make the O_DIRECT read block count configurable

WALG_DIRECT_IO already reads PGDATA with O_DIRECT during backup-push, but the block count was hardcoded to 32 (128 KiB per read). Expose it via WALG_DIRECT_IO_BLOCK_COUNT (default 32, so unset behavior is unchanged) so operators can request larger aligned reads (e.g. 1024 => 4 MiB), which cuts per-read syscall overhead on fast NVMe. The resolved block size is computed once at reader construction and reused on Seek. A non-positive value is rejected with an error (it would otherwise yield a zero-length aligned buffer).

## backup-push --verify: buffer the O_DIRECT verify tee into block-sized chunks

For --verify, the file read is tee'd to a page-verification consumer through an unbuffered io.Pipe, so the read is throttled to the verifier's lock-step drain rate. On the DIRECT_IO path the file arrives in WALG_DIRECT_IO_BLOCK_COUNT-sized blocks, so add newTeeReadCloserDirectIO, which buffers the tee writes to that block size (verifier woken once per block instead of once per io.Copy chunk) and flushes before closing the pipe so the final block is verified. The non-DIRECT_IO path keeps the original unbuffered newTeeReadCloser unchanged.
