### PR TITLE
drop noop mongo_test

### DIFF
--- a/.github/workflows/dockertests-par.yml
+++ b/.github/workflows/dockertests-par.yml
@@ -69,7 +69,6 @@ jobs:
         "make TEST=\"pg10_daemon_backup_and_restore_test\" pg_integration_test",
         "make TEST=\"pg10_daemon_client_test\" pg_integration_test",
         "make TEST=\"pg10_prefetch_test\" pg_integration_test",
-        "make mongo_test",
         "make MONGO_VERSION=\"8.0.3\" MONGO_REPO=\"repo.mongodb.org\" MONGO_PACKAGE=\"mongodb-org\" mongo_catch_up_features",
         "make MONGO_VERSION=\"8.0.3\" MONGO_REPO=\"repo.mongodb.com\" MONGO_PACKAGE=\"mongodb-enterprise\" mongo_catch_up_features",
         "make MONGO_VERSION=\"8.0.3\" MONGO_REPO=\"repo.mongodb.com\" MONGO_PACKAGE=\"mongodb-enterprise\" mongo_binary_features",

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,6 @@ mariadb_integration_test: unlink_brotli load_docker_common
 	docker compose build mariadb && docker compose build mariadb_tests
 	docker compose up --force-recreate --exit-code-from mariadb_tests mariadb_tests
 
-mongo_test: deps mongo_build unlink_brotli
-
 mongo_build: $(CMD_FILES) $(PKG_FILES)
 	(cd $(MAIN_MONGO_PATH) && go build $(if $(ENABLE_RACE_DETECTION),-race) $(BUILD_ARGS) -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -gcflags "$(BUILD_GCFLAGS)" -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/mongo.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/mongo.gitRevision=$(GIT_REVISION) -X github.com/wal-g/wal-g/cmd/mongo.walgVersion=$(WALG_VERSION)")
 


### PR DESCRIPTION
as mentioned in https://github.com/wal-g/wal-g/pull/2270 current mongo_test is noop.

let's land it
