### PR TITLE
docker/redis_tests: switch to project-managed deps and redis build flow

### DIFF
--- a/docker/redis_tests/Dockerfile
+++ b/docker/redis_tests/Dockerfile
@@ -1,20 +1,26 @@
 FROM wal-g/golang:latest AS build
-ENV GOEXPERIMENT=jsonv2
 WORKDIR /go/src/github.com/wal-g/wal-g
 
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends --no-install-suggests git
+
+COPY .git .git
+COPY .gitmodules .gitmodules
 COPY go.mod go.mod
+COPY go.sum go.sum
 COPY vendor/ vendor/
 COPY internal/ internal/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
 COPY main/ main/
 COPY utility/ utility/
+COPY test/ test/
+COPY testtools/ testtools/
+COPY link_brotli.sh link_brotli.sh
+COPY CMakeLists-brotli.txt CMakeLists-brotli.txt
+COPY Makefile Makefile
 
-ENV USE_BROTLI=1
-RUN sed -i 's|#cgo LDFLAGS: -lbrotli.*|&-static -lbrotlicommon-static -lm|' \
-        vendor/github.com/google/brotli/go/cbrotli/cgo.go && \
-    cd main/redis && \
-    go build -mod vendor -tags brotli -race -o wal-g -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+RUN go get -v -t ./... && USE_BROTLI=1 make ENABLE_RACE_DETECTION=1 deps redis_build
 
 FROM wal-g/redis:latest
 


### PR DESCRIPTION
add git to the build image and include repository metadata plus expanded source inputs needed by dependency tooling copy additional files and directories required for dependency/bootstrap steps, including go.sum, tests, Brotli link script, and Makefile/CMake config remove custom sed patching of Brotli CGO linker flags and direct go build invocation replace ad-hoc build logic with unified pipeline: go get test deps, then run deps + redis_build with Brotli and race detection enabled

This aligns Redis test image builds with the same centralized dependency/build approach used in other test Dockerfiles.
