### PR TITLE
fix(mysql): guard binlog server disconnect cleanup against nil connection

### DIFF
--- a/internal/databases/mysql/binlog_server_handler.go
+++ b/internal/databases/mysql/binlog_server_handler.go
@@ -500,7 +500,12 @@ func handleBinlogConnection(
 		}
 		return
 	}
-	defer conn.Close()
+
+	defer func() {
+		if !conn.Closed() {
+			conn.Close()
+		}
+	}()
 
 	for {
 		if err := conn.HandleCommand(); err != nil {


### PR DESCRIPTION

The MySQL binlog replication server could panic while tearing down a replica connection after a broken pipe / proxy disconnect. The close path called into the go-mysql server connection without checking whether the underlying packet connection had been initialized, which caused a nil-pointer dereference during reconnect churn.

addresses: https://github.com/wal-g/wal-g/actions/runs/32118514347/job/95655686325
