### PR TITLE
feat(compression): add support for uncompressed archives on Windows

### DIFF
--- a/internal/compression/compression_windows.go
+++ b/internal/compression/compression_windows.go
@@ -6,16 +6,19 @@ package compression
 import (
 	"github.com/wal-g/wal-g/internal/compression/lz4"
 	"github.com/wal-g/wal-g/internal/compression/lzma"
+	"github.com/wal-g/wal-g/internal/compression/none"
 )
 
-var CompressingAlgorithms = []string{lz4.AlgorithmName, lzma.AlgorithmName}
+var CompressingAlgorithms = []string{lz4.AlgorithmName, lzma.AlgorithmName, none.AlgorithmName}
 
 var Compressors = map[string]Compressor{
 	lz4.AlgorithmName:  lz4.Compressor{},
 	lzma.AlgorithmName: lzma.Compressor{},
+	none.AlgorithmName: none.Compressor{},
 }
 
 var Decompressors = []Decompressor{
 	lz4.Decompressor{},
 	lzma.Decompressor{},
+	none.Decompressor{},
 }


### PR DESCRIPTION
Register the `none` compression algorithm in the Windows-specific compression registry by adding its compressor, decompressor, and algorithm name to the supported implementations.
