### PR TITLE
Clean up internal archive status files

### DIFF
--- a/internal/asm/archive_status_manager.go
+++ b/internal/asm/archive_status_manager.go
@@ -15,4 +15,7 @@ type ArchiveStatusManager interface {
 	MarkWalUploaded(string) error
 	UnmarkWalFile(string) error
 	RenameReady(string) error
+	// ListUploaded returns the names of WAL files marked as uploaded,
+	// up to limit entries. A limit <= 0 means no limit.
+	ListUploaded(limit int) ([]string, error)
 }

--- a/internal/asm/archive_status_manager_datafolder.go
+++ b/internal/asm/archive_status_manager_datafolder.go
@@ -30,3 +30,7 @@ func (asm DataFolderASM) UnmarkWalFile(walFilePath string) error {
 func (asm DataFolderASM) RenameReady(walFileName string) error {
 	return asm.folder.RenameFile(walFileName+".ready", walFileName+".done")
 }
+
+func (asm DataFolderASM) ListUploaded(limit int) ([]string, error) {
+	return asm.folder.ListFiles(limit)
+}

--- a/internal/asm/archive_status_manager_fake.go
+++ b/internal/asm/archive_status_manager_fake.go
@@ -44,3 +44,18 @@ func (asm *FakeASM) UnmarkWalFile(walFilePath string) error {
 func (asm *FakeASM) RenameReady(walFilePath string) error {
 	return nil
 }
+
+func (asm *FakeASM) ListUploaded(limit int) ([]string, error) {
+	asm.mutex.Lock()
+	defer asm.mutex.Unlock()
+	files := make([]string, 0, len(asm.uploaded))
+	for name, uploaded := range asm.uploaded {
+		if uploaded {
+			files = append(files, name)
+			if limit > 0 && len(files) >= limit {
+				break
+			}
+		}
+	}
+	return files, nil
+}

--- a/internal/asm/archive_status_manager_nop.go
+++ b/internal/asm/archive_status_manager_nop.go
@@ -21,3 +21,7 @@ func (asm NopASM) UnmarkWalFile(walFilePath string) error {
 func (asm NopASM) RenameReady(walFilePath string) error {
 	return nil
 }
+
+func (asm NopASM) ListUploaded(limit int) ([]string, error) {
+	return nil, nil
+}

--- a/internal/databases/postgres/bguploader.go
+++ b/internal/databases/postgres/bguploader.go
@@ -139,6 +139,8 @@ func (b *BgUploader) scanAndProcessFiles() {
 		}
 	}
 
+	go b.cleanStatusFiles()
+
 	for {
 		files, err := os.ReadDir(filepath.Join(b.dir, archiveStatusDir))
 		if err != nil {
@@ -230,4 +232,42 @@ func (b *BgUploader) upload(ctx context.Context, walStatusFilename string) bool 
 	}
 
 	return true
+}
+
+// cleanStatusFiles scans wal-g archive status directory to remove obsolete
+// status files left between runs. A status file is obsolete when the
+// corresponding WAL segment no longer has a .ready or .done entry in
+// PostgreSQL's archive_status directory. The number of files processed is
+// limited to avoid slowing down wal-push on clusters with a large backlog of
+// stale marker files.
+func (b *BgUploader) cleanStatusFiles() {
+	limit := int((b.maxNumUploaded + b.maxParallelWorkers) * 2)
+	files, err := b.uploader.ArchiveStatusManager.ListUploaded(limit)
+	if err != nil {
+		tracelog.ErrorLogger.Print("Failed to list walg archive status files: ", err)
+		return
+	}
+
+	for _, walName := range files {
+		select {
+		case <-b.ctx.Done():
+			return
+		default:
+		}
+
+		readyPath := filepath.Join(b.dir, archiveStatusDir, walName+readySuffix)
+		donePath := filepath.Join(b.dir, archiveStatusDir, walName+".done")
+
+		_, readyErr := os.Stat(readyPath)
+		_, doneErr := os.Stat(donePath)
+
+		if os.IsNotExist(readyErr) && os.IsNotExist(doneErr) {
+			err := b.uploader.ArchiveStatusManager.UnmarkWalFile(walName)
+			if err != nil {
+				tracelog.ErrorLogger.Printf("Failed to remove obsolete walg archive status file %s: %v", walName, err)
+			} else {
+				tracelog.InfoLogger.Printf("Removed obsolete walg archive status file: %s", walName)
+			}
+		}
+	}
 }

--- a/internal/fsutil/data_folder.go
+++ b/internal/fsutil/data_folder.go
@@ -29,4 +29,7 @@ type DataFolder interface {
 	DeleteFile(filename string) error
 	CreateFile(filename string) error
 	RenameFile(oldFileName string, newFileName string) error
+	// ListFiles returns the names of files in the folder, up to limit entries.
+	// A limit <= 0 means no limit.
+	ListFiles(limit int) ([]string, error)
 }

--- a/internal/fsutil/disk_data_folder.go
+++ b/internal/fsutil/disk_data_folder.go
@@ -71,3 +71,20 @@ func (folder *DiskDataFolder) RenameFile(oldFileName string, newFileName string)
 	newPath := filepath.Join(folder.Path, newFileName)
 	return os.Rename(oldPath, newPath)
 }
+
+func (folder *DiskDataFolder) ListFiles(limit int) ([]string, error) {
+	entries, err := os.ReadDir(folder.Path)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.Type().IsDir() {
+			files = append(files, entry.Name())
+			if limit > 0 && len(files) >= limit {
+				break
+			}
+		}
+	}
+	return files, nil
+}

--- a/testtools/mock_data_folder.go
+++ b/testtools/mock_data_folder.go
@@ -54,3 +54,14 @@ func (folder *MockDataFolder) OpenWriteOnlyFile(filename string) (io.WriteCloser
 func (folder *MockDataFolder) RenameFile(oldFilename string, newFilename string) error {
 	return nil
 }
+
+func (folder *MockDataFolder) ListFiles(limit int) ([]string, error) {
+	files := make([]string, 0, len(*folder))
+	for name := range *folder {
+		files = append(files, name)
+		if limit > 0 && len(files) >= limit {
+			break
+		}
+	}
+	return files, nil
+}


### PR DESCRIPTION
### Database name 

PostgreSQL

# Pull request description

The wal-push command for PostgreSQL leaves walg specific status files to track if it has already uploaded more than one segment in a previous run. When doing so it leaves empty status files in `pg_wal/walg_data/walg_archive_status` that are never purged.

On write busy clusters, it leaves millions of empty, which consumes inodes, make the the directory grow over hundreds of megabytes. It also makes `pg_rewind` very slow as it needs removes `pg_wal/walg_data` when running.

This PR adds a goroutine to `wal-push` to clean `pg_wal/walg_data/walg_archive_status` when running, using a best effort approach so that the clean up does not slow down the command. The criteria to remove a status file is to check if PostgreSQL has recycled the corresponding WAL file, which does not interfere with `--pg-ready-rename`.

