### PR TITLE
build: standardize race-enabled MongoDB and Redis builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ mariadb_integration_test: unlink_brotli load_docker_common
 	docker compose up --force-recreate --exit-code-from mariadb_tests mariadb_tests
 
 mongo_build: $(CMD_FILES) $(PKG_FILES)
-	(cd $(MAIN_MONGO_PATH) && go build $(if $(ENABLE_RACE_DETECTION),-race) $(BUILD_ARGS) -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -gcflags "$(BUILD_GCFLAGS)" -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/mongo.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/mongo.gitRevision=$(GIT_REVISION) -X github.com/wal-g/wal-g/cmd/mongo.walgVersion=$(WALG_VERSION)")
+	(cd $(MAIN_MONGO_PATH) && go build $(if $(ENABLE_RACE_DETECTION),-race) -mod vendor -tags "$(BUILD_TAGS)" -o wal-g -gcflags "$(BUILD_GCFLAGS)" -ldflags "-s -w -X github.com/wal-g/wal-g/cmd/mongo.buildDate=`date -u +%Y.%m.%d_%H:%M:%S` -X github.com/wal-g/wal-g/cmd/mongo.gitRevision=$(GIT_REVISION) -X github.com/wal-g/wal-g/cmd/mongo.walgVersion=$(WALG_VERSION)")
 
 mongo_install: mongo_build
 	mv $(MAIN_MONGO_PATH)/wal-g $(GOBIN)/wal-g

--- a/tests_func/Dockerfile.mongodb
+++ b/tests_func/Dockerfile.mongodb
@@ -9,15 +9,13 @@ COPY staging/wal-g ${WALG_REPO}/
 
 WORKDIR ${WALG_REPO}
 
-RUN make link_external_deps && \
-    make BUILD_ARGS=-race mongo_build && \
-    cp main/mongo/wal-g /usr/bin/wal-g
+RUN make ENABLE_RACE_DETECTION=1 link_external_deps mongo_build
 
 ###
 
 FROM ubuntu:focal
 
-COPY --from=build /usr/bin/wal-g /usr/bin/wal-g
+COPY --from=build /go/src/github.com/wal-g/wal-g/main/mongo/wal-g /usr/bin/wal-g
 
 ENV DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
 

--- a/tests_func/Dockerfile.redis
+++ b/tests_func/Dockerfile.redis
@@ -9,15 +9,13 @@ COPY staging/wal-g ${WALG_REPO}/
 
 WORKDIR ${WALG_REPO}
 
-RUN make link_external_deps && \
-    make BUILD_ARGS=-race redis_build && \
-    cp main/redis/wal-g /usr/bin/wal-g
+RUN make ENABLE_RACE_DETECTION=1 link_external_deps redis_build
 
 ###
 
 FROM ubuntu:focal
 
-COPY --from=build /usr/bin/wal-g /usr/bin/wal-g
+COPY --from=build /go/src/github.com/wal-g/wal-g/main/redis/wal-g /usr/bin/wal-g
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Use ENABLE_RACE_DETECTION instead of BUILD_ARGS=-race when building MongoDB and Redis test binaries, and copy the resulting binaries directly from the build workspace.
