### PR TITLE
build(st_tests): switch Docker build to Makefile-driven pg build with…

### DIFF
--- a/docker/st_tests/Dockerfile
+++ b/docker/st_tests/Dockerfile
@@ -1,25 +1,27 @@
 FROM wal-g/golang:latest AS build
-ENV GOEXPERIMENT=jsonv2
 WORKDIR /go/src/github.com/wal-g/wal-g
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends --no-install-suggests \
-    liblzo2-dev
+    liblzo2-dev git
 
+COPY .git .git
+COPY .gitmodules .gitmodules
 COPY go.mod go.mod
+COPY go.sum go.sum
 COPY vendor/ vendor/
 COPY internal/ internal/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
 COPY main/ main/
 COPY utility/ utility/
+COPY test/ test/
+COPY testtools/ testtools/
+COPY link_brotli.sh link_brotli.sh
+COPY CMakeLists-brotli.txt CMakeLists-brotli.txt
+COPY Makefile Makefile
 
-RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
-        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
-    sed -i 's|\(#cgo LDFLAGS:\) .*|\1 -Wl,-Bstatic -llzo2 -Wl,-Bdynamic|' \
-        vendor/github.com/cyberdelia/lzo/lzo.go && \
-    cd main/pg && \
-    go build -mod vendor -race -o wal-g -tags "brotli lzo" -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+RUN go get -v -t ./... && USE_BROTLI=1 USE_LZO=1 make ENABLE_RACE_DETECTION=1 deps pg_build
 
 FROM wal-g/ubuntu:18.04
 


### PR DESCRIPTION
… full test context

remove GOEXPERIMENT=jsonv2 from the build stage
install git in addition to liblzo2-dev
copy VCS metadata and module files needed by build/version logic (.git, .gitmodules, go.sum) include test-related inputs and build scripts in context (test, testtools, link_brotli.sh, CMakeLists-brotli.txt, Makefile) replace inline sed patching + manual go build -race with: go get -v -t ./... && USE_BROTLI=1 USE_LZO=1 make ENABLE_RACE_DETECTION=1 deps pg_build keep runtime stage and entrypoint behavior unchanged

