### PR TITLE
feat(zstd): configurable compression level and parallel block encoding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,10 @@ To configure where WAL-G stores backups, please consult the [Storages](STORAGES.
 To configure the compression method used for backups. Possible options are: `lz4`, `lzma`, `zstd`, `brotli`, `none`. The default method is `lz4`. LZ4 is the fastest method, but the compression ratio is bad.
 LZMA is way much slower. However, it compresses backups about 6 times better than LZ4. Brotli and zstd are a good trade-off between speed and compression ratio, which is about 3 times better than LZ4. None compression method disables compression.
 
+* `WALG_ZSTD_LEVEL`
+
+To configure the zstd compression level when `WALG_COMPRESSION_METHOD` is `zstd`. Possible options are: `fastest`, `default`, `better`, `best`. When unset, `default` is used. Higher levels compress better at the cost of more CPU time.
+
 ### Encryption
 
 * `YC_CSE_KMS_KEY_ID`

--- a/internal/compression/zstd/compressor.go
+++ b/internal/compression/zstd/compressor.go
@@ -12,10 +12,21 @@ const (
 	FileExtension = "zst"
 )
 
-type Compressor struct{}
+// Compressor writes zstd-compressed streams. A zero Level keeps the historical
+// default (zstd.SpeedDefault), so an unconfigured Compressor behaves as before.
+type Compressor struct {
+	Level zstd.EncoderLevel
+}
 
 func (compressor Compressor) NewWriter(writer io.Writer) ioextensions.WriteFlushCloser {
-	zw, err := zstd.NewWriter(writer, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	level := compressor.Level
+	if level == 0 { // level not set: preserve the previous default
+		level = zstd.SpeedDefault
+	}
+	zw, err := zstd.NewWriter(writer,
+		zstd.WithEncoderLevel(level),
+		zstd.WithConcurrentBlocks(true),
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -25,4 +36,12 @@ func (compressor Compressor) NewWriter(writer io.Writer) ioextensions.WriteFlush
 
 func (compressor Compressor) FileExtension() string {
 	return FileExtension
+}
+
+// EncoderLevelFromName resolves a WALG_ZSTD_LEVEL value ("fastest", "default",
+// "better", "best") to a zstd encoder level. The match ignores case; the
+// returned bool is false when the name is not recognized.
+func EncoderLevelFromName(name string) (zstd.EncoderLevel, bool) {
+	ok, level := zstd.EncoderLevelFromString(name)
+	return level, ok
 }

--- a/internal/compression/zstd/compressor_test.go
+++ b/internal/compression/zstd/compressor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,4 +71,43 @@ func TestCompressDecompress(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestCompressDecompressLevels(t *testing.T) {
+	levels := []zstd.EncoderLevel{
+		zstd.SpeedFastest,
+		zstd.SpeedDefault,
+		zstd.SpeedBetterCompression,
+		zstd.SpeedBestCompression,
+	}
+
+	buff := make([]byte, 1<<16)
+	rand.New(rand.NewSource(0x1337c0deb357beef)).Read(buff)
+
+	for _, level := range levels {
+		var comp bytes.Buffer
+		wc := Compressor{Level: level}.NewWriter(&comp)
+		_, err := wc.Write(buff)
+		require.NoError(t, err, level.String())
+		require.NoError(t, wc.Close(), level.String())
+
+		rdr, err := Decompressor{}.Decompress(&comp)
+		require.NoError(t, err, level.String())
+
+		var decomp bytes.Buffer
+		_, err = io.Copy(&decomp, rdr)
+		require.NoError(t, err, level.String())
+		require.NoError(t, rdr.Close(), level.String())
+
+		assert.True(t, bytes.Equal(buff, decomp.Bytes()), "roundtrip mismatch at level %s", level.String())
+	}
+}
+
+func TestEncoderLevelFromName(t *testing.T) {
+	level, ok := EncoderLevelFromName("best")
+	require.True(t, ok)
+	assert.Equal(t, zstd.SpeedBestCompression, level)
+
+	_, ok = EncoderLevelFromName("nonsense")
+	assert.False(t, ok)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ const (
 	DeltaMaxStepsSetting          = "WALG_DELTA_MAX_STEPS"
 	DeltaOriginSetting            = "WALG_DELTA_ORIGIN"
 	CompressionMethodSetting      = "WALG_COMPRESSION_METHOD"
+	ZstdLevelSetting              = "WALG_ZSTD_LEVEL"
 	StoragePrefixSetting          = "WALG_STORAGE_PREFIX"
 	DiskRateLimitSetting          = "WALG_DISK_RATE_LIMIT"
 	NetworkRateLimitSetting       = "WALG_NETWORK_RATE_LIMIT"
@@ -368,6 +369,7 @@ var (
 		DeltaMaxStepsSetting:          true,
 		DeltaOriginSetting:            true,
 		CompressionMethodSetting:      true,
+		ZstdLevelSetting:              true,
 		StoragePrefixSetting:          true,
 		DiskRateLimitSetting:          true,
 		NetworkRateLimitSetting:       true,

--- a/internal/configure.go
+++ b/internal/configure.go
@@ -92,6 +92,20 @@ func (err UnknownZstdLevelError) Error() string {
 	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
 }
 
+type ZstdLevelWithoutZstdMethodError struct {
+	error
+}
+
+func newZstdLevelWithoutZstdMethodError(method string) ZstdLevelWithoutZstdMethodError {
+	return ZstdLevelWithoutZstdMethodError{
+		errors.Errorf("WALG_ZSTD_LEVEL is set but the compression method is '%s', not 'zstd'",
+			method)}
+}
+
+func (err ZstdLevelWithoutZstdMethodError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}
+
 type UnmarshallingError struct {
 	error
 }
@@ -209,14 +223,15 @@ func ConfigureCompressor() (compression.Compressor, error) {
 	if !ok {
 		return nil, newUnknownCompressionMethodError(compressionMethod)
 	}
-	if compressionMethod == zstdcompression.AlgorithmName {
-		if levelName := viper.GetString(conf.ZstdLevelSetting); levelName != "" {
-			level, levelOK := zstdcompression.EncoderLevelFromName(levelName)
-			if !levelOK {
-				return nil, newUnknownZstdLevelError(levelName)
-			}
-			compressor = zstdcompression.Compressor{Level: level}
+	if levelName := viper.GetString(conf.ZstdLevelSetting); levelName != "" {
+		if compressionMethod != zstdcompression.AlgorithmName {
+			return nil, newZstdLevelWithoutZstdMethodError(compressionMethod)
 		}
+		level, levelOK := zstdcompression.EncoderLevelFromName(levelName)
+		if !levelOK {
+			return nil, newUnknownZstdLevelError(levelName)
+		}
+		compressor = zstdcompression.Compressor{Level: level}
 	}
 	return compressor, nil
 }

--- a/internal/configure.go
+++ b/internal/configure.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/compression"
+	zstdcompression "github.com/wal-g/wal-g/internal/compression/zstd"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/internal/crypto/awskms"
@@ -74,6 +75,20 @@ func newUnknownCompressionMethodError(method string) UnknownCompressionMethodErr
 }
 
 func (err UnknownCompressionMethodError) Error() string {
+	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
+}
+
+type UnknownZstdLevelError struct {
+	error
+}
+
+func newUnknownZstdLevelError(level string) UnknownZstdLevelError {
+	return UnknownZstdLevelError{
+		errors.Errorf("Unknown zstd level: '%s', supported levels are: fastest, default, better, best",
+			level)}
+}
+
+func (err UnknownZstdLevelError) Error() string {
 	return fmt.Sprintf(tracelog.GetErrorFormatter(), err.error)
 }
 
@@ -190,10 +205,20 @@ func GetPgSlotName() (pgSlotName string) {
 
 func ConfigureCompressor() (compression.Compressor, error) {
 	compressionMethod := viper.GetString(conf.CompressionMethodSetting)
-	if _, ok := compression.Compressors[compressionMethod]; !ok {
+	compressor, ok := compression.Compressors[compressionMethod]
+	if !ok {
 		return nil, newUnknownCompressionMethodError(compressionMethod)
 	}
-	return compression.Compressors[compressionMethod], nil
+	if compressionMethod == zstdcompression.AlgorithmName {
+		if levelName := viper.GetString(conf.ZstdLevelSetting); levelName != "" {
+			level, levelOK := zstdcompression.EncoderLevelFromName(levelName)
+			if !levelOK {
+				return nil, newUnknownZstdLevelError(levelName)
+			}
+			compressor = zstdcompression.Compressor{Level: level}
+		}
+	}
+	return compressor, nil
 }
 
 func getPGArchiveStatusFolderPath() string {

--- a/internal/configure_test.go
+++ b/internal/configure_test.go
@@ -7,11 +7,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/compression/lz4"
 	"github.com/wal-g/wal-g/internal/compression/lzma"
+	walgzstd "github.com/wal-g/wal-g/internal/compression/zstd"
 	"github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/limiters"
 	"github.com/wal-g/wal-g/testtools"
@@ -176,6 +178,30 @@ func TestConfigureCompressor_ErrorWhenViperClear(t *testing.T) {
 
 func TestConfigureCompressor_FailsOnInvalidCompressorString(t *testing.T) {
 	viper.Set(config.CompressionMethodSetting, "kek123kek")
+	compressor, err := internal.ConfigureCompressor()
+	assert.Error(t, err)
+	assert.Equal(t, compressor, nil)
+	resetToDefaults()
+}
+func TestConfigureCompressor_ZstdMethodWithLevel(t *testing.T) {
+	viper.Set(config.CompressionMethodSetting, "zstd")
+	viper.Set(config.ZstdLevelSetting, "best")
+	compressor, err := internal.ConfigureCompressor()
+	assert.NoError(t, err)
+	assert.Equal(t, compressor, walgzstd.Compressor{Level: zstd.SpeedBestCompression})
+	resetToDefaults()
+}
+func TestConfigureCompressor_FailsOnInvalidZstdLevel(t *testing.T) {
+	viper.Set(config.CompressionMethodSetting, "zstd")
+	viper.Set(config.ZstdLevelSetting, "kek123kek")
+	compressor, err := internal.ConfigureCompressor()
+	assert.Error(t, err)
+	assert.Equal(t, compressor, nil)
+	resetToDefaults()
+}
+func TestConfigureCompressor_FailsOnZstdLevelWithoutZstdMethod(t *testing.T) {
+	viper.Set(config.CompressionMethodSetting, "lz4")
+	viper.Set(config.ZstdLevelSetting, "fastest")
 	compressor, err := internal.ConfigureCompressor()
 	assert.Error(t, err)
 	assert.Equal(t, compressor, nil)


### PR DESCRIPTION
### Database name
All databases (compression is database agnostic).

# Pull request description

### Describe what this PR fixes
Implements #2425. zstd compression was hardcoded to SpeedDefault with no way to tune it. This adds a `WALG_ZSTD_LEVEL` setting (`fastest`, `default`, `better`, `best`) mapped to the encoder levels, defaulting to the previous behavior when unset and failing explicitly on an unknown value. It also enables parallel block encoding on the zstd writer, which speeds up streaming compression while keeping a valid single frame zstd output, so existing backups and restores are unaffected.

### Please provide steps to reproduce (if it's a bug)
Not a bug. To use: set `WALG_ZSTD_LEVEL=best` (or `fastest`/`better`) together with `WALG_COMPRESSION_METHOD=zstd`.

### Please add config and wal-g stdout/stderr logs for debug purpose
Not applicable (feature change). Covered by unit tests in `internal/compression/zstd/compressor_test.go`.
