### PR TITLE
Retry S3 requests on HTTP 499 (ClientDisconnected)

### DIFF
--- a/pkg/storages/s3/retryer.go
+++ b/pkg/storages/s3/retryer.go
@@ -35,7 +35,7 @@ func (r ConnResetRetryer) ShouldRetry(req *request.Request) bool {
 	}
 
 	// Some S3-compatible servers (e.g. MinIO) return HTTP 499 with error code
-	// "ClientDisconnected" when the request context is cancelled server-side
+	// "ClientDisconnected" when the request context is canceled server-side
 	// (including on the server's own shutdown), not necessarily because the
 	// client actually disconnected. Treat it as a transient failure worth
 	// retrying rather than aborting the whole backup on a single occurrence.

--- a/pkg/storages/s3/retryer.go
+++ b/pkg/storages/s3/retryer.go
@@ -34,5 +34,15 @@ func (r ConnResetRetryer) ShouldRetry(req *request.Request) bool {
 		return true
 	}
 
+	// Some S3-compatible servers (e.g. MinIO) return HTTP 499 with error code
+	// "ClientDisconnected" when the request context is cancelled server-side
+	// (including on the server's own shutdown), not necessarily because the
+	// client actually disconnected. Treat it as a transient failure worth
+	// retrying rather than aborting the whole backup on a single occurrence.
+	if req.HTTPResponse != nil && req.HTTPResponse.StatusCode == 499 {
+		tracelog.InfoLogger.Printf("S3 returned HTTP 499 (ClientDisconnected), retrying request")
+		return true
+	}
+
 	return r.Retryer.ShouldRetry(req)
 }

--- a/pkg/storages/s3/retryer_test.go
+++ b/pkg/storages/s3/retryer_test.go
@@ -49,6 +49,12 @@ func TestConnResetRetryerOperationAborted(t *testing.T) {
 	assert.True(t, retryer.ShouldRetry(&request.Request{HTTPResponse: resp}))
 }
 
+func TestConnResetRetryerClientDisconnected(t *testing.T) {
+	retryer := NewConnResetRetryer(client.DefaultRetryer{NumMaxRetries: 15})
+	resp := &http.Response{StatusCode: 499}
+	assert.True(t, retryer.ShouldRetry(&request.Request{HTTPResponse: resp}))
+}
+
 func TestConnResetRetryerThrottling(t *testing.T) {
 	retryer := client.DefaultRetryer{NumMaxRetries: 15}
 	resp := &http.Response{StatusCode: 429}


### PR DESCRIPTION
## Problem

We run WAL-G backups against a MinIO gateway. During a scale-down of the backend pool, one of the MinIO pods was terminated while it had an active multipart upload PUT in flight. MinIO returned its own `ErrClientDisconnected` error (`Code: "ClientDisconnected"`, HTTP status 499) — this is raised whenever the request context is cancelled, which includes the server's own shutdown, not only an actual client-side disconnect.

`ConnResetRetryer.ShouldRetry` did not treat HTTP 499 as retryable, so a single occurrence aborted the entire backup:

```
ERROR: failed to upload 'my-cluster/basebackups_005/base_.../tar_partitions/part_021.tar.lz4' to bucket 'my-backups-bucket':
MultipartUpload: upload multipart failed
	upload id: 01ABCXYZ...
caused by: ClientDisconnected: Client disconnected before response was ready
	status code: 499, request id: ..., host id:
ERROR: Unable to continue the backup process because of the loss of a part 21.
```

This is the same class of problem fixed in #2218 (transient network errors aborting the whole backup) — here it's a transient server-side response instead of a raw socket error.

## Fix

Add an HTTP 499 check to `ConnResetRetryer.ShouldRetry`, following the exact same pattern already used for HTTP 409 (`OperationAborted`). Added a unit test mirroring `TestConnResetRetryerOperationAborted`.

## Testing

```
go test ./pkg/storages/s3/... -run TestConnResetRetryer -v
```
All pass, including the new `TestConnResetRetryerClientDisconnected`. `go vet` and `go build` clean on the package.