### PR TITLE
fix SA1019 staticcheck exclusion, fixes linting errors on master

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,8 +75,8 @@ linters:
         - name: redefines-builtin-id
     staticcheck:
       checks:
-        - -SA1019
         - all
+        - -SA1019
   exclusions:
     generated: lax
     presets:

--- a/internal/databases/mysql/xtrabackup.go
+++ b/internal/databases/mysql/xtrabackup.go
@@ -274,7 +274,6 @@ func xtrabackupFetchInhouse(ctx context.Context, backup internal.Backup, prepare
 
 	if inplace && sentinel.IsIncremental {
 		// apply diff-files to dataDir inplace (and leave required leftovers incrementalDir)
-		//nolint:staticcheck
 		go xbstream.AsyncDiffBackupSink(&wg, streamReader, dataDir, tempDeltaDir)
 	} else {
 		destinationDir := tempDeltaDir

--- a/internal/databases/postgres/tar_interpreter.go
+++ b/internal/databases/postgres/tar_interpreter.go
@@ -84,7 +84,6 @@ func (tarInterpreter *FileTarInterpreter) Interpret(fileReader io.Reader, fileIn
 	targetPath := path.Join(tarInterpreter.DBDataDirectory, fileInfo.Name)
 	targetPath = filepath.ToSlash(targetPath)
 	fsync := !viper.GetBool(conf.TarDisableFsyncSetting)
-	//nolint:staticcheck
 	switch fileInfo.Typeflag {
 	case tar.TypeReg, tar.TypeRegA:
 		// temporary switch to determine if new unwrap logic should be used

--- a/internal/file_tar_interpreter.go
+++ b/internal/file_tar_interpreter.go
@@ -29,7 +29,6 @@ func (tarInterpreter *FileTarInterpreter) Interpret(reader io.Reader, fileInfo *
 	tracelog.DebugLogger.Println("Interpreting: ", fileInfo.Name)
 	targetPath := path.Join(tarInterpreter.DirectoryToSave, fileInfo.Name)
 	switch fileInfo.Typeflag {
-	//nolint:staticcheck
 	case tar.TypeReg, tar.TypeRegA:
 		return tarInterpreter.interpretRegularFile(targetPath, fileInfo, reader)
 	case tar.TypeDir:


### PR DESCRIPTION
aws sdk v1 deprecation warnings were getting through

aws sdk v1 deprecation addressed by #2280