### PR TITLE
fix(etcd-tests): wait for etcd readiness before client commands

### DIFF
--- a/docker/etcd_tests/export_common.sh
+++ b/docker/etcd_tests/export_common.sh
@@ -7,11 +7,52 @@ export WALG_ETCD_DATA_DIR='/tmp/etcd/cluster'
 export ETCD_RESTORE_DATA_DIR='/tmp/etcd/restore_cluster'
 export ETCD_LOG_LEVEL='info'
 export ETCDCTL_API=3
+export ETCD_ENDPOINT='http://127.0.0.1:2379'
+
+wait_for_etcd() {
+    for _ in $(seq 1 60); do
+        if etcdctl --endpoints "$ETCD_ENDPOINT" endpoint health >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "etcd failed to become ready in time" >&2
+    return 1
+}
+
+start_etcd() {
+    local data_dir="${1:-$WALG_ETCD_DATA_DIR}"
+    etcd \
+        --data-dir "$data_dir" \
+        --listen-client-urls "$ETCD_ENDPOINT" \
+        --advertise-client-urls "$ETCD_ENDPOINT" \
+        --listen-peer-urls http://127.0.0.1:2380 \
+        --initial-advertise-peer-urls http://127.0.0.1:2380 \
+        --initial-cluster default=http://127.0.0.1:2380 \
+        >/tmp/etcd.log 2>&1 &
+
+    wait_for_etcd
+}
+
+kill_etcd() {
+    pkill -x etcd || true
+    for _ in $(seq 1 50); do
+        if ! pgrep -x etcd >/dev/null; then
+            break
+        fi
+        sleep 0.2
+    done
+
+    if pgrep -x etcd >/dev/null; then
+        pkill -9 -x etcd || true
+    fi
+}
 
 etcd_kill_and_clean_data() {
-    etcd --data-dir $WALG_ETCD_DATA_DIR &
-    etcdctl del "" --from-key=true
-    pkill etcd
+    start_etcd "$WALG_ETCD_DATA_DIR"
+    etcdctl --endpoints "$ETCD_ENDPOINT" del "" --from-key=true
+    kill_etcd
 
     rm -rf "${WALG_FILE_PREFIX}"
     rm -rf "${ETCD_RESTORE_DATA_DIR}"

--- a/docker/etcd_tests/scripts/tests/etcd_full_backup_test.sh
+++ b/docker/etcd_tests/scripts/tests/etcd_full_backup_test.sh
@@ -3,9 +3,9 @@ set -e -x
 
 . /usr/local/export_common.sh
 
-etcd --data-dir $WALG_ETCD_DATA_DIR &
+start_etcd "$WALG_ETCD_DATA_DIR"
 
-etcdctl put testing "should stay after backup is fetched"
+etcdctl --endpoints "$ETCD_ENDPOINT" put testing "should stay after backup is fetched"
 
 mkdir -p $WALG_FILE_PREFIX
 
@@ -13,12 +13,12 @@ wal-g backup-push
 
 expected_output=$(etcdctl get "" --prefix=true)
 
-pkill etcd
+kill_etcd
 wal-g backup-fetch LATEST
 
-etcd --data-dir $ETCD_RESTORE_DATA_DIR &
+start_etcd "$ETCD_RESTORE_DATA_DIR"
 
-actual_output=$(etcdctl get "" --prefix=true)
+actual_output=$(etcdctl --endpoints "$ETCD_ENDPOINT" get "" --prefix=true)
 
 if [ "$actual_output" != "$expected_output" ]; then
   echo "Error: actual output doesn't match expected output"
@@ -27,4 +27,4 @@ if [ "$actual_output" != "$expected_output" ]; then
   exit 1
 fi
 
-pkill etcd
+kill_etcd

--- a/docker/etcd_tests/scripts/tests/etcd_wal_push_fetch_test.sh
+++ b/docker/etcd_tests/scripts/tests/etcd_wal_push_fetch_test.sh
@@ -3,7 +3,7 @@ set -e -x
 
 . /usr/local/export_common.sh
 
-etcd --data-dir $WALG_ETCD_DATA_DIR &
+start_etcd "$WALG_ETCD_DATA_DIR"
 
 mkdir -p $WALG_FILE_PREFIX
 
@@ -34,4 +34,4 @@ for file in $expected_fetched_wals; do
   fi
 done
 
-pkill etcd
+kill_etcd


### PR DESCRIPTION
This fixes ETCD integration hangs caused by a startup race in the test harness.

The scripts were launching etcd in the background and immediately issuing etcdctl commands without waiting for the server to become ready. In CI this can stall the job while etcd is still booting.



example job hung: https://github.com/wal-g/wal-g/actions/runs/31563627444/job/94012481324
