### PR TITLE
perf: avoid C.NULL conversion in libsodium write loop

### DIFF
--- a/internal/crypto/libsodium/writer.go
+++ b/internal/crypto/libsodium/writer.go
@@ -95,7 +95,7 @@ func (writer *Writer) writeNextChunk(last bool) (err error) {
 		&outLen,
 		(*C.uchar)(&writer.in[0]),
 		(C.ulonglong)(writer.inIdx),
-		(*C.uchar)(C.NULL),
+		nil,
 		(C.ulonglong)(0),
 		tag,
 	)


### PR DESCRIPTION
Pass nil as the additional-data pointer in
crypto_secretstream_xchacha20poly1305_push instead of converting C.NULL on every encrypted chunk.
