### PR TITLE
build: standardize MySQL test image builds

### DIFF
--- a/docker/mysql_tests/Dockerfile
+++ b/docker/mysql_tests/Dockerfile
@@ -1,17 +1,22 @@
 FROM wal-g/golang:latest AS build
-ENV GOEXPERIMENT=jsonv2
 WORKDIR /go/src/github.com/wal-g/wal-g
 
 COPY go.mod go.mod
+COPY go.sum go.sum
 COPY vendor/ vendor/
 COPY internal/ internal/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
 COPY main/ main/
 COPY utility/ utility/
+COPY Makefile Makefile
+COPY submodules/ submodules/
+COPY test/ test/
+COPY testtools/ testtools/
+COPY link_brotli.sh link_brotli.sh
+COPY CMakeLists-brotli.txt CMakeLists-brotli.txt
 
-RUN cd main/mysql && \
-    go build -mod vendor -tags brotli -race -o wal-g -ldflags "-s -w -X main.buildDate=`date -u +%Y.%m.%d_%H:%M:%S`"
+RUN USE_BROTLI=1 make ENABLE_RACE_DETECTION=1 deps mysql_build
 
 FROM wal-g/mysql:latest
 COPY --from=build /go/src/github.com/wal-g/wal-g/main/mysql/wal-g /usr/bin


### PR DESCRIPTION
Use the Makefile dependency and build targets for the MySQL test image instead of invoking go build directly. Add the required build files, Brotli sources, and test dependencies to the Docker build context, and enable Brotli and race detection through the standard build flags.
