### PR TITLE
Greenplum: count the shared AO/AOCS/PAX volume per backup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       &&  mkdir -p /export/gpdeletetargetbucket
       &&  mkdir -p /export/gpdeletegarbagebucket
       &&  mkdir -p /export/gp-journal-test-bucket
+      &&  mkdir -p /export/gp-shared-size-test-bucket
       &&  mkdir -p /export/cloudberry-delete-target-bucket
       &&  mkdir -p /export/cloudberry-delete-garbage-bucket
       &&  mkdir -p /export/mysqlfullxtrabackupbucket
@@ -179,6 +180,7 @@ services:
       &&  mkdir -p /export/cloudberry-aostorage-test-bucket
       &&  mkdir -p /export/cloudberry-paxstorage-test-bucket
       &&  mkdir -p /export/cloudberry-journal-test-bucket
+      &&  mkdir -p /export/cloudberry-shared-size-test-bucket
       &&  mkdir -p /export/cloudberry-delta-backup-test-bucket
       &&  mkdir -p /export/cloudberry-partial-table-bucket
       &&  mkdir -p /export/createrestorepointbucket

--- a/docker/cloudberry_tests/scripts/configs/shared_size_test_config.json
+++ b/docker/cloudberry_tests/scripts/configs/shared_size_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://cloudberry-shared-size-test-bucket",
+"WALG_LOG_LEVEL": "DEVEL"

--- a/docker/cloudberry_tests/scripts/tests/shared_size_test.sh
+++ b/docker/cloudberry_tests/scripts/tests/shared_size_test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e -x
+CONFIG_FILE="/tmp/configs/shared_size_test_config.json"
+
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/pg_scripts/wrap_config_file.sh ${TMP_CONFIG}
+source /tmp/tests/test_functions/util.sh
+
+# The cluster backups, oldest first. Taken from the sentinels rather than from the journals: this
+# test pushes backups without --count-journals, so there are no journals to derive them from.
+get_backup_name() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/ 2>&1 \
+        | awk '{ print $NF }' | grep _backup_stop_sentinel.json \
+        | sed 's/_backup_stop_sentinel.json//' | sort | awk "FNR == $1 {print}"
+}
+
+# get_shared_size <backup> <object> - the cluster-wide volume recorded in one of the two objects
+get_shared_size() {
+    wal-g --config=${TMP_CONFIG} st cat basebackups_005/$1/$2 | jq ".SharedSize"
+}
+
+count_shared_size_objects() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/$1/ 2>&1 | grep -c _files_metadata.json || true
+}
+
+count_cluster_journals() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/ 2>&1 | grep -c journal_ || true
+}
+
+bootstrap_gp_cluster
+setup_wal_archiving
+
+wal-g --config=${TMP_CONFIG} st rm / --target=all || true
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+# The shared volume is recorded on every backup-push, with no flag of its own
+insert_data
+run_backup_logged ${TMP_CONFIG}
+sleep 1
+
+FIRST=$(get_backup_name 1)
+test "0" -eq $(count_cluster_journals)
+test "2" -eq $(count_shared_size_objects ${FIRST})
+
+# insert_data creates an AO, a CO and a PAX table, so this backup pushed files to both aosegments/
+# and paxfiles/. The two volumes stay in objects of their own instead of being summed into one.
+test "0" -ne $(get_shared_size ${FIRST} ao_files_metadata.json)
+test "0" -ne $(get_shared_size ${FIRST} pax_files_metadata.json)
+
+# Permanent backups are counted too: they occupy the shared storage like any other
+insert_data
+run_backup_logged ${TMP_CONFIG} --permanent
+sleep 1
+
+PERMANENT=$(get_backup_name 2)
+test "0" -ne $(get_shared_size ${PERMANENT} ao_files_metadata.json)
+test "0" -ne $(get_shared_size ${PERMANENT} pax_files_metadata.json)
+
+# The objects live under the backup name, so every delete mode removes them along with the backup
+# without any code of its own
+wal-g --config=${TMP_CONFIG} delete target ${FIRST} --confirm
+
+test "0" -eq $(count_shared_size_objects ${FIRST})
+test "2" -eq $(count_shared_size_objects ${PERMANENT})
+
+cleanup
+rm ${TMP_CONFIG}

--- a/docker/gp_tests/scripts/configs/shared_size_test_config.json
+++ b/docker/gp_tests/scripts/configs/shared_size_test_config.json
@@ -1,0 +1,2 @@
+"WALE_S3_PREFIX": "s3://gp-shared-size-test-bucket",
+"WALG_LOG_LEVEL": "DEVEL"

--- a/docker/gp_tests/scripts/tests/shared_size_test.sh
+++ b/docker/gp_tests/scripts/tests/shared_size_test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e -x
+CONFIG_FILE="/tmp/configs/shared_size_test_config.json"
+
+COMMON_CONFIG="/tmp/configs/common_config.json"
+TMP_CONFIG="/tmp/configs/tmp_config.json"
+cat ${CONFIG_FILE} > ${TMP_CONFIG}
+echo "," >> ${TMP_CONFIG}
+cat ${COMMON_CONFIG} >> ${TMP_CONFIG}
+/tmp/pg_scripts/wrap_config_file.sh ${TMP_CONFIG}
+source /tmp/tests/test_functions/util.sh
+
+# The cluster backups, oldest first. Taken from the sentinels rather than from the journals: this
+# test pushes backups without --count-journals, so there are no journals to derive them from.
+get_backup_name() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/ 2>&1 \
+        | awk '{ print $NF }' | grep _backup_stop_sentinel.json \
+        | sed 's/_backup_stop_sentinel.json//' | sort | awk "FNR == $1 {print}"
+}
+
+# get_shared_size <backup> <object> - the cluster-wide volume recorded in one of the two objects
+get_shared_size() {
+    wal-g --config=${TMP_CONFIG} st cat basebackups_005/$1/$2 | jq ".SharedSize"
+}
+
+count_shared_size_objects() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/$1/ 2>&1 | grep -c _files_metadata.json || true
+}
+
+count_cluster_journals() {
+    wal-g --config=${TMP_CONFIG} st ls basebackups_005/ 2>&1 | grep -c journal_ || true
+}
+
+bootstrap_gp_cluster
+setup_wal_archiving
+enable_pitr_extension
+
+wal-g --config=${TMP_CONFIG} st rm / --target=all || true
+wal-g --config=${TMP_CONFIG} delete everything FORCE --confirm
+
+# The shared volume is recorded on every backup-push, with no flag of its own
+insert_data
+run_backup_logged ${TMP_CONFIG}
+sleep 1
+
+FIRST=$(get_backup_name 1)
+test "0" -eq $(count_cluster_journals)
+test "2" -eq $(count_shared_size_objects ${FIRST})
+
+# insert_data creates an AO and a CO table, so the backup pushed something to aosegments/. There are
+# no PAX relations on Greenplum, so that volume is a genuine zero rather than a missing measurement,
+# and it is kept in an object of its own instead of being folded into the AO one.
+test "0" -ne $(get_shared_size ${FIRST} ao_files_metadata.json)
+test "0" -eq $(get_shared_size ${FIRST} pax_files_metadata.json)
+
+# Permanent backups are counted too: they occupy the shared storage like any other
+insert_data
+run_backup_logged ${TMP_CONFIG} --permanent
+sleep 1
+
+PERMANENT=$(get_backup_name 2)
+test "0" -ne $(get_shared_size ${PERMANENT} ao_files_metadata.json)
+
+# The objects live under the backup name, so every delete mode removes them along with the backup
+# without any code of its own
+wal-g --config=${TMP_CONFIG} delete target ${FIRST} --confirm
+
+test "0" -eq $(count_shared_size_objects ${FIRST})
+test "2" -eq $(count_shared_size_objects ${PERMANENT})
+
+cleanup
+rm ${TMP_CONFIG}

--- a/internal/databases/greenplum/README.journal.md
+++ b/internal/databases/greenplum/README.journal.md
@@ -1,6 +1,8 @@
-# Journal objects
+# Journal and shared size objects
 
 A journal records the volume of WAL archived between one backup and the next. It is the same object every WAL-G database keeps, and it knows nothing about Greenplum specifics such as AO/AOCS or PAX storage.
+
+The shared size is the second, independent figure: the volume a backup added to the AO/AOCS and PAX storage shared between backups. It is Greenplum-specific and lives in objects of its own.
 
 ## Storage layout
 
@@ -8,8 +10,10 @@ A journal records the volume of WAL archived between one backup and the next. It
 basebackups_005/                                 ← cluster
   backup_<timestamp>_backup_stop_sentinel.json   ← names the backup of every segment
   journal_backup_<timestamp>                     ← WAL volume, whole cluster
+  backup_<timestamp>/{ao,pax}_files_metadata.json ← shared volume, whole cluster
 segments_005/seg-1/                              ← coordinator
   basebackups_005/journal_base_<...>             ← journal of this segment
+  basebackups_005/{aosegments,paxfiles}/         ← the shared storage itself
   wal_005/                                       ← WAL of this segment
 segments_005/seg0/                               ← segment 0, and so on
   ...
@@ -42,3 +46,13 @@ The volume is measured differently at the two levels. A **segment** sums the sto
 The cluster figure is therefore not a wall-clock window: a segment finishes its ``backup-push`` before the coordinator creates the restore point, so WAL archived in between lands in that segment's *next* interval. Nothing is lost or double counted along the chain, but the total is not the volume archived cluster-wide between two backup finish times.
 
 Sizes come from the storage object sizes, so they reflect compression and encryption — unlike an estimate derived from the LSN difference.
+
+## Shared size
+
+AO/AOCS and PAX files live in storage shared between backups, where an unchanged file is uploaded once and reused later through deduplication.
+
+Each **segment** records what its uploaders actually pushed as ``UploadedSharedSize`` in its own ``ao_files_metadata.json`` and ``pax_files_metadata.json`` — a deduplicated file never reaches the uploader and is not counted. The **coordinator** sums the segments into the cluster-level pair as ``SharedSize``.
+
+AO and PAX stay in separate objects all the way up — separate deduplication age limits, separate cleanup passes.
+
+**TODO: make it exact.** ``SharedSize`` is never revisited after the backup is created, so when a backup is deleted its share vanishes even though newer backups still reuse some of its files, and the total drifts below the real storage size. The fix is a rule of ownership — an object belongs to the oldest surviving backup referencing it — recomputed on the segment during ``cleanupAOSegments``/``cleanupPaxFiles``, which already load every backup's metadata.

--- a/internal/databases/greenplum/ao_metadata.go
+++ b/internal/databases/greenplum/ao_metadata.go
@@ -27,6 +27,13 @@ type BackupAOFileDesc struct {
 
 type AOFilesMetadataDTO struct {
 	Files BackupAOFiles
+	// UploadedSharedSize is the volume this backup uploaded to the shared aosegments/ storage:
+	// Files smaller than WALG_GP_AOSEG_SIZE_THRESHOLD go into the regular tar balls and are not
+	// part of it.
+	//
+	// It is what this backup uploaded, not what it owns: at the cluster level a backup can be
+	// charged for the files of an older backup that was deleted while this one still reused them.
+	UploadedSharedSize int64 `json:",omitempty"`
 }
 
 type BackupAOFiles map[string]*BackupAOFileDesc

--- a/internal/databases/greenplum/ao_storage_uploader.go
+++ b/internal/databases/greenplum/ao_storage_uploader.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
-	"github.com/wal-g/wal-g/internal/compression"
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/internal/fsutil"
 	"github.com/wal-g/wal-g/internal/ioextensions"
@@ -39,10 +38,12 @@ type AoStorageUploader struct {
 func NewAoStorageUploader(uploader internal.Uploader, baseAoFiles BackupAOFiles,
 	crypter crypto.Crypter, files internal.BundleFiles, isIncremental bool, deduplicationAgeLimit time.Duration,
 	newAoSegFilesID string) *AoStorageUploader {
-	// Separate uploader for AO/AOCS relfiles with disabled file size tracking since
-	// WAL-G does not count them
-	aoSegUploader := uploader.Clone()
-	aoSegUploader.DisableSizeTracking()
+	// Separate uploader for AO/AOCS relfiles, with a size counter of its own: cloning would share
+	// the counter of the backup uploader, and WAL-G does not count these files in the backup size.
+	//
+	// No compressor: AO/AOCS segment files are already compressed in most cases.
+	// TODO: lookup the compression details for each relation and compress it when compression is turned off
+	aoSegUploader := internal.NewRegularUploader(nil, uploader.Folder())
 
 	return &AoStorageUploader{
 		uploader:            aoSegUploader,
@@ -169,6 +170,13 @@ func (u *AoStorageUploader) GetFiles() *AOFilesMetadataDTO {
 	return u.meta
 }
 
+// UploadedDataSize is the volume this backup pushed to the shared aosegments/ storage, as counted
+// by the uploader after compression and encryption. Files reused from an older backup via
+// deduplication never reach the uploader, so they are not counted.
+func (u *AoStorageUploader) UploadedDataSize() (int64, error) {
+	return u.uploader.UploadedDataSize()
+}
+
 func (u *AoStorageUploader) skipAoUpload(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, storageKey string,
 	initialUploadTS time.Time, isIncremented bool, checksum string) error {
 	u.addAoFileMetadata(cfi, storageKey, aoMeta, true, isIncremented, initialUploadTS, checksum)
@@ -213,14 +221,7 @@ func (u *AoStorageUploader) regularAoUpload(ctx context.Context,
 	hasher := xxh3.New128()
 	hashingReader := io.TeeReader(fileReadCloser, ioextensions.NewLimitedWriter(hasher, aoMeta.eof))
 
-	// do not compress AO/AOCS segment files since they are already compressed in most cases
-	// TODO: lookup the compression details for each relation and compress it when compression is turned off
-	var compressor compression.Compressor
-
-	uploadContents := internal.CompressAndEncrypt(ctx, hashingReader, compressor, u.crypter)
-	uploadPath := path.Join(AoStoragePath, storageKey)
-	err = u.uploader.Upload(ctx, uploadPath, uploadContents)
-	if err != nil {
+	if err = u.upload(ctx, hashingReader, storageKey); err != nil {
 		return err
 	}
 
@@ -258,11 +259,7 @@ func (u *AoStorageUploader) incrementalAoUpload(ctx context.Context,
 }
 
 func (u *AoStorageUploader) upload(ctx context.Context, reader io.Reader, storageKey string) error {
-	// do not compress AO/AOCS segment files since they are already compressed in most cases
-	// TODO: lookup the compression details for each relation and compress it when compression is turned off
-	var compressor compression.Compressor
-
-	uploadContents := internal.CompressAndEncrypt(ctx, reader, compressor, u.crypter)
+	uploadContents := internal.CompressAndEncrypt(ctx, reader, u.uploader.Compression(), u.crypter)
 	uploadPath := path.Join(AoStoragePath, storageKey)
 	return u.uploader.Upload(ctx, uploadPath, uploadContents)
 }

--- a/internal/databases/greenplum/backup_push_handler.go
+++ b/internal/databases/greenplum/backup_push_handler.go
@@ -236,10 +236,24 @@ func (bh *BackupHandler) HandleBackupPush(ctx context.Context) {
 	err = bh.uploadRestorePointMetadata(ctx, restoreLSNs, timeLine, timelineBySegment)
 	tracelog.ErrorLogger.FatalOnError(err)
 
+	bh.handleSharedSize(ctx, rootFolder)
 	bh.handleJournalInfo(ctx, rootFolder)
 
 	tracelog.InfoLogger.Printf("Backup %s successfully created", bh.currBackupInfo.backupName)
 	bh.disconnect(ctx)
+}
+
+// handleSharedSize maintains the cluster-wide shared size objects, holding the volume this backup
+// added to the AO/AOCS and PAX storages shared between backups. The per-segment volumes it sums up
+// are recorded in the files metadata the segment WAL-G instances write during seg-backup-push, so
+// this runs once they have all finished.
+func (bh *BackupHandler) handleSharedSize(ctx context.Context, rootFolder storage.Folder) {
+	if err := UploadSharedSizes(ctx, rootFolder, bh.currBackupInfo.backupName); err != nil {
+		tracelog.WarningLogger.Printf("can not record the shared storage size: %s", err.Error())
+		return
+	}
+
+	tracelog.InfoLogger.Printf("uploaded shared size info for %s", bh.currBackupInfo.backupName)
 }
 
 // handleJournalInfo maintains the cluster-wide journal_<backup> object, holding the WAL volume all

--- a/internal/databases/greenplum/pax/metadata.go
+++ b/internal/databases/greenplum/pax/metadata.go
@@ -32,6 +32,13 @@ type BackupFiles map[string]BackupFileDesc
 // FilesMetadataDTO is the shape persisted to `pax_files_metadata.json`.
 type FilesMetadataDTO struct {
 	Files BackupFiles
+	// UploadedSharedSize is the volume this backup uploaded to the shared paxfiles/ storage:
+	// Files smaller than WALG_GP_PAXFILE_SIZE_THRESHOLD go into the regular tar balls and are not
+	// part of it.
+	//
+	// It is what this backup uploaded, not what it owns: at the cluster level a backup can be
+	// charged for the files of an older backup that was deleted while this one still reused them.
+	UploadedSharedSize int64 `json:",omitempty"`
 }
 
 func NewFilesMetadataDTO() *FilesMetadataDTO {

--- a/internal/databases/greenplum/pax/storage_uploader.go
+++ b/internal/databases/greenplum/pax/storage_uploader.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
-	"github.com/wal-g/wal-g/internal/compression"
 	"github.com/wal-g/wal-g/internal/crypto"
 	"github.com/wal-g/wal-g/utility"
 )
@@ -29,9 +28,9 @@ type StorageUploader struct {
 
 func NewStorageUploader(uploader internal.Uploader, baseFiles BackupFiles, crypter crypto.Crypter,
 	files internal.BundleFiles, deduplicationAgeLimit time.Duration, newPaxFilesID string) *StorageUploader {
-	// Separate uploader for PAX files with disabled file size tracking, matching the AO/AOCS handling path.
-	paxFileUploader := uploader.Clone()
-	paxFileUploader.DisableSizeTracking()
+	// Separate uploader for PAX files, with a size counter of its own and no compressor
+	// (PAX/PORC files are already compressed internally).
+	paxFileUploader := internal.NewRegularUploader(nil, uploader.Folder())
 
 	return &StorageUploader{
 		uploader:            paxFileUploader,
@@ -46,6 +45,13 @@ func NewStorageUploader(uploader internal.Uploader, baseFiles BackupFiles, crypt
 
 func (u *StorageUploader) GetFiles() *FilesMetadataDTO {
 	return u.meta
+}
+
+// UploadedDataSize is the volume this backup pushed to the shared paxfiles/ storage, as counted by
+// the uploader after compression and encryption. Files reused from an older backup via
+// deduplication never reach the uploader, so they are not counted.
+func (u *StorageUploader) UploadedDataSize() (int64, error) {
+	return u.uploader.UploadedDataSize()
 }
 
 func (u *StorageUploader) AddFile(ctx context.Context,
@@ -107,10 +113,7 @@ func (u *StorageUploader) regularUpload(ctx context.Context,
 	}
 	defer utility.LoggedClose(fileReadCloser, "Failed to close PAX file")
 
-	// PAX/PORC files are already compressed internally; do not re-compress.
-	var compressor compression.Compressor
-
-	uploadContents := internal.CompressAndEncrypt(ctx, fileReadCloser, compressor, u.crypter)
+	uploadContents := internal.CompressAndEncrypt(ctx, fileReadCloser, u.uploader.Compression(), u.crypter)
 	uploadPath := path.Join(StoragePath, storageKey)
 	if err := u.uploader.Upload(ctx, uploadPath, uploadContents); err != nil {
 		return err

--- a/internal/databases/greenplum/shared_size.go
+++ b/internal/databases/greenplum/shared_size.go
@@ -1,0 +1,174 @@
+package greenplum
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/pax"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/utility"
+)
+
+// SharedSizeDTO is the cluster-level counterpart of the per-segment files metadata. A cluster
+// uploads nothing of its own and has no shared file to list, so it records neither the file list
+// nor the uploaded volume, only the total its segments are accountable for.
+//
+// It is stored under the same names the segments use, ao_files_metadata.json and
+// pax_files_metadata.json, one folder level up. The name is shared but the shape is not: the two
+// are told apart by the folder they are read from, and nothing reads the cluster-level one as
+// AOFilesMetadataDTO or vice versa (LoadStorageAoFiles and pax.LoadStoragePaxFiles are only ever
+// given a segment folder).
+type SharedSizeDTO struct {
+	// SharedSize is the volume, in bytes, the backup added to one of the shared storages. It is the
+	// sum of what the segments uploaded when the backup is created, and is meant to be recalculated
+	// later, when a neighboring backup is deleted and this one inherits objects still in use.
+	SharedSize int64 `json:"SharedSize"`
+}
+
+// sharedStorageKind is one of the two storages shared between backups, described by everything the
+// cluster-wide bookkeeping needs to know about it: where a segment reports what it uploaded, and
+// where the cluster total is kept.
+//
+// Both live under basebackups_005/<backup>/, which is what makes the cluster-level objects
+// disappear together with the backup: the path reduces to the backup name exactly like the sentinel
+// does, so every delete mode picks them up without any code of its own (see
+// utility.StripLeftmostBackupName).
+type sharedStorageKind struct {
+	name            string
+	path            func(backupName string) string
+	readSegmentSize func(ctx context.Context, baseBackupsFolder storage.Folder, backupName string) (int64, error)
+}
+
+func sharedStorageKinds() []sharedStorageKind {
+	return []sharedStorageKind{
+		{name: "AO/AOCS", path: getAOFilesMetadataPath, readSegmentSize: readUploadedAOSize},
+		{name: "PAX", path: pax.GetFilesMetadataPath, readSegmentSize: readUploadedPaxSize},
+	}
+}
+
+// UploadSharedSizes writes the cluster-wide shared size of backupName, one object per shared
+// storage, each summed from what the segments named in the backup sentinel reported uploading.
+//
+// Unlike the journal this is recorded on every backup-push, with no flag and for permanent backups
+// too: a permanent backup occupies the shared storage like any other, and leaving it out would
+// break the property that the sizes of all backups add up to the size of the storage.
+func UploadSharedSizes(ctx context.Context, rootFolder storage.Folder, backupName string) error {
+	segments, ok, err := segmentsOfBackup(ctx, rootFolder, backupName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("can not read the sentinel of backup %s", backupName)
+	}
+
+	baseBackupsFolder := rootFolder.GetSubFolder(utility.BaseBackupPath)
+	for _, kind := range sharedStorageKinds() {
+		sum, ok := sumOverSegments(ctx, rootFolder, backupName, segments, kind)
+		if !ok {
+			// A partial sum would understate the real volume and be indistinguishable from a
+			// genuinely small one, so the object is left unwritten rather than written wrong. An
+			// absent object means "never determined", which a zero could not express.
+			continue
+		}
+
+		dto := SharedSizeDTO{SharedSize: sum}
+		if err := internal.UploadDto(ctx, baseBackupsFolder, dto, kind.path(backupName)); err != nil {
+			return fmt.Errorf("failed to upload the cluster-wide %s shared size: %w", kind.name, err)
+		}
+	}
+
+	return nil
+}
+
+// sumOverSegments adds up the volume every segment of the backup uploaded to one shared storage.
+//
+// A partial sum would silently understate the real volume, so a single segment failing to report
+// makes the whole aggregate unavailable (ok == false) rather than wrong.
+func sumOverSegments(ctx context.Context, rootFolder storage.Folder, backupName string,
+	segments []SegmentMetadata, kind sharedStorageKind) (int64, bool) {
+	sum := int64(0)
+	missing := make([]int, 0)
+	for _, meta := range segments {
+		if meta.BackupName == "" {
+			// Written by a WAL-G old enough not to record the segment backup name in the sentinel.
+			tracelog.WarningLogger.Printf("Sentinel does not name the backup of segment %d", meta.ContentID)
+			missing = append(missing, meta.ContentID)
+			continue
+		}
+
+		segFolder := rootFolder.GetSubFolder(FormatSegmentStoragePrefix(meta.ContentID)).
+			GetSubFolder(utility.BaseBackupPath)
+		size, err := kind.readSegmentSize(ctx, segFolder, meta.BackupName)
+		if err != nil {
+			// The segment backup was pushed by a WAL-G old enough not to report the uploaded volume.
+			tracelog.WarningLogger.Printf("Can not read the %s volume uploaded by segment %d backup %s: %v",
+				kind.name, meta.ContentID, meta.BackupName, err)
+			missing = append(missing, meta.ContentID)
+			continue
+		}
+
+		sum += size
+	}
+
+	if len(missing) > 0 {
+		tracelog.WarningLogger.Printf("The %s files metadata of backup %s is unavailable on segments %v, "+
+			"the cluster-wide shared volume can not be calculated", kind.name, backupName, missing)
+		return 0, false
+	}
+
+	tracelog.DebugLogger.Printf("Backup %s added %d bytes to the shared %s storage over %d segments",
+		backupName, sum, kind.name, len(segments))
+
+	return sum, true
+}
+
+// aoUploadedSizeView and paxUploadedSizeView are the parts of the segment files metadata needed to
+// learn the uploaded volume. The file lists those objects also carry are skipped: only the segments
+// have any use for them.
+type aoUploadedSizeView struct {
+	UploadedSharedSize int64
+}
+
+type paxUploadedSizeView struct {
+	UploadedSharedSize int64
+}
+
+func readUploadedAOSize(ctx context.Context, baseBackupsFolder storage.Folder, backupName string) (int64, error) {
+	var meta aoUploadedSizeView
+	if err := internal.FetchDto(ctx, baseBackupsFolder, &meta, getAOFilesMetadataPath(backupName)); err != nil {
+		return 0, err
+	}
+	return meta.UploadedSharedSize, nil
+}
+
+func readUploadedPaxSize(ctx context.Context, baseBackupsFolder storage.Folder, backupName string) (int64, error) {
+	var meta paxUploadedSizeView
+	if err := internal.FetchDto(ctx, baseBackupsFolder, &meta, pax.GetFilesMetadataPath(backupName)); err != nil {
+		return 0, err
+	}
+	return meta.UploadedSharedSize, nil
+}
+
+// FetchAOSharedSize is the volume backupName added to the shared AO/AOCS storage cluster-wide.
+// A missing object is an error rather than a zero: it means the volume was never determined.
+//
+// rootFolder must be the cluster root. Given a segment folder this would read that segment's files
+// metadata, which has no SharedSize, and report a zero.
+func FetchAOSharedSize(ctx context.Context, rootFolder storage.Folder, backupName string) (int64, error) {
+	return fetchSharedSize(ctx, rootFolder, getAOFilesMetadataPath(backupName))
+}
+
+// FetchPaxSharedSize is the volume backupName added to the shared PAX storage cluster-wide.
+func FetchPaxSharedSize(ctx context.Context, rootFolder storage.Folder, backupName string) (int64, error) {
+	return fetchSharedSize(ctx, rootFolder, pax.GetFilesMetadataPath(backupName))
+}
+
+func fetchSharedSize(ctx context.Context, rootFolder storage.Folder, path string) (int64, error) {
+	var dto SharedSizeDTO
+	if err := internal.FetchDto(ctx, rootFolder.GetSubFolder(utility.BaseBackupPath), &dto, path); err != nil {
+		return 0, err
+	}
+	return dto.SharedSize, nil
+}

--- a/internal/databases/greenplum/shared_size_test.go
+++ b/internal/databases/greenplum/shared_size_test.go
@@ -1,0 +1,121 @@
+package greenplum_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/internal/databases/greenplum"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/pax"
+	"github.com/wal-g/wal-g/pkg/storages/storage"
+	"github.com/wal-g/wal-g/testtools"
+	"github.com/wal-g/wal-g/utility"
+)
+
+func TestUploadSharedSizes(t *testing.T) {
+	segBackups := map[int]string{
+		-1: "base_000000010000000000000001",
+		0:  "base_000000010000000000000002",
+		1:  "base_000000010000000000000003",
+	}
+
+	t.Run("keeps the two shared storages in objects of their own", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, gpBackupName, segBackups)
+		putSegmentFilesMetadata(t, root, -1, segBackups[-1], 6, 4)
+		putSegmentFilesMetadata(t, root, 0, segBackups[0], 12, 8)
+		putSegmentFilesMetadata(t, root, 1, segBackups[1], 18, 12)
+
+		require.NoError(t, greenplum.UploadSharedSizes(t.Context(), root, gpBackupName))
+
+		aoSize, err := greenplum.FetchAOSharedSize(t.Context(), root, gpBackupName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(36), aoSize)
+
+		paxSize, err := greenplum.FetchPaxSharedSize(t.Context(), root, gpBackupName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(24), paxSize, "the PAX volume must not be folded into the AO one")
+	})
+
+	t.Run("a backup that added nothing shared records a zero", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, gpBackupName, segBackups)
+		for contentID, segBackup := range segBackups {
+			putSegmentFilesMetadata(t, root, contentID, segBackup, 0, 0)
+		}
+
+		require.NoError(t, greenplum.UploadSharedSizes(t.Context(), root, gpBackupName))
+
+		aoSize, err := greenplum.FetchAOSharedSize(t.Context(), root, gpBackupName)
+		require.NoError(t, err, "everything being deduplicated is a known zero, not a missing measurement")
+		assert.Zero(t, aoSize)
+	})
+
+	t.Run("leaves the object unwritten when a single segment does not report", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, gpBackupName, segBackups)
+		putSegmentFilesMetadata(t, root, -1, segBackups[-1], 6, 4)
+		putSegmentFilesMetadata(t, root, 0, segBackups[0], 12, 8)
+		// Segment 1 has no files metadata at all, so neither sum can be trusted.
+
+		require.NoError(t, greenplum.UploadSharedSizes(t.Context(), root, gpBackupName),
+			"an unavailable volume must not fail the whole backup-push")
+
+		_, err := greenplum.FetchAOSharedSize(t.Context(), root, gpBackupName)
+		assert.Error(t, err, "a partial sum must not be recorded as if it were the real volume")
+		_, err = greenplum.FetchPaxSharedSize(t.Context(), root, gpBackupName)
+		assert.Error(t, err)
+	})
+
+	t.Run("one storage staying unavailable does not hold back the other", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+		putGpSentinel(t, root, gpBackupName, segBackups)
+		for contentID, segBackup := range segBackups {
+			putSegmentAOFilesMetadata(t, root, contentID, segBackup, 5)
+		}
+		// None of the segments wrote PAX metadata, as on a cluster without PAX relations.
+
+		require.NoError(t, greenplum.UploadSharedSizes(t.Context(), root, gpBackupName))
+
+		aoSize, err := greenplum.FetchAOSharedSize(t.Context(), root, gpBackupName)
+		require.NoError(t, err)
+		assert.Equal(t, int64(15), aoSize)
+
+		_, err = greenplum.FetchPaxSharedSize(t.Context(), root, gpBackupName)
+		assert.Error(t, err)
+	})
+
+	t.Run("reports the backup being gone instead of recording a zero", func(t *testing.T) {
+		root := testtools.MakeDefaultInMemoryStorageFolder()
+
+		assert.Error(t, greenplum.UploadSharedSizes(t.Context(), root, gpBackupName))
+	})
+}
+
+// putSegmentFilesMetadata writes the two files metadata objects a segment backup-push leaves next
+// to its backup, each reporting the volume it uploaded to its shared storage.
+func putSegmentFilesMetadata(t *testing.T, root storage.Folder, contentID int, backupName string,
+	aoSize, paxSize int64) {
+	t.Helper()
+
+	putSegmentAOFilesMetadata(t, root, contentID, backupName, aoSize)
+
+	// The file list is there to keep the reader honest: it is what the size view must skip.
+	folder := root.GetSubFolder(greenplum.FormatSegmentStoragePrefix(contentID))
+	putDTO(t, folder, utility.BaseBackupPath+pax.GetFilesMetadataPath(backupName),
+		pax.FilesMetadataDTO{
+			Files:              pax.BackupFiles{"base/13/16385_pax/3": {StoragePath: "paxfiles/3", Kind: pax.FileKindData}},
+			UploadedSharedSize: paxSize,
+		})
+}
+
+func putSegmentAOFilesMetadata(t *testing.T, root storage.Folder, contentID int, backupName string, aoSize int64) {
+	t.Helper()
+
+	folder := root.GetSubFolder(greenplum.FormatSegmentStoragePrefix(contentID))
+	putDTO(t, folder, utility.BaseBackupPath+backupName+"/"+greenplum.AOFilesMetadataName,
+		greenplum.AOFilesMetadataDTO{
+			Files:              greenplum.BackupAOFiles{"1337.1": {StoragePath: "aosegments/1337.1", EOF: 4096}},
+			UploadedSharedSize: aoSize,
+		})
+}

--- a/internal/databases/greenplum/tar_ball_composer.go
+++ b/internal/databases/greenplum/tar_ball_composer.go
@@ -285,15 +285,30 @@ func (c *GpTarBallComposer) FinishComposing() (internal.TarFileSets, error) {
 		return nil, err
 	}
 
-	err = internal.UploadDto(c.reqCtx, c.uploader.Folder(), c.aoStorageUploader.GetFiles(), getAOFilesMetadataPath(c.backupName))
+	// The metadata carries the uploaded volume, so that the coordinator can sum it into the
+	// cluster-wide journal without the segments reporting it back through any other channel.
+	aoMeta := c.aoStorageUploader.GetFiles()
+	aoMeta.UploadedSharedSize, err = c.aoStorageUploader.UploadedDataSize()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the uploaded AO files size: %w", err)
+	}
+
+	err = internal.UploadDto(c.reqCtx, c.uploader.Folder(), aoMeta, getAOFilesMetadataPath(c.backupName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload AO files metadata: %v", err)
 	}
 
-	err = internal.UploadDto(c.reqCtx, c.uploader.Folder(), c.paxStorageUploader.GetFiles(), pax.GetFilesMetadataPath(c.backupName))
+	paxMeta := c.paxStorageUploader.GetFiles()
+	paxMeta.UploadedSharedSize, err = c.paxStorageUploader.UploadedDataSize()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the uploaded PAX files size: %w", err)
+	}
+
+	err = internal.UploadDto(c.reqCtx, c.uploader.Folder(), paxMeta, pax.GetFilesMetadataPath(c.backupName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload PAX files metadata: %v", err)
 	}
+
 	return c.tarFileSets, nil
 }
 


### PR DESCRIPTION
This PR adds shared part of backup (AO/AOCS/PAX) counting for Greenplum/Cloudberry.

Each segment's uploader now counts the bytes it actually pushed and records them as UploadedSharedSize in its own files metadata; the coordinator sums the segments into `basebackups_005/<backup>/{ao,pax}_files_metadata.json`.

Design decisions:
1. Shared Part counted in simplified way - for first version count only bytes uploaded during backup. No recalculation when older backups deleted.
2. Recorded on every backup-push, even for permanent backups: a permanent backup occupies the shared storage like any other. 
3. When a segment fails to report, the object is left unwritten rather than recorded as a zero.



