### PR TITLE
Daemon: possible client bugfixes

### DIFF
--- a/cmd/daemonclient/main.go
+++ b/cmd/daemonclient/main.go
@@ -75,12 +75,17 @@ func parseArgs(args []string) (*commandOpts, *flag.FlagSet, error) {
 	opts.SocketName = args[0]
 
 	command := strings.ToLower(args[1])
-	cmd, ok := commands[command]
+	template, ok := commands[command]
 	if !ok {
 		return nil, fs, fmt.Errorf("unsupported command %v", command)
 	}
 
-	cmd.name = command
+	cmd := &commandOpts{
+		name:    command,
+		msgType: template.msgType,
+		args:    template.args,
+	}
+
 	if len(args) < 2+len(cmd.args) {
 		return cmd, fs, errCommandArguments
 	}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"net"
 	"time"
 )
@@ -22,6 +23,9 @@ func getMessage(messageType SocketMessageType, messageArgs []string) ([]byte, er
 	case 0:
 		return binary.BigEndian.AppendUint16(messageType.ToBytes(), uint16(3)), nil
 	case 1:
+		if len(messageArgs[0])+3 > math.MaxUint16 {
+			return nil, fmt.Errorf("unsupported arg size: message length %d exceeds uint16 max", len(messageArgs[0])+3)
+		}
 		res := binary.BigEndian.AppendUint16(messageType.ToBytes(), uint16(len(messageArgs[0])+3))
 		return append(res, []byte(messageArgs[0])...), nil
 	}
@@ -59,13 +63,14 @@ func SendCommand(opts *RunOptions) (SocketMessageType, error) {
 		return ErrorType, fmt.Errorf("unix socket write error: %w", err)
 	}
 
-	resp := make([]byte, 512)
-	n, err := socketConnection.Read(resp)
+	// The daemon always sends exactly one response byte (OkType, ErrorType, or
+	// ArchiveNonExistenceType). Reading a fixed 512-byte buffer risks silently
+	// misclassifying a multi-byte error payload if its first byte collides with a
+	// known type constant. Read exactly one byte instead.
+	resp := make([]byte, 1)
+	_, err = socketConnection.Read(resp)
 	if err != nil {
 		return ErrorType, fmt.Errorf("unix socket read error: %w", err)
-	}
-	if n < 1 {
-		return ErrorType, fmt.Errorf("daemon response error [message type: %v, args: %v]", string(opts.MessageType), opts.MessageArgs)
 	}
 	if !OkType.IsEqual(resp[0]) {
 		return SocketMessageType(resp[0]), fmt.Errorf("daemon command run error [message type: %v, args: %v, daemon response: %v]",

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -63,15 +63,16 @@ func SendCommand(opts *RunOptions) (SocketMessageType, error) {
 		return ErrorType, fmt.Errorf("unix socket write error: %w", err)
 	}
 
-	// The daemon always sends exactly one response byte (OkType, ErrorType, or
-	// ArchiveNonExistenceType). Reading a fixed 512-byte buffer risks silently
-	// misclassifying a multi-byte error payload if its first byte collides with a
-	// known type constant. Read exactly one byte instead.
 	resp := make([]byte, 1)
-	_, err = socketConnection.Read(resp)
+	n, err := socketConnection.Read(resp)
 	if err != nil {
 		return ErrorType, fmt.Errorf("unix socket read error: %w", err)
 	}
+
+	if n < 1 {
+		return ErrorType, fmt.Errorf("daemon response error [message type: %v, args: %v]", string(opts.MessageType), opts.MessageArgs)
+	}
+
 	if !OkType.IsEqual(resp[0]) {
 		return SocketMessageType(resp[0]), fmt.Errorf("daemon command run error [message type: %v, args: %v, daemon response: %v]",
 			string(opts.MessageType), opts.MessageArgs, string(resp[0]))


### PR DESCRIPTION
### Database name
postgres

# Pull request description
During daemon usage we encountered some crashes. In this pr i fix some minor things that can possibly lead to crash

- avoid direct command opts changes
- check message length
- daemon return only one status byte so change read 512 to read 1
