### PR TITLE
build: remove redundant go get from CI and Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
-
-      - name: Get dependencies
-        run: go get -v -t ./...
-
       - name: Mark repo and submodule as safe
         run: |
           git config --global --add safe.directory $GITHUB_WORKSPACE

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Build dependencies
         run: |
-          go get -v -t ./...
           curl --retry 5 --retry-delay 0 -sL "https://github.com/jedisct1/libsodium/releases/download/$env:LIBSODIUM_VERSION-RELEASE/libsodium-$env:LIBSODIUM_VERSION-mingw.tar.gz" -o "libsodium-$env:LIBSODIUM_VERSION-mingw.tar.gz"
           tar -xf .\libsodium-$env:LIBSODIUM_VERSION-mingw.tar.gz
           mkdir tmp

--- a/docker/etcd_tests/Dockerfile
+++ b/docker/etcd_tests/Dockerfile
@@ -23,7 +23,7 @@ COPY Makefile Makefile
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.31.0/cmake-3.31.0-linux-x86_64.tar.gz && \
     tar xf cmake-3.31.0-linux-x86_64.tar.gz -C /usr --strip-components=1
 
-RUN go get -v -t ./... && USE_BROTLI=1 make ENABLE_RACE_DETECTION=1 deps etcd_build
+RUN USE_BROTLI=1 make ENABLE_RACE_DETECTION=1 deps etcd_build
 
 FROM wal-g/etcd:latest
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/etcd/wal-g /usr/bin

--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -22,7 +22,7 @@ COPY CMakeLists-brotli.txt CMakeLists-brotli.txt
 COPY Makefile Makefile
 
 RUN --mount=type=cache,target=/gocache GOCACHE=/gocache \
-    go get -v -t ./... && USE_BROTLI=1 USE_LZO=1 make ENABLE_RACE_DETECTION=1 deps pg_build build_client
+    USE_BROTLI=1 USE_LZO=1 make ENABLE_RACE_DETECTION=1 deps pg_build build_client
 
 RUN --mount=type=cache,target=/gocache cd pkg/storages/swift && GOCACHE=/gocache go test -v -c
 RUN --mount=type=cache,target=/gocache cd pkg/storages/sh && GOCACHE=/gocache go test -v -c

--- a/docker/pg_tests/Dockerfile_prefix
+++ b/docker/pg_tests/Dockerfile_prefix
@@ -28,7 +28,7 @@ COPY CMakeLists-brotli.txt CMakeLists-brotli.txt
 COPY Makefile Makefile
 
 RUN --mount=type=cache,target=/gocache GOCACHE=/gocache \
-    go get -v -t ./... && USE_LIBSODIUM=1 USE_BROTLI=1 USE_LZO=1 make ENABLE_RACE_DETECTION=1 deps pg_build build_client
+    USE_LIBSODIUM=1 USE_BROTLI=1 USE_LZO=1 make ENABLE_RACE_DETECTION=1 deps pg_build build_client
 
 RUN --mount=type=cache,target=/gocache cd pkg/storages/swift && GOCACHE=/gocache go test -v -c
 RUN --mount=type=cache,target=/gocache cd pkg/storages/sh && GOCACHE=/gocache go test -v -c

--- a/docker/redis_tests/Dockerfile
+++ b/docker/redis_tests/Dockerfile
@@ -20,7 +20,7 @@ COPY link_brotli.sh link_brotli.sh
 COPY CMakeLists-brotli.txt CMakeLists-brotli.txt
 COPY Makefile Makefile
 
-RUN go get -v -t ./... && USE_BROTLI=1 make ENABLE_RACE_DETECTION=1 deps redis_build
+RUN USE_BROTLI=1 make ENABLE_RACE_DETECTION=1 deps redis_build
 
 FROM wal-g/redis:latest
 

--- a/docker/st_tests/Dockerfile
+++ b/docker/st_tests/Dockerfile
@@ -21,7 +21,7 @@ COPY link_brotli.sh link_brotli.sh
 COPY CMakeLists-brotli.txt CMakeLists-brotli.txt
 COPY Makefile Makefile
 
-RUN go get -v -t ./... && USE_BROTLI=1 USE_LZO=1 make ENABLE_RACE_DETECTION=1 deps pg_build
+RUN USE_BROTLI=1 USE_LZO=1 make ENABLE_RACE_DETECTION=1 deps pg_build
 
 FROM wal-g/ubuntu:18.04
 


### PR DESCRIPTION
Remove legacy `go get -v -t ./...` invocations from GitHub Actions workflows and Docker build stages.

Modern versions of Go automatically resolve and download module dependencies during `go build` and `go test`, making the explicit dependency fetch step unnecessary.

