### PR TITLE
attempts to make partial backups faster

### DIFF
--- a/internal/databases/mongo/binary/partial.go
+++ b/internal/databases/mongo/binary/partial.go
@@ -1,7 +1,6 @@
 package binary
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/mongodb/mongo-tools/common/util"
@@ -141,11 +140,15 @@ func GetTarFilesFilter(
 }
 
 func convertToFile(ident string) string {
-	return fmt.Sprintf("/%s.wt", ident)
+	builder := strings.Builder{}
+	builder.WriteRune('/')
+	builder.WriteString(ident)
+	builder.WriteString(".wt")
+	return builder.String()
 }
 
 func localPathFromURI(uri string) string {
-	tracelog.InfoLogger.Printf("URI: %s", uri)
+	//tracelog.DebugLogger.Printf("URI: %s", uri) removed due to efficiency
 	return strings.SplitN(uri, ":", 3)[2]
 }
 


### PR DESCRIPTION
### Database name
MongoDB

# Pull request description

### Describe what this PR fixes
I commented debug print due to efficiency, because, theoretically we spend a lot of time to print this if we have large number of namespaces. Also, I replaced fmt.Sprintf with strings.Builder, because it's much faster

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
