### PR TITLE
Postgres and Greenplum journal (WAL) counting

### DIFF
--- a/.github/workflows/dockertests-par.yml
+++ b/.github/workflows/dockertests-par.yml
@@ -57,6 +57,7 @@ jobs:
         "make TEST=\"pg10_delete_target_delta_test\" pg_integration_test",
         "make TEST=\"pg10_delete_target_test\" pg_integration_test",
         "make TEST=\"pg10_delete_without_confirm_test\" pg_integration_test",
+        "make TEST=\"pg10_journals_test\" pg_integration_test",
         "make TEST=\"pg10_delta_backup_fullscan_test\" pg_integration_test",
         "make TEST=\"pg10_ghost_table_test\" pg_integration_test",
         "make TEST=\"pg10_several_delta_backups_test\" pg_integration_test",

--- a/cmd/gp/backup_push.go
+++ b/cmd/gp/backup_push.go
@@ -20,6 +20,7 @@ const (
 	addUserDataFlag       = "add-user-data"
 	deltaFromUserDataFlag = "delta-from-user-data"
 	deltaFromNameFlag     = "delta-from-name"
+	countJournalsFlag     = "count-journals"
 
 	permanentShorthand  = "p"
 	fullBackupShorthand = "f"
@@ -64,7 +65,7 @@ var (
 			tracelog.ErrorLogger.FatalOnError(err)
 
 			arguments := greenplum.NewBackupArguments(uploader, permanent, fullBackup, userData, prepareSegmentFwdArgs(), logsDir,
-				segPollInterval, segPollRetries, deltaBaseSelector)
+				segPollInterval, segPollRetries, deltaBaseSelector, countJournals)
 			backupHandler, err := greenplum.NewBackupHandler(cmd.Context(), arguments)
 			tracelog.ErrorLogger.FatalOnError(err)
 			backupHandler.HandleBackupPush(cmd.Context())
@@ -76,12 +77,14 @@ var (
 	deltaFromName     = ""
 	deltaFromUserData = ""
 	fullBackup        = false
+	countJournals     = false
 )
 
 // prepare arguments that are going to be forwarded to segments
 func prepareSegmentFwdArgs() []greenplum.SegmentFwdArg {
 	return []greenplum.SegmentFwdArg{
 		{Name: permanentFlag, Value: strconv.FormatBool(permanent)},
+		{Name: countJournalsFlag, Value: strconv.FormatBool(countJournals)},
 	}
 }
 
@@ -98,4 +101,6 @@ func init() {
 		"", "Select the backup specified by name as the target for the delta backup")
 	backupPushCmd.Flags().StringVar(&deltaFromUserData, deltaFromUserDataFlag,
 		"", "Select the backup specified by UserData as the target for the delta backup")
+	backupPushCmd.Flags().BoolVar(&countJournals, countJournalsFlag,
+		false, "Create 'journal_<backup>' objects in storage and maintain the WAL volume required to get from one backup to the next")
 }

--- a/cmd/gp/backup_push_segment.go
+++ b/cmd/gp/backup_push_segment.go
@@ -65,7 +65,7 @@ var (
 				permanent, verifyPageChecksums,
 				fullBackup, storeAllCorruptBlocks,
 				tarBallComposerType, greenplum.NewSegDeltaBackupConfigurator(deltaBaseSelector),
-				userData, viper.GetBool(conf.WithoutFilesMetadataSetting))
+				userData, viper.GetBool(conf.WithoutFilesMetadataSetting), countJournals)
 
 			backupHandler, err := greenplum.NewSegBackupHandler(cmd.Context(), arguments)
 			tracelog.ErrorLogger.FatalOnError(err)
@@ -87,6 +87,8 @@ func init() {
 		"", "Select the backup specified by UserData as the target for the delta backup")
 	segBackupPushCmd.Flags().StringVar(&userDataRaw, addUserDataFlag,
 		"", "Write the provided user data to the backup sentinel and metadata files.")
+	segBackupPushCmd.Flags().BoolVar(&countJournals, countJournalsFlag,
+		false, "Maintain the 'journal_<backup>' object tracking the WAL volume archived by this segment")
 	segBackupPushCmd.PersistentFlags().IntVar(&contentID, "content-id", 0, "segment content ID")
 	_ = segBackupPushCmd.MarkFlagRequired("content-id")
 	cmd.AddCommand(segBackupPushCmd)

--- a/cmd/pg/backup_push.go
+++ b/cmd/pg/backup_push.go
@@ -26,6 +26,7 @@ const (
 	deltaFromNameFlag         = "delta-from-name"
 	addUserDataFlag           = "add-user-data"
 	withoutFilesMetadataFlag  = "without-files-metadata"
+	countJournalsFlag         = "count-journals"
 
 	permanentShorthand             = "p"
 	fullBackupShorthand            = "f"
@@ -108,7 +109,7 @@ var (
 				permanent, verifyPageChecksums || viper.GetBool(conf.VerifyPageChecksumsSetting),
 				fullBackup, storeAllCorruptBlocks || viper.GetBool(conf.StoreAllCorruptBlocksSetting),
 				tarBallComposerType, postgres.NewRegularDeltaBackupConfigurator(deltaBaseSelector),
-				userData, withoutFilesMetadata)
+				userData, withoutFilesMetadata, countJournals)
 
 			backupHandler, err := postgres.NewBackupHandler(cmd.Context(), arguments)
 			tracelog.ErrorLogger.FatalOnError(err)
@@ -126,6 +127,7 @@ var (
 	deltaFromUserData     = ""
 	userDataRaw           = ""
 	withoutFilesMetadata  = false
+	countJournals         = false
 )
 
 func chooseTarBallComposer() postgres.TarBallComposerType {
@@ -175,6 +177,8 @@ func init() {
 		"", "Write the provided user data to the backup sentinel and metadata files.")
 	backupPushCmd.Flags().BoolVar(&withoutFilesMetadata, withoutFilesMetadataFlag,
 		false, "Do not track files metadata, significantly reducing memory usage")
+	backupPushCmd.Flags().BoolVar(&countJournals, countJournalsFlag,
+		false, "Create 'journal_<backup>' objects in storage and maintain the WAL volume required to get from one backup to the next")
 	backupPushCmd.Flags().StringVar(&targetStorage, "target-storage", "",
 		targetStorageDescription)
 }

--- a/cmd/pg/delete.go
+++ b/cmd/pg/delete.go
@@ -133,8 +133,7 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 
 	target := deleteHandler.HandleDeleteTarget(cmd.Context(), targetBackupSelector, confirmed, findFullBackup)
 
-	internal.DeleteJournalInfo(cmd.Context(), folder, target.GetBackupName(), utility.WalPath,
-		&internal.JournalFiles{}, confirmed)
+	internal.DeleteJournalInfo(cmd.Context(), folder, target.GetBackupName(), utility.WalPath, confirmed)
 }
 
 func runDeleteGarbage(cmd *cobra.Command, args []string) {

--- a/cmd/pg/delete.go
+++ b/cmd/pg/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wal-g/wal-g/internal/multistorage"
 	"github.com/wal-g/wal-g/internal/multistorage/policies"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
 )
 
 const UseSentinelTimeFlag = "use-sentinel-time"
@@ -130,7 +131,10 @@ func runDeleteTarget(cmd *cobra.Command, args []string) {
 	targetBackupSelector, err := internal.CreateTargetDeleteBackupSelector(cmd, args, deleteTargetUserData, postgres.NewGenericMetaFetcher())
 	tracelog.ErrorLogger.FatalOnError(err)
 
-	deleteHandler.HandleDeleteTarget(cmd.Context(), targetBackupSelector, confirmed, findFullBackup)
+	target := deleteHandler.HandleDeleteTarget(cmd.Context(), targetBackupSelector, confirmed, findFullBackup)
+
+	internal.DeleteJournalInfo(cmd.Context(), folder, target.GetBackupName(), utility.WalPath,
+		&internal.JournalFiles{}, confirmed)
 }
 
 func runDeleteGarbage(cmd *cobra.Command, args []string) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
       &&  mkdir -p /export/delete-garbage-multist-fo-bucket
       &&  mkdir -p /export/gpdeletetargetbucket
       &&  mkdir -p /export/gpdeletegarbagebucket
+      &&  mkdir -p /export/gp-journal-test-bucket
       &&  mkdir -p /export/cloudberry-delete-target-bucket
       &&  mkdir -p /export/cloudberry-delete-garbage-bucket
       &&  mkdir -p /export/mysqlfullxtrabackupbucket
@@ -177,6 +178,7 @@ services:
       &&  mkdir -p /export/cloudberry-delete-before-time-bucket
       &&  mkdir -p /export/cloudberry-aostorage-test-bucket
       &&  mkdir -p /export/cloudberry-paxstorage-test-bucket
+      &&  mkdir -p /export/cloudberry-journal-test-bucket
       &&  mkdir -p /export/cloudberry-delta-backup-test-bucket
       &&  mkdir -p /export/cloudberry-partial-table-bucket
       &&  mkdir -p /export/createrestorepointbucket
@@ -196,6 +198,7 @@ services:
       &&  mkdir -p /export/receivewalbucket
       &&  mkdir -p /export/severaldeltabackupsbucket
       &&  mkdir -p /export/walperftestbucket
+      &&  mkdir -p /export/pg-journal-test-bucket
       &&  mkdir -p /export/orioledb-compatibility
       &&  mkdir -p /export/orioledb-simple
       &&  mkdir -p /export/orioledb-compressed
@@ -520,6 +523,11 @@ services:
     <<: *pg10_test_common
     container_name: wal-g_pg10_delete_target_delta_find_full_test
     command: /tmp/tests/delete_target_delta_find_full_test.sh
+
+  pg10_journals_test:
+    <<: *pg10_test_common
+    container_name: wal-g_pg10_journals_test
+    command: /tmp/tests/journals_test.sh
 
   pg10_ghost_table_test:
     <<: *pg10_test_common

--- a/docker/cloudberry_tests/scripts/configs/journals_test_config.json
+++ b/docker/cloudberry_tests/scripts/configs/journals_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://cloudberry-journal-test-bucket",
+"WALG_LOG_LEVEL": "DEVEL"

--- a/docker/cloudberry_tests/scripts/tests/journals_test.sh
+++ b/docker/cloudberry_tests/scripts/tests/journals_test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -e -x
+CONFIG_FILE="/tmp/configs/journals_test_config.json"
+
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/pg_scripts/wrap_config_file.sh ${TMP_CONFIG}
+source /tmp/tests/test_functions/util.sh
+
+# The names of the cluster-wide journals, oldest first. One per cluster backup.
+get_cluster_journals() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/ 2>&1 | grep journal_ | awk '{ print $NF }' | sort
+}
+
+get_cluster_journal_count() {
+    get_cluster_journals | wc -l
+}
+
+# get_backup_name <n> - name of the n-th oldest backup, derived from its journal name
+get_backup_name() {
+    JOURNAL_NAME=$(get_cluster_journals | awk "FNR == $1 {print}")
+    echo ${JOURNAL_NAME#"journal_"}
+}
+
+# get_cluster_journal_size <n> - SizeToNextBackup recorded for the n-th oldest backup
+get_cluster_journal_size() {
+    JOURNAL_NAME=$(get_cluster_journals | awk "FNR == $1 {print}")
+    wal-g --config=${TMP_CONFIG} st cat basebackups_005/$JOURNAL_NAME | jq ".SizeToNextBackup"
+}
+
+count_segment_journals() {
+    wal-g --config=${TMP_CONFIG} st ls segments_005/seg$1/basebackups_005/ 2>&1 | grep journal_ | wc -l
+}
+
+bootstrap_gp_cluster
+setup_wal_archiving
+
+wal-g --config=${TMP_CONFIG} st rm / --target=all || true
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+for i in 1 2 3
+do
+    insert_data
+    run_backup_logged ${TMP_CONFIG} --count-journals
+    sleep 1
+done
+
+# Every backup got a cluster-wide journal, and every segment got its own one
+test "3" -eq $(get_cluster_journal_count)
+for CONTENT_ID in -1 0 1 2
+do
+    test "3" -eq $(count_segment_journals ${CONTENT_ID})
+done
+
+# The newest backup has nothing after it yet, the older ones accumulated some WAL
+FIRST_SIZE=$(get_cluster_journal_size 1)
+SECOND_SIZE=$(get_cluster_journal_size 2)
+test "0" -ne $FIRST_SIZE
+test "0" -ne $SECOND_SIZE
+test "0" -eq $(get_cluster_journal_size 3)
+
+# Deleting a backup in the middle merges its interval into the previous one
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 2) --confirm
+
+test "2" -eq $(get_cluster_journal_count)
+for CONTENT_ID in -1 0 1 2
+do
+    test "2" -eq $(count_segment_journals ${CONTENT_ID})
+done
+
+test $((FIRST_SIZE + SECOND_SIZE)) -eq $(get_cluster_journal_size 1)
+test "0" -eq $(get_cluster_journal_size 2)
+
+# Deleting the newest backup leaves the remaining one as the newest
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 2) --confirm
+
+test "1" -eq $(get_cluster_journal_count)
+test "0" -eq $(get_cluster_journal_size 1)
+
+# Deleting the last remaining backup removes its journals everywhere
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 1) --confirm
+
+test "0" -eq $(get_cluster_journal_count)
+for CONTENT_ID in -1 0 1 2
+do
+    test "0" -eq $(count_segment_journals ${CONTENT_ID})
+done
+
+cleanup
+rm ${TMP_CONFIG}

--- a/docker/gp_tests/scripts/configs/journals_test_config.json
+++ b/docker/gp_tests/scripts/configs/journals_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://gp-journal-test-bucket",
+"WALG_LOG_LEVEL": "DEVEL"

--- a/docker/gp_tests/scripts/tests/journals_test.sh
+++ b/docker/gp_tests/scripts/tests/journals_test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e -x
+CONFIG_FILE="/tmp/configs/journals_test_config.json"
+
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/pg_scripts/wrap_config_file.sh ${TMP_CONFIG}
+source /tmp/tests/test_functions/util.sh
+
+# The names of the cluster-wide journals, oldest first. One per gp backup.
+get_cluster_journals() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/ 2>&1 | grep journal_ | awk '{ print $NF }' | sort
+}
+
+get_cluster_journal_count() {
+    get_cluster_journals | wc -l
+}
+
+# get_backup_name <n> - name of the n-th oldest backup, derived from its journal name
+get_backup_name() {
+    JOURNAL_NAME=$(get_cluster_journals | awk "FNR == $1 {print}")
+    echo ${JOURNAL_NAME#"journal_"}
+}
+
+# get_cluster_journal_size <n> - SizeToNextBackup recorded for the n-th oldest backup
+get_cluster_journal_size() {
+    JOURNAL_NAME=$(get_cluster_journals | awk "FNR == $1 {print}")
+    wal-g --config=${TMP_CONFIG} st cat basebackups_005/$JOURNAL_NAME | jq ".SizeToNextBackup"
+}
+
+count_segment_journals() {
+    wal-g --config=${TMP_CONFIG} st ls segments_005/seg$1/basebackups_005/ 2>&1 | grep journal_ | wc -l
+}
+
+bootstrap_gp_cluster
+setup_wal_archiving
+enable_pitr_extension
+
+wal-g --config=${TMP_CONFIG} st rm / --target=all || true
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+for i in 1 2 3
+do
+    insert_data
+    run_backup_logged ${TMP_CONFIG} --count-journals
+    sleep 1
+done
+
+# Every backup got a cluster-wide journal, and every segment got its own one
+test "3" -eq $(get_cluster_journal_count)
+for CONTENT_ID in -1 0 1 2
+do
+    test "3" -eq $(count_segment_journals ${CONTENT_ID})
+done
+
+# The newest backup has nothing after it yet, the older ones accumulated some WAL
+FIRST_SIZE=$(get_cluster_journal_size 1)
+SECOND_SIZE=$(get_cluster_journal_size 2)
+test "0" -ne $FIRST_SIZE
+test "0" -ne $SECOND_SIZE
+test "0" -eq $(get_cluster_journal_size 3)
+
+# Deleting a backup in the middle merges its interval into the previous one
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 2) --confirm
+
+test "2" -eq $(get_cluster_journal_count)
+for CONTENT_ID in -1 0 1 2
+do
+    test "2" -eq $(count_segment_journals ${CONTENT_ID})
+done
+
+test $((FIRST_SIZE + SECOND_SIZE)) -eq $(get_cluster_journal_size 1)
+test "0" -eq $(get_cluster_journal_size 2)
+
+# Deleting the newest backup leaves the remaining one as the newest
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 2) --confirm
+
+test "1" -eq $(get_cluster_journal_count)
+test "0" -eq $(get_cluster_journal_size 1)
+
+# Deleting the last remaining backup removes its journals everywhere
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 1) --confirm
+
+test "0" -eq $(get_cluster_journal_count)
+for CONTENT_ID in -1 0 1 2
+do
+    test "0" -eq $(count_segment_journals ${CONTENT_ID})
+done
+
+cleanup
+rm ${TMP_CONFIG}

--- a/docker/pg_tests/scripts/configs/journals_test_config.json
+++ b/docker/pg_tests/scripts/configs/journals_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://pg-journal-test-bucket",
+"WALG_LOG_LEVEL": "DEVEL"

--- a/docker/pg_tests/scripts/tests/journals_test.sh
+++ b/docker/pg_tests/scripts/tests/journals_test.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+set -e -x
+
+. /tmp/tests/test_functions/prepare_config.sh
+prepare_config "/tmp/configs/journals_test_config.json"
+
+get_journal_count() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/ 2>&1 | grep journal_ | awk '{ printf $7 "\n" }' | wc -l
+}
+
+get_journal_name() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/ 2>&1 | grep journal_ | awk '{ printf $7 "\n"}' | sort | awk "FNR == $1 {print}"
+}
+
+get_backup_name() {
+    JOURNAL_NAME=$(get_journal_name $1)
+    echo ${JOURNAL_NAME#"journal_"}
+}
+
+get_journal_size() {
+    JOURNAL_NAME=$(get_journal_name $1)
+    wal-g --config=${TMP_CONFIG} st cat basebackups_005/$JOURNAL_NAME | jq '.SizeToNextBackup'
+}
+
+force_new_wal() {
+    if awk 'BEGIN {exit !('"$PG_VERSION"' >= 10)}'; then
+        echo 'select pg_switch_wal();' | psql postgres
+    else
+        echo 'select pg_switch_xlog();' | psql postgres
+    fi
+    sleep 1
+}
+
+initdb ${PGDATA}
+PG_VERSION=$(cat "${PGDATA}/PG_VERSION")
+
+echo "archive_mode = on" >> ${PGDATA}/postgresql.conf
+echo "archive_command = '/usr/bin/timeout 600 wal-g --config=${TMP_CONFIG} wal-push %p'" >> ${PGDATA}/postgresql.conf
+echo "archive_timeout = 600" >> ${PGDATA}/postgresql.conf
+
+pg_ctl -D ${PGDATA} -w start
+
+wal-g --config=${TMP_CONFIG} st rm / --target=all || true
+
+# Create backup #1 with journals
+pgbench -i -s 1 postgres
+force_new_wal
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --count-journals
+sleep 1
+
+# Check count of backups and content of them
+test "1" -eq $(get_journal_count)
+test "0" -eq $(get_journal_size 1)
+
+# Create backup #2 with journals
+pgbench -i -s 1 postgres
+force_new_wal
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --count-journals
+sleep 1
+
+# Check count of backups and content of them
+test "2" -eq $(get_journal_count)
+test "0" -ne $(get_journal_size 1)
+test "0" -eq $(get_journal_size 2)
+
+# Create backup #3 with journals
+pgbench -i -s 1 postgres
+force_new_wal
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --count-journals
+sleep 1
+
+# Check count of backups and content of them
+test "3" -eq $(get_journal_count)
+
+FIRST_BACKUP_SIZE=$(get_journal_size 1)
+test "0" -ne $FIRST_BACKUP_SIZE
+
+SECOND_BACKUP_SIZE=$(get_journal_size 2)
+test "0" -ne $SECOND_BACKUP_SIZE
+
+THIRD_BACKUP_SIZE=$(get_journal_size 3)
+test "0" -eq $THIRD_BACKUP_SIZE
+
+# We can successfully delete backup in the middle
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 2) --confirm
+test "2" -eq $(get_journal_count)
+
+NEW_FIRST_BACKUP_SIZE=$(get_journal_size 1)
+test $NEW_FIRST_BACKUP_SIZE -eq $(($SECOND_BACKUP_SIZE + $FIRST_BACKUP_SIZE))
+
+NEW_SECOND_BACKUP_SIZE=$(get_journal_size 2)
+test "0" -eq $NEW_SECOND_BACKUP_SIZE
+
+# We can successfully delete the last backup
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 2) --confirm
+test "1" -eq $(get_journal_count)
+test "0" -eq $(get_journal_size 1)
+
+# We can successfully delete the single backup
+wal-g --config=${TMP_CONFIG} delete target $(get_backup_name 1) --confirm
+test "0" -eq $(get_journal_count)
+
+/tmp/scripts/drop_pg.sh
+rm ${TMP_CONFIG}

--- a/docs/Greenplum.md
+++ b/docs/Greenplum.md
@@ -100,6 +100,17 @@ wal-g backup-push --delta-from-user-data "{ \"x\": [3], \"y\": 4 }" --config=/pa
 
 To prevent WAL-G from falling back to a full scan delta backup when it fails to download delta files.
 
+#### Journal size (WAL volume) accounting
+
+Run ``backup-push`` with the ``--count-journals`` flag to track the volume of WAL accumulated between one backup and the next one. The size is computed from the actual storage object sizes of the archived WAL segments, so it correctly reflects compression, unlike an LSN-difference estimate.
+
+```bash
+wal-g backup-push --count-journals --config=/path/to/config.yaml
+```
+Journal accounting is skipped for permanent backups (marked with ``--permanent``), since they are not expected to be removed and don't take part in WAL retention planning.
+
+Currently, only ``delete target`` cleans up and re-merges the corresponding journal entries when a backup is removed; other ``delete`` modes (``before``, ``retain``, ``everything``, ``garbage``) leave existing journals untouched.
+
 ### ``backup-fetch``
 
 When fetching base backups, the user should pass in the cluster restore configuration and the name of the backup.

--- a/docs/PostgreSQL.md
+++ b/docs/PostgreSQL.md
@@ -214,6 +214,18 @@ If a backup is started from a standby server, WAL-G will monitor the timeline of
 
 ``backup-push`` can also be run with the ``--permanent`` flag, which will mark the backup as permanent and prevent it from being removed when running ``delete``.
 
+#### Journal size (WAL volume) accounting
+
+Run ``backup-push`` with the ``--count-journals`` flag to maintain a ``journal_<backup>`` object per backup in storage, tracking the volume of WAL accumulated between that backup and the next one. The size is computed from the actual storage object sizes of the archived WAL segments, so it correctly reflects compression, unlike an LSN-difference estimate.
+
+```bash
+wal-g backup-push $PGDATA --count-journals
+```
+
+Journal accounting is skipped for permanent backups (marked with ``--permanent``), since they are not expected to be removed and don't take part in WAL retention planning.
+
+Currently, only ``delete target`` cleans up and re-merges the corresponding journal entry when a backup is removed this way; other ``delete`` modes (``before``, ``retain``, ``retain-after``, ``everything``, ``garbage``) leave existing journals untouched.
+
 #### Remote backup
 
 WAL-G backup-push allows for two data streaming options:

--- a/internal/databases/greenplum/README.journal.md
+++ b/internal/databases/greenplum/README.journal.md
@@ -1,0 +1,50 @@
+# Journal objects
+
+A journal records the volume of WAL archived between one backup and the next. It is the same object every WAL-G database keeps, and it knows nothing about Greenplum specifics such as AO/AOCS or PAX storage.
+
+## Storage layout
+
+```
+basebackups_005/                                 ← cluster
+  backup_<timestamp>_backup_stop_sentinel.json   ← names the backup of every segment
+  journal_backup_<timestamp>                     ← WAL volume, whole cluster
+segments_005/seg-1/                              ← coordinator
+  basebackups_005/journal_base_<...>             ← journal of this segment
+  wal_005/                                       ← WAL of this segment
+segments_005/seg0/                               ← segment 0, and so on
+  ...
+```
+
+The cluster-wide journal is the one to read; the per-segment ones are the inputs it is aggregated from.
+
+Unlike the sentinel, ``journal_<backup>`` does not reduce to the backup name, so no delete mode removes it on its own — it has to be deleted by hand, which is what ``DeleteJournalInfo`` is for.
+
+## How it works
+
+A segment knows nothing about the cluster, and the coordinator never looks at the WAL itself, only at what the segments recorded.
+
+Each **segment**, during ``seg backup-push``, measures the WAL it archived into its own ``wal_005/`` and keeps it in its own journal as ``SizeToNextBackup``, exactly like a standalone Postgres would.
+
+The **coordinator**, at the end of the cluster ``backup-push``, walks the segments named in the *previous* backup's sentinel and writes their sum into that backup's journal.
+
+Journals are written only when ``backup-push`` is given ``--count-journals``, and never for permanent backups: those are not expected to be removed and take no part in WAL retention planning.
+
+A partial sum would silently understate the real volume and be indistinguishable from a genuinely small one, so a single unreadable segment journal leaves the previous ``SizeToNextBackup`` untouched rather than overwriting it with a wrong value.
+
+## Fields
+
+| Field | Meaning |
+| --- | --- |
+| ``PriorBackupEnd`` | Completion time of the backup preceding this one. Points at the previous backup, and is re-linked when a backup in the middle is deleted, so that the deleted interval is merged into the previous one. |
+| ``CurrentBackupEnd`` | Completion time of this backup. Orders the ``journal_<backup>`` objects chronologically — the names alone do not — which is how the previous and the next journal are located. |
+| ``SizeToNextBackup`` | Bytes of WAL archived between this backup and the next one. Belongs to the interval *after* the backup, so it is zero for the newest one and is filled in when the following backup is created. |
+
+``SizeToNextBackup`` is **not** the volume of the ``(PriorBackupEnd; CurrentBackupEnd]`` interval of the same object. Those two timestamps describe the interval *before* the backup and exist to navigate the chain of journals — to find the previous backup and to re-link the chain around a deleted one. ``SizeToNextBackup`` covers the interval *after* the backup instead, the one that ends at the next backup.
+
+The two are one step apart: when a journal is recalculated, the result is written into the **previous** backup's ``SizeToNextBackup``, never into its own.
+
+How the volume is obtained differs by level. A segment sums the storage sizes of the WAL files in its own ``wal_005/`` whose timestamps fall into ``(PriorBackupEnd; CurrentBackupEnd]``, which is what ``JournalFiles`` does. The coordinator ignores both timestamps and simply adds up what the segments have already measured for themselves, which is what ``SegmentsSizeCalculator`` does.
+
+That aggregate is deliberately not a wall-clock window. A segment finishes its ``backup-push`` before the coordinator creates the restore point, so WAL archived in between belongs to that segment's *next* interval. Nothing is lost or double counted along the chain, but the cluster figure is not the volume archived cluster-wide between two backup finish times.
+
+Sizes come from the storage object sizes, so they reflect compression and encryption — unlike an estimate derived from the LSN difference.

--- a/internal/databases/greenplum/README.journal.md
+++ b/internal/databases/greenplum/README.journal.md
@@ -33,18 +33,12 @@ A partial sum would silently understate the real volume and be indistinguishable
 
 ## Fields
 
-| Field | Meaning |
-| --- | --- |
-| ``PriorBackupEnd`` | Completion time of the backup preceding this one. Points at the previous backup, and is re-linked when a backup in the middle is deleted, so that the deleted interval is merged into the previous one. |
-| ``CurrentBackupEnd`` | Completion time of this backup. Orders the ``journal_<backup>`` objects chronologically — the names alone do not — which is how the previous and the next journal are located. |
-| ``SizeToNextBackup`` | Bytes of WAL archived between this backup and the next one. Belongs to the interval *after* the backup, so it is zero for the newest one and is filled in when the following backup is created. |
+* ``PriorBackupEnd`` — completion time of the preceding backup. Re-linked when a backup in the middle is deleted, merging its interval into the previous one.
+* ``CurrentBackupEnd`` — completion time of this backup. Orders the ``journal_<backup>`` objects chronologically, which their names alone do not.
+* ``SizeToNextBackup`` — bytes of WAL archived between this backup and the **next** one: zero for the newest backup, filled in when the following one is created. Deliberately *not* the volume of this object's own ``(PriorBackupEnd; CurrentBackupEnd]`` — those timestamps describe the interval *before* the backup and only serve to navigate the chain. The two are one step apart, so a recalculation writes its result into the **previous** backup's journal, never into its own.
 
-``SizeToNextBackup`` is **not** the volume of the ``(PriorBackupEnd; CurrentBackupEnd]`` interval of the same object. Those two timestamps describe the interval *before* the backup and exist to navigate the chain of journals — to find the previous backup and to re-link the chain around a deleted one. ``SizeToNextBackup`` covers the interval *after* the backup instead, the one that ends at the next backup.
+The volume is measured differently at the two levels. A **segment** sums the storage sizes of the WAL files in its own ``wal_005/`` falling into ``(PriorBackupEnd; CurrentBackupEnd]`` (``JournalFiles``); the **coordinator** ignores both timestamps and adds up what the segments already measured (``UpdateClusterIntervalSize``).
 
-The two are one step apart: when a journal is recalculated, the result is written into the **previous** backup's ``SizeToNextBackup``, never into its own.
-
-How the volume is obtained differs by level. A segment sums the storage sizes of the WAL files in its own ``wal_005/`` whose timestamps fall into ``(PriorBackupEnd; CurrentBackupEnd]``, which is what ``JournalFiles`` does. The coordinator ignores both timestamps and simply adds up what the segments have already measured for themselves, which is what ``SegmentsSizeCalculator`` does.
-
-That aggregate is deliberately not a wall-clock window. A segment finishes its ``backup-push`` before the coordinator creates the restore point, so WAL archived in between belongs to that segment's *next* interval. Nothing is lost or double counted along the chain, but the cluster figure is not the volume archived cluster-wide between two backup finish times.
+The cluster figure is therefore not a wall-clock window: a segment finishes its ``backup-push`` before the coordinator creates the restore point, so WAL archived in between lands in that segment's *next* interval. Nothing is lost or double counted along the chain, but the total is not the volume archived cluster-wide between two backup finish times.
 
 Sizes come from the storage object sizes, so they reflect compression and encryption — unlike an estimate derived from the LSN difference.

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -242,10 +242,9 @@ func (bh *BackupHandler) HandleBackupPush(ctx context.Context) {
 	bh.disconnect(ctx)
 }
 
-// handleJournalInfo maintains the cluster-wide journal_<backup> object, holding the WAL volume
-// accumulated across all segments between this backup and the next one. The per-segment journals it
-// sums up are written by the segment WAL-G instances during seg-backup-push, so this runs once they
-// have all finished (see SegmentsSizeCalculator).
+// handleJournalInfo maintains the cluster-wide journal_<backup> object, holding the WAL volume all
+// segments accumulated between this backup and the next one. It sums the per-segment journals, so
+// it must run after the segments have finished (see UpdateClusterIntervalSize).
 func (bh *BackupHandler) handleJournalInfo(ctx context.Context, rootFolder storage.Folder) {
 	if !bh.arguments.countJournals {
 		tracelog.InfoLogger.Printf("WAL journal counting mode is disabled: option is disabled")
@@ -273,7 +272,7 @@ func (bh *BackupHandler) handleJournalInfo(ctx context.Context, rootFolder stora
 		return
 	}
 
-	if err := journalInfo.UpdateIntervalSize(ctx, rootFolder, SegmentsSizeCalculator{}); err != nil {
+	if err := UpdateClusterIntervalSize(ctx, rootFolder, journalInfo); err != nil {
 		tracelog.WarningLogger.Printf("can not calculate journal size: %s", err.Error())
 		return
 	}

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
 )
 
@@ -40,6 +41,7 @@ type BackupArguments struct {
 	segPollRetries  int
 
 	deltaBaseSelector internal.BackupSelector
+	countJournals     bool
 }
 
 type SegmentUserData struct {
@@ -174,6 +176,10 @@ func (bh *BackupHandler) HandleBackupPush(ctx context.Context) {
 	bh.currBackupInfo.startTime = utility.TimeNowCrossPlatformUTC()
 	initGpLog(bh.arguments.logsDir)
 
+	// Must capture before uploadSentinel: it calls uploader.ChangeDirectory(basebackups_005),
+	// which mutates the uploader's stored folder in place.
+	rootFolder := bh.workers.Uploader.Folder()
+
 	err := bh.checkPrerequisites(ctx)
 	tracelog.ErrorLogger.FatalfOnError("Backup prerequisites check failed: %v\n", err)
 
@@ -230,8 +236,49 @@ func (bh *BackupHandler) HandleBackupPush(ctx context.Context) {
 	err = bh.uploadRestorePointMetadata(ctx, restoreLSNs, timeLine, timelineBySegment)
 	tracelog.ErrorLogger.FatalOnError(err)
 
+	bh.handleJournalInfo(ctx, rootFolder)
+
 	tracelog.InfoLogger.Printf("Backup %s successfully created", bh.currBackupInfo.backupName)
 	bh.disconnect(ctx)
+}
+
+// handleJournalInfo maintains the cluster-wide journal_<backup> object, holding the WAL volume
+// accumulated across all segments between this backup and the next one. The per-segment journals it
+// sums up are written by the segment WAL-G instances during seg-backup-push, so this runs once they
+// have all finished (see SegmentsSizeCalculator).
+func (bh *BackupHandler) handleJournalInfo(ctx context.Context, rootFolder storage.Folder) {
+	if !bh.arguments.countJournals {
+		tracelog.InfoLogger.Printf("WAL journal counting mode is disabled: option is disabled")
+		return
+	}
+	if bh.arguments.isPermanent {
+		tracelog.InfoLogger.Printf("WAL journal counting mode is disabled: the backup is permanent")
+		return
+	}
+
+	mostRecentJournalInfo, err := internal.GetMostRecentJournalInfo(ctx, rootFolder, ClusterJournalDir)
+	if err != nil {
+		tracelog.WarningLogger.Printf("can not find the last journal info: %s", err.Error())
+	}
+
+	journalInfo := internal.NewEmptyJournalInfo(
+		bh.currBackupInfo.backupName,
+		mostRecentJournalInfo.CurrentBackupEnd,
+		bh.currBackupInfo.finishTime,
+		ClusterJournalDir,
+	)
+
+	if err := journalInfo.Upload(ctx, rootFolder); err != nil {
+		tracelog.WarningLogger.Printf("can not upload the journal info: %s", err.Error())
+		return
+	}
+
+	if err := journalInfo.UpdateIntervalSize(ctx, rootFolder, SegmentsSizeCalculator{}); err != nil {
+		tracelog.WarningLogger.Printf("can not calculate journal size: %s", err.Error())
+		return
+	}
+
+	tracelog.InfoLogger.Printf("uploaded journal info for %s", bh.currBackupInfo.backupName)
 }
 
 func (bh *BackupHandler) uploadRestorePointMetadata(
@@ -570,7 +617,8 @@ func NewBackupHandler(ctx context.Context, arguments BackupArguments) (bh *Backu
 
 // NewBackupArguments creates a BackupArgument object to hold the arguments from the cmd
 func NewBackupArguments(uploader internal.Uploader, isPermanent, isFull bool, userData interface{}, fwdArgs []SegmentFwdArg, logsDir string,
-	segPollInterval time.Duration, segPollRetries int, deltaBaseSelector internal.BackupSelector) BackupArguments {
+	segPollInterval time.Duration, segPollRetries int, deltaBaseSelector internal.BackupSelector,
+	countJournals bool) BackupArguments {
 	return BackupArguments{
 		Uploader:          uploader,
 		isPermanent:       isPermanent,
@@ -581,6 +629,7 @@ func NewBackupArguments(uploader internal.Uploader, isPermanent, isFull bool, us
 		segPollInterval:   segPollInterval,
 		segPollRetries:    segPollRetries,
 		deltaBaseSelector: deltaBaseSelector,
+		countJournals:     countJournals,
 	}
 }
 

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -151,6 +151,11 @@ func (h *DeleteHandler) HandleDeleteTarget(ctx context.Context, targetSelector i
 	folderFilter := func(name string) bool { return true }
 	err = h.DeleteTarget(ctx, target, h.args.Confirmed, h.args.FindFull, folderFilter)
 	tracelog.ErrorLogger.FatalOnError(err)
+
+	// Runs after dispatchDeleteCmd on purpose: the cluster-wide size is recalculated from the
+	// segment journals, which the segment handlers above have just re-merged.
+	internal.DeleteJournalInfo(ctx, h.Folder, target.GetBackupName(), ClusterJournalDir,
+		SegmentsSizeCalculator{}, h.args.Confirmed)
 }
 
 func (h *DeleteHandler) dispatchDeleteCmd(ctx context.Context, target internal.BackupObject, delType SegDeleteType) error {

--- a/internal/databases/greenplum/delete_handler.go
+++ b/internal/databases/greenplum/delete_handler.go
@@ -154,8 +154,7 @@ func (h *DeleteHandler) HandleDeleteTarget(ctx context.Context, targetSelector i
 
 	// Runs after dispatchDeleteCmd on purpose: the cluster-wide size is recalculated from the
 	// segment journals, which the segment handlers above have just re-merged.
-	internal.DeleteJournalInfo(ctx, h.Folder, target.GetBackupName(), ClusterJournalDir,
-		SegmentsSizeCalculator{}, h.args.Confirmed)
+	DeleteClusterJournalInfo(ctx, h.Folder, target.GetBackupName(), h.args.Confirmed)
 }
 
 func (h *DeleteHandler) dispatchDeleteCmd(ctx context.Context, target internal.BackupObject, delType SegDeleteType) error {

--- a/internal/databases/greenplum/journal.go
+++ b/internal/databases/greenplum/journal.go
@@ -10,45 +10,72 @@ import (
 	"github.com/wal-g/wal-g/utility"
 )
 
-// ClusterJournalDir is empty on purpose. Unlike a single Postgres instance, a Greenplum cluster has
-// no WAL directory of its own: every segment archives into its own segments_005/seg<N>/wal_005/.
-// The cluster-wide journal is summed from the per-segment journals instead of being measured
-// against a directory, see SegmentsSizeCalculator.
+// ClusterJournalDir is empty on purpose: a Greenplum cluster has no WAL directory of its own,
+// every segment archives into its own segments_005/seg<N>/wal_005/.
 const ClusterJournalDir = ""
 
-// SegmentsSizeCalculator derives the WAL volume of a whole Greenplum backup by summing the
-// per-segment journals, each of which is maintained by the WAL-G instance running on that segment's
-// host during seg-backup-push.
-//
-// The sum spans the intervals the segments measured for themselves, which do not line up with a
-// single wall-clock window: a segment finishes its backup-push before the coordinator creates the
-// restore point, so WAL archived in between belongs to that segment's next interval. Nothing is
-// lost or double counted along the chain, but the aggregate is not the same as the volume archived
-// cluster-wide between two backup finish times.
-type SegmentsSizeCalculator struct{}
+// UpdateClusterIntervalSize stores the WAL volume the segments accumulated between the backup
+// preceding ji and ji itself as that backup's SizeToNextBackup. Cluster-wide counterpart of
+// JournalInfo.UpdateIntervalSize; rootFolder is the cluster root. See README.journal.md for why
+// the aggregate is not a wall-clock window.
+func UpdateClusterIntervalSize(ctx context.Context, rootFolder storage.Folder, ji internal.JournalInfo) error {
+	prevJi, ok, err := ji.Previous(ctx, rootFolder)
+	if err != nil || !ok {
+		return err
+	}
 
-// Calculate sums the SizeToNextBackup of the segment journals belonging to prevJi's backup.
-// The rootFolder argument is the cluster root, the same folder the cluster journal itself lives in.
-//
-// A partial sum would silently understate the real volume and be indistinguishable from a genuinely
-// small one, so a single unreadable segment journal makes the whole aggregate unavailable (ok=false)
-// rather than wrong.
-func (SegmentsSizeCalculator) Calculate(
-	ctx context.Context,
-	rootFolder storage.Folder,
-	_, prevJi internal.JournalInfo,
-) (int64, bool, error) {
 	backupName := strings.TrimPrefix(prevJi.JournalName, internal.JournalPrefix)
+	sum, ok, err := SumSegmentWalSize(ctx, rootFolder, backupName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// Not measured rather than zero: keep the value the backup-push wrote.
+		tracelog.WarningLogger.Printf("Can not determine the WAL volume of backup %s, "+
+			"leaving its SizeToNextBackup intact", backupName)
+		return nil
+	}
 
-	return SumSegmentWalSize(ctx, rootFolder, backupName)
+	prevJi.SizeToNextBackup = sum
+
+	return prevJi.Upload(ctx, rootFolder)
+}
+
+// DeleteClusterJournalInfo removes the cluster-wide journal of backupName and re-links its
+// neighbors. Cluster-wide counterpart of internal.DeleteJournalInfo, differing only in how the
+// merged interval is recalculated. A backup pushed without journal counting has none, which is
+// not an error.
+func DeleteClusterJournalInfo(ctx context.Context, rootFolder storage.Folder, backupName string, confirmed bool) {
+	journalInfo, err := internal.NewJournalInfo(ctx, backupName, rootFolder, ClusterJournalDir)
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can't find the journal info: %s", err.Error())
+		return
+	}
+
+	if !confirmed {
+		tracelog.InfoLogger.Printf("Journal info to delete: %+v", journalInfo)
+		return
+	}
+
+	newerJi, ok, err := journalInfo.Unlink(ctx, rootFolder)
+	if err != nil {
+		tracelog.ErrorLogger.Print(err)
+		return
+	}
+
+	if ok {
+		if err := UpdateClusterIntervalSize(ctx, rootFolder, newerJi); err != nil {
+			tracelog.ErrorLogger.Print(err)
+			return
+		}
+	}
+
+	tracelog.InfoLogger.Printf("Deleted journal info: %+v", journalInfo)
 }
 
 // SumSegmentWalSize is the volume of WAL the segments archived between backupName and the backup
-// following it, taken from the journal every segment keeps for itself.
-//
-// A partial sum would silently understate the real volume and be indistinguishable from a genuinely
-// small one, so a single segment failing to report makes the whole aggregate unavailable (ok=false)
-// rather than wrong.
+// following it, taken from the journal every segment keeps for itself. ok == false when any
+// segment fails to report: a partial sum would understate the volume rather than be missing.
 func SumSegmentWalSize(ctx context.Context, rootFolder storage.Folder, backupName string) (int64, bool, error) {
 	segments, ok, err := segmentsOfBackup(ctx, rootFolder, backupName)
 	if err != nil || !ok {
@@ -90,9 +117,8 @@ func SumSegmentWalSize(ctx context.Context, rootFolder storage.Folder, backupNam
 	return sum, true, nil
 }
 
-// segmentsOfBackup lists the segment backups a cluster backup is made of. It reports ok == false
-// when the backup itself is gone: a journal can outlive its backup, since delete modes other than
-// 'delete target' remove the backup without touching the journals.
+// segmentsOfBackup lists the segment backups a cluster backup is made of, ok == false when the
+// backup itself is gone: a journal can outlive its backup.
 func segmentsOfBackup(ctx context.Context, rootFolder storage.Folder, backupName string,
 ) ([]SegmentMetadata, bool, error) {
 	backup, err := NewBackup(rootFolder, backupName)

--- a/internal/databases/greenplum/journal.go
+++ b/internal/databases/greenplum/journal.go
@@ -1,0 +1,111 @@
+package greenplum
+
+import (
+	"context"
+	"strings"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
+)
+
+// ClusterJournalDir is empty on purpose. Unlike a single Postgres instance, a Greenplum cluster has
+// no WAL directory of its own: every segment archives into its own segments_005/seg<N>/wal_005/.
+// The cluster-wide journal is summed from the per-segment journals instead of being measured
+// against a directory, see SegmentsSizeCalculator.
+const ClusterJournalDir = ""
+
+// SegmentsSizeCalculator derives the WAL volume of a whole Greenplum backup by summing the
+// per-segment journals, each of which is maintained by the WAL-G instance running on that segment's
+// host during seg-backup-push.
+//
+// The sum spans the intervals the segments measured for themselves, which do not line up with a
+// single wall-clock window: a segment finishes its backup-push before the coordinator creates the
+// restore point, so WAL archived in between belongs to that segment's next interval. Nothing is
+// lost or double counted along the chain, but the aggregate is not the same as the volume archived
+// cluster-wide between two backup finish times.
+type SegmentsSizeCalculator struct{}
+
+// Calculate sums the SizeToNextBackup of the segment journals belonging to prevJi's backup.
+// The rootFolder argument is the cluster root, the same folder the cluster journal itself lives in.
+//
+// A partial sum would silently understate the real volume and be indistinguishable from a genuinely
+// small one, so a single unreadable segment journal makes the whole aggregate unavailable (ok=false)
+// rather than wrong.
+func (SegmentsSizeCalculator) Calculate(
+	ctx context.Context,
+	rootFolder storage.Folder,
+	_, prevJi internal.JournalInfo,
+) (int64, bool, error) {
+	backupName := strings.TrimPrefix(prevJi.JournalName, internal.JournalPrefix)
+
+	return SumSegmentWalSize(ctx, rootFolder, backupName)
+}
+
+// SumSegmentWalSize is the volume of WAL the segments archived between backupName and the backup
+// following it, taken from the journal every segment keeps for itself.
+//
+// A partial sum would silently understate the real volume and be indistinguishable from a genuinely
+// small one, so a single segment failing to report makes the whole aggregate unavailable (ok=false)
+// rather than wrong.
+func SumSegmentWalSize(ctx context.Context, rootFolder storage.Folder, backupName string) (int64, bool, error) {
+	segments, ok, err := segmentsOfBackup(ctx, rootFolder, backupName)
+	if err != nil || !ok {
+		return 0, false, err
+	}
+
+	sum := int64(0)
+	missing := make([]int, 0)
+	for _, meta := range segments {
+		if meta.BackupName == "" {
+			// Written by a WAL-G old enough not to record the segment backup name in the sentinel.
+			tracelog.WarningLogger.Printf("Sentinel does not name the backup of segment %d", meta.ContentID)
+			missing = append(missing, meta.ContentID)
+			continue
+		}
+
+		segFolder := rootFolder.GetSubFolder(FormatSegmentStoragePrefix(meta.ContentID))
+		ji, err := internal.NewJournalInfo(ctx, meta.BackupName, segFolder, utility.WalPath)
+		if err != nil {
+			// The segment backup was pushed without journal counting, or its journal is already gone.
+			tracelog.WarningLogger.Printf("Can not read the journal of segment %d backup %s: %v",
+				meta.ContentID, meta.BackupName, err)
+			missing = append(missing, meta.ContentID)
+			continue
+		}
+
+		sum += ji.SizeToNextBackup
+	}
+
+	if len(missing) > 0 {
+		tracelog.WarningLogger.Printf("Journals of backup %s are unavailable on segments %v, "+
+			"the cluster-wide WAL volume can not be calculated", backupName, missing)
+		return 0, false, nil
+	}
+
+	tracelog.DebugLogger.Printf("Backup %s accumulated %d bytes of WAL over %d segments",
+		backupName, sum, len(segments))
+
+	return sum, true, nil
+}
+
+// segmentsOfBackup lists the segment backups a cluster backup is made of. It reports ok == false
+// when the backup itself is gone: a journal can outlive its backup, since delete modes other than
+// 'delete target' remove the backup without touching the journals.
+func segmentsOfBackup(ctx context.Context, rootFolder storage.Folder, backupName string,
+) ([]SegmentMetadata, bool, error) {
+	backup, err := NewBackup(rootFolder, backupName)
+	if err != nil {
+		return nil, false, err
+	}
+
+	sentinel, err := backup.GetSentinel(ctx)
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can not read the sentinel of backup %s, "+
+			"the cluster-wide value can not be calculated: %v", backupName, err)
+		return nil, false, nil
+	}
+
+	return sentinel.Segments, true, nil
+}

--- a/internal/databases/greenplum/journal_test.go
+++ b/internal/databases/greenplum/journal_test.go
@@ -1,0 +1,259 @@
+package greenplum_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/testtools"
+	"github.com/wal-g/wal-g/utility"
+)
+
+const (
+	gpBackupName     = "backup_20260721T120000Z"
+	prevGpBackupName = "backup_20260721T100000Z"
+)
+
+// putSegmentJournal writes the journal a segment WAL-G instance would have left behind after
+// pushing segBackupName and then measuring the WAL it archived until the next backup.
+func putSegmentJournal(t *testing.T, root storage.Folder, contentID int, segBackupName string, size int64) {
+	t.Helper()
+	putSegmentJournalInfo(t, root, contentID, segBackupName, func(ji *internal.JournalInfo) {
+		ji.SizeToNextBackup = size
+	})
+}
+
+func putSegmentJournalInfo(t *testing.T, root storage.Folder, contentID int, segBackupName string,
+	fill func(*internal.JournalInfo)) {
+	t.Helper()
+
+	ji := internal.NewEmptyJournalInfo(segBackupName, time.Time{}, time.Now(), utility.WalPath)
+	fill(&ji)
+
+	segFolder := root.GetSubFolder(greenplum.FormatSegmentStoragePrefix(contentID))
+	require.NoError(t, ji.Upload(t.Context(), segFolder))
+}
+
+// putGpSentinel writes a cluster sentinel naming one segment backup per content ID.
+func putGpSentinel(t *testing.T, root storage.Folder, backupName string, segBackupNames map[int]string) {
+	t.Helper()
+
+	segments := make([]greenplum.SegmentMetadata, 0, len(segBackupNames))
+	for contentID, segBackupName := range segBackupNames {
+		segments = append(segments, greenplum.SegmentMetadata{
+			ContentID:  contentID,
+			BackupName: segBackupName,
+		})
+	}
+
+	putDTO(t, root, utility.BaseBackupPath+internal.SentinelNameFromBackup(backupName),
+		greenplum.BackupSentinelDto{Segments: segments})
+}
+
+// prevJournal is the cluster journal the calculator is asked to fill in the size for.
+func prevJournal(backupName string) internal.JournalInfo {
+	return internal.NewEmptyJournalInfo(backupName, time.Time{}, time.Now(), greenplum.ClusterJournalDir)
+}
+
+// putClusterJournal writes the cluster-wide journal of a Greenplum backup, the one 'delete target'
+// re-links, and returns it.
+func putClusterJournal(t *testing.T, root storage.Folder, backupName string,
+	priorEnd, end time.Time, size int64) internal.JournalInfo {
+	t.Helper()
+
+	ji := internal.NewEmptyJournalInfo(backupName, priorEnd, end, greenplum.ClusterJournalDir)
+	ji.SizeToNextBackup = size
+	require.NoError(t, ji.Upload(t.Context(), root))
+	return ji
+}
+
+func readClusterJournal(t *testing.T, root storage.Folder, backupName string) internal.JournalInfo {
+	t.Helper()
+
+	ji, err := internal.NewJournalInfo(t.Context(), backupName, root, greenplum.ClusterJournalDir)
+	require.NoError(t, err)
+	return ji
+}
+
+func TestSegmentsSizeCalculator(t *testing.T) {
+	segBackups := map[int]string{
+		-1: "base_000000010000000000000001",
+		0:  "base_000000010000000000000002",
+		1:  "base_000000010000000000000003",
+	}
+
+	t.Run("sums the journals of every segment including the coordinator", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, prevGpBackupName, segBackups)
+		putSegmentJournal(t, root, -1, segBackups[-1], 100)
+		putSegmentJournal(t, root, 0, segBackups[0], 200)
+		putSegmentJournal(t, root, 1, segBackups[1], 300)
+
+		size, ok, err := greenplum.SegmentsSizeCalculator{}.Calculate(
+			t.Context(), root, internal.JournalInfo{}, prevJournal(prevGpBackupName))
+
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, int64(600), size)
+	})
+
+	t.Run("reports no size when a single segment journal is missing", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, prevGpBackupName, segBackups)
+		putSegmentJournal(t, root, -1, segBackups[-1], 100)
+		putSegmentJournal(t, root, 0, segBackups[0], 200)
+
+		size, ok, err := greenplum.SegmentsSizeCalculator{}.Calculate(
+			t.Context(), root, internal.JournalInfo{}, prevJournal(prevGpBackupName))
+
+		require.NoError(t, err)
+		assert.False(t, ok, "a partial sum would understate the real WAL volume")
+		assert.Equal(t, int64(0), size)
+	})
+
+	t.Run("reports no size when the sentinel does not name the segment backup", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, prevGpBackupName, map[int]string{-1: ""})
+
+		_, ok, err := greenplum.SegmentsSizeCalculator{}.Calculate(
+			t.Context(), root, internal.JournalInfo{}, prevJournal(prevGpBackupName))
+
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("reports no size when the backup sentinel is gone", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+
+		_, ok, err := greenplum.SegmentsSizeCalculator{}.Calculate(
+			t.Context(), root, internal.JournalInfo{}, prevJournal(prevGpBackupName))
+
+		require.NoError(t, err, "a journal outliving its backup must not fail the whole backup-push")
+		assert.False(t, ok)
+	})
+}
+
+func TestUpdateIntervalSizeWithSegmentsCalculator(t *testing.T) {
+	segBackups := map[int]string{-1: "base_000000010000000000000001", 0: "base_000000010000000000000002"}
+
+	newClusterJournal := func(t *testing.T, root storage.Folder, backupName string, end time.Time) internal.JournalInfo {
+		t.Helper()
+		ji := internal.NewEmptyJournalInfo(backupName, time.Time{}, end, greenplum.ClusterJournalDir)
+		require.NoError(t, ji.Upload(t.Context(), root))
+		return ji
+	}
+
+	t.Run("stores the segment sum as SizeToNextBackup of the previous backup", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, prevGpBackupName, segBackups)
+		putSegmentJournal(t, root, -1, segBackups[-1], 100)
+		putSegmentJournal(t, root, 0, segBackups[0], 200)
+
+		prevJi := newClusterJournal(t, root, prevGpBackupName, time.Now().Add(-time.Hour))
+		curJi := newClusterJournal(t, root, gpBackupName, time.Now())
+
+		require.NoError(t, curJi.UpdateIntervalSize(t.Context(), root, greenplum.SegmentsSizeCalculator{}))
+
+		require.NoError(t, prevJi.Read(t.Context(), root))
+		assert.Equal(t, int64(300), prevJi.SizeToNextBackup)
+		assert.Equal(t, int64(0), curJi.SizeToNextBackup, "the newest backup has nothing after it yet")
+	})
+
+	t.Run("leaves the previous size intact when the sum is unavailable", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, prevGpBackupName, segBackups)
+		putSegmentJournal(t, root, -1, segBackups[-1], 100)
+		// The journal of segment 0 is missing, so the sum can not be trusted.
+
+		prevJi := newClusterJournal(t, root, prevGpBackupName, time.Now().Add(-time.Hour))
+		prevJi.SizeToNextBackup = 4096
+		require.NoError(t, prevJi.Upload(t.Context(), root))
+
+		curJi := newClusterJournal(t, root, gpBackupName, time.Now())
+
+		require.NoError(t, curJi.UpdateIntervalSize(t.Context(), root, greenplum.SegmentsSizeCalculator{}))
+
+		require.NoError(t, prevJi.Read(t.Context(), root))
+		assert.Equal(t, int64(4096), prevJi.SizeToNextBackup, "must not be overwritten with a partial sum")
+	})
+}
+
+// TestDeleteClusterJournalRemergesFromSegments covers what the gp delete handler does after the
+// segment handlers have re-merged their own journals: the cluster-wide size of the backup preceding
+// the deleted one is recalculated from the segment journals, so that the cluster-wide figure keeps
+// matching their sum instead of being merged separately at the cluster level.
+func TestDeleteClusterJournalRemergesFromSegments(t *testing.T) {
+	const (
+		firstBackup  = "backup_20260721T100000Z"
+		secondBackup = "backup_20260721T110000Z"
+		thirdBackup  = "backup_20260721T120000Z"
+	)
+	// The sizes the two deleted intervals had at the cluster level, as pushed by backup-push.
+	const firstSize, secondSize = 300, 3000
+
+	// setupCluster lays out three backups whose segment journals have already been re-merged by the
+	// segment delete handlers, i.e. the journals of secondBackup are gone and its volume has been
+	// added to the journals of firstBackup: 100+1000 on the coordinator and 200+2000 on segment 0.
+	setupCluster := func(t *testing.T) (storage.Folder, time.Time) {
+		t.Helper()
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		firstSegBackups := map[int]string{-1: "base_000000010000000000000001", 0: "base_000000010000000000000002"}
+
+		putGpSentinel(t, root, firstBackup, firstSegBackups)
+		putSegmentJournal(t, root, -1, firstSegBackups[-1], 100+1000)
+		putSegmentJournal(t, root, 0, firstSegBackups[0], 200+2000)
+
+		end := time.Now().Truncate(time.Second)
+		putClusterJournal(t, root, firstBackup, time.Time{}, end.Add(-2*time.Hour), firstSize)
+		putClusterJournal(t, root, secondBackup, end.Add(-2*time.Hour), end.Add(-time.Hour), secondSize)
+		putClusterJournal(t, root, thirdBackup, end.Add(-time.Hour), end, 0)
+
+		return root, end
+	}
+
+	t.Run("the merged size is the sum over the segments", func(t *testing.T) {
+		root, _ := setupCluster(t)
+
+		internal.DeleteJournalInfo(t.Context(), root, secondBackup, greenplum.ClusterJournalDir,
+			greenplum.SegmentsSizeCalculator{}, true)
+
+		merged := readClusterJournal(t, root, firstBackup).SizeToNextBackup
+		assert.Equal(t, int64(1100+2200), merged, "must be recalculated from the re-merged segment journals")
+		assert.Equal(t, int64(firstSize+secondSize), merged, "the two intervals must be merged, not lost")
+	})
+
+	t.Run("the deleted journal is gone and the newer one covers its interval", func(t *testing.T) {
+		root, end := setupCluster(t)
+
+		internal.DeleteJournalInfo(t.Context(), root, secondBackup, greenplum.ClusterJournalDir,
+			greenplum.SegmentsSizeCalculator{}, true)
+
+		_, err := internal.NewJournalInfo(t.Context(), secondBackup, root, greenplum.ClusterJournalDir)
+		assert.Error(t, err)
+
+		third := readClusterJournal(t, root, thirdBackup)
+		assert.True(t, third.PriorBackupEnd.Equal(end.Add(-2*time.Hour)),
+			"the newer journal must start where the deleted one started")
+		assert.Zero(t, third.SizeToNextBackup, "the newest backup still has nothing after it")
+	})
+
+	t.Run("a missing segment journal leaves the previous size intact", func(t *testing.T) {
+		root, _ := setupCluster(t)
+		// The coordinator journal of firstBackup is lost, so its segments no longer add up.
+		require.NoError(t, root.GetSubFolder(greenplum.FormatSegmentStoragePrefix(-1)).
+			GetSubFolder(utility.BaseBackupPath).
+			DeleteObjects(t.Context(), []storage.Object{
+				storage.NewLocalObject(internal.JournalPrefix+"base_000000010000000000000001", time.Time{}, 0),
+			}))
+
+		internal.DeleteJournalInfo(t.Context(), root, secondBackup, greenplum.ClusterJournalDir,
+			greenplum.SegmentsSizeCalculator{}, true)
+
+		assert.Equal(t, int64(firstSize), readClusterJournal(t, root, firstBackup).SizeToNextBackup,
+			"a partial sum must not overwrite the size measured at backup-push time")
+	})
+}

--- a/internal/databases/greenplum/journal_test.go
+++ b/internal/databases/greenplum/journal_test.go
@@ -54,11 +54,6 @@ func putGpSentinel(t *testing.T, root storage.Folder, backupName string, segBack
 		greenplum.BackupSentinelDto{Segments: segments})
 }
 
-// prevJournal is the cluster journal the calculator is asked to fill in the size for.
-func prevJournal(backupName string) internal.JournalInfo {
-	return internal.NewEmptyJournalInfo(backupName, time.Time{}, time.Now(), greenplum.ClusterJournalDir)
-}
-
 // putClusterJournal writes the cluster-wide journal of a Greenplum backup, the one 'delete target'
 // re-links, and returns it.
 func putClusterJournal(t *testing.T, root storage.Folder, backupName string,
@@ -79,7 +74,7 @@ func readClusterJournal(t *testing.T, root storage.Folder, backupName string) in
 	return ji
 }
 
-func TestSegmentsSizeCalculator(t *testing.T) {
+func TestSumSegmentWalSize(t *testing.T) {
 	segBackups := map[int]string{
 		-1: "base_000000010000000000000001",
 		0:  "base_000000010000000000000002",
@@ -93,8 +88,7 @@ func TestSegmentsSizeCalculator(t *testing.T) {
 		putSegmentJournal(t, root, 0, segBackups[0], 200)
 		putSegmentJournal(t, root, 1, segBackups[1], 300)
 
-		size, ok, err := greenplum.SegmentsSizeCalculator{}.Calculate(
-			t.Context(), root, internal.JournalInfo{}, prevJournal(prevGpBackupName))
+		size, ok, err := greenplum.SumSegmentWalSize(t.Context(), root, prevGpBackupName)
 
 		require.NoError(t, err)
 		assert.True(t, ok)
@@ -107,8 +101,7 @@ func TestSegmentsSizeCalculator(t *testing.T) {
 		putSegmentJournal(t, root, -1, segBackups[-1], 100)
 		putSegmentJournal(t, root, 0, segBackups[0], 200)
 
-		size, ok, err := greenplum.SegmentsSizeCalculator{}.Calculate(
-			t.Context(), root, internal.JournalInfo{}, prevJournal(prevGpBackupName))
+		size, ok, err := greenplum.SumSegmentWalSize(t.Context(), root, prevGpBackupName)
 
 		require.NoError(t, err)
 		assert.False(t, ok, "a partial sum would understate the real WAL volume")
@@ -119,8 +112,7 @@ func TestSegmentsSizeCalculator(t *testing.T) {
 		root := testtools.MakeDefaultInMemoryStorageFolder()
 		putGpSentinel(t, root, prevGpBackupName, map[int]string{-1: ""})
 
-		_, ok, err := greenplum.SegmentsSizeCalculator{}.Calculate(
-			t.Context(), root, internal.JournalInfo{}, prevJournal(prevGpBackupName))
+		_, ok, err := greenplum.SumSegmentWalSize(t.Context(), root, prevGpBackupName)
 
 		require.NoError(t, err)
 		assert.False(t, ok)
@@ -129,15 +121,14 @@ func TestSegmentsSizeCalculator(t *testing.T) {
 	t.Run("reports no size when the backup sentinel is gone", func(t *testing.T) {
 		root := testtools.MakeDefaultInMemoryStorageFolder()
 
-		_, ok, err := greenplum.SegmentsSizeCalculator{}.Calculate(
-			t.Context(), root, internal.JournalInfo{}, prevJournal(prevGpBackupName))
+		_, ok, err := greenplum.SumSegmentWalSize(t.Context(), root, prevGpBackupName)
 
 		require.NoError(t, err, "a journal outliving its backup must not fail the whole backup-push")
 		assert.False(t, ok)
 	})
 }
 
-func TestUpdateIntervalSizeWithSegmentsCalculator(t *testing.T) {
+func TestUpdateClusterIntervalSize(t *testing.T) {
 	segBackups := map[int]string{-1: "base_000000010000000000000001", 0: "base_000000010000000000000002"}
 
 	newClusterJournal := func(t *testing.T, root storage.Folder, backupName string, end time.Time) internal.JournalInfo {
@@ -156,7 +147,7 @@ func TestUpdateIntervalSizeWithSegmentsCalculator(t *testing.T) {
 		prevJi := newClusterJournal(t, root, prevGpBackupName, time.Now().Add(-time.Hour))
 		curJi := newClusterJournal(t, root, gpBackupName, time.Now())
 
-		require.NoError(t, curJi.UpdateIntervalSize(t.Context(), root, greenplum.SegmentsSizeCalculator{}))
+		require.NoError(t, greenplum.UpdateClusterIntervalSize(t.Context(), root, curJi))
 
 		require.NoError(t, prevJi.Read(t.Context(), root))
 		assert.Equal(t, int64(300), prevJi.SizeToNextBackup)
@@ -175,7 +166,7 @@ func TestUpdateIntervalSizeWithSegmentsCalculator(t *testing.T) {
 
 		curJi := newClusterJournal(t, root, gpBackupName, time.Now())
 
-		require.NoError(t, curJi.UpdateIntervalSize(t.Context(), root, greenplum.SegmentsSizeCalculator{}))
+		require.NoError(t, greenplum.UpdateClusterIntervalSize(t.Context(), root, curJi))
 
 		require.NoError(t, prevJi.Read(t.Context(), root))
 		assert.Equal(t, int64(4096), prevJi.SizeToNextBackup, "must not be overwritten with a partial sum")
@@ -218,8 +209,7 @@ func TestDeleteClusterJournalRemergesFromSegments(t *testing.T) {
 	t.Run("the merged size is the sum over the segments", func(t *testing.T) {
 		root, _ := setupCluster(t)
 
-		internal.DeleteJournalInfo(t.Context(), root, secondBackup, greenplum.ClusterJournalDir,
-			greenplum.SegmentsSizeCalculator{}, true)
+		greenplum.DeleteClusterJournalInfo(t.Context(), root, secondBackup, true)
 
 		merged := readClusterJournal(t, root, firstBackup).SizeToNextBackup
 		assert.Equal(t, int64(1100+2200), merged, "must be recalculated from the re-merged segment journals")
@@ -229,8 +219,7 @@ func TestDeleteClusterJournalRemergesFromSegments(t *testing.T) {
 	t.Run("the deleted journal is gone and the newer one covers its interval", func(t *testing.T) {
 		root, end := setupCluster(t)
 
-		internal.DeleteJournalInfo(t.Context(), root, secondBackup, greenplum.ClusterJournalDir,
-			greenplum.SegmentsSizeCalculator{}, true)
+		greenplum.DeleteClusterJournalInfo(t.Context(), root, secondBackup, true)
 
 		_, err := internal.NewJournalInfo(t.Context(), secondBackup, root, greenplum.ClusterJournalDir)
 		assert.Error(t, err)
@@ -250,8 +239,7 @@ func TestDeleteClusterJournalRemergesFromSegments(t *testing.T) {
 				storage.NewLocalObject(internal.JournalPrefix+"base_000000010000000000000001", time.Time{}, 0),
 			}))
 
-		internal.DeleteJournalInfo(t.Context(), root, secondBackup, greenplum.ClusterJournalDir,
-			greenplum.SegmentsSizeCalculator{}, true)
+		greenplum.DeleteClusterJournalInfo(t.Context(), root, secondBackup, true)
 
 		assert.Equal(t, int64(firstSize), readClusterJournal(t, root, firstBackup).SizeToNextBackup,
 			"a partial sum must not overwrite the size measured at backup-push time")

--- a/internal/databases/greenplum/segment_delete_handler.go
+++ b/internal/databases/greenplum/segment_delete_handler.go
@@ -115,9 +115,8 @@ func (h SegDeleteTargetHandler) Delete(ctx context.Context, segBackup SegBackup)
 	}
 
 	// The cluster-level journal is recalculated from the segment ones, so this must happen
-	// before the coordinator sums them up (see SegmentsSizeCalculator).
-	internal.DeleteJournalInfo(ctx, h.Folder, segTarget.GetBackupName(), utility.WalPath,
-		&internal.JournalFiles{}, h.args.Confirmed)
+	// before the coordinator sums them up (see UpdateClusterIntervalSize).
+	internal.DeleteJournalInfo(ctx, h.Folder, segTarget.GetBackupName(), utility.WalPath, h.args.Confirmed)
 
 	if err := cleanupAOSegments(ctx, segTarget, h.Folder, h.args.Confirmed); err != nil {
 		return err

--- a/internal/databases/greenplum/segment_delete_handler.go
+++ b/internal/databases/greenplum/segment_delete_handler.go
@@ -114,6 +114,11 @@ func (h SegDeleteTargetHandler) Delete(ctx context.Context, segBackup SegBackup)
 		return err
 	}
 
+	// The cluster-level journal is recalculated from the segment ones, so this must happen
+	// before the coordinator sums them up (see SegmentsSizeCalculator).
+	internal.DeleteJournalInfo(ctx, h.Folder, segTarget.GetBackupName(), utility.WalPath,
+		&internal.JournalFiles{}, h.args.Confirmed)
+
 	if err := cleanupAOSegments(ctx, segTarget, h.Folder, h.args.Confirmed); err != nil {
 		return err
 	}

--- a/internal/databases/postgres/backup_push_handler.go
+++ b/internal/databases/postgres/backup_push_handler.go
@@ -64,6 +64,7 @@ type BackupArguments struct {
 	withoutFilesMetadata     bool
 	composerInitFunc         func(ctx context.Context, handler *BackupHandler) error
 	preventConcurrentBackups bool
+	countJournals            bool
 }
 
 // CurBackupInfo holds all information that is harvest during the backup process
@@ -120,7 +121,8 @@ type BackupHandler struct {
 // NewBackupArguments creates a BackupArgument object to hold the arguments from the cmd
 func NewBackupArguments(uploader internal.Uploader, pgDataDirectory string, backupsFolder string, isPermanent bool,
 	verifyPageChecksums bool, isFullBackup bool, storeAllCorruptBlocks bool, tarBallComposerType TarBallComposerType,
-	deltaConfigurator DeltaBackupConfigurator, userData interface{}, withoutFilesMetadata bool) BackupArguments {
+	deltaConfigurator DeltaBackupConfigurator, userData interface{}, withoutFilesMetadata bool,
+	countJournals bool) BackupArguments {
 	return BackupArguments{
 		Uploader:              uploader,
 		pgDataDirectory:       pgDataDirectory,
@@ -132,6 +134,7 @@ func NewBackupArguments(uploader internal.Uploader, pgDataDirectory string, back
 		deltaConfigurator:     deltaConfigurator,
 		userData:              userData,
 		withoutFilesMetadata:  withoutFilesMetadata,
+		countJournals:         countJournals,
 		composerInitFunc: func(ctx context.Context, handler *BackupHandler) error {
 			return configureTarBallComposer(ctx, handler, tarBallComposerType)
 		},
@@ -385,12 +388,51 @@ func (bh *BackupHandler) uploadBackup(ctx context.Context) internal.TarFileSets 
 // TODO : unit tests
 func (bh *BackupHandler) HandleBackupPush(ctx context.Context) {
 	bh.CurBackupInfo.StartTime = utility.TimeNowCrossPlatformUTC()
+	// Must capture before dispatch: handleBackupPushLocal/Remote call uploader.ChangeDirectory(...),
+	// which mutates bh.Arguments.Uploader's stored folder in place.
+	rootFolder := bh.Arguments.Uploader.Folder()
 
 	if bh.Arguments.pgDataDirectory == "" {
 		bh.handleBackupPushRemote(ctx)
 	} else {
 		bh.handleBackupPushLocal(ctx)
 	}
+
+	bh.handleJournalInfo(ctx, rootFolder)
+}
+
+// handleJournalInfo maintains a journal_<backup> object in storage tracking the WAL volume
+// accumulated between this backup and the next one (see internal.JournalInfo).
+func (bh *BackupHandler) handleJournalInfo(ctx context.Context, rootFolder storage.Folder) {
+	if !bh.Arguments.countJournals {
+		tracelog.InfoLogger.Printf("WAL journal counting mode is disabled: option is disabled")
+		return
+	}
+	if bh.Arguments.isPermanent {
+		tracelog.InfoLogger.Printf("WAL journal counting mode is disabled: the backup is permanent")
+		return
+	}
+
+	finishTime := utility.TimeNowCrossPlatformUTC()
+
+	mostRecentJournalInfo, err := internal.GetMostRecentJournalInfo(ctx, rootFolder, utility.WalPath)
+	if err != nil {
+		tracelog.WarningLogger.Printf("can not find the last journal info: %s", err.Error())
+	}
+
+	journalInfo := internal.NewEmptyJournalInfo(bh.CurBackupInfo.Name, mostRecentJournalInfo.CurrentBackupEnd, finishTime, utility.WalPath)
+
+	if err := journalInfo.Upload(ctx, rootFolder); err != nil {
+		tracelog.WarningLogger.Printf("can not upload the journal info: %s", err.Error())
+		return
+	}
+
+	if err := journalInfo.UpdateIntervalSize(ctx, rootFolder, &internal.JournalFiles{}); err != nil {
+		tracelog.WarningLogger.Printf("can not calculate journal size: %s", err.Error())
+		return
+	}
+
+	tracelog.InfoLogger.Printf("uploaded journal info for %s", bh.CurBackupInfo.Name)
 }
 
 func (bh *BackupHandler) handleBackupPushRemote(ctx context.Context) {

--- a/internal/databases/postgres/backup_push_handler_test.go
+++ b/internal/databases/postgres/backup_push_handler_test.go
@@ -1,0 +1,92 @@
+package postgres
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/pkg/storages/memory"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
+)
+
+func journalInfoExists(t *testing.T, folder storage.Folder, backupName string) bool {
+	t.Helper()
+	exists, err := folder.GetSubFolder(utility.BaseBackupPath).Exists(t.Context(), internal.JournalPrefix+backupName)
+	require.NoError(t, err)
+	return exists
+}
+
+func TestHandleJournalInfo(t *testing.T) {
+	// handleJournalInfo stamps CurrentBackupEnd using real wall-clock time
+	// (utility.TimeNowCrossPlatformUTC), so the folder's LastModified clock must be real too.
+	newFolder := func() storage.Folder {
+		return memory.NewFolder("", memory.NewKVS())
+	}
+
+	t.Run("does nothing when count journals is disabled", func(t *testing.T) {
+		folder := newFolder()
+
+		bh := &BackupHandler{
+			CurBackupInfo: CurBackupInfo{Name: "base_000000010000000000000001"},
+			Arguments:     BackupArguments{countJournals: false},
+		}
+		bh.handleJournalInfo(t.Context(), folder)
+
+		assert.False(t, journalInfoExists(t, folder, bh.CurBackupInfo.Name))
+	})
+
+	t.Run("does nothing for permanent backups", func(t *testing.T) {
+		folder := newFolder()
+
+		bh := &BackupHandler{
+			CurBackupInfo: CurBackupInfo{Name: "base_000000010000000000000001"},
+			Arguments:     BackupArguments{countJournals: true, isPermanent: true},
+		}
+		bh.handleJournalInfo(t.Context(), folder)
+
+		assert.False(t, journalInfoExists(t, folder, bh.CurBackupInfo.Name))
+	})
+
+	t.Run("computes WAL volume accumulated between two backups", func(t *testing.T) {
+		folder := newFolder()
+
+		bh1 := &BackupHandler{
+			CurBackupInfo: CurBackupInfo{Name: "base_000000010000000000000001"},
+			Arguments:     BackupArguments{countJournals: true},
+		}
+		bh1.handleJournalInfo(t.Context(), folder)
+		require.True(t, journalInfoExists(t, folder, bh1.CurBackupInfo.Name))
+
+		// WAL segments archived between the two backups; storage object size is what
+		// should end up counted (i.e. compressed size, not any uncompressed estimate).
+		time.Sleep(time.Millisecond)
+		err := folder.GetSubFolder(utility.WalPath).PutObject(
+			t.Context(), "000000010000000000000001.lz4", bytes.NewBufferString(strings.Repeat("a", 5)))
+		require.NoError(t, err)
+
+		time.Sleep(time.Millisecond)
+		err = folder.GetSubFolder(utility.WalPath).PutObject(
+			t.Context(), "000000010000000000000002.lz4", bytes.NewBufferString(strings.Repeat("a", 10)))
+		require.NoError(t, err)
+
+		time.Sleep(time.Millisecond)
+		bh2 := &BackupHandler{
+			CurBackupInfo: CurBackupInfo{Name: "base_000000010000000000000003"},
+			Arguments:     BackupArguments{countJournals: true},
+		}
+		bh2.handleJournalInfo(t.Context(), folder)
+
+		ji1, err := internal.NewJournalInfo(t.Context(), bh1.CurBackupInfo.Name, folder, utility.WalPath)
+		require.NoError(t, err)
+		assert.Equal(t, int64(15), ji1.SizeToNextBackup)
+
+		ji2, err := internal.NewJournalInfo(t.Context(), bh2.CurBackupInfo.Name, folder, utility.WalPath)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), ji2.SizeToNextBackup)
+	})
+}

--- a/internal/databases/postgres/catchup_push_handler.go
+++ b/internal/databases/postgres/catchup_push_handler.go
@@ -35,7 +35,7 @@ func HandleCatchupPush(ctx context.Context, pgDataDirectory string, fromLSN LSN)
 		uploader, pgDataDirectory, utility.CatchupPath, false,
 		false, false, false,
 		RegularComposer, NewCatchupDeltaBackupConfigurator(fakePreviousBackupSentinelDto),
-		userData, false)
+		userData, false, false)
 	if orioledb.IsEnabled(pgDataDirectory) {
 		tracelog.InfoLogger.Printf("Catchup incremental backup is not implemented for orioledb. Full backup will be performed.")
 	}

--- a/internal/delete_handler.go
+++ b/internal/delete_handler.go
@@ -158,7 +158,7 @@ func (h *DeleteHandler) HandleDeleteRetainAfter(ctx context.Context, args []stri
 	tracelog.ErrorLogger.FatalOnError(err)
 }
 
-func (h *DeleteHandler) HandleDeleteTarget(ctx context.Context, targetSelector BackupSelector, confirmed, findFull bool) {
+func (h *DeleteHandler) HandleDeleteTarget(ctx context.Context, targetSelector BackupSelector, confirmed, findFull bool) BackupObject {
 	target, err := h.FindTargetBySelector(ctx, targetSelector)
 	tracelog.ErrorLogger.FatalOnError(err)
 
@@ -171,6 +171,8 @@ func (h *DeleteHandler) HandleDeleteTarget(ctx context.Context, targetSelector B
 	folderFilter := func(name string) bool { return true }
 	err = h.DeleteTarget(ctx, target, confirmed, findFull, folderFilter)
 	tracelog.ErrorLogger.FatalOnError(err)
+
+	return target
 }
 
 func (h *DeleteHandler) HandleDeleteEverything(ctx context.Context, args []string, permanentBackups []string, confirmed bool) {

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -17,10 +17,9 @@ import (
 )
 
 const (
-	JournalPrefix           = "journal_"
-	JournalTimeLayout       = "20060102T150405Z"
-	cantFindJournal         = "can not find appropriate journal on S3"
-	fullJournalPrefixLength = len(JournalPrefix) + len(StreamPrefix)
+	JournalPrefix     = "journal_"
+	JournalTimeLayout = "20060102T150405Z"
+	cantFindJournal   = "can not find appropriate journal on S3"
 )
 
 type direction = int
@@ -54,15 +53,15 @@ type JournalInfo struct {
 // NewEmptyJournalInfo creates instance of JournalInfo without sync with S3
 func NewEmptyJournalInfo(
 	backupName string,
-	currentBackupEnd time.Time,
 	priorBackupEnd time.Time,
+	currentBackupEnd time.Time,
 	journalDir string,
 ) JournalInfo {
 	return JournalInfo{
 		JournalName:          fmt.Sprintf("%s%s", JournalPrefix, backupName),
 		JournalDirectoryName: journalDir,
-		PriorBackupEnd:       currentBackupEnd,
-		CurrentBackupEnd:     priorBackupEnd,
+		PriorBackupEnd:       priorBackupEnd,
+		CurrentBackupEnd:     currentBackupEnd,
 		SizeToNextBackup:     0,
 	}
 }
@@ -120,27 +119,30 @@ func (ji *JournalInfo) GetNext(ctx context.Context, folder storage.Folder, direc
 	if err != nil {
 		return JournalInfo{}, err
 	}
-	currentJournalTimestamp := getJournalTimestamp(ji.JournalName)
 
-	objs = filterJournalsInfoFiles(objs)
+	candidates, err := loadJournalCandidates(ctx, folder, filterJournalsInfoFiles(objs))
+	if err != nil {
+		return JournalInfo{}, err
+	}
+
 	switch direction {
 	case older:
-		objs = filterJournalsInfoOlderThen(objs, currentJournalTimestamp)
+		candidates = filterCandidatesOlderThen(candidates, ji.CurrentBackupEnd)
 	case newer:
-		objs = filterJournalsInfoNewerThen(objs, currentJournalTimestamp)
+		candidates = filterCandidatesNewerThen(candidates, ji.CurrentBackupEnd)
 	}
-	objs = sortJournalsInfo(objs)
+	sortCandidates(candidates)
 
-	if len(objs) == 0 {
+	if len(candidates) == 0 {
 		return JournalInfo{}, xerrors.New(cantFindJournal)
 	}
 
 	var journalName string
 	switch direction {
 	case older:
-		journalName = objs[len(objs)-1].GetName()
+		journalName = candidates[len(candidates)-1].obj.GetName()
 	case newer:
-		journalName = objs[0].GetName()
+		journalName = candidates[0].obj.GetName()
 	}
 
 	backupName := strings.TrimPrefix(
@@ -161,8 +163,15 @@ func (ji *JournalInfo) GetNext(ctx context.Context, folder storage.Folder, direc
 
 // Delete deletes the current JournalInfo from S3,
 // updates the PriorBackupEnd of a newer JournalInfo with the PriorBackupEnd of the current one,
-// updates the older one journal size.
+// updates the older one journal size. The size of the merged interval is recalculated from the
+// journal files archived in ji.JournalDirectoryName, which is what a database keeping its journals
+// in a directory of its own needs. See DeleteWith for the databases that do not.
 func (ji *JournalInfo) Delete(ctx context.Context, folder storage.Folder) error {
+	return ji.DeleteWith(ctx, folder, &JournalFiles{})
+}
+
+// DeleteWith is Delete with the size of the merged interval recalculated by calc.
+func (ji *JournalInfo) DeleteWith(ctx context.Context, folder storage.Folder, calc IntervalSizeCalculator) error {
 	err := folder.
 		GetSubFolder(utility.BaseBackupPath).
 		DeleteObjects(ctx, []storage.Object{storage.NewLocalObject(ji.JournalName, time.Time{}, 0)})
@@ -197,12 +206,42 @@ func (ji *JournalInfo) Delete(ctx context.Context, folder storage.Folder) error 
 		return err
 	}
 
-	err = newerJi.UpdateIntervalSize(ctx, folder, &JournalFiles{})
+	err = newerJi.UpdateIntervalSize(ctx, folder, calc)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// DeleteJournalInfo removes the journal of the given backup and re-links the neighboring journals,
+// so that the journal volume of the deleted interval is accounted for by the previous backup.
+// A backup pushed without journal counting has no journal at all, which is not an error.
+func DeleteJournalInfo(
+	ctx context.Context,
+	folder storage.Folder,
+	backupName string,
+	journalDir string,
+	calc IntervalSizeCalculator,
+	confirmed bool,
+) {
+	journalInfo, err := NewJournalInfo(ctx, backupName, folder, journalDir)
+	if err != nil {
+		tracelog.WarningLogger.Printf("Can't find the journal info: %s", err.Error())
+		return
+	}
+
+	if !confirmed {
+		tracelog.InfoLogger.Printf("Journal info to delete: %+v", journalInfo)
+		return
+	}
+
+	if err := journalInfo.DeleteWith(ctx, folder, calc); err != nil {
+		tracelog.ErrorLogger.Print(err)
+		return
+	}
+
+	tracelog.InfoLogger.Printf("Deleted journal info: %+v", journalInfo)
 }
 
 // GetMostRecentJournalInfo receives the most recently created JournalInfo on S3
@@ -220,12 +259,17 @@ func GetMostRecentJournalInfo(
 	}
 
 	objs = filterJournalsInfoFiles(objs)
-	objs = sortJournalsInfo(objs)
 	if len(objs) == 0 {
 		return JournalInfo{}, JournalsNotFound
 	}
 
-	theMostRecentJournalObject := objs[len(objs)-1]
+	candidates, err := loadJournalCandidates(ctx, folder, objs)
+	if err != nil {
+		return JournalInfo{}, err
+	}
+	sortCandidates(candidates)
+
+	theMostRecentJournalObject := candidates[len(candidates)-1].obj
 	theMostRecentBackupName := strings.TrimPrefix(theMostRecentJournalObject.GetName(), JournalPrefix)
 	backupInfo, err := NewJournalInfo(
 		ctx,
@@ -240,32 +284,40 @@ func GetMostRecentJournalInfo(
 	return backupInfo, nil
 }
 
+// IntervalSizeCalculator computes the volume of journal data accumulated in the semi-interval
+// (ji.PriorBackupEnd; ji.CurrentBackupEnd], which is stored as prevJi.SizeToNextBackup.
+type IntervalSizeCalculator interface {
+	// Calculate returns ok == false when the size can not be determined. In that case the caller
+	// must leave prevJi.SizeToNextBackup as it is instead of resetting it to zero, since a missing
+	// measurement is indistinguishable from a genuine zero once it has been written to storage.
+	Calculate(ctx context.Context, folder storage.Folder, ji, prevJi JournalInfo) (size int64, ok bool, err error)
+}
+
 type JournalFiles struct {
 	files       []storage.Object
 	initialized bool
 }
 
-// UpdateIntervalSize calculates the size of the SizeToNextBackup in the semi-interval (PriorBackupEnd; CurrentBackupEnd]
-// using journal files on JournalDirectoryName and save it for the previous JournalInfo
-func (ji *JournalInfo) UpdateIntervalSize(ctx context.Context, folder storage.Folder, journalFilesObj *JournalFiles) error {
-	var err error
-	if !journalFilesObj.initialized {
-		// doing this 1 time for reusing it in next runs during single calculation
+func (c *JournalFiles) Calculate(
+	ctx context.Context,
+	folder storage.Folder,
+	ji, _ JournalInfo,
+) (int64, bool, error) {
+	if !c.initialized {
 		journalFiles, _, err := folder.GetSubFolder(ji.JournalDirectoryName).ListFolder(ctx)
 		if err != nil {
-			return err
+			return 0, false, err
 		}
-		journalFilesObj.files = journalFiles
-		journalFilesObj.initialized = true
+		c.files = journalFiles
+		c.initialized = true
 	}
 
-	journalFiles := journalFilesObj.files
-	if len(journalFiles) == 0 {
-		return nil
+	if len(c.files) == 0 {
+		return 0, false, nil
 	}
 
 	sum := int64(0)
-	for _, journal := range journalFiles {
+	for _, journal := range c.files {
 		timestamp := journal.GetLastModified()
 
 		isInInterval := timestamp.After(ji.PriorBackupEnd) && timestamp.Before(ji.CurrentBackupEnd)
@@ -277,6 +329,12 @@ func (ji *JournalInfo) UpdateIntervalSize(ctx context.Context, folder storage.Fo
 		}
 	}
 
+	return sum, true, nil
+}
+
+// UpdateIntervalSize calculates the size of the SizeToNextBackup in the semi-interval (PriorBackupEnd; CurrentBackupEnd]
+// and saves it for the previous JournalInfo
+func (ji *JournalInfo) UpdateIntervalSize(ctx context.Context, folder storage.Folder, calc IntervalSizeCalculator) error {
 	prevJi, err := ji.GetNext(ctx, folder, older)
 	if err != nil {
 		// There can only be one backup on S3 or we can delete the oldest one
@@ -285,28 +343,20 @@ func (ji *JournalInfo) UpdateIntervalSize(ctx context.Context, folder storage.Fo
 		}
 		return err
 	}
-	prevJi.SizeToNextBackup = sum
 
-	err = prevJi.Upload(ctx, folder)
+	sum, ok, err := calc.Calculate(ctx, folder, *ji, prevJi)
 	if err != nil {
 		return err
 	}
-
-	return nil
-}
-
-func getJournalTimestamp(journal string) time.Time {
-	if journal == "" {
-		return time.Time{}
+	if !ok {
+		tracelog.WarningLogger.Printf("Can not determine the journal size for %s, leaving SizeToNextBackup of %s intact",
+			ji.JournalName, prevJi.JournalName)
+		return nil
 	}
 
-	timestampStr := journal[fullJournalPrefixLength:]
-	timestamp, err := time.Parse(JournalTimeLayout, timestampStr)
-	if err != nil {
-		tracelog.WarningLogger.Printf("Error during parsing timestamp '%s': %s", journal, err)
-	}
+	prevJi.SizeToNextBackup = sum
 
-	return timestamp
+	return prevJi.Upload(ctx, folder)
 }
 
 func filterJournalsInfoFiles(objects []storage.Object) []storage.Object {
@@ -319,31 +369,51 @@ func filterJournalsInfoFiles(objects []storage.Object) []storage.Object {
 	return newObjects
 }
 
-func filterJournalsInfoOlderThen(objects []storage.Object, timestamp time.Time) []storage.Object {
-	newObjects := make([]storage.Object, 0, len(objects))
-	for _, obj := range objects {
-		objTimestamp := getJournalTimestamp(obj.GetName())
-		if objTimestamp.Before(timestamp) {
-			newObjects = append(newObjects, obj)
-		}
-	}
-	return newObjects
+// journalCandidate pairs a journal's storage object with its CurrentBackupEnd, i.e. the
+// completion time of the backup it belongs to.
+type journalCandidate struct {
+	obj       storage.Object
+	timestamp time.Time
 }
 
-func filterJournalsInfoNewerThen(objects []storage.Object, timestamp time.Time) []storage.Object {
-	newObjects := make([]storage.Object, 0, len(objects))
+// loadJournalCandidates reads each journal's CurrentBackupEnd from its content instead of
+// deriving a timestamp from the associated backup's name, since backup naming conventions
+// differ across databases (e.g. MySQL's "stream_<timestamp>" vs Postgres' "base_<timeline><segno>").
+func loadJournalCandidates(ctx context.Context, folder storage.Folder, objects []storage.Object) ([]journalCandidate, error) {
+	candidates := make([]journalCandidate, 0, len(objects))
 	for _, obj := range objects {
-		objTimestamp := getJournalTimestamp(obj.GetName())
-		if objTimestamp.After(timestamp) {
-			newObjects = append(newObjects, obj)
+		backupName := strings.TrimPrefix(obj.GetName(), JournalPrefix)
+		ji, err := NewJournalInfo(ctx, backupName, folder, "")
+		if err != nil {
+			return nil, err
 		}
+		candidates = append(candidates, journalCandidate{obj: obj, timestamp: ji.CurrentBackupEnd})
 	}
-	return newObjects
+	return candidates, nil
 }
 
-func sortJournalsInfo(objects []storage.Object) []storage.Object {
-	slices.SortFunc(objects, func(a, b storage.Object) int {
-		return getJournalTimestamp(a.GetName()).Compare(getJournalTimestamp(b.GetName()))
+func filterCandidatesOlderThen(candidates []journalCandidate, timestamp time.Time) []journalCandidate {
+	newCandidates := make([]journalCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		if c.timestamp.Before(timestamp) {
+			newCandidates = append(newCandidates, c)
+		}
+	}
+	return newCandidates
+}
+
+func filterCandidatesNewerThen(candidates []journalCandidate, timestamp time.Time) []journalCandidate {
+	newCandidates := make([]journalCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		if c.timestamp.After(timestamp) {
+			newCandidates = append(newCandidates, c)
+		}
+	}
+	return newCandidates
+}
+
+func sortCandidates(candidates []journalCandidate) {
+	slices.SortFunc(candidates, func(a, b journalCandidate) int {
+		return a.timestamp.Compare(b.timestamp)
 	})
-	return objects
 }

--- a/internal/journal.go
+++ b/internal/journal.go
@@ -120,98 +120,97 @@ func (ji *JournalInfo) GetNext(ctx context.Context, folder storage.Folder, direc
 		return JournalInfo{}, err
 	}
 
-	candidates, err := loadJournalCandidates(ctx, folder, filterJournalsInfoFiles(objs))
+	journals, err := loadJournalsInfo(ctx, folder, filterJournalsInfoFiles(objs))
 	if err != nil {
 		return JournalInfo{}, err
 	}
 
 	switch direction {
 	case older:
-		candidates = filterCandidatesOlderThen(candidates, ji.CurrentBackupEnd)
+		journals = filterJournalsInfoOlderThen(journals, ji.CurrentBackupEnd)
 	case newer:
-		candidates = filterCandidatesNewerThen(candidates, ji.CurrentBackupEnd)
+		journals = filterJournalsInfoNewerThen(journals, ji.CurrentBackupEnd)
 	}
-	sortCandidates(candidates)
+	journals = sortJournalsInfo(journals)
 
-	if len(candidates) == 0 {
+	if len(journals) == 0 {
 		return JournalInfo{}, xerrors.New(cantFindJournal)
 	}
 
-	var journalName string
+	var next JournalInfo
 	switch direction {
 	case older:
-		journalName = candidates[len(candidates)-1].obj.GetName()
+		next = journals[len(journals)-1]
 	case newer:
-		journalName = candidates[0].obj.GetName()
+		next = journals[0]
 	}
 
-	backupName := strings.TrimPrefix(
-		journalName,
-		JournalPrefix,
-	)
-	newerJournalInfo, err := NewJournalInfo(
-		ctx,
-		backupName,
-		folder,
-		ji.JournalDirectoryName,
-	)
+	// JournalDirectoryName is not part of the stored object, it comes from the caller.
+	next.JournalDirectoryName = ji.JournalDirectoryName
+
+	return next, nil
+}
+
+// Previous is the journal of the backup preceding this one, ok == false when this is the oldest.
+func (ji *JournalInfo) Previous(ctx context.Context, folder storage.Folder) (JournalInfo, bool, error) {
+	prevJi, err := ji.GetNext(ctx, folder, older)
 	if err != nil {
-		return JournalInfo{}, err
+		if err.Error() == cantFindJournal {
+			return JournalInfo{}, false, nil
+		}
+		return JournalInfo{}, false, err
 	}
-	return newerJournalInfo, err
+
+	return prevJi, true, nil
 }
 
-// Delete deletes the current JournalInfo from S3,
-// updates the PriorBackupEnd of a newer JournalInfo with the PriorBackupEnd of the current one,
-// updates the older one journal size. The size of the merged interval is recalculated from the
-// journal files archived in ji.JournalDirectoryName, which is what a database keeping its journals
-// in a directory of its own needs. See DeleteWith for the databases that do not.
-func (ji *JournalInfo) Delete(ctx context.Context, folder storage.Folder) error {
-	return ji.DeleteWith(ctx, folder, &JournalFiles{})
-}
-
-// DeleteWith is Delete with the size of the merged interval recalculated by calc.
-func (ji *JournalInfo) DeleteWith(ctx context.Context, folder storage.Folder, calc IntervalSizeCalculator) error {
+// Unlink deletes the journal object and merges the interval it covered into the newer journal,
+// which is returned so that the caller can recalculate the size of the merged interval.
+// ok == false when this was the newest journal and there is nothing to merge into.
+func (ji *JournalInfo) Unlink(ctx context.Context, folder storage.Folder) (JournalInfo, bool, error) {
 	err := folder.
 		GetSubFolder(utility.BaseBackupPath).
 		DeleteObjects(ctx, []storage.Object{storage.NewLocalObject(ji.JournalName, time.Time{}, 0)})
 	if err != nil {
-		return err
+		return JournalInfo{}, false, err
 	}
 
 	newerJi, err := ji.GetNext(ctx, folder, newer)
 	if err != nil {
 		if err.Error() != cantFindJournal {
-			return err
+			return JournalInfo{}, false, err
 		}
 
 		// SizeToNextBackup is the sum in bytes of binlogs between two backups.
 		// If the current backup was the newest one, the older one will be the newest then,
 		// and the SizeToNextBackup of it should be equal to zero.
-		olderJi, err := ji.GetNext(ctx, folder, older)
-		if err != nil {
-			if err.Error() != cantFindJournal {
-				return err
-			}
-			return nil
+		olderJi, ok, err := ji.Previous(ctx, folder)
+		if err != nil || !ok {
+			return JournalInfo{}, false, err
 		}
 
 		olderJi.SizeToNextBackup = 0
-		return olderJi.Upload(ctx, folder)
+		return JournalInfo{}, false, olderJi.Upload(ctx, folder)
 	}
 
 	newerJi.PriorBackupEnd = ji.PriorBackupEnd
 	err = newerJi.Upload(ctx, folder)
 	if err != nil {
+		return JournalInfo{}, false, err
+	}
+
+	return newerJi, true, nil
+}
+
+// Delete unlinks the journal and recalculates the merged interval from JournalDirectoryName.
+// A database that measures the interval differently calls Unlink itself instead.
+func (ji *JournalInfo) Delete(ctx context.Context, folder storage.Folder) error {
+	newerJi, ok, err := ji.Unlink(ctx, folder)
+	if err != nil || !ok {
 		return err
 	}
 
-	err = newerJi.UpdateIntervalSize(ctx, folder, calc)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return newerJi.UpdateIntervalSize(ctx, folder, &JournalFiles{})
 }
 
 // DeleteJournalInfo removes the journal of the given backup and re-links the neighboring journals,
@@ -222,7 +221,6 @@ func DeleteJournalInfo(
 	folder storage.Folder,
 	backupName string,
 	journalDir string,
-	calc IntervalSizeCalculator,
 	confirmed bool,
 ) {
 	journalInfo, err := NewJournalInfo(ctx, backupName, folder, journalDir)
@@ -236,7 +234,7 @@ func DeleteJournalInfo(
 		return
 	}
 
-	if err := journalInfo.DeleteWith(ctx, folder, calc); err != nil {
+	if err := journalInfo.Delete(ctx, folder); err != nil {
 		tracelog.ErrorLogger.Print(err)
 		return
 	}
@@ -263,61 +261,46 @@ func GetMostRecentJournalInfo(
 		return JournalInfo{}, JournalsNotFound
 	}
 
-	candidates, err := loadJournalCandidates(ctx, folder, objs)
+	journals, err := loadJournalsInfo(ctx, folder, objs)
 	if err != nil {
 		return JournalInfo{}, err
 	}
-	sortCandidates(candidates)
+	journals = sortJournalsInfo(journals)
 
-	theMostRecentJournalObject := candidates[len(candidates)-1].obj
-	theMostRecentBackupName := strings.TrimPrefix(theMostRecentJournalObject.GetName(), JournalPrefix)
-	backupInfo, err := NewJournalInfo(
-		ctx,
-		theMostRecentBackupName,
-		folder,
-		journalDir,
-	)
-	if err != nil {
-		return JournalInfo{}, err
-	}
+	backupInfo := journals[len(journals)-1]
+	// JournalDirectoryName is not part of the stored object, it comes from the caller.
+	backupInfo.JournalDirectoryName = journalDir
 
 	return backupInfo, nil
 }
 
-// IntervalSizeCalculator computes the volume of journal data accumulated in the semi-interval
-// (ji.PriorBackupEnd; ji.CurrentBackupEnd], which is stored as prevJi.SizeToNextBackup.
-type IntervalSizeCalculator interface {
-	// Calculate returns ok == false when the size can not be determined. In that case the caller
-	// must leave prevJi.SizeToNextBackup as it is instead of resetting it to zero, since a missing
-	// measurement is indistinguishable from a genuine zero once it has been written to storage.
-	Calculate(ctx context.Context, folder storage.Folder, ji, prevJi JournalInfo) (size int64, ok bool, err error)
-}
-
+// JournalFiles caches a journal directory listing, to be reused across one recalculation.
 type JournalFiles struct {
 	files       []storage.Object
 	initialized bool
 }
 
-func (c *JournalFiles) Calculate(
-	ctx context.Context,
-	folder storage.Folder,
-	ji, _ JournalInfo,
-) (int64, bool, error) {
-	if !c.initialized {
+// UpdateIntervalSize calculates the size of the SizeToNextBackup in the semi-interval (PriorBackupEnd; CurrentBackupEnd]
+// using journal files on JournalDirectoryName and save it for the previous JournalInfo
+func (ji *JournalInfo) UpdateIntervalSize(ctx context.Context, folder storage.Folder, journalFilesObj *JournalFiles) error {
+	if !journalFilesObj.initialized {
+		// doing this 1 time for reusing it in next runs during single calculation
 		journalFiles, _, err := folder.GetSubFolder(ji.JournalDirectoryName).ListFolder(ctx)
 		if err != nil {
-			return 0, false, err
+			return err
 		}
-		c.files = journalFiles
-		c.initialized = true
+		journalFilesObj.files = journalFiles
+		journalFilesObj.initialized = true
 	}
 
-	if len(c.files) == 0 {
-		return 0, false, nil
+	journalFiles := journalFilesObj.files
+	if len(journalFiles) == 0 {
+		// Not measured rather than zero: overwriting SizeToNextBackup with a 0 would lose it.
+		return nil
 	}
 
 	sum := int64(0)
-	for _, journal := range c.files {
+	for _, journal := range journalFiles {
 		timestamp := journal.GetLastModified()
 
 		isInInterval := timestamp.After(ji.PriorBackupEnd) && timestamp.Before(ji.CurrentBackupEnd)
@@ -329,34 +312,19 @@ func (c *JournalFiles) Calculate(
 		}
 	}
 
-	return sum, true, nil
-}
-
-// UpdateIntervalSize calculates the size of the SizeToNextBackup in the semi-interval (PriorBackupEnd; CurrentBackupEnd]
-// and saves it for the previous JournalInfo
-func (ji *JournalInfo) UpdateIntervalSize(ctx context.Context, folder storage.Folder, calc IntervalSizeCalculator) error {
-	prevJi, err := ji.GetNext(ctx, folder, older)
-	if err != nil {
-		// There can only be one backup on S3 or we can delete the oldest one
-		if err.Error() == cantFindJournal {
-			return nil
-		}
+	// There can only be one backup on S3 or we can delete the oldest one
+	prevJi, ok, err := ji.Previous(ctx, folder)
+	if err != nil || !ok {
 		return err
 	}
-
-	sum, ok, err := calc.Calculate(ctx, folder, *ji, prevJi)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		tracelog.WarningLogger.Printf("Can not determine the journal size for %s, leaving SizeToNextBackup of %s intact",
-			ji.JournalName, prevJi.JournalName)
-		return nil
-	}
-
 	prevJi.SizeToNextBackup = sum
 
-	return prevJi.Upload(ctx, folder)
+	err = prevJi.Upload(ctx, folder)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func filterJournalsInfoFiles(objects []storage.Object) []storage.Object {
@@ -369,51 +337,45 @@ func filterJournalsInfoFiles(objects []storage.Object) []storage.Object {
 	return newObjects
 }
 
-// journalCandidate pairs a journal's storage object with its CurrentBackupEnd, i.e. the
-// completion time of the backup it belongs to.
-type journalCandidate struct {
-	obj       storage.Object
-	timestamp time.Time
-}
-
-// loadJournalCandidates reads each journal's CurrentBackupEnd from its content instead of
-// deriving a timestamp from the associated backup's name, since backup naming conventions
-// differ across databases (e.g. MySQL's "stream_<timestamp>" vs Postgres' "base_<timeline><segno>").
-func loadJournalCandidates(ctx context.Context, folder storage.Folder, objects []storage.Object) ([]journalCandidate, error) {
-	candidates := make([]journalCandidate, 0, len(objects))
+// loadJournalsInfo reads the journal behind every object, so that they can be ordered by
+// CurrentBackupEnd. Their names can not be used for that: backup naming conventions differ across
+// databases (MySQL's "stream_<timestamp>" vs Postgres' "base_<timeline><segno>").
+func loadJournalsInfo(ctx context.Context, folder storage.Folder, objects []storage.Object) ([]JournalInfo, error) {
+	journals := make([]JournalInfo, 0, len(objects))
 	for _, obj := range objects {
 		backupName := strings.TrimPrefix(obj.GetName(), JournalPrefix)
 		ji, err := NewJournalInfo(ctx, backupName, folder, "")
 		if err != nil {
 			return nil, err
 		}
-		candidates = append(candidates, journalCandidate{obj: obj, timestamp: ji.CurrentBackupEnd})
+		journals = append(journals, ji)
 	}
-	return candidates, nil
+	return journals, nil
 }
 
-func filterCandidatesOlderThen(candidates []journalCandidate, timestamp time.Time) []journalCandidate {
-	newCandidates := make([]journalCandidate, 0, len(candidates))
-	for _, c := range candidates {
-		if c.timestamp.Before(timestamp) {
-			newCandidates = append(newCandidates, c)
+func filterJournalsInfoOlderThen(journals []JournalInfo, timestamp time.Time) []JournalInfo {
+	newJournals := make([]JournalInfo, 0, len(journals))
+	for _, ji := range journals {
+		if ji.CurrentBackupEnd.Before(timestamp) {
+			newJournals = append(newJournals, ji)
 		}
 	}
-	return newCandidates
+	return newJournals
 }
 
-func filterCandidatesNewerThen(candidates []journalCandidate, timestamp time.Time) []journalCandidate {
-	newCandidates := make([]journalCandidate, 0, len(candidates))
-	for _, c := range candidates {
-		if c.timestamp.After(timestamp) {
-			newCandidates = append(newCandidates, c)
+func filterJournalsInfoNewerThen(journals []JournalInfo, timestamp time.Time) []JournalInfo {
+	newJournals := make([]JournalInfo, 0, len(journals))
+	for _, ji := range journals {
+		if ji.CurrentBackupEnd.After(timestamp) {
+			newJournals = append(newJournals, ji)
 		}
 	}
-	return newCandidates
+	return newJournals
 }
 
-func sortCandidates(candidates []journalCandidate) {
-	slices.SortFunc(candidates, func(a, b journalCandidate) int {
-		return a.timestamp.Compare(b.timestamp)
+func sortJournalsInfo(journals []JournalInfo) []JournalInfo {
+	slices.SortFunc(journals, func(a, b JournalInfo) int {
+		return a.CurrentBackupEnd.Compare(b.CurrentBackupEnd)
 	})
+	return journals
 }

--- a/internal/journal_test.go
+++ b/internal/journal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/pkg/storages/memory"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -175,6 +176,24 @@ func TestDeleteJournalInEnd(t *testing.T) {
 	assert.Equal(t, int64(33), ji1.SizeToNextBackup)
 	assert.Equal(t, int64(0), ji2.SizeToNextBackup)
 	fmt.Println(ji1.JournalName, ji2.JournalName, ji3.JournalName)
+}
+
+// An empty journal directory means the size was not measured, not that it is zero: overwriting a
+// previously computed SizeToNextBackup with 0 would silently lose it.
+func TestEmptyJournalDirectoryKeepsPreviousSize(t *testing.T) {
+	folder, uploader := initTestS3()
+	generateAndUploadData(t, uploader)
+
+	ji1, _, ji3 := CreateThreeJournals(t, folder)
+
+	emptyDirFolder := memory.NewFolder("", memory.NewKVS())
+	require.NoError(t, ji1.Upload(t.Context(), emptyDirFolder))
+	require.NoError(t, ji3.Upload(t.Context(), emptyDirFolder))
+
+	assert.NoError(t, ji3.UpdateIntervalSize(t.Context(), emptyDirFolder, &internal.JournalFiles{}))
+
+	require.NoError(t, ji1.Read(t.Context(), emptyDirFolder))
+	assert.Equal(t, int64(33), ji1.SizeToNextBackup)
 }
 
 func TestSafetyOfRepeatingMethodCalls(t *testing.T) {


### PR DESCRIPTION
### Postgres and Greenplum

Common:
* Use `JournalInfo` in our code instead of `storage.Object` - in this way we do not depend on backup naming pattern (Postgres' naming doesn't contain timestamp).

For postgres:
* Add `count-journals` feature like MySQL has.

For greenplum/cloudberry:
  * Each segment's WAL-G instance counts the WAL it archives into its own `segments_005/seg<N>/wal_005` during `seg-backup-push`, and the coordinator sums the per-segment journals into a cluster-wide `journal_<backup>`.