### PR TITLE
change fatal to error propogation to close mongodb backup cursor properly

### DIFF
--- a/internal/nop_tarball.go
+++ b/internal/nop_tarball.go
@@ -26,7 +26,7 @@ func (tarBall *NOPTarBall) CloseTar() error                                     
 func (tarBall *NOPTarBall) Size() int64            { return tarBall.partSize.Load() }
 func (tarBall *NOPTarBall) AddSize(i int64)        { tarBall.partSize.Add(i) }
 func (tarBall *NOPTarBall) TarWriter() *tar.Writer { return tarBall.tarWriter }
-func (tarBall *NOPTarBall) AwaitUploads()          {}
+func (tarBall *NOPTarBall) AwaitUploads() error    { return nil }
 
 // NOPTarBallMaker creates a new NOPTarBall. Used
 // for testing purposes.

--- a/internal/storage_tar_ball.go
+++ b/internal/storage_tar_ball.go
@@ -66,11 +66,12 @@ func (tarBall *StorageTarBall) CloseTar() error {
 	return nil
 }
 
-func (tarBall *StorageTarBall) AwaitUploads() {
+func (tarBall *StorageTarBall) AwaitUploads() error {
 	tarBall.uploader.Finish()
 	if tarBall.uploader.Failed() {
-		tracelog.ErrorLogger.Fatal("Unable to complete uploads")
+		return errors.New("unable to complete uploads")
 	}
+	return nil
 }
 
 func GetBackupTarPath(backupName, fileName string) string {
@@ -96,11 +97,11 @@ func (tarBall *StorageTarBall) startUpload(ctx context.Context, name string, cry
 		if err != nil {
 			tracelog.ErrorLogger.Printf("upload: could not upload '%s'\n", path)
 			tracelog.ErrorLogger.Printf("%v\n", err)
-			err = pipeReader.Close()
-			tracelog.ErrorLogger.FatalfOnError("Failed to close pipe: %v", err)
-			tracelog.ErrorLogger.Fatalf(
-				"Unable to continue the backup process because of the loss of a part %d.\n",
-				tarBall.partNumber)
+			// Close the read side with the error so that the writer side (tar packing)
+			// unblocks with the same error and the failure propagates up the call stack
+			// instead of terminating the process. This lets deferred cleanup run
+			// (e.g. closing the MongoDB $backupCursor).
+			_ = pipeReader.CloseWithError(err)
 		}
 	}()
 

--- a/internal/tar_ball.go
+++ b/internal/tar_ball.go
@@ -16,7 +16,7 @@ type TarBall interface {
 	Size() int64
 	AddSize(int64)
 	TarWriter() *tar.Writer
-	AwaitUploads()
+	AwaitUploads() error
 	Name() string
 }
 

--- a/internal/tar_ball_queue.go
+++ b/internal/tar_ball_queue.go
@@ -88,14 +88,18 @@ func (tarQueue *TarBallQueue) FinishQueue() error {
 		if err != nil {
 			return errors.Wrap(err, "HandleWalkedFSObject: failed to close tarball")
 		}
-		tarBall.AwaitUploads()
+		if err := tarBall.AwaitUploads(); err != nil {
+			return err
+		}
 	}
 
 	// At this point no new tarballs should be put into uploadQueue
 	for len(tarQueue.uploadQueue) > 0 {
 		select {
 		case otb := <-tarQueue.uploadQueue:
-			otb.AwaitUploads()
+			if err := otb.AwaitUploads(); err != nil {
+				return err
+			}
 		default:
 		}
 	}
@@ -120,7 +124,9 @@ func (tarQueue *TarBallQueue) FinishTarBall(tarBall TarBall) error {
 	for len(tarQueue.uploadQueue) > tarQueue.maxUploadQueue {
 		select {
 		case otb := <-tarQueue.uploadQueue:
-			otb.AwaitUploads()
+			if err := otb.AwaitUploads(); err != nil {
+				return err
+			}
 		default:
 		}
 	}

--- a/testtools/tarballs.go
+++ b/testtools/tarballs.go
@@ -77,7 +77,7 @@ func (tarBall *FileTarBall) CloseTar() error {
 func (tarBall *FileTarBall) Size() int64            { return tarBall.partSize.Load() }
 func (tarBall *FileTarBall) AddSize(i int64)        { tarBall.partSize.Add(i) }
 func (tarBall *FileTarBall) TarWriter() *tar.Writer { return tarBall.tarWriter }
-func (tarBall *FileTarBall) AwaitUploads()          {}
+func (tarBall *FileTarBall) AwaitUploads() error    { return nil }
 
 // BufferTarBall represents a tarball that is
 // written to buffer.
@@ -112,4 +112,4 @@ func (tarBall *BufferTarBall) TarWriter() *tar.Writer {
 	return tarBall.tarWriter
 }
 
-func (tarBall *BufferTarBall) AwaitUploads() {}
+func (tarBall *BufferTarBall) AwaitUploads() error { return nil }


### PR DESCRIPTION


### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
