### PR TITLE
Add `wal-g st stat` command to print metadata of a single object

### DIFF
--- a/cmd/common/st/stat_object.go
+++ b/cmd/common/st/stat_object.go
@@ -1,0 +1,37 @@
+package st
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/multistorage/exec"
+	"github.com/wal-g/wal-g/internal/storagetools"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+const statObjectShortDescription = "Prints metadata of the specified storage object"
+
+// statObjectCmd represents the statObject command
+var statObjectCmd = &cobra.Command{
+	Use:   "stat relative_object_path",
+	Short: statObjectShortDescription,
+	Long: "Prints metadata of a single storage object in the same format as 'wal-g st ls'. " +
+		"The metadata is fetched with a single cheap request (HEAD/stat) instead of listing the folder.",
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
+		if glob {
+			tracelog.ErrorLogger.FatalOnError(
+				fmt.Errorf("the --glob flag isn't supported by 'stat', because expanding a pattern requires listing"))
+		}
+		err := exec.OnStorage(ctx, targetStorage, func(folder storage.Folder) error {
+			return storagetools.HandleStatObject(ctx, args[0], folder)
+		})
+		tracelog.ErrorLogger.FatalOnError(err)
+	},
+}
+
+func init() {
+	StorageToolsCmd.AddCommand(statObjectCmd)
+}

--- a/docs/StorageTools.md
+++ b/docs/StorageTools.md
@@ -12,6 +12,17 @@ Prints listing of the objects in the provided storage folder.
 
 ``wal-g st ls --all-versions`` show all object versions including deleted objects (S3 with versioning enabled). Delete markers are labeled with `DELETE` in the output. This is useful for debugging or inspecting the full version history of objects.
 
+### ``stat``
+Prints metadata (type, size, last modification time, name) of a single storage object in the same format as ``ls``.
+
+Unlike ``ls``, it doesn't list the folder: the metadata is fetched with a single cheap request (`HEAD`/`stat`) to the storage. This makes it much faster than listing a folder that contains a lot of objects.
+
+The command fails if the object doesn't exist. The ``--glob`` flag isn't supported here, because expanding a pattern would require listing.
+
+Example:
+
+``wal-g st stat path/to/remote_file`` print metadata of the single file.
+
 ### ``get``
 Download the specified storage object. By default, the command will try to apply the decompression and decryption (if configured).
 

--- a/internal/multistorage/folder.go
+++ b/internal/multistorage/folder.go
@@ -250,6 +250,68 @@ func (mf Folder) ExistsInAll(ctx context.Context, objectRelativePath string) (bo
 	return true, consts.AllStorages, nil
 }
 
+// StatObject fetches the object's metadata from multiple storages. A specific implementation is selected using
+// policies.Policies.
+func (mf Folder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	object, _, err := StatObject(ctx, mf, objectRelativePath)
+	return object, err
+}
+
+// StatObject is like storage.Folder.StatObject, but it also provides the name of the storage where the object is found.
+func StatObject(ctx context.Context, folder storage.Folder, objectRelativePath string) (storage.Object, string, error) {
+	mf, ok := folder.(Folder)
+	if !ok {
+		object, err := folder.StatObject(ctx, objectRelativePath)
+		return object, consts.DefaultStorage, err
+	}
+
+	switch mf.policies.Read {
+	case policies.ReadPolicyFirst:
+		return mf.StatObjectInFirst(ctx, objectRelativePath)
+	case policies.ReadPolicyFoundFirst:
+		return mf.StatObjectFoundFirst(ctx, objectRelativePath)
+	default:
+		panic(fmt.Sprintf("unknown read object policy %d", mf.policies.Read))
+	}
+}
+
+// StatObjectInFirst fetches the object's metadata from the first storage.
+func (mf Folder) StatObjectInFirst(ctx context.Context, objectRelativePath string) (storage.Object, string, error) {
+	if len(mf.usedFolders) == 0 {
+		return nil, "", ErrNoUsedStorages
+	}
+	first := mf.usedFolders[0]
+	object, err := first.StatObject(ctx, objectRelativePath)
+	if err != nil {
+		if _, ok := err.(storage.ObjectNotFoundError); ok {
+			mf.statsCollector.ReportOperationResult(first.StorageName, stats.OperationExists, true)
+			return nil, first.StorageName, err
+		}
+		mf.statsCollector.ReportOperationResult(first.StorageName, stats.OperationExists, false)
+		return nil, first.StorageName, fmt.Errorf("stat object in %q: %w", first.StorageName, err)
+	}
+	mf.statsCollector.ReportOperationResult(first.StorageName, stats.OperationExists, true)
+	return object, first.StorageName, nil
+}
+
+// StatObjectFoundFirst fetches the object's metadata from all used storages in order and returns the first one found.
+func (mf Folder) StatObjectFoundFirst(ctx context.Context, objectRelativePath string) (storage.Object, string, error) {
+	for _, f := range mf.usedFolders {
+		object, err := f.StatObject(ctx, objectRelativePath)
+		if err != nil {
+			if _, ok := err.(storage.ObjectNotFoundError); ok {
+				mf.statsCollector.ReportOperationResult(f.StorageName, stats.OperationExists, true)
+				continue
+			}
+			mf.statsCollector.ReportOperationResult(f.StorageName, stats.OperationExists, false)
+			return nil, f.StorageName, fmt.Errorf("stat object in %q: %w", f.StorageName, err)
+		}
+		mf.statsCollector.ReportOperationResult(f.StorageName, stats.OperationExists, true)
+		return object, f.StorageName, nil
+	}
+	return nil, consts.AllStorages, storage.NewObjectNotFoundError(objectRelativePath)
+}
+
 // ReadObject reads the object from multiple storages. A specific implementation is selected using policies.Policies.
 func (mf Folder) ReadObject(ctx context.Context, objectRelativePath string) (io.ReadCloser, error) {
 	file, _, err := ReadObject(ctx, mf, objectRelativePath)

--- a/internal/storagetools/stat_object_handler.go
+++ b/internal/storagetools/stat_object_handler.go
@@ -1,0 +1,29 @@
+package storagetools
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+// HandleStatObject prints metadata of a single object in the same format as the folder listing does. Unlike listing,
+// it fetches the metadata with a cheap point lookup (HEAD/stat) instead of enumerating the whole folder.
+func HandleStatObject(ctx context.Context, objectPath string, folder storage.Folder) error {
+	return statObject(ctx, objectPath, folder, os.Stdout)
+}
+
+func statObject(ctx context.Context, objectPath string, folder storage.Folder, output io.Writer) error {
+	object, err := folder.StatObject(ctx, objectPath)
+	if err != nil {
+		return fmt.Errorf("stat object %q: %w", objectPath, err)
+	}
+
+	err = WriteObjectsList([]ListElement{NewListObject(object)}, output)
+	if err != nil {
+		return fmt.Errorf("write object stat: %w", err)
+	}
+	return nil
+}

--- a/internal/storagetools/stat_object_handler_test.go
+++ b/internal/storagetools/stat_object_handler_test.go
@@ -1,0 +1,53 @@
+package storagetools
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/pkg/storages/memory"
+	memmock "github.com/wal-g/wal-g/pkg/storages/memory/mock"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+)
+
+func TestStatObject(t *testing.T) {
+	t.Run("print metadata of an existing object", func(t *testing.T) {
+		folder := memory.NewFolder("test/", memory.NewKVS())
+		require.NoError(t, folder.PutObject(t.Context(), "a/b/file", bytes.NewBufferString("12345")))
+
+		var output bytes.Buffer
+		err := statObject(t.Context(), "a/b/file", folder, &output)
+		require.NoError(t, err)
+
+		assert.Contains(t, output.String(), "a/b/file")
+		assert.Contains(t, output.String(), "5")
+		assert.Contains(t, output.String(), string(Object))
+	})
+
+	t.Run("return not found error for a missing object", func(t *testing.T) {
+		folder := memory.NewFolder("test/", memory.NewKVS())
+
+		var output bytes.Buffer
+		err := statObject(t.Context(), "nonexistent", folder, &output)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+		assert.Empty(t, output.String())
+	})
+
+	t.Run("do not list the folder", func(t *testing.T) {
+		memFolder := memory.NewFolder("test/", memory.NewKVS())
+		require.NoError(t, memFolder.PutObject(t.Context(), "a/b/file", bytes.NewBufferString("12345")))
+
+		folder := memmock.NewFolder(memFolder)
+		folder.ListFolderMock = func(context.Context) ([]storage.Object, []storage.Folder, error) {
+			t.Error("stat must not list the folder")
+			return nil, nil, nil
+		}
+
+		var output bytes.Buffer
+		err := statObject(t.Context(), "a/b/file", folder, &output)
+		require.NoError(t, err)
+	})
+}

--- a/pkg/storages/azure/folder.go
+++ b/pkg/storages/azure/folder.go
@@ -57,6 +57,33 @@ func (folder *Folder) Exists(ctx context.Context, objectRelativePath string) (bo
 	return true, nil
 }
 
+func (folder *Folder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	path := storage.JoinPath(folder.path, objectRelativePath)
+	blobClient := folder.containerClient.NewBlockBlobClient(path)
+	props, err := blobClient.GetProperties(ctx, nil)
+	if err != nil && bloberror.HasCode(err, bloberror.BlobNotFound) {
+		return nil, storage.NewObjectNotFoundError(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get Azure object stats %q: %w", path, err)
+	}
+
+	var size int64
+	if props.ContentLength != nil {
+		size = *props.ContentLength
+	}
+	var lastModified time.Time
+	if props.LastModified != nil {
+		lastModified = *props.LastModified
+	}
+	var versionID string
+	if props.VersionID != nil {
+		versionID = *props.VersionID
+	}
+
+	return storage.NewLocalObjectWithVersion(objectRelativePath, lastModified, size, versionID, ""), nil
+}
+
 func (folder *Folder) ListFolder(ctx context.Context) ([]storage.Object, []storage.Folder, error) {
 	var objects []storage.Object
 	var subFolders []storage.Folder

--- a/pkg/storages/fs/folder.go
+++ b/pkg/storages/fs/folder.go
@@ -101,6 +101,21 @@ func (folder *Folder) Exists(_ context.Context, objectRelativePath string) (bool
 	return true, nil
 }
 
+func (folder *Folder) StatObject(_ context.Context, objectRelativePath string) (storage.Object, error) {
+	filePath := folder.GetFilePath(objectRelativePath)
+	info, err := os.Stat(filePath)
+	if os.IsNotExist(err) {
+		return nil, storage.NewObjectNotFoundError(filePath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to get file stats %v: %w", objectRelativePath, err)
+	}
+	if info.IsDir() {
+		return nil, storage.NewObjectNotFoundError(filePath)
+	}
+	return storage.NewLocalObject(objectRelativePath, info.ModTime(), info.Size()), nil
+}
+
 func (folder *Folder) GetSubFolder(subFolderRelativePath string) storage.Folder {
 	sf := NewFolder(folder.rootPath, path.Join(folder.subPath, subFolderRelativePath))
 	_ = sf.EnsureExists()

--- a/pkg/storages/gcs/folder.go
+++ b/pkg/storages/gcs/folder.go
@@ -125,6 +125,21 @@ func (folder *Folder) Exists(ctx context.Context, objectRelativePath string) (bo
 	return true, nil
 }
 
+func (folder *Folder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	objPath := folder.joinPath(folder.path, objectRelativePath)
+	object := folder.BuildObjectHandle(objPath)
+	ctx, cancel := folder.createTimeoutContext(ctx)
+	defer cancel()
+	attrs, err := object.Attrs(ctx)
+	if err == gcs.ErrObjectNotExist {
+		return nil, storage.NewObjectNotFoundError(objPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get GCS object stats %q: %w", objPath, err)
+	}
+	return storage.NewLocalObject(objectRelativePath, attrs.Updated, attrs.Size), nil
+}
+
 func (folder *Folder) GetSubFolder(subFolderRelativePath string) storage.Folder {
 	return NewFolder(
 		folder.bucket,

--- a/pkg/storages/memory/folder.go
+++ b/pkg/storages/memory/folder.go
@@ -30,6 +30,15 @@ func (folder *Folder) Exists(_ context.Context, objectRelativePath string) (bool
 	return exists, nil
 }
 
+func (folder *Folder) StatObject(_ context.Context, objectRelativePath string) (storage.Object, error) {
+	objectAbsPath := path.Join(folder.path, objectRelativePath)
+	object, exists := folder.KVS.Load(objectAbsPath)
+	if !exists {
+		return nil, storage.NewObjectNotFoundError(objectAbsPath)
+	}
+	return storage.NewLocalObject(objectRelativePath, object.Timestamp, int64(object.Size)), nil
+}
+
 func (folder *Folder) GetPath() string {
 	return folder.path
 }

--- a/pkg/storages/memory/mock/folder.go
+++ b/pkg/storages/memory/mock/folder.go
@@ -15,6 +15,7 @@ type Folder struct {
 	ListFolderMock    func(ctx context.Context) (objects []storage.Object, subFolders []storage.Folder, err error)
 	DeleteObjectsMock func(ctx context.Context, objectRelativePaths []storage.Object) error
 	ExistsMock        func(ctx context.Context, objectRelativePath string) (bool, error)
+	StatObjectMock    func(ctx context.Context, objectRelativePath string) (storage.Object, error)
 	GetSubFolderMock  func(subFolderRelativePath string) storage.Folder
 	ReadObjectMock    func(ctx context.Context, objectRelativePath string) (io.ReadCloser, error)
 	PutObjectMock     func(ctx context.Context, name string, content io.Reader) error
@@ -33,6 +34,13 @@ func (f *Folder) Exists(ctx context.Context, objectRelativePath string) (bool, e
 		return f.ExistsMock(ctx, objectRelativePath)
 	}
 	return f.MemFolder.Exists(ctx, objectRelativePath)
+}
+
+func (f *Folder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	if f.StatObjectMock != nil {
+		return f.StatObjectMock(ctx, objectRelativePath)
+	}
+	return f.MemFolder.StatObject(ctx, objectRelativePath)
 }
 
 func (f *Folder) GetPath() string {

--- a/pkg/storages/oss/folder.go
+++ b/pkg/storages/oss/folder.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
 	"github.com/wal-g/tracelog"
@@ -140,9 +141,10 @@ func partitionObjects(keys []storage.Object, size int) [][]storage.Object {
 	return parts
 }
 
-func (f *Folder) Exists(ctx context.Context, objectRelativePath string) (bool, error) {
+// headObject performs a HEAD request for a single object. Returns a nil result if the object doesn't exist.
+func (f *Folder) headObject(ctx context.Context, objectRelativePath string) (*oss.HeadObjectResult, error) {
 	objectPath := f.GetPath() + objectRelativePath
-	_, err := f.ossAPI.HeadObject(ctx, &oss.HeadObjectRequest{
+	result, err := f.ossAPI.HeadObject(ctx, &oss.HeadObjectRequest{
 		Bucket: oss.Ptr(f.bucket),
 		Key:    oss.Ptr(objectPath),
 	})
@@ -150,12 +152,46 @@ func (f *Folder) Exists(ctx context.Context, objectRelativePath string) (bool, e
 	if err != nil {
 		var serviceError *oss.ServiceError
 		if errors.As(err, &serviceError) && serviceError.Code == "NoSuchKey" {
-			return false, nil
+			return nil, nil
 		}
-		return false, fmt.Errorf("failed to check oss object '%s' existence: %w", objectPath, err)
+		return nil, fmt.Errorf("failed to head oss object '%s': %w", objectPath, err)
 	}
 
-	return true, nil
+	return result, nil
+}
+
+func (f *Folder) Exists(ctx context.Context, objectRelativePath string) (bool, error) {
+	result, err := f.headObject(ctx, objectRelativePath)
+	if err != nil {
+		return false, err
+	}
+	return result != nil, nil
+}
+
+func (f *Folder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	result, err := f.headObject(ctx, objectRelativePath)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, storage.NewObjectNotFoundError(f.GetPath() + objectRelativePath)
+	}
+
+	// ContentLength is -1 when the Content-Length header is absent.
+	size := result.ContentLength
+	if size < 0 {
+		size = 0
+	}
+	var lastModified time.Time
+	if result.LastModified != nil {
+		lastModified = *result.LastModified
+	}
+	var versionID string
+	if result.VersionId != nil {
+		versionID = *result.VersionId
+	}
+
+	return storage.NewLocalObjectWithVersion(objectRelativePath, lastModified, size, versionID, ""), nil
 }
 
 func (f *Folder) GetSubFolder(subFolderRelativePath string) storage.Folder {

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -59,29 +59,65 @@ func GetSSECustomerKeyMD5(sseCustomerKey string) string {
 	return base64.StdEncoding.EncodeToString(hash[:])
 }
 
-func (folder *Folder) Exists(ctx context.Context, objectRelativePath string) (bool, error) {
+// headObject performs a HEAD request for a single object. Returns a nil output if the object doesn't exist.
+func (folder *Folder) headObject(ctx context.Context, objectRelativePath string) (*s3.HeadObjectOutput, error) {
 	objectPath := folder.path + objectRelativePath
-	stopSentinelObjectInput := &s3.HeadObjectInput{
+	input := &s3.HeadObjectInput{
 		Bucket: folder.bucket,
 		Key:    aws.String(objectPath),
 	}
 
 	if folder.uploader.serverSideEncryption != "" && folder.uploader.SSECustomerKey != "" {
-		stopSentinelObjectInput.SSECustomerAlgorithm = aws.String(folder.uploader.serverSideEncryption)
-		stopSentinelObjectInput.SSECustomerKey = aws.String(folder.uploader.SSECustomerKey)
+		input.SSECustomerAlgorithm = aws.String(folder.uploader.serverSideEncryption)
+		input.SSECustomerKey = aws.String(folder.uploader.SSECustomerKey)
 
 		customerKeyMD5 := GetSSECustomerKeyMD5(folder.uploader.SSECustomerKey)
-		stopSentinelObjectInput.SSECustomerKeyMD5 = aws.String(customerKeyMD5)
+		input.SSECustomerKeyMD5 = aws.String(customerKeyMD5)
 	}
 
-	_, err := folder.s3API.HeadObjectWithContext(ctx, stopSentinelObjectInput)
+	output, err := folder.s3API.HeadObjectWithContext(ctx, input)
 	if err != nil {
 		if isAwsNotExist(err) {
-			return false, nil
+			return nil, nil
 		}
-		return false, errors.Wrapf(err, "failed to check s3 object '%s' existence", objectPath)
+		return nil, errors.Wrapf(err, "failed to head s3 object '%s'", objectPath)
 	}
-	return true, nil
+	return output, nil
+}
+
+func (folder *Folder) Exists(ctx context.Context, objectRelativePath string) (bool, error) {
+	output, err := folder.headObject(ctx, objectRelativePath)
+	if err != nil {
+		return false, err
+	}
+	return output != nil, nil
+}
+
+func (folder *Folder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	output, err := folder.headObject(ctx, objectRelativePath)
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return nil, storage.NewObjectNotFoundError(folder.path + objectRelativePath)
+	}
+
+	var size int64
+	if output.ContentLength != nil {
+		size = *output.ContentLength
+	}
+	var lastModified time.Time
+	if output.LastModified != nil {
+		lastModified = *output.LastModified
+	}
+
+	return storage.NewLocalObjectWithVersion(
+		objectRelativePath,
+		lastModified,
+		size,
+		aws.StringValue(output.VersionId),
+		"",
+	), nil
 }
 
 func (folder *Folder) PutObject(ctx context.Context, name string, content io.Reader) error {

--- a/pkg/storages/sh/folder.go
+++ b/pkg/storages/sh/folder.go
@@ -129,6 +129,28 @@ func (folder *Folder) Exists(_ context.Context, objectRelativePath string) (bool
 	return true, nil
 }
 
+func (folder *Folder) StatObject(_ context.Context, objectRelativePath string) (storage.Object, error) {
+	client, err := folder.sftpLazy.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	objPath := filepath.Join(folder.path, objectRelativePath)
+	info, err := client.Stat(objPath)
+
+	if os.IsNotExist(err) {
+		return nil, storage.NewObjectNotFoundError(objPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get stats of object %q via SFTP: %w", objPath, err)
+	}
+	if info.IsDir() {
+		return nil, storage.NewObjectNotFoundError(objPath)
+	}
+
+	return storage.NewLocalObject(objectRelativePath, info.ModTime(), info.Size()), nil
+}
+
 func (folder *Folder) GetSubFolder(subFolderRelativePath string) storage.Folder {
 	return NewFolder(folder.sftpLazy, path.Join(folder.path, subFolderRelativePath))
 }

--- a/pkg/storages/storage/folder.go
+++ b/pkg/storages/storage/folder.go
@@ -26,6 +26,10 @@ type Folder interface {
 	// Exists checks if an object exists in the folder.
 	Exists(ctx context.Context, objectRelativePath string) (bool, error)
 
+	// StatObject fetches metadata of a single object without listing the folder. Implementations must use a cheap
+	// point lookup (HEAD/stat) instead of a listing. Must return ObjectNotFoundError if the object doesn't exist.
+	StatObject(ctx context.Context, objectRelativePath string) (Object, error)
+
 	// GetSubFolder returns a handle to the subfolder. Does not have to instantiate the subfolder in any material form.
 	GetSubFolder(subFolderRelativePath string) Folder
 

--- a/pkg/storages/storage/mocks/Folder.go
+++ b/pkg/storages/storage/mocks/Folder.go
@@ -173,6 +173,32 @@ func (_m *Folder) ReadObject(ctx context.Context, objectRelativePath string) (io
 	return r0, r1
 }
 
+// StatObject provides a mock function with given fields: ctx, objectRelativePath
+func (_m *Folder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	ret := _m.Called(ctx, objectRelativePath)
+
+	var r0 storage.Object
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (storage.Object, error)); ok {
+		return rf(ctx, objectRelativePath)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) storage.Object); ok {
+		r0 = rf(ctx, objectRelativePath)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(storage.Object)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, objectRelativePath)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewFolder creates a new instance of Folder. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewFolder(t interface {

--- a/pkg/storages/storage/testing.go
+++ b/pkg/storages/storage/testing.go
@@ -45,6 +45,26 @@ func RunFolderTest(storageFolder Folder, t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, b)
 
+	statObject, err := storageFolder.StatObject(ctx, "file0")
+	assert.NoError(t, err)
+	if err == nil {
+		assert.Equal(t, "file0", statObject.GetName())
+		assert.Equal(t, int64(len(token)), statObject.GetSize())
+	}
+	statObject, err = sub1.StatObject(ctx, "file1")
+	assert.NoError(t, err)
+	if err == nil {
+		assert.Equal(t, int64(len("data1")), statObject.GetSize())
+	}
+	statObject, err = storageFolder.StatObject(ctx, "Sub1/file1")
+	assert.NoError(t, err)
+	if err == nil {
+		assert.Equal(t, int64(len("data1")), statObject.GetSize())
+	}
+	_, err = storageFolder.StatObject(ctx, "Tumba Yumba")
+	assert.Error(t, err)
+	assert.IsType(t, ObjectNotFoundError{}, err)
+
 	objects, subFolders, err := storageFolder.ListFolder(ctx)
 	assert.NoError(t, err)
 	t.Log(subFolders[0].GetPath())
@@ -107,6 +127,9 @@ func RunFolderTest(storageFolder Folder, t *testing.T) {
 	b, err = sub1.Exists(ctx, "file1")
 	assert.NoError(t, err)
 	assert.False(t, b)
+
+	_, err = storageFolder.StatObject(ctx, "file0")
+	assert.IsType(t, ObjectNotFoundError{}, err)
 
 	_, err = sub1.ReadObject(ctx, "Tumba Yumba")
 	assert.Error(t, err.(ObjectNotFoundError))

--- a/pkg/storages/swift/folder.go
+++ b/pkg/storages/swift/folder.go
@@ -40,6 +40,18 @@ func (folder *Folder) Exists(ctx context.Context, objectRelativePath string) (bo
 	return true, nil
 }
 
+func (folder *Folder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	path := storage.JoinPath(folder.path, objectRelativePath)
+	obj, _, err := folder.connection.Object(ctx, folder.container.Name, path)
+	if err == swift.ObjectNotFound {
+		return nil, storage.NewObjectNotFoundError(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get Swift object stats %q: %w", path, err)
+	}
+	return storage.NewLocalObject(objectRelativePath, obj.LastModified, obj.Bytes), nil
+}
+
 func (folder *Folder) ListFolder(ctx context.Context) (objects []storage.Object, subFolders []storage.Folder, err error) {
 	//Iterate
 	err = folder.connection.ObjectsWalk(

--- a/test/mocks/mock_folder.go
+++ b/test/mocks/mock_folder.go
@@ -184,6 +184,21 @@ func (mr *MockFolderMockRecorder) SetVersioningEnabled(ctx, enable any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVersioningEnabled", reflect.TypeOf((*MockFolder)(nil).SetVersioningEnabled), ctx, enable)
 }
 
+// StatObject mocks base method.
+func (m *MockFolder) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StatObject", ctx, objectRelativePath)
+	ret0, _ := ret[0].(storage.Object)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StatObject indicates an expected call of StatObject.
+func (mr *MockFolderMockRecorder) StatObject(ctx, objectRelativePath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatObject", reflect.TypeOf((*MockFolder)(nil).StatObject), ctx, objectRelativePath)
+}
+
 // Validate mocks base method.
 func (m *MockFolder) Validate(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/test/mocks/mock_folder_ext.go
+++ b/test/mocks/mock_folder_ext.go
@@ -200,6 +200,21 @@ func (mr *MockFolderExtMockRecorder) SetVersioningEnabled(ctx, enable any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVersioningEnabled", reflect.TypeOf((*MockFolderExt)(nil).SetVersioningEnabled), ctx, enable)
 }
 
+// StatObject mocks base method.
+func (m *MockFolderExt) StatObject(ctx context.Context, objectRelativePath string) (storage.Object, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StatObject", ctx, objectRelativePath)
+	ret0, _ := ret[0].(storage.Object)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StatObject indicates an expected call of StatObject.
+func (mr *MockFolderExtMockRecorder) StatObject(ctx, objectRelativePath any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatObject", reflect.TypeOf((*MockFolderExt)(nil).StatObject), ctx, objectRelativePath)
+}
+
 // Validate mocks base method.
 func (m *MockFolderExt) Validate(ctx context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Getting metadata of one file previously required `st ls`, which enumerates the whole folder and gets expensive on folders with many objects.

Add StatObject to the storage.Folder interface, implemented via a point lookup (HEAD/stat) in every backend, and expose it as `st stat <path>`. The output matches `st ls` so the two are interchangeable.
