### PR TITLE
fix: Correctly read `OrioleDBOndiskPageHeader`

### DIFF
--- a/internal/databases/postgres/orioledb/incremental_page_reader.go
+++ b/internal/databases/postgres/orioledb/incremental_page_reader.go
@@ -20,6 +20,10 @@ import (
 const (
 	CompressedPageSize        = 512
 	SignatureMagicNumber byte = 0x55
+
+	// OndiskPageHeaderSize is sizeof(OrioleDBOndiskPageHeader)
+	OndiskPageHeaderSize   = 16
+	compressPageSizeOffset = 4
 )
 
 var DatabasePageSize = int64(walparser.BlockSize)
@@ -101,12 +105,16 @@ func (pageReader *incrementalPageReader) Close() error {
 
 // TODO : unit tests
 // TODO : "initialize" is rather meaningless name, maybe this func should be decomposed
-func (pageReader *incrementalPageReader) initialize(deltaBitmap *roaring.Bitmap) (size int64, err error) {
+func (pageReader *incrementalPageReader) initialize(deltaBitmap *roaring.Bitmap) (int64, error) {
 	var headerBuffer bytes.Buffer
 	headerBuffer.Write(IncrementFileHeader)
 	fileSize := pageReader.FileSize
 	headerBuffer.Write(utility.ToBytes(uint64(fileSize)))
-	pageReader.Compressed = fileSize%DatabasePageSize != 0
+	compressed, err := pageReader.detectCompressed()
+	if err != nil {
+		return 0, err
+	}
+	pageReader.Compressed = compressed
 	pageSize := DatabasePageSize
 	if pageReader.Compressed {
 		pageSize = CompressedPageSize
@@ -126,8 +134,24 @@ func (pageReader *incrementalPageReader) initialize(deltaBitmap *roaring.Bitmap)
 	pageReader.WriteDiffMapToHeader(&headerBuffer)
 	pageReader.Next = headerBuffer.Bytes()
 	pageDataSize := int64(len(pageReader.Blocks)) * pageSize
-	size = int64(headerBuffer.Len()) + pageDataSize
-	return
+	size := int64(headerBuffer.Len()) + pageDataSize
+	return size, nil
+}
+
+// detectCompressed reads the first page's on-disk header: compressPageSize is
+// zero for a plain page and non-zero for a compressed one.
+func (pageReader *incrementalPageReader) detectCompressed() (bool, error) {
+	if pageReader.FileSize < OndiskPageHeaderSize {
+		return false, nil
+	}
+	header := make([]byte, OndiskPageHeaderSize)
+	if _, err := io.ReadFull(pageReader.PagedFile, header); err != nil {
+		return false, err
+	}
+	if _, err := pageReader.PagedFile.Seek(0, io.SeekStart); err != nil {
+		return false, err
+	}
+	return binary.LittleEndian.Uint16(header[compressPageSizeOffset:]) != 0, nil
 }
 
 func (pageReader *incrementalPageReader) DeltaBitmapInitialize(deltaBitmap *roaring.Bitmap) {
@@ -148,7 +172,7 @@ func (pageReader *incrementalPageReader) DeltaBitmapInitialize(deltaBitmap *roar
 
 func (pageReader *incrementalPageReader) FullScanCompressedInitialize() error {
 	readBytes := uint32(0)
-	const sizeOfHeader = 8
+	const sizeOfHeader = OndiskPageHeaderSize
 	for {
 		header := make([]byte, sizeOfHeader)
 
@@ -160,9 +184,9 @@ func (pageReader *incrementalPageReader) FullScanCompressedInitialize() error {
 			}
 			return err
 		}
-		pageSize := binary.LittleEndian.Uint16(header)
-		// because pageSize is aligned to 4 bytes
-		chkpNum := binary.LittleEndian.Uint32(header[4:])
+		// checkpointNum comes first, compressPageSize follows it
+		chkpNum := binary.LittleEndian.Uint32(header)
+		pageSize := binary.LittleEndian.Uint16(header[compressPageSizeOffset:])
 		blocksTotal := (pageSize + sizeOfHeader + CompressedPageSize - 1) / CompressedPageSize
 		fullSize := blocksTotal*CompressedPageSize - sizeOfHeader
 


### PR DESCRIPTION
### Database name

Postgres -> OrioleDB

# Pull request description

### Describe what this PR fixes

- Checking if an orioledb page compressed was fragile, add `incrementalPageReader.detectCompressed()` which checks `OrioledbDBOndiskPageHeader.compress_page_size`
- Correctly read `checkpointNum` and `compress_page_size` of `OrioleDBOndiskPageHeader` struct in `FullScanCompressedInitialize()`

### Please provide steps to reproduce (if it's a bug)

`OrioleDBOndiskPageHeader` definition is here https://github.com/orioledb/orioledb/blob/77e29b8c744363967e073ed7a1235e1596d5b0d0/include/orioledb.h#L382

### Please add config and wal-g stdout/stderr logs for debug purpose

