### PR TITLE
Document s3 config options used with S3_ENDPOINT_SOURCE 

### DIFF
--- a/docs/STORAGES.md
+++ b/docs/STORAGES.md
@@ -32,6 +32,18 @@ WAL-G can automatically determine the S3 bucket's region using `s3:GetBucketLoca
 
 Overrides the default hostname to connect to an S3-compatible service. i.e, `http://s3-like-service:9000`
 
+* `S3_ENDPOINT_SOURCE`
+
+Use to bypass balancer and connect directly to host. In the balancer-bypass mode we replace the request host with the address of a specific node returned by the endpoint source.
+
+* `S3_ENDPOINT_PORT`
+
+Sets port to use for s3 connection. By default 443 is used.
+
+* `S3_ENDPOINT_PROTOCOL`
+
+When `S3_ENDPOINT_SOURCE` is set, use this option to specify protocol (http, https). By default will use protocol from  `AWS_ENDPOINT`
+
 * `AWS_S3_FORCE_PATH_STYLE`
 
 To enable path-style addressing (i.e., `http://s3.amazonaws.com/BUCKET/KEY`) when connecting to an S3-compatible service that lack of support for sub-domain style bucket URLs (i.e., `http://BUCKET.s3.amazonaws.com/KEY`). Defaults to `false`.

--- a/pkg/storages/s3/configure.go
+++ b/pkg/storages/s3/configure.go
@@ -35,6 +35,7 @@ const (
 	maxPartSizeSetting              = "S3_MAX_PART_SIZE"
 	endpointSourceSetting           = "S3_ENDPOINT_SOURCE"
 	endpointPortSetting             = "S3_ENDPOINT_PORT"
+	endpointProtocolSetting         = "S3_ENDPOINT_PROTOCOL"
 	logLevelSetting                 = "S3_LOG_LEVEL"
 	useListObjectsV1Setting         = "S3_USE_LIST_OBJECTS_V1"
 	rangeBatchEnabledSetting        = "S3_RANGE_BATCH_ENABLED"
@@ -55,6 +56,7 @@ var SettingList = []string{
 	endpointPortSetting,
 	endpointSetting,
 	endpointSourceSetting,
+	endpointProtocolSetting,
 	regionSetting,
 	forcePathStyleSetting,
 	accessKeyIDSetting,
@@ -195,6 +197,7 @@ func ConfigureStorage(
 		Endpoint:                 settings[endpointSetting],
 		EndpointSource:           settings[endpointSourceSetting],
 		EndpointPort:             port,
+		EndpointProtocol:         settings[endpointProtocolSetting],
 		Bucket:                   bucket,
 		RootPath:                 rootPath,
 		AccessKey:                strings.TrimSpace(setting.FirstDefined(settings, accessKeyIDSetting, accessKeySetting)),

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+//nolint:gocyclo
 func createSession(config *Config) (*session.Session, error) {
 	sessOpts := session.Options{}
 	if config.CACertFile != "" {
@@ -241,7 +242,7 @@ func detectAWSRegionByBucket(bucket string, config *aws.Config) (string, error) 
 }
 
 // endpointSchemeAndHost splits the configured endpoint into a connection scheme and a host.
-// A scheme-less endpoint defaults to https, matching the AWS SDK behaviour.
+// A scheme-less endpoint defaults to https, matching the AWS SDK behavior.
 func endpointSchemeAndHost(endpoint string) (scheme, host string) {
 	switch {
 	case strings.HasPrefix(endpoint, "https://"):

--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -68,6 +68,11 @@ func createSession(config *Config) (*session.Session, error) {
 		// name in the Host header. The connection scheme follows the configured endpoint
 		// instead of being hardcoded to plain HTTP.
 		scheme, host := endpointSchemeAndHost(config.Endpoint)
+
+		if config.EndpointProtocol != "" {
+			scheme = config.EndpointProtocol
+		}
+
 		if scheme == "https" {
 			// The TCP connection goes straight to the node address, so TLS SNI and
 			// certificate verification must be pinned to the real endpoint name rather

--- a/pkg/storages/s3/storage.go
+++ b/pkg/storages/s3/storage.go
@@ -22,6 +22,7 @@ type Config struct {
 	Endpoint                 string
 	EndpointSource           string
 	EndpointPort             string
+	EndpointProtocol         string
 	Bucket                   string
 	RootPath                 string
 	AccessKey                string


### PR DESCRIPTION
### Database name
s3

# Pull request description
Document config options `S3_ENDPOINT_SOURCE`, `S3_ENDPOINT_PORT`, and add option `S3_ENDPOINT_PROTOCOL`
