### PR TITLE
add shallow coping of http client cause of sessions are sharing http …

### DIFF
--- a/pkg/storages/s3/session.go
+++ b/pkg/storages/s3/session.go
@@ -125,7 +125,9 @@ func configureSession(sess *session.Session, config *Config) error {
 			MaxThrottleDelay: config.MaxThrottlingRetryDelay,
 		}))
 
-	awsConfig.HTTPClient.Transport = NewRoundTripperWithLogging(awsConfig.HTTPClient.Transport)
+	httpClient := *awsConfig.HTTPClient
+	httpClient.Transport = NewRoundTripperWithLogging(httpClient.Transport)
+	awsConfig.HTTPClient = &httpClient
 	accessKey := config.AccessKey
 	secretKey := config.Secrets.SecretKey
 	sessionToken := config.SessionToken

--- a/pkg/storages/s3/session_test.go
+++ b/pkg/storages/s3/session_test.go
@@ -1,0 +1,44 @@
+package s3
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSessionWithHTTPSEndpointSourceTwice(t *testing.T) {
+	originalTransport := http.DefaultClient.Transport
+	t.Cleanup(func() {
+		http.DefaultClient.Transport = originalTransport
+	})
+
+	config := &Config{
+		Secrets:          &Secrets{},
+		Region:           "us-east-1",
+		Endpoint:         "https://s3.example.com",
+		EndpointSource:   "https://endpoint-source.example.com",
+		EndpointPort:     "443",
+		EndpointProtocol: "https",
+	}
+
+	first, err := createSession(config)
+	require.NoError(t, err)
+	second, err := createSession(config)
+	require.NoError(t, err)
+
+	require.NotSame(t, first.Config.HTTPClient, second.Config.HTTPClient)
+	assertSessionTransport(t, first.Config.HTTPClient.Transport, "s3.example.com")
+	assertSessionTransport(t, second.Config.HTTPClient.Transport, "s3.example.com")
+}
+
+func assertSessionTransport(t *testing.T, roundTripper http.RoundTripper, serverName string) {
+	t.Helper()
+
+	logging, ok := roundTripper.(*loggingTransport)
+	require.True(t, ok)
+	transport, ok := logging.underlying.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.Equal(t, serverName, transport.TLSClientConfig.ServerName)
+}


### PR DESCRIPTION
…client now

### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
