### PR TITLE
Make Greenplum/Cloudberry independent from search_path setting value

### DIFF
--- a/internal/databases/greenplum/ao_check_segment_length_handler.go
+++ b/internal/databases/greenplum/ao_check_segment_length_handler.go
@@ -194,18 +194,18 @@ FROM
       relfilenode, 
       relnamespace 
     FROM 
-      pg_class 
-      JOIN pg_appendonly ON oid OPERATOR(pg_catalog.=) relid
+      pg_catalog.pg_class
+      JOIN pg_catalog.pg_appendonly ON oid OPERATOR(pg_catalog.=) relid
   ) a, 
   (
     SELECT 
       relname, 
       segrelid 
     FROM 
-      pg_class 
-      JOIN pg_appendonly ON oid OPERATOR(pg_catalog.=) segrelid
+      pg_catalog.pg_class 
+      JOIN pg_catalog.pg_appendonly ON oid OPERATOR(pg_catalog.=) segrelid
   ) b, 
-  pg_namespace n 
+  pg_catalog.pg_namespace n 
 WHERE 
   a.relpersistence OPERATOR(pg_catalog.=) 'p' 
   AND a.segrelid OPERATOR(pg_catalog.=) b.segrelid 
@@ -247,7 +247,7 @@ func (checker *AOLengthCheckSegmentHandler) getDatabasesInfo(ctx context.Context
 		}
 	}()
 
-	rows, err := conn.Query(ctx, "SELECT datname, oid FROM pg_database WHERE datallowconn")
+	rows, err := conn.Query(ctx, "SELECT datname, oid FROM pg_catalog.pg_database WHERE datallowconn")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -510,15 +510,11 @@ func getGpClusterInfo(ctx context.Context, conn *pgx.Conn) (
 		return globalCluster, Version{}, nil, err
 	}
 
-	versionStr, err := queryRunner.GetGreenplumVersion(ctx)
+	version, err = queryRunner.GetGreenplumVersion(ctx)
 	if err != nil {
 		return globalCluster, Version{}, nil, err
 	}
-	tracelog.InfoLogger.Printf("Greenplum version: %s", versionStr)
-	version, err = parseGreenplumVersion(versionStr)
-	if err != nil {
-		return globalCluster, Version{}, nil, err
-	}
+	tracelog.InfoLogger.Printf("Greenplum version: %s", version)
 
 	segConfigs, err := queryRunner.GetGreenplumSegmentsInfo(ctx)
 	if err != nil {

--- a/internal/databases/greenplum/pax_relfile_storage_map.go
+++ b/internal/databases/greenplum/pax_relfile_storage_map.go
@@ -17,14 +17,11 @@ import (
 // PAX is a Cloudberry-only access method, so for plain Greenplum and unknown flavors
 // the function short-circuits to an empty map without contacting the catalog.
 func NewPaxRelFileStorageMap(ctx context.Context, queryRunner *GpQueryRunner) (pax.RelFileStorageMap, error) {
-	versionStr, err := queryRunner.GetGreenplumVersion(ctx)
+	version, err := queryRunner.GetGreenplumVersion(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query greenplum version")
 	}
-	version, err := parseGreenplumVersion(versionStr)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse greenplum version")
-	}
+
 	if version.Flavor != Cloudberry {
 		tracelog.DebugLogger.Printf("Skipping PAX storage map: flavor=%s does not support PAX", version.Flavor)
 		return pax.RelFileStorageMap{}, nil

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -43,15 +43,45 @@ func ToGpQueryRunner(queryRunner *postgres.PgQueryRunner) *GpQueryRunner {
 }
 
 // BuildCreateGreenplumRestorePoint formats a query to create a restore point
-func (queryRunner *GpQueryRunner) buildCreateGreenplumRestorePoint(restorePointName string) string {
-	return fmt.Sprintf("SELECT (gp_create_restore_point('%s'))::text", restorePointName)
+func (queryRunner *GpQueryRunner) buildCreateGreenplumRestorePoint(
+	restorePointName string,
+	version Version,
+) (string, error) {
+	var queryTemplate string
+
+	switch version.Flavor {
+	case Greenplum:
+		queryTemplate = "SELECT (public.gp_create_restore_point('%s'))::text"
+	case Cloudberry:
+		queryTemplate = "SELECT (pg_catalog.gp_create_restore_point('%s'))::text"
+	default:
+		return "", postgres.NewUnsupportedPostgresVersionError(queryRunner.Version)
+	}
+
+	return fmt.Sprintf(queryTemplate, restorePointName), nil
 }
 
 // CreateGreenplumRestorePoint creates a restore point
-func (queryRunner *GpQueryRunner) CreateGreenplumRestorePoint(ctx context.Context,
-	restorePointName string) (restoreLSNs map[int]string, err error) {
+func (queryRunner *GpQueryRunner) CreateGreenplumRestorePoint(
+	ctx context.Context,
+	restorePointName string,
+) (restoreLSNs map[int]string, err error) {
 	conn := queryRunner.Connection
-	rows, err := conn.Query(ctx, queryRunner.buildCreateGreenplumRestorePoint(restorePointName))
+	versionStr, err := queryRunner.GetGreenplumVersion(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting version: %w", err)
+	}
+	version, err := parseGreenplumVersion(versionStr)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing version: %w", err)
+	}
+
+	createRestorePointQuery, err := queryRunner.buildCreateGreenplumRestorePoint(restorePointName, version)
+	if err != nil {
+		return nil, fmt.Errorf("error building create restore point query: %w", err)
+	}
+
+	rows, err := conn.Query(ctx, createRestorePointQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -67,13 +67,9 @@ func (queryRunner *GpQueryRunner) CreateGreenplumRestorePoint(
 	restorePointName string,
 ) (restoreLSNs map[int]string, err error) {
 	conn := queryRunner.Connection
-	versionStr, err := queryRunner.GetGreenplumVersion(ctx)
+	version, err := queryRunner.GetGreenplumVersion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting version: %w", err)
-	}
-	version, err := parseGreenplumVersion(versionStr)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing version: %w", err)
 	}
 
 	createRestorePointQuery, err := queryRunner.buildCreateGreenplumRestorePoint(restorePointName, version)
@@ -155,12 +151,19 @@ func (queryRunner *GpQueryRunner) GetGreenplumSegmentsInfo(ctx context.Context) 
 }
 
 // GetGreenplumVersion returns version
-func (queryRunner *GpQueryRunner) GetGreenplumVersion(ctx context.Context) (version string, err error) {
+func (queryRunner *GpQueryRunner) GetGreenplumVersion(ctx context.Context) (Version, error) {
 	conn := queryRunner.Connection
-	err = conn.QueryRow(ctx, "SELECT pg_catalog.version()").Scan(&version)
-	if err != nil {
-		return "", err
+
+	var versionStr string
+	if err := conn.QueryRow(ctx, "SELECT pg_catalog.version()").Scan(&versionStr); err != nil {
+		return Version{}, err
 	}
+
+	version, err := parseGreenplumVersion(versionStr)
+	if err != nil {
+		return Version{}, fmt.Errorf("error parsing version: %w", err)
+	}
+
 	return version, nil
 }
 
@@ -435,11 +438,7 @@ JOIN (
 `
 
 func (queryRunner *GpQueryRunner) buildAORelPgClassQuery(ctx context.Context) (string, error) {
-	versionStr, err := queryRunner.GetGreenplumVersion(ctx)
-	if err != nil {
-		return "", err
-	}
-	version, err := parseGreenplumVersion(versionStr)
+	version, err := queryRunner.GetGreenplumVersion(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/internal/databases/greenplum/restore_point.go
+++ b/internal/databases/greenplum/restore_point.go
@@ -177,10 +177,10 @@ func createRestorePoint(ctx context.Context, conn *pgx.Conn, restorePointName st
 						var pgOptions, switchFunction string
 						if gpVersion.Flavor == Greenplum && gpVersion.Major == 6 {
 							pgOptions = "-c gp_session_role=utility"
-							switchFunction = "pg_switch_xlog()"
+							switchFunction = "pg_catalog.pg_switch_xlog()"
 						} else {
 							pgOptions = "-c gp_role=utility"
-							switchFunction = "pg_switch_wal()"
+							switchFunction = "pg_catalog.pg_switch_wal()"
 						}
 						return fmt.Sprintf("PGOPTIONS='%s' psql -h %s -p %d -d postgres -c 'select %s;'",
 							pgOptions, seg[0].Hostname, seg[0].Port, switchFunction,

--- a/internal/databases/greenplum/version.go
+++ b/internal/databases/greenplum/version.go
@@ -26,6 +26,10 @@ type Version struct {
 	Flavor Flavor // Note: can be '' for old backups
 }
 
+func (v Version) String() string {
+	return fmt.Sprintf("%s (%s)", v.Flavor.String(), v.Version.String())
+}
+
 func NewVersion(v *version.Version, flavor Flavor) Version {
 	return Version{
 		Version: v,

--- a/internal/databases/greenplum/version_test.go
+++ b/internal/databases/greenplum/version_test.go
@@ -9,36 +9,43 @@ import (
 
 func TestParseGreenplumVersion(t *testing.T) {
 	var tests = []struct {
-		name   string
-		input  string
-		result Version
+		name         string
+		input        string
+		result       Version
+		resultString string
 	}{
 		{
-			name:   "greenplum 6.25 instance",
-			input:  "PostgreSQL 9.4.26 (Greenplum Database 6.25.3-mdb+yezzey+yagpcc-r+dev.40.gf0f10f9335 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Jul 24 2024 13:29:56",
-			result: NewVersion(version.Must(version.NewVersion("6.25.3")), Greenplum),
+			name:         "greenplum 6.25 instance",
+			input:        "PostgreSQL 9.4.26 (Greenplum Database 6.25.3-mdb+yezzey+yagpcc-r+dev.40.gf0f10f9335 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Jul 24 2024 13:29:56",
+			result:       NewVersion(version.Must(version.NewVersion("6.25.3")), Greenplum),
+			resultString: "greenplum (6.25.3)",
 		},
 		{
-			name:   "greengage 6.27 instance",
-			input:  "PostgreSQL 9.4.26 (Greengage Database 6.27.0 build commit:0123456789abcdef) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit",
-			result: NewVersion(version.Must(version.NewVersion("6.27.0")), Greenplum),
+			name:         "greengage 6.27 instance",
+			input:        "PostgreSQL 9.4.26 (Greengage Database 6.27.0 build commit:0123456789abcdef) on x86_64-pc-linux-gnu, compiled by gcc-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit",
+			result:       NewVersion(version.Must(version.NewVersion("6.27.0")), Greenplum),
+			resultString: "greenplum (6.27.0)",
 		},
 		{
-			name:   "cloudberry 1.6.0",
-			input:  "PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Sep 13 2024 07:33:38",
-			result: NewVersion(version.Must(version.NewVersion("1.6.0")), Cloudberry),
+			name:         "cloudberry 1.6.0",
+			input:        "PostgreSQL 14.4 (Cloudberry Database 1.6.0 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit compiled on Sep 13 2024 07:33:38",
+			result:       NewVersion(version.Must(version.NewVersion("1.6.0")), Cloudberry),
+			resultString: "cloudberry (1.6.0)",
 		},
 		{
-			name:   "apache cloudberry dev",
-			input:  "PostgreSQL 14.4 (Apache Cloudberry 1.0.0+00da831 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit compiled on Feb 25 2025 10:24:41",
-			result: NewVersion(version.Must(version.NewVersion("1.0.0")), Cloudberry),
+			name:         "apache cloudberry dev",
+			input:        "PostgreSQL 14.4 (Apache Cloudberry 1.0.0+00da831 build dev) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0, 64-bit compiled on Feb 25 2025 10:24:41",
+			result:       NewVersion(version.Must(version.NewVersion("1.0.0")), Cloudberry),
+			resultString: "cloudberry (1.0.0)",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			version, err := parseGreenplumVersion(tt.input)
+
 			assert.NoError(t, err)
 			assert.Equalf(t, tt.result, version, tt.name)
+			assert.Equalf(t, tt.resultString, version.String(), tt.name)
 		})
 	}
 }


### PR DESCRIPTION
### Database name

- Cloudberry
- Greenplum

# Pull request description

This PR adds support for using fully qualified names for certain functions and views. Fully qualified names are already partially used in the codebase, so support has been added for the missing ones.

### Describe what this PR fixes

The current version of WAL-G references some functions and views without using their fully qualified names, which can lead to errors if the `search_path` setting is changed. In particular, in Greenplum 6.x, the `gp_create_restore_point` function is installed into the `public` schema as part of the `gp_pitr` extension, whereas in Cloudberry it is part of the DBMS core and is located in `pg_catalog`.
