### PR TITLE
test(orioledb): assert compressed delta backups actually diff and restore correctly

### DIFF
--- a/docker/orioledb/Dockerfile
+++ b/docker/orioledb/Dockerfile
@@ -34,7 +34,7 @@ ENV PGDATA /var/lib/postgresql/17/main
 
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends --no-install-suggests \
-		curl
+		curl jq
 
 RUN mkdir -p /usr/src/postgresql/contrib/orioledb && chmod 777 /usr/src/postgresql/contrib/orioledb
 
@@ -42,7 +42,7 @@ WORKDIR /usr/src/postgresql/contrib/orioledb
 RUN set -eux; \
 	git init; \
 	git remote add origin https://github.com/orioledb/orioledb.git; \
-	git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +beta16-pre-2:refs/remotes/origin/main; \
+	git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +beta16:refs/remotes/origin/main; \
 	git checkout --progress --force -B main refs/remotes/origin/main;
 
 WORKDIR /

--- a/docker/orioledb/scripts/tests/compressed_test.sh
+++ b/docker/orioledb/scripts/tests/compressed_test.sh
@@ -28,16 +28,82 @@ wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
 
 psql -d postgres -f /tmp/scripts/compressed_prepare.sql
 pgbench -Igvpf -i -s 4 postgres
-wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+wal-g --config=${TMP_CONFIG} backup-push ${PGDATA} --full
+
+# Full backup's size is the baseline the delta backup below must be much
+# smaller than.
+FULL_BACKUP_SIZE=$(wal-g --config=${TMP_CONFIG} backup-list --json --detail | jq -r '.[-1].uncompressed_size')
+
 pgbench -Id -i -s 4 postgres
 
 psql -d postgres -f /tmp/scripts/compressed_prepare.sql
 pgbench -Igvpf -i -s 8 postgres
 pg_dumpall -f /tmp/dump1 --restrict-key=orioledbkey
+
+# Fingerprint of the compressed table's content right before the delta
+# backup-push below.
+PGBENCH_ACCOUNTS_FINGERPRINT=$(psql -d postgres -tAc \
+    "SELECT md5(string_agg(aid || ',' || abalance || ',' || filler, '' ORDER BY aid)) FROM pgbench_accounts")
+
 pgbench -c 2 -T 100000000 -S &
 sleep 1
 wal-g --config=${TMP_CONFIG} backup-push ${PGDATA}
+DELTA_BACKUP_NAME=$(wal-g --config=${TMP_CONFIG} backup-list --json --detail | jq -r '.[-1].backup_name')
+DELTA_BACKUP_SIZE=$(wal-g --config=${TMP_CONFIG} backup-list --json --detail | jq -r '.[-1].uncompressed_size')
+
+case "${DELTA_BACKUP_NAME}" in
+  *_D_*) ;;
+  *) echo "Expected a delta backup, got '${DELTA_BACKUP_NAME}'" && exit 1 ;;
+esac
+
+# A true page-level/chkpNum-filtered diff of the compressed OrioleDB files
+# should ship a small fraction of the full backup's size.
+if [ "${DELTA_BACKUP_SIZE}" -ge $((FULL_BACKUP_SIZE / 2)) ]; then
+    echo "Delta backup (${DELTA_BACKUP_SIZE}) is not meaningfully smaller than the full backup (${FULL_BACKUP_SIZE})"
+    exit 1
+fi
+if [ "${DELTA_BACKUP_SIZE}" -le 0 ]; then
+    echo "Delta backup reported a non-positive size (${DELTA_BACKUP_SIZE})"
+    exit 1
+fi
+
 pg_ctl -D ${PGDATA} stop
+
+# Restore the delta backup on its own into a scratch data directory with
+# recovery_target=immediate, i.e. with the least possible WAL replayed on
+# top of the fetched files.
+DELTA_CHECK_PGDATA=/tmp/pgdata_delta_check
+rm -rf ${DELTA_CHECK_PGDATA}
+wal-g --config=${TMP_CONFIG} backup-fetch ${DELTA_CHECK_PGDATA} ${DELTA_BACKUP_NAME}
+touch ${DELTA_CHECK_PGDATA}/recovery.signal
+echo "archive_mode = off" >> ${DELTA_CHECK_PGDATA}/postgresql.conf
+echo "restore_command = 'echo \"WAL file restoration: %f, %p\" && /usr/bin/wal-g --config=${TMP_CONFIG} wal-fetch \"%f\" \"%p\"'" >> ${DELTA_CHECK_PGDATA}/postgresql.conf
+echo "recovery_target = 'immediate'" >> ${DELTA_CHECK_PGDATA}/postgresql.conf
+echo "recovery_target_action = 'promote'" >> ${DELTA_CHECK_PGDATA}/postgresql.conf
+
+# wait_while_pg_not_ready.sh reads $PGDATA, so swap it for the scratch check
+# and restore it afterwards for the rest of the script.
+ORIGINAL_PGDATA=${PGDATA}
+export PGDATA=${DELTA_CHECK_PGDATA}
+
+pg_ctl -D ${PGDATA} -w start
+/tmp/scripts/wait_while_pg_not_ready.sh
+
+RESTORED_FINGERPRINT=$(psql -d postgres -tAc \
+    "SELECT md5(string_agg(aid || ',' || abalance || ',' || filler, '' ORDER BY aid)) FROM pgbench_accounts")
+
+pg_ctl -D ${PGDATA} stop
+rm -rf ${PGDATA}
+
+export PGDATA=${ORIGINAL_PGDATA}
+
+if [ "${PGBENCH_ACCOUNTS_FINGERPRINT}" != "${RESTORED_FINGERPRINT}" ]; then
+    echo "Delta backup restore mismatch for pgbench_accounts"
+    echo "expected: ${PGBENCH_ACCOUNTS_FINGERPRINT}"
+    echo "got:      ${RESTORED_FINGERPRINT}"
+    exit 1
+fi
+
 rm -rf $PGDATA
 
 wal-g --config=${TMP_CONFIG} backup-fetch ${PGDATA} LATEST


### PR DESCRIPTION
### Database name

PostgreSQL -> OrioleDB

# Pull request description

Adds checks that backup-push of a compressed OrioleDB table produces a real delta (not a size-of-full fallback) and that restoring it with minimal WAL replay (recovery_target=immediate) reproduces the data exactly.

Also bumps orioledb to `beta16`.

### Please provide steps to reproduce (if it's a bug)

### Please add config and wal-g stdout/stderr logs for debug purpose

