### PR TITLE
perf(compression): disable concurrent zstd block encoding

### DIFF
--- a/internal/compression/zstd/compressor.go
+++ b/internal/compression/zstd/compressor.go
@@ -25,7 +25,6 @@ func (compressor Compressor) NewWriter(writer io.Writer) ioextensions.WriteFlush
 	}
 	zw, err := zstd.NewWriter(writer,
 		zstd.WithEncoderLevel(level),
-		zstd.WithConcurrentBlocks(true),
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Remove the explicit `WithConcurrentBlocks(true)` option when creating zstd writers, allowing the encoder to use its default block processing behavior.

it reverts default behaviour to the previous state. as found by @jorsol, enabling concurrency blocks double memory consumption, which is not acceptable with default settings
