### PR TITLE
fix(mongo): replay catch-up from appliedThrough

### DIFF
--- a/internal/databases/mongo/binary/oplog_reply.go
+++ b/internal/databases/mongo/binary/oplog_reply.go
@@ -64,7 +64,11 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 
 	var emptyTS models.Timestamp
 	if replayArgs.Since == emptyTS {
-		replayArgs.Since, err = mongoClient.LastOplogTS(ctx)
+		if replayArgs.WithCatchUpReconfig {
+			replayArgs.Since, err = mongoClient.CatchUpStartTS(ctx)
+		} else {
+			replayArgs.Since, err = mongoClient.LastOplogTS(ctx)
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/databases/mongo/client/client.go
+++ b/internal/databases/mongo/client/client.go
@@ -82,6 +82,7 @@ type MongoDriver interface {
 	Close(ctx context.Context, shutdown bool) error
 	ChangeOplogLastTimestamp(ctx context.Context, opTime models.OpTime) error
 	LastOplogTS(ctx context.Context) (lastTS models.Timestamp, err error)
+	CatchUpStartTS(ctx context.Context) (models.Timestamp, error)
 }
 
 // OplogCursor defines methods to work with mongodb cursor.
@@ -301,6 +302,38 @@ func (mc *MongoClient) LastOplogTS(ctx context.Context) (lastTS models.Timestamp
 		return models.Timestamp{}, err
 	}
 	return models.TimestampFromBson(op.Timestamp), nil
+}
+
+// CatchUpStartTS returns the last point known to be applied to the data files.
+func (mc *MongoClient) CatchUpStartTS(ctx context.Context) (models.Timestamp, error) {
+	lastOplogTS, err := mc.LastOplogTS(ctx)
+	if err != nil {
+		return models.Timestamp{}, err
+	}
+
+	var minValid struct {
+		AppliedThrough *struct {
+			TS bson.Timestamp `bson:"ts"`
+		} `bson:"appliedThrough"`
+	}
+	err = mc.c.Database(oplogDatabaseName).
+		Collection("replset.minvalid").
+		FindOne(ctx, bson.M{}).
+		Decode(&minValid)
+	if err != nil {
+		return models.Timestamp{}, fmt.Errorf("failed to get appliedThrough: %w", err)
+	}
+	if minValid.AppliedThrough == nil || minValid.AppliedThrough.TS == (bson.Timestamp{}) {
+		return lastOplogTS, nil
+	}
+
+	appliedThroughTS := models.TimestampFromBson(minValid.AppliedThrough.TS)
+	if models.LessTS(lastOplogTS, appliedThroughTS) {
+		return models.Timestamp{}, fmt.Errorf(
+			"appliedThrough %s is ahead of the last oplog entry %s",
+			appliedThroughTS.String(), lastOplogTS.String())
+	}
+	return appliedThroughTS, nil
 }
 
 // Close disconnects from mongodb

--- a/internal/databases/mongo/client/mocks/MongoDriver.go
+++ b/internal/databases/mongo/client/mocks/MongoDriver.go
@@ -181,6 +181,32 @@ func (_m *MongoDriver) LastOplogTS(ctx context.Context) (models.Timestamp, error
 	return r0, r1
 }
 
+// CatchUpStartTS provides a mock function with given fields: ctx
+func (_m *MongoDriver) CatchUpStartTS(ctx context.Context) (models.Timestamp, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CatchUpStartTS")
+	}
+
+	var r0 models.Timestamp
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (models.Timestamp, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) models.Timestamp); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(models.Timestamp)
+	}
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 // LastWriteTS provides a mock function with given fields: ctx
 func (_m *MongoDriver) LastWriteTS(ctx context.Context) (models.Timestamp, models.Timestamp, error) {
 	ret := _m.Called(ctx)


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
