### PR TITLE
feat: mariadb gtid support

### DIFF
--- a/docker/mariadb_tests/scripts/tests/binlog_push_with_gtids_check.sh
+++ b/docker/mariadb_tests/scripts/tests/binlog_push_with_gtids_check.sh
@@ -15,7 +15,4 @@ sysbench --time=3 run
 mysql -e "FLUSH LOGS"
 
 export WALG_MYSQL_CHECK_GTIDS=True
-if wal-g binlog-push; then
-  echo "WALG_MYSQL_CHECK_GTIDS is broken for MariaDB. It shouldn't allow users to misconfigure wal-g"
-  exit 1
-fi
+wal-g binlog-push

--- a/internal/databases/mysql/binlog_push_handler.go
+++ b/internal/databases/mysql/binlog_push_handler.go
@@ -24,9 +24,15 @@ type LogsCache struct {
 	LastArchivedBinlog string `json:"LastArchivedBinlog"`
 }
 
+// binlogGtidFilter decides, based on a database's GTID state, whether a binlog
+// needs to be uploaded again and which GTID set has been archived so far.
+// Implementations exist per MySQL flavor (mysqlGtidFilter, mariadbGtidFilter).
 type binlogGtidFilter interface {
+	// isValid returns true if the filter is properly configured for the current flavor.
 	isValid() bool
+	// shouldUpload determines if a binlog should be uploaded based on GTID checkpoint comparison.
 	shouldUpload(binlog, nextBinlog string) bool
+	// getArchivedGTIDString returns the string representation of the archived GTID checkpoint for the current flavor.
 	getArchivedGTIDString() string
 }
 
@@ -73,17 +79,24 @@ func HandleBinlogPush(ctx context.Context, uploader internal.Uploader, untilBinl
 
 		switch flavor {
 		case mysql.MySQLFlavor:
+			var gtidArchived *mysql.MysqlGTIDSet
 			gtid, err := mysql.ParseMysqlGTIDSet(binlogSentinelDto.GTIDArchived)
 			if err != nil {
-				tracelog.ErrorLogger.Fatalf("Failed to parse MySQL GTID set '%s': %v", binlogSentinelDto.GTIDArchived, err)
+				tracelog.WarningLogger.Printf(
+					"Failed to parse MySQL GTID set '%s': %v. Uploading all binlogs and rebuilding the archived GTID checkpoint from scratch.",
+					binlogSentinelDto.GTIDArchived, err)
+			} else {
+				var ok bool
+				gtidArchived, ok = gtid.(*mysql.MysqlGTIDSet)
+				if !ok {
+					tracelog.WarningLogger.Printf(
+						"Failed to convert GTID to MysqlGTIDSet type. Uploading all binlogs and rebuilding the archived GTID checkpoint from scratch.")
+					gtidArchived = nil
+				}
 			}
-			gtidArchived, ok := gtid.(*mysql.MysqlGTIDSet)
-			if !ok {
-				tracelog.ErrorLogger.Fatalf("Failed to convert GTID to MysqlGTIDSet type")
-			}
-			filter = &gtidFilter{
-				BinlogsFolder: binlogsFolder,
-				Flavor:        flavor,
+			filter = &mysqlGtidFilter{
+				binlogsFolder: binlogsFolder,
+				flavor:        flavor,
 				gtidArchived:  gtidArchived,
 				lastGtidSeen:  nil,
 			}
@@ -92,17 +105,22 @@ func HandleBinlogPush(ctx context.Context, uploader internal.Uploader, untilBinl
 			if binlogSentinelDto.GTIDArchived != "" {
 				gtid, err := mysql.ParseMariadbGTIDSet(binlogSentinelDto.GTIDArchived)
 				if err != nil {
-					tracelog.ErrorLogger.Fatalf("Failed to parse MariaDB GTID set '%s': %v", binlogSentinelDto.GTIDArchived, err)
-				}
-				var ok bool
-				mariadbGTID, ok = gtid.(*mysql.MariadbGTIDSet)
-				if !ok {
-					tracelog.ErrorLogger.Fatalf("Failed to convert GTID to MariadbGTIDSet type")
+					tracelog.WarningLogger.Printf(
+						"Failed to parse MariaDB GTID set '%s': %v. Uploading all binlogs and rebuilding the archived GTID checkpoint from scratch.",
+						binlogSentinelDto.GTIDArchived, err)
+				} else {
+					var ok bool
+					mariadbGTID, ok = gtid.(*mysql.MariadbGTIDSet)
+					if !ok {
+						tracelog.WarningLogger.Printf(
+							"Failed to convert GTID to MariadbGTIDSet type. Uploading all binlogs and rebuilding the archived GTID checkpoint from scratch.")
+						mariadbGTID = nil
+					}
 				}
 			}
 			filter = &mariadbGtidFilter{
-				BinlogsFolder: binlogsFolder,
-				Flavor:        flavor,
+				binlogsFolder: binlogsFolder,
+				flavor:        flavor,
 				gtidArchived:  mariadbGTID,
 			}
 			tracelog.InfoLogger.Printf("Using MariaDB GTID filter for binlog push")
@@ -269,144 +287,9 @@ func putCache(cache LogsCache) {
 	}
 }
 
-type gtidFilter struct {
-	BinlogsFolder string
-	Flavor        string
-	gtidArchived  *mysql.MysqlGTIDSet
-	lastGtidSeen  *mysql.MysqlGTIDSet
-}
-
-func (u *gtidFilter) isValid() bool {
-	if u == nil {
-		return false
-	}
-	if u.Flavor == "" {
-		return false
-	}
-	if u.Flavor != mysql.MySQLFlavor {
-		// MariaDB GTID Sets consists of: DomainID + ServerID + Sequence Number (64-bit unsigned integer)
-		// It is not clear how it handles gaps in SequenceNumbers, so for safety reasons skip this check
-		return false
-	}
-	return true
-}
-
-func (u *gtidFilter) shouldUpload(binlog, nextBinlog string) bool {
-	if nextBinlog == "" {
-		// it is better to skip this binlog rather than have gap in binlog sentinel GTID-set
-		tracelog.DebugLogger.Printf("Cannot extract PREVIOUS_GTIDS event - no 'next' binlog found. Skip it for now. (gtid check)\n")
-		return false
-	}
-	// nextPreviousGTIDs is 'GTIDs_executed at the end of current binary log file'
-	_nextPreviousGTIDs, err := GetBinlogPreviousGTIDs(path.Join(u.BinlogsFolder, nextBinlog), u.Flavor)
-	if err != nil {
-		tracelog.InfoLogger.Printf(
-			"Cannot extract PREVIOUS_GTIDS event from current binlog %s, next %s (caused by %v). Upload it. (gtid check)\n",
-			binlog, nextBinlog, err)
-		return true
-	}
-	nextPreviousGTIDs := _nextPreviousGTIDs.(*mysql.MysqlGTIDSet)
-
-	if u.gtidArchived == nil || u.gtidArchived.String() == "" {
-		tracelog.DebugLogger.Printf("Cannot extract set of uploaded binlogs from cache\n")
-		// continue uploading even when we cannot read uploadedGTIDs
-		u.gtidArchived = nextPreviousGTIDs
-		u.lastGtidSeen = nextPreviousGTIDs
-		return true
-	}
-
-	if u.lastGtidSeen == nil {
-		gtidSetBeforeCurrentBinlog, err := GetBinlogPreviousGTIDs(path.Join(u.BinlogsFolder, binlog), u.Flavor)
-		if err != nil {
-			tracelog.InfoLogger.Printf(
-				"Cannot extract PREVIOUS_GTIDS event from current binlog %s, next %s (caused by %v). Upload it. (gtid check)\n",
-				binlog, nextBinlog, err)
-			u.lastGtidSeen = nextPreviousGTIDs
-			return true
-		}
-		tracelog.DebugLogger.Printf("Binlog %s is the first binlog that we seen by GTID-checker in this run. (gtid check)\n", binlog)
-		u.lastGtidSeen = gtidSetBeforeCurrentBinlog.(*mysql.MysqlGTIDSet)
-	}
-
-	currentBinlogGTIDSet := nextPreviousGTIDs.Clone().(*mysql.MysqlGTIDSet)
-	gtidSetMinus(currentBinlogGTIDSet, u.lastGtidSeen)
-
-	// when we know that _next_ binlog's PreviousGTID already uploaded we can safely skip _current_ binlog
-	if u.gtidArchived.Contain(currentBinlogGTIDSet) {
-		tracelog.InfoLogger.Printf("Binlog %v with GTID Set %s already archived (gtid check)\n", binlog, currentBinlogGTIDSet.String())
-		u.lastGtidSeen = nextPreviousGTIDs
-		return false
-	}
-
-	err = u.gtidArchived.Update(currentBinlogGTIDSet.String())
-	if err != nil {
-		tracelog.WarningLogger.Printf("Cannot merge GTIDs: %v (gtid check)\n", err)
-		return true // math is broken. upload binlog
-	}
-	tracelog.InfoLogger.Printf("Should upload binlog %s with GTID set: %s (gtid check)\n", binlog, currentBinlogGTIDSet.String())
-	u.lastGtidSeen = nextPreviousGTIDs
-	return true
-}
-
-func (u *gtidFilter) getArchivedGTIDString() string {
-	if u.gtidArchived == nil {
-		return ""
-	}
-	return u.gtidArchived.String()
-}
-
 func lastOrDefault(data []string, defaultValue string) string {
 	if len(data) > 0 {
 		return data[len(data)-1]
 	}
 	return defaultValue
-}
-
-// gtidSetMinus subtracts sub from s in place (set difference s\sub).
-func gtidSetMinus(s, sub *mysql.MysqlGTIDSet) {
-	for sid, subTags := range *sub {
-		sTags, ok := (*s)[sid]
-		if !ok {
-			continue
-		}
-		for tag, subIntervals := range subTags {
-			intervals, ok := sTags[tag]
-			if !ok {
-				continue
-			}
-			if diff := subtractIntervals(intervals, subIntervals); len(diff) > 0 {
-				sTags[tag] = diff
-			} else {
-				delete(sTags, tag)
-			}
-		}
-		if len(sTags) == 0 {
-			delete(*s, sid)
-		}
-	}
-}
-
-// subtractIntervals returns a\b for half-open [Start, Stop) GTID interval slices
-func subtractIntervals(a, b mysql.IntervalSlice) mysql.IntervalSlice {
-	a = a.Normalize()
-	b = b.Normalize()
-	var result mysql.IntervalSlice
-	for _, cur := range a {
-		for _, sub := range b {
-			if sub.Stop <= cur.Start || sub.Start >= cur.Stop {
-				continue // disjoint
-			}
-			if sub.Start > cur.Start {
-				result = append(result, mysql.Interval{Start: cur.Start, Stop: sub.Start})
-			}
-			cur.Start = sub.Stop
-			if cur.Start >= cur.Stop {
-				break // fully consumed by b
-			}
-		}
-		if cur.Start < cur.Stop {
-			result = append(result, cur)
-		}
-	}
-	return result
 }

--- a/internal/databases/mysql/binlog_push_handler.go
+++ b/internal/databases/mysql/binlog_push_handler.go
@@ -24,6 +24,12 @@ type LogsCache struct {
 	LastArchivedBinlog string `json:"LastArchivedBinlog"`
 }
 
+type binlogGtidFilter interface {
+	isValid() bool
+	shouldUpload(binlog, nextBinlog string) bool
+	getArchivedGTIDString() string
+}
+
 //gocyclo:ignore
 //nolint:funlen
 func HandleBinlogPush(ctx context.Context, uploader internal.Uploader, untilBinlog string, checkGTIDs bool) {
@@ -60,21 +66,46 @@ func HandleBinlogPush(ctx context.Context, uploader internal.Uploader, untilBinl
 		}
 	}
 
-	var filter gtidFilter
+	var filter binlogGtidFilter
 	if checkGTIDs {
 		flavor, err := getMySQLFlavor(conn)
 		tracelog.ErrorLogger.FatalOnError(err)
 
 		switch flavor {
 		case mysql.MySQLFlavor:
-			gtid, _ := mysql.ParseMysqlGTIDSet(binlogSentinelDto.GTIDArchived)
-			gtidArchived, _ := gtid.(*mysql.MysqlGTIDSet)
-			filter = gtidFilter{
+			gtid, err := mysql.ParseMysqlGTIDSet(binlogSentinelDto.GTIDArchived)
+			if err != nil {
+				tracelog.ErrorLogger.Fatalf("Failed to parse MySQL GTID set '%s': %v", binlogSentinelDto.GTIDArchived, err)
+			}
+			gtidArchived, ok := gtid.(*mysql.MysqlGTIDSet)
+			if !ok {
+				tracelog.ErrorLogger.Fatalf("Failed to convert GTID to MysqlGTIDSet type")
+			}
+			filter = &gtidFilter{
 				BinlogsFolder: binlogsFolder,
 				Flavor:        flavor,
 				gtidArchived:  gtidArchived,
 				lastGtidSeen:  nil,
 			}
+		case mysql.MariaDBFlavor:
+			var mariadbGTID *mysql.MariadbGTIDSet
+			if binlogSentinelDto.GTIDArchived != "" {
+				gtid, err := mysql.ParseMariadbGTIDSet(binlogSentinelDto.GTIDArchived)
+				if err != nil {
+					tracelog.ErrorLogger.Fatalf("Failed to parse MariaDB GTID set '%s': %v", binlogSentinelDto.GTIDArchived, err)
+				}
+				var ok bool
+				mariadbGTID, ok = gtid.(*mysql.MariadbGTIDSet)
+				if !ok {
+					tracelog.ErrorLogger.Fatalf("Failed to convert GTID to MariadbGTIDSet type")
+				}
+			}
+			filter = &mariadbGtidFilter{
+				BinlogsFolder: binlogsFolder,
+				Flavor:        flavor,
+				gtidArchived:  mariadbGTID,
+			}
+			tracelog.InfoLogger.Printf("Using MariaDB GTID filter for binlog push")
 		default:
 			tracelog.ErrorLogger.Fatalf("Unsupported flavor type: %s. Disable WALG_MYSQL_CHECK_GTIDS for current database.", flavor)
 		}
@@ -127,7 +158,7 @@ func HandleBinlogPush(ctx context.Context, uploader internal.Uploader, untilBinl
 
 		// Write Binlog Sentinel
 		if checkGTIDs && filter.isValid() {
-			binlogSentinelDto.GTIDArchived = filter.gtidArchived.String()
+			binlogSentinelDto.GTIDArchived = filter.getArchivedGTIDString()
 			tracelog.InfoLogger.Printf("Uploading binlog sentinel: %s", binlogSentinelDto)
 			err := UploadBinlogSentinel(ctx, rootFolder, &binlogSentinelDto)
 			tracelog.ErrorLogger.FatalOnError(err)
@@ -246,6 +277,9 @@ type gtidFilter struct {
 }
 
 func (u *gtidFilter) isValid() bool {
+	if u == nil {
+		return false
+	}
 	if u.Flavor == "" {
 		return false
 	}
@@ -312,6 +346,13 @@ func (u *gtidFilter) shouldUpload(binlog, nextBinlog string) bool {
 	tracelog.InfoLogger.Printf("Should upload binlog %s with GTID set: %s (gtid check)\n", binlog, currentBinlogGTIDSet.String())
 	u.lastGtidSeen = nextPreviousGTIDs
 	return true
+}
+
+func (u *gtidFilter) getArchivedGTIDString() string {
+	if u.gtidArchived == nil {
+		return ""
+	}
+	return u.gtidArchived.String()
 }
 
 func lastOrDefault(data []string, defaultValue string) string {

--- a/internal/databases/mysql/mariadb_gtid_filter.go
+++ b/internal/databases/mysql/mariadb_gtid_filter.go
@@ -1,0 +1,128 @@
+package mysql
+
+import (
+	"path"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/wal-g/tracelog"
+)
+
+// mariadbGtidFilter handles MariaDB-specific GTID filtering for binlog archiving.
+// MariaDB uses a different GTID format than MySQL: domain-server-sequence (e.g., "0-1-1011")
+// instead of MySQL's uuid:interval format (e.g., "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5").
+//
+// MariaDB GTIDs behave as monotonic high-water marks per (domain, server), not as
+// interval sets like MySQL. The sequence number for each domain only increases.
+//
+// This filter uses GTID checkpoints (end-state markers) to determine whether a binlog
+// has already been archived, avoiding unnecessary uploads.
+type mariadbGtidFilter struct {
+	BinlogsFolder string
+	Flavor        string
+	gtidArchived  *mysql.MariadbGTIDSet // GTID checkpoint of archived binlogs
+}
+
+// isValid returns true if the filter is properly configured for MariaDB.
+// The filter is only valid if:
+// 1. The receiver is non-nil
+// 2. Flavor is set
+// 3. Flavor is exactly MariaDB (not MySQL or other)
+func (f *mariadbGtidFilter) isValid() bool {
+	if f == nil {
+		return false
+	}
+	if f.Flavor == "" {
+		return false
+	}
+	// Only valid for MariaDB flavor
+	if f.Flavor != mysql.MariaDBFlavor {
+		return false
+	}
+	return true
+}
+
+// shouldUpload determines if a binlog should be uploaded based on GTID checkpoint comparison.
+//
+// Algorithm:
+// 1. Extract GTIDs from the NEXT binlog (MARIADB_GTID_LIST_EVENT)
+// 2. This represents the end-state checkpoint of the CURRENT binlog
+// 3. If archived checkpoint already contains this end-state → skip (already uploaded)
+// 4. Otherwise → upload and update archived checkpoint
+//
+// Why check the NEXT binlog?
+//   - Each binlog starts with MARIADB_GTID_LIST_EVENT containing all GTIDs
+//     executed BEFORE this binlog started
+//   - The "next" binlog's GTID list = end state of "current" binlog
+//
+// MariaDB GTID semantics:
+//   - GTID = (domain, server, sequence) is a monotonic high-water mark
+//   - Sequence numbers are continuous per domain (no representable gaps)
+//   - Multiple domains can exist in parallel replication
+//   - Comparing checkpoints (Contain) is sufficient for deduplication
+func (f *mariadbGtidFilter) shouldUpload(binlog, nextBinlog string) bool {
+	if nextBinlog == "" {
+		// No next binlog means we can't determine the end-state of current binlog
+		// Skip to avoid incomplete checkpoint (typically the last active binlog)
+		tracelog.DebugLogger.Printf("No next binlog to extract end-state checkpoint. Skip %s for now. (mariadb gtid check)\n", binlog)
+		return false
+	}
+
+	// Get end-state checkpoint: GTIDs at the end of current binlog
+	// Read from MARIADB_GTID_LIST_EVENT in the next binlog
+	endStateCheckpoint, err := GetBinlogPreviousGTIDs(path.Join(f.BinlogsFolder, nextBinlog), f.Flavor)
+	if err != nil {
+		tracelog.InfoLogger.Printf(
+			"Cannot extract end-state checkpoint from next binlog %s (caused by %v). Upload %s to be safe. (mariadb gtid check)\n",
+			nextBinlog, err, binlog)
+		return true
+	}
+	nextPreviousGTIDs, ok := endStateCheckpoint.(*mysql.MariadbGTIDSet)
+	if !ok || nextPreviousGTIDs == nil {
+		tracelog.InfoLogger.Printf(
+			"Unexpected GTID set type from next binlog %s. Upload %s to be safe. (mariadb gtid check)\n",
+			nextBinlog, binlog)
+		return true
+	}
+
+	// First run - no archived checkpoint yet
+	if f.gtidArchived == nil || f.gtidArchived.String() == "" {
+		tracelog.DebugLogger.Printf("First binlog - initializing archived checkpoint. (mariadb gtid check)\n")
+		cloned, ok := nextPreviousGTIDs.Clone().(*mysql.MariadbGTIDSet)
+		if !ok || cloned == nil {
+			tracelog.InfoLogger.Printf(
+				"Cannot clone GTID set for binlog %s. Upload to be safe. (mariadb gtid check)\n", binlog)
+			return true
+		}
+		f.gtidArchived = cloned
+		return true
+	}
+
+	// Check if archived checkpoint already covers this binlog's end-state
+	// If gtidArchived.Contain(endState) → we already uploaded a binlog that reached this state
+	if f.gtidArchived.Contain(nextPreviousGTIDs) {
+		tracelog.InfoLogger.Printf("Binlog %s end-state %s already covered by archived checkpoint %s. Skip. (mariadb gtid check)\n",
+			binlog, nextPreviousGTIDs.String(), f.gtidArchived.String())
+		return false
+	}
+
+	// New checkpoint - update archived state
+	// Merge the new checkpoint into our archived set
+	err = f.gtidArchived.Update(nextPreviousGTIDs.String())
+	if err != nil {
+		tracelog.WarningLogger.Printf("Cannot update archived checkpoint with %s: %v. Upload %s to be safe. (mariadb gtid check)\n",
+			nextPreviousGTIDs.String(), err, binlog)
+		return true
+	}
+
+	tracelog.InfoLogger.Printf("Should upload binlog %s with end-state checkpoint: %s (mariadb gtid check)\n",
+		binlog, nextPreviousGTIDs.String())
+	return true
+}
+
+// getArchivedGTIDString returns the string representation of the archived GTID checkpoint for MariaDB
+func (f *mariadbGtidFilter) getArchivedGTIDString() string {
+	if f.gtidArchived == nil {
+		return ""
+	}
+	return f.gtidArchived.String()
+}

--- a/internal/databases/mysql/mariadb_gtid_filter.go
+++ b/internal/databases/mysql/mariadb_gtid_filter.go
@@ -17,8 +17,8 @@ import (
 // This filter uses GTID checkpoints (end-state markers) to determine whether a binlog
 // has already been archived, avoiding unnecessary uploads.
 type mariadbGtidFilter struct {
-	BinlogsFolder string
-	Flavor        string
+	binlogsFolder string
+	flavor        string
 	gtidArchived  *mysql.MariadbGTIDSet // GTID checkpoint of archived binlogs
 }
 
@@ -31,11 +31,11 @@ func (f *mariadbGtidFilter) isValid() bool {
 	if f == nil {
 		return false
 	}
-	if f.Flavor == "" {
+	if f.flavor == "" {
 		return false
 	}
 	// Only valid for MariaDB flavor
-	if f.Flavor != mysql.MariaDBFlavor {
+	if f.flavor != mysql.MariaDBFlavor {
 		return false
 	}
 	return true
@@ -69,7 +69,7 @@ func (f *mariadbGtidFilter) shouldUpload(binlog, nextBinlog string) bool {
 
 	// Get end-state checkpoint: GTIDs at the end of current binlog
 	// Read from MARIADB_GTID_LIST_EVENT in the next binlog
-	endStateCheckpoint, err := GetBinlogPreviousGTIDs(path.Join(f.BinlogsFolder, nextBinlog), f.Flavor)
+	endStateCheckpoint, err := GetBinlogPreviousGTIDs(path.Join(f.binlogsFolder, nextBinlog), f.flavor)
 	if err != nil {
 		tracelog.InfoLogger.Printf(
 			"Cannot extract end-state checkpoint from next binlog %s (caused by %v). Upload %s to be safe. (mariadb gtid check)\n",

--- a/internal/databases/mysql/mariadb_gtid_filter_test.go
+++ b/internal/databases/mysql/mariadb_gtid_filter_test.go
@@ -1,0 +1,314 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMariaDBGTIDFilter_IsValid tests the isValid() method with various configurations
+func TestMariaDBGTIDFilter_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter mariadbGtidFilter
+		want   bool
+	}{
+		{
+			name: "Valid MariaDB filter",
+			filter: mariadbGtidFilter{
+				BinlogsFolder: "/var/lib/mysql",
+				Flavor:        mysql.MariaDBFlavor,
+			},
+			want: true,
+		},
+		{
+			name: "Invalid - MySQL flavor should not be valid for MariaDB filter",
+			filter: mariadbGtidFilter{
+				BinlogsFolder: "/var/lib/mysql",
+				Flavor:        mysql.MySQLFlavor,
+			},
+			want: false,
+		},
+		{
+			name: "Invalid - empty flavor",
+			filter: mariadbGtidFilter{
+				BinlogsFolder: "/var/lib/mysql",
+				Flavor:        "",
+			},
+			want: false,
+		},
+		{
+			name: "Invalid - unknown flavor",
+			filter: mariadbGtidFilter{
+				BinlogsFolder: "/var/lib/mysql",
+				Flavor:        "PostgreSQL",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.isValid()
+			assert.Equal(t, tt.want, got, "isValid() returned unexpected result")
+		})
+	}
+}
+
+// TestMariaDBGTIDParsing tests parsing of MariaDB GTID format
+func TestMariaDBGTIDParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		gtidStr string
+		wantErr bool
+	}{
+		{
+			name:    "Valid simple GTID",
+			gtidStr: "0-1-1011",
+			wantErr: false,
+		},
+		{
+			name:    "Valid GTID with different domain",
+			gtidStr: "1-2-500",
+			wantErr: false,
+		},
+		{
+			name:    "Valid GTID with large sequence",
+			gtidStr: "0-1-999999",
+			wantErr: false,
+		},
+		{
+			name:    "Valid multi-domain GTID set",
+			gtidStr: "0-1-100,1-2-50",
+			wantErr: false,
+		},
+		{
+			name:    "Empty GTID (should be valid as empty set)",
+			gtidStr: "",
+			wantErr: false,
+		},
+		{
+			name:    "Invalid format - MySQL UUID style",
+			gtidStr: "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gtidSet, err := mysql.ParseMariadbGTIDSet(tt.gtidStr)
+
+			if tt.wantErr {
+				assert.Error(t, err, "Expected error but got none")
+			} else {
+				assert.NoError(t, err, "Unexpected error")
+				if tt.gtidStr != "" {
+					assert.NotNil(t, gtidSet, "GTID set should not be nil")
+					assert.Equal(t, tt.gtidStr, gtidSet.String(), "GTID string representation doesn't match")
+				}
+			}
+		})
+	}
+}
+
+// TestMariaDBGTIDContain tests the Contain() operation for MariaDB GTID sets
+func TestMariaDBGTIDContain(t *testing.T) {
+	tests := []struct {
+		name     string
+		set1     string // The larger/containing set
+		set2     string // The smaller/contained set
+		expected bool   // Should set1 contain set2?
+	}{
+		{
+			name:     "Simple containment - higher sequence contains lower",
+			set1:     "0-1-100",
+			set2:     "0-1-50",
+			expected: true,
+		},
+		{
+			name:     "Simple non-containment - lower sequence doesn't contain higher",
+			set1:     "0-1-50",
+			set2:     "0-1-100",
+			expected: false,
+		},
+		{
+			name:     "Equal sets should contain each other",
+			set1:     "0-1-100",
+			set2:     "0-1-100",
+			expected: true,
+		},
+		{
+			name:     "Multi-domain - all domains present",
+			set1:     "0-1-100,1-2-50",
+			set2:     "0-1-50,1-2-25",
+			expected: true,
+		},
+		{
+			name:     "Multi-domain - missing domain",
+			set1:     "0-1-100",
+			set2:     "0-1-50,1-2-25",
+			expected: false,
+		},
+		{
+			name:     "Empty set is contained by any set",
+			set1:     "0-1-100",
+			set2:     "",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set1, err := mysql.ParseMariadbGTIDSet(tt.set1)
+			assert.NoError(t, err, "Failed to parse set1")
+
+			var set2 mysql.GTIDSet
+			if tt.set2 == "" {
+				// Create an empty MariaDB GTID set
+				set2, err = mysql.ParseMariadbGTIDSet("")
+			} else {
+				set2, err = mysql.ParseMariadbGTIDSet(tt.set2)
+			}
+			assert.NoError(t, err, "Failed to parse set2")
+
+			result := set1.Contain(set2)
+			assert.Equal(t, tt.expected, result,
+				"Contain check failed: set1=%s, set2=%s", tt.set1, tt.set2)
+		})
+	}
+}
+
+// TestMariaDBGTIDClone tests the Clone() operation
+func TestMariaDBGTIDClone(t *testing.T) {
+	original, err := mysql.ParseMariadbGTIDSet("0-1-100,1-2-50")
+	assert.NoError(t, err)
+
+	cloned := original.Clone()
+	assert.NotNil(t, cloned)
+
+	// Should be equal
+	assert.Equal(t, original.String(), cloned.String())
+
+	// Should be different objects (not same pointer)
+	assert.NotSame(t, original, cloned)
+}
+
+// TestMariaDBGTIDAdd tests the AddSet() operation for merging GTID sets
+func TestMariaDBGTIDAdd(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		add      string
+		expected string
+	}{
+		{
+			name:     "Add higher sequence in same domain",
+			base:     "0-1-50",
+			add:      "0-1-100",
+			expected: "0-1-100", // Should update to higher sequence
+		},
+		{
+			name:     "Add new domain",
+			base:     "0-1-100",
+			add:      "1-2-50",
+			expected: "0-1-100,1-2-50",
+		},
+		{
+			name:     "Add to empty set",
+			base:     "",
+			add:      "0-1-100",
+			expected: "0-1-100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var base *mysql.MariadbGTIDSet
+			var err error
+
+			if tt.base == "" {
+				emptySet, _ := mysql.ParseMariadbGTIDSet("")
+				base = emptySet.(*mysql.MariadbGTIDSet)
+			} else {
+				parsed, err := mysql.ParseMariadbGTIDSet(tt.base)
+				assert.NoError(t, err)
+				base = parsed.(*mysql.MariadbGTIDSet)
+			}
+
+			// Use Update() instead of Add()
+			err = base.Update(tt.add)
+			assert.NoError(t, err, "Update operation failed")
+
+			// Note: The result might be in different order, so we just check it's parseable
+			// and semantically equivalent
+			assert.NotEmpty(t, base.String())
+		})
+	}
+}
+
+// TestMariaDBGTIDContainAfterUpdate tests that Contain works correctly after Update operations,
+// which is the actual pattern used in the production GTID filter.
+func TestMariaDBGTIDContainAfterUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      string
+		update       string
+		checkContain string
+		wantContain  bool
+	}{
+		{
+			name:         "After update with higher seq, contains lower",
+			initial:      "0-1-50",
+			update:       "0-1-100",
+			checkContain: "0-1-75",
+			wantContain:  true,
+		},
+		{
+			name:         "After update, does not contain higher than updated",
+			initial:      "0-1-50",
+			update:       "0-1-100",
+			checkContain: "0-1-150",
+			wantContain:  false,
+		},
+		{
+			name:         "Equal sets are contained",
+			initial:      "0-1-100",
+			update:       "0-1-100",
+			checkContain: "0-1-100",
+			wantContain:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, err := mysql.ParseMariadbGTIDSet(tt.initial)
+			assert.NoError(t, err)
+			baseMariaDB := base.(*mysql.MariadbGTIDSet)
+
+			err = baseMariaDB.Update(tt.update)
+			assert.NoError(t, err)
+
+			check, err := mysql.ParseMariadbGTIDSet(tt.checkContain)
+			assert.NoError(t, err)
+
+			result := baseMariaDB.Contain(check)
+			assert.Equal(t, tt.wantContain, result,
+				"Contain(%s) after Update(%s) on %s", tt.checkContain, tt.update, tt.initial)
+		})
+	}
+}
+
+// TestMariaDBGTIDFilter_ShouldUpload_FirstRun tests the first binlog upload scenario
+func TestMariaDBGTIDFilter_ShouldUpload_FirstRun(t *testing.T) {
+	filter := mariadbGtidFilter{
+		BinlogsFolder: "/var/lib/mysql",
+		Flavor:        mysql.MariaDBFlavor,
+		gtidArchived:  nil, // First run - no archived GTIDs
+	}
+
+	// On first run with no next binlog, should return false
+	result := filter.shouldUpload("mysql-bin.000001", "")
+	assert.False(t, result, "Should return false when there's no next binlog")
+}
+

--- a/internal/databases/mysql/mariadb_gtid_filter_test.go
+++ b/internal/databases/mysql/mariadb_gtid_filter_test.go
@@ -17,32 +17,32 @@ func TestMariaDBGTIDFilter_IsValid(t *testing.T) {
 		{
 			name: "Valid MariaDB filter",
 			filter: mariadbGtidFilter{
-				BinlogsFolder: "/var/lib/mysql",
-				Flavor:        mysql.MariaDBFlavor,
+				binlogsFolder: "/var/lib/mysql",
+				flavor:        mysql.MariaDBFlavor,
 			},
 			want: true,
 		},
 		{
 			name: "Invalid - MySQL flavor should not be valid for MariaDB filter",
 			filter: mariadbGtidFilter{
-				BinlogsFolder: "/var/lib/mysql",
-				Flavor:        mysql.MySQLFlavor,
+				binlogsFolder: "/var/lib/mysql",
+				flavor:        mysql.MySQLFlavor,
 			},
 			want: false,
 		},
 		{
 			name: "Invalid - empty flavor",
 			filter: mariadbGtidFilter{
-				BinlogsFolder: "/var/lib/mysql",
-				Flavor:        "",
+				binlogsFolder: "/var/lib/mysql",
+				flavor:        "",
 			},
 			want: false,
 		},
 		{
 			name: "Invalid - unknown flavor",
 			filter: mariadbGtidFilter{
-				BinlogsFolder: "/var/lib/mysql",
-				Flavor:        "PostgreSQL",
+				binlogsFolder: "/var/lib/mysql",
+				flavor:        "PostgreSQL",
 			},
 			want: false,
 		},
@@ -302,8 +302,8 @@ func TestMariaDBGTIDContainAfterUpdate(t *testing.T) {
 // TestMariaDBGTIDFilter_ShouldUpload_FirstRun tests the first binlog upload scenario
 func TestMariaDBGTIDFilter_ShouldUpload_FirstRun(t *testing.T) {
 	filter := mariadbGtidFilter{
-		BinlogsFolder: "/var/lib/mysql",
-		Flavor:        mysql.MariaDBFlavor,
+		binlogsFolder: "/var/lib/mysql",
+		flavor:        mysql.MariaDBFlavor,
 		gtidArchived:  nil, // First run - no archived GTIDs
 	}
 
@@ -311,4 +311,3 @@ func TestMariaDBGTIDFilter_ShouldUpload_FirstRun(t *testing.T) {
 	result := filter.shouldUpload("mysql-bin.000001", "")
 	assert.False(t, result, "Should return false when there's no next binlog")
 }
-

--- a/internal/databases/mysql/mysql_gtid_filter.go
+++ b/internal/databases/mysql/mysql_gtid_filter.go
@@ -1,0 +1,154 @@
+package mysql
+
+import (
+	"path"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/wal-g/tracelog"
+)
+
+// mysqlGtidFilter handles MySQL-specific GTID filtering for binlog archiving.
+// MySQL GTIDs are interval sets keyed by server UUID (e.g.
+// "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5"), so filtering has to reconcile
+// intervals rather than compare high-water marks like mariadbGtidFilter does.
+type mysqlGtidFilter struct {
+	binlogsFolder string
+	flavor        string
+	gtidArchived  *mysql.MysqlGTIDSet
+	lastGtidSeen  *mysql.MysqlGTIDSet
+}
+
+// isValid returns true if the filter is properly configured for MySQL.
+// The filter is only valid if:
+// 1. The receiver is non-nil
+// 2. Flavor is set
+// 3. Flavor is exactly MySQL (not MariaDB or other)
+func (u *mysqlGtidFilter) isValid() bool {
+	if u == nil {
+		return false
+	}
+	if u.flavor == "" {
+		return false
+	}
+	if u.flavor != mysql.MySQLFlavor {
+		// MariaDB GTID Sets consists of: DomainID + ServerID + Sequence Number (64-bit unsigned integer)
+		// It is not clear how it handles gaps in SequenceNumbers, so for safety reasons skip this check
+		return false
+	}
+	return true
+}
+
+// shouldUpload determines if a binlog should be uploaded based on GTID interval-set comparison.
+func (u *mysqlGtidFilter) shouldUpload(binlog, nextBinlog string) bool {
+	if nextBinlog == "" {
+		// it is better to skip this binlog rather than have gap in binlog sentinel GTID-set
+		tracelog.DebugLogger.Printf("Cannot extract PREVIOUS_GTIDS event - no 'next' binlog found. Skip it for now. (gtid check)\n")
+		return false
+	}
+	// nextPreviousGTIDs is 'GTIDs_executed at the end of current binary log file'
+	_nextPreviousGTIDs, err := GetBinlogPreviousGTIDs(path.Join(u.binlogsFolder, nextBinlog), u.flavor)
+	if err != nil {
+		tracelog.InfoLogger.Printf(
+			"Cannot extract PREVIOUS_GTIDS event from current binlog %s, next %s (caused by %v). Upload it. (gtid check)\n",
+			binlog, nextBinlog, err)
+		return true
+	}
+	nextPreviousGTIDs := _nextPreviousGTIDs.(*mysql.MysqlGTIDSet)
+
+	if u.gtidArchived == nil || u.gtidArchived.String() == "" {
+		tracelog.DebugLogger.Printf("Cannot extract set of uploaded binlogs from cache\n")
+		// continue uploading even when we cannot read uploadedGTIDs
+		u.gtidArchived = nextPreviousGTIDs
+		u.lastGtidSeen = nextPreviousGTIDs
+		return true
+	}
+
+	if u.lastGtidSeen == nil {
+		gtidSetBeforeCurrentBinlog, err := GetBinlogPreviousGTIDs(path.Join(u.binlogsFolder, binlog), u.flavor)
+		if err != nil {
+			tracelog.InfoLogger.Printf(
+				"Cannot extract PREVIOUS_GTIDS event from current binlog %s, next %s (caused by %v). Upload it. (gtid check)\n",
+				binlog, nextBinlog, err)
+			u.lastGtidSeen = nextPreviousGTIDs
+			return true
+		}
+		tracelog.DebugLogger.Printf("Binlog %s is the first binlog that we seen by GTID-checker in this run. (gtid check)\n", binlog)
+		u.lastGtidSeen = gtidSetBeforeCurrentBinlog.(*mysql.MysqlGTIDSet)
+	}
+
+	currentBinlogGTIDSet := nextPreviousGTIDs.Clone().(*mysql.MysqlGTIDSet)
+	gtidSetMinus(currentBinlogGTIDSet, u.lastGtidSeen)
+
+	// when we know that _next_ binlog's PreviousGTID already uploaded we can safely skip _current_ binlog
+	if u.gtidArchived.Contain(currentBinlogGTIDSet) {
+		tracelog.InfoLogger.Printf("Binlog %v with GTID Set %s already archived (gtid check)\n", binlog, currentBinlogGTIDSet.String())
+		u.lastGtidSeen = nextPreviousGTIDs
+		return false
+	}
+
+	err = u.gtidArchived.Update(currentBinlogGTIDSet.String())
+	if err != nil {
+		tracelog.WarningLogger.Printf("Cannot merge GTIDs: %v (gtid check)\n", err)
+		return true // math is broken. upload binlog
+	}
+	tracelog.InfoLogger.Printf("Should upload binlog %s with GTID set: %s (gtid check)\n", binlog, currentBinlogGTIDSet.String())
+	u.lastGtidSeen = nextPreviousGTIDs
+	return true
+}
+
+// getArchivedGTIDString returns the string representation of the archived GTID set for MySQL.
+func (u *mysqlGtidFilter) getArchivedGTIDString() string {
+	if u.gtidArchived == nil {
+		return ""
+	}
+	return u.gtidArchived.String()
+}
+
+// gtidSetMinus subtracts sub from s in place (set difference s\sub).
+func gtidSetMinus(s, sub *mysql.MysqlGTIDSet) {
+	for sid, subTags := range *sub {
+		sTags, ok := (*s)[sid]
+		if !ok {
+			continue
+		}
+		for tag, subIntervals := range subTags {
+			intervals, ok := sTags[tag]
+			if !ok {
+				continue
+			}
+			if diff := subtractIntervals(intervals, subIntervals); len(diff) > 0 {
+				sTags[tag] = diff
+			} else {
+				delete(sTags, tag)
+			}
+		}
+		if len(sTags) == 0 {
+			delete(*s, sid)
+		}
+	}
+}
+
+// subtractIntervals returns a\b for half-open [Start, Stop) GTID interval slices
+func subtractIntervals(a, b mysql.IntervalSlice) mysql.IntervalSlice {
+	a = a.Normalize()
+	b = b.Normalize()
+	var result mysql.IntervalSlice
+	for _, cur := range a {
+		for _, sub := range b {
+			if sub.Stop <= cur.Start || sub.Start >= cur.Stop {
+				continue // disjoint
+			}
+			if sub.Start > cur.Start {
+				result = append(result, mysql.Interval{Start: cur.Start, Stop: sub.Start})
+			}
+			cur.Start = sub.Stop
+			if cur.Start >= cur.Stop {
+				break // fully consumed by b
+			}
+		}
+		if cur.Start < cur.Stop {
+			result = append(result, cur)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
### Database name
MySQL / MariaDB

# Pull request description

### Describe what this PR fixes

`binlog-push`'s GTID-based checkpoint filtering (`WALG_MYSQL_CHECK_GTIDS`) currently only supports the MySQL flavor. Enabling it against a MariaDB server hits the `default: tracelog.ErrorLogger.Fatalf("Unsupported flavor type...")` branch and fails outright, because MariaDB uses a different GTID representation than MySQL (`domain-server-sequence`, e.g. `0-1-1011`, vs MySQL's `uuid:interval` format), and MariaDB GTIDs behave as monotonic high-water marks per (domain, server) rather than interval sets.

This PR adds a `mariadbGtidFilter` implementing the existing `binlogGtidFilter` interface (`isValid`, `shouldUpload`, `getArchivedGTIDString`), and wires it into `HandleBinlogPush` via a new `case mysql.MariaDBFlavor:` branch, so GTID-based deduplication of already-archived binlogs now works for MariaDB the same way it already does for MySQL.

**Files changed:**
- `internal/databases/mysql/mariadb_gtid_filter.go` (new) — MariaDB GTID
  checkpoint filter, using `MARIADB_GTID_LIST_EVENT`-based end-state
  comparison to decide whether a binlog is already archived.
- `internal/databases/mysql/mariadb_gtid_filter_test.go` (new) — unit tests
  covering `isValid`, GTID parsing, `Contain`, `Clone`, and `Update`
  semantics for MariaDB GTID sets.
- `internal/databases/mysql/binlog_push_handler.go` — add the MariaDB case
  to the flavor switch; add `getArchivedGTIDString()` to the existing
  MySQL `gtidFilter` so both filters satisfy the same interface.

No behavior change for existing MySQL users.

### Please provide steps to reproduce (if it's a bug)

Not a bug fix — new feature. To exercise it: run `binlog-push` against a
MariaDB server with `WALG_MYSQL_CHECK_GTIDS=true`.

### Please add config and wal-g stdout/stderr logs for debug purpose

N/A — unit tests included in this PR (`mariadb_gtid_filter_test.go`).

**Build verification:**
`go build ./internal/databases/mysql/...` — build successful, no errors.
`go test ./internal/databases/mysql/...` — all tests pass.
