### PR TITLE
chore(docker): remove unused /root/testtools creation in mysql and ma…

### DIFF
--- a/docker/mariadb_tests/Dockerfile
+++ b/docker/mariadb_tests/Dockerfile
@@ -15,8 +15,6 @@ RUN make ENABLE_RACE_DETECTION=1 mysql_build
 FROM wal-g/mariadb:latest
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin
 
-RUN mkdir /root/testtools
-
 COPY docker/mariadb_tests/scripts/ /tmp
 
 CMD /tmp/run_integration_tests.sh

--- a/docker/mysql_tests/Dockerfile
+++ b/docker/mysql_tests/Dockerfile
@@ -16,8 +16,6 @@ RUN cd main/mysql && \
 FROM wal-g/mysql:latest
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin
 
-RUN mkdir /root/testtools
-
 COPY docker/mysql_tests/scripts/ /tmp
 
 CMD /tmp/run_integration_tests.sh

--- a/docker/mysql_tests/Dockerfile_base
+++ b/docker/mysql_tests/Dockerfile_base
@@ -16,8 +16,6 @@ RUN cd main/mysql && \
 FROM wal-g/mysql:latest
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin
 
-RUN mkdir /root/testtools
-
 COPY docker/mysql_tests/scripts/ /tmp
 
 CMD /tmp/run_integration_tests.sh  -p /tmp/base_tests

--- a/docker/mysql_tests/Dockerfile_copy
+++ b/docker/mysql_tests/Dockerfile_copy
@@ -16,8 +16,6 @@ RUN cd main/mysql && \
 FROM wal-g/mysql:latest
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin
 
-RUN mkdir /root/testtools
-
 COPY docker/mysql_tests/scripts/ /tmp
 
 CMD /tmp/run_integration_tests.sh  -p /tmp/copy_tests

--- a/docker/mysql_tests/Dockerfile_delete
+++ b/docker/mysql_tests/Dockerfile_delete
@@ -16,8 +16,6 @@ RUN cd main/mysql && \
 FROM wal-g/mysql:latest
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin
 
-RUN mkdir /root/testtools
-
 COPY docker/mysql_tests/scripts/ /tmp
 
 CMD /tmp/run_integration_tests.sh -p /tmp/delete_tests

--- a/docker/mysql_tests/Dockerfile_v8
+++ b/docker/mysql_tests/Dockerfile_v8
@@ -21,8 +21,6 @@ FROM wal-g/mysql8:latest
 
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin
 
-RUN mkdir /root/testtools
-
 COPY docker/mysql_tests/scripts/ /tmp
 
 CMD /tmp/run_integration_tests.sh  -p /tmp/mysql8_tests


### PR DESCRIPTION
…riadb test images

drop redundant RUN mkdir /root/testtools from MySQL and MariaDB test Dockerfiles keep build, binary copy, test scripts copy, and test entrypoints unchanged simplify image layers without changing integration test behavior
