### PR TITLE
HasTag command for non-string types

### DIFF
--- a/internal/databases/redis/backup_info_handler.go
+++ b/internal/databases/redis/backup_info_handler.go
@@ -38,8 +38,8 @@ func getField(ctx context.Context, folder storage.Folder, v *archive.Backup, fie
 
 	r := reflect.ValueOf(v)
 	f := reflect.Indirect(r).FieldByName(field)
-	if f.IsValid() {
-		return f.String(), nil
+	if f.IsValid() && f.CanInterface() {
+		return fmt.Sprint(f.Interface()), nil
 	}
 	return "", fmt.Errorf("no %s field in struct %v", field, &v)
 }

--- a/internal/databases/redis/backup_info_handler_test.go
+++ b/internal/databases/redis/backup_info_handler_test.go
@@ -1,0 +1,42 @@
+package redis
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/internal/databases/redis/archive"
+	"github.com/wal-g/wal-g/testtools"
+	"github.com/wal-g/wal-g/utility"
+)
+
+func TestHandleBackupInfoTagFormatsNonStringFields(t *testing.T) {
+	folder := testtools.MakeDefaultInMemoryStorageFolder()
+	backup := archive.Backup{
+		BackupName:  "aof_20260729T144621Z",
+		HasTS:       true,
+		TSFileCount: 92,
+	}
+	serialized, err := json.Marshal(backup)
+	require.NoError(t, err)
+	require.NoError(t, folder.GetSubFolder(utility.BaseBackupPath).PutObject(
+		t.Context(), backup.BackupName+utility.SentinelSuffix, bytes.NewReader(serialized),
+	))
+
+	for _, test := range []struct {
+		tag  string
+		want string
+	}{
+		{tag: "HasTS", want: "true\n"},
+		{tag: "TSFileCount", want: "92\n"},
+	} {
+		t.Run(test.tag, func(t *testing.T) {
+			output := new(bytes.Buffer)
+
+			HandleBackupInfo(t.Context(), folder, backup.BackupName, output, test.tag)
+
+			require.Equal(t, test.want, output.String())
+		})
+	}
+}


### PR DESCRIPTION
### Database name
redis

# Pull request description
fixin backup-info custom tag output format

### Describe what this PR fixes
True or 42 won't return without that

### Please provide steps to reproduce (if it's a bug)
wal-g backup-info --tag HasTS