### PR TITLE
perf(zstd): reuse encoders across writers

### DIFF
--- a/internal/compression/zstd/compressor.go
+++ b/internal/compression/zstd/compressor.go
@@ -2,6 +2,7 @@ package zstd
 
 import (
 	"io"
+	"sync"
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/wal-g/wal-g/internal/ioextensions"
@@ -11,6 +12,79 @@ const (
 	AlgorithmName = "zstd"
 	FileExtension = "zst"
 )
+
+// encoderPools holds one pool of encoders per encoder level. Building an encoder
+// allocates its match tables and block buffers, and wal-g asks for a new writer
+// for every tar part and every WAL segment, so without reuse that setup cost is
+// paid once per uploaded member. Pools are keyed by level because a process can
+// hold both the registry default and a configured Compressor.
+//
+// sync.Pool is drained on every GC cycle, so the retained encoder state stays
+// bounded by the number of writers actually in flight.
+var encoderPools sync.Map // zstd.EncoderLevel -> *sync.Pool
+
+func encoderPool(level zstd.EncoderLevel) *sync.Pool {
+	if pool, ok := encoderPools.Load(level); ok {
+		return pool.(*sync.Pool)
+	}
+	pool, _ := encoderPools.LoadOrStore(level, &sync.Pool{
+		New: func() any {
+			encoder, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(level))
+			if err != nil {
+				panic(err)
+			}
+			return encoder
+		},
+	})
+	return pool.(*sync.Pool)
+}
+
+// pooledWriter encodes a single stream and hands its encoder back on Close.
+//
+// The encoder must be returned exactly once. CloseTar can reach Close a second
+// time, because a closed archive/tar.Writer reports success when closed again
+// and the cascade then closes the writer underneath it as well. An encoder
+// returned twice would be handed to two writers at once and both streams would
+// be encoded into whichever destination was reset last.
+type pooledWriter struct {
+	*zstd.Encoder
+	pool   *sync.Pool
+	once   sync.Once
+	closed bool
+}
+
+// Write and Flush refuse a closed writer with the same error the bare encoder
+// used to return. Without the check they would reach an encoder that may
+// already be reset onto another writer's destination and silently encode into
+// that stream instead of failing.
+
+func (writer *pooledWriter) Write(data []byte) (int, error) {
+	if writer.closed {
+		return 0, zstd.ErrEncoderClosed
+	}
+	return writer.Encoder.Write(data)
+}
+
+func (writer *pooledWriter) Flush() error {
+	if writer.closed {
+		return zstd.ErrEncoderClosed
+	}
+	return writer.Encoder.Flush()
+}
+
+func (writer *pooledWriter) Close() error {
+	var err error
+	writer.once.Do(func() {
+		writer.closed = true
+		err = writer.Encoder.Close()
+		// An encoder that failed to close is left out of the pool rather than
+		// recycled into the next backup member.
+		if err == nil {
+			writer.pool.Put(writer.Encoder)
+		}
+	})
+	return err
+}
 
 // Compressor writes zstd-compressed streams. A zero Level keeps the historical
 // default (zstd.SpeedDefault), so an unconfigured Compressor behaves as before.
@@ -23,14 +97,11 @@ func (compressor Compressor) NewWriter(writer io.Writer) ioextensions.WriteFlush
 	if level == 0 { // level not set: preserve the previous default
 		level = zstd.SpeedDefault
 	}
-	zw, err := zstd.NewWriter(writer,
-		zstd.WithEncoderLevel(level),
-	)
-	if err != nil {
-		panic(err)
-	}
+	pool := encoderPool(level)
+	encoder := pool.Get().(*zstd.Encoder)
+	encoder.Reset(writer)
 
-	return zw
+	return &pooledWriter{Encoder: encoder, pool: pool}
 }
 
 func (compressor Compressor) FileExtension() string {

--- a/internal/compression/zstd/compressor_test.go
+++ b/internal/compression/zstd/compressor_test.go
@@ -2,9 +2,11 @@ package zstd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -110,4 +112,179 @@ func TestEncoderLevelFromName(t *testing.T) {
 
 	_, ok = EncoderLevelFromName("nonsense")
 	assert.False(t, ok)
+}
+
+// benchPayload imitates a postgres WAL segment: mostly structured and
+// repetitive, with pockets of incompressible data.
+func benchPayload(n int) []byte {
+	buf := make([]byte, n)
+	rnd := rand.New(rand.NewSource(0x1337c0deb357beef))
+	for i := 0; i < n; i += 512 {
+		end := i + 512
+		if end > n {
+			end = n
+		}
+		if (i/512)%4 == 0 {
+			rnd.Read(buf[i:end])
+		} else {
+			for j := i; j < end; j++ {
+				buf[j] = byte(j % 71)
+			}
+		}
+	}
+	return buf
+}
+
+func roundtrip(t *testing.T, compressed *bytes.Buffer) []byte {
+	t.Helper()
+	reader, err := Decompressor{}.Decompress(compressed)
+	require.NoError(t, err)
+	decompressed, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	return decompressed
+}
+
+// A writer can be closed twice: archive/tar.Writer reports success when it is
+// closed again, so CascadeWriteCloser goes on to close the compressing writer
+// underneath a second time. The encoder must reach the pool only once, or two
+// later writers share it and one stream lands in the other's destination.
+func TestCloseTwiceKeepsEncodersIndependent(t *testing.T) {
+	var closedTwice bytes.Buffer
+	first := Compressor{}.NewWriter(&closedTwice)
+	_, err := first.Write([]byte("first stream"))
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	require.NoError(t, first.Close())
+
+	payloads := [][]byte{
+		bytes.Repeat([]byte("aaaa"), 1<<14),
+		bytes.Repeat([]byte("bbbb"), 1<<14),
+	}
+	buffers := make([]bytes.Buffer, len(payloads))
+	writers := make([]io.WriteCloser, len(payloads))
+	for i := range writers {
+		writers[i] = Compressor{}.NewWriter(&buffers[i])
+	}
+	for i := range writers {
+		_, err := writers[i].Write(payloads[i])
+		require.NoError(t, err, "writer %d", i)
+	}
+	for i := range writers {
+		require.NoError(t, writers[i].Close(), "writer %d", i)
+	}
+	for i := range writers {
+		assert.True(t, bytes.Equal(payloads[i], roundtrip(t, &buffers[i])),
+			"writer %d did not get its own data back", i)
+	}
+
+	assert.Equal(t, "first stream", string(roundtrip(t, &closedTwice)))
+}
+
+// Tar parts are compressed concurrently, so pooled encoders must never be
+// handed to two writers at once. Worth running under -race.
+func TestConcurrentWritersProduceIndependentStreams(t *testing.T) {
+	const writerCount = 8
+
+	payloads := make([][]byte, writerCount)
+	buffers := make([]bytes.Buffer, writerCount)
+	errs := make([]error, writerCount)
+	for i := range payloads {
+		payloads[i] = bytes.Repeat([]byte{byte('a' + i)}, 1<<18)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < writerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			writer := Compressor{}.NewWriter(&buffers[i])
+			if _, err := writer.Write(payloads[i]); err != nil {
+				errs[i] = err
+				return
+			}
+			errs[i] = writer.Close()
+		}()
+	}
+	wg.Wait()
+
+	for i := range payloads {
+		require.NoError(t, errs[i], "writer %d", i)
+		assert.True(t, bytes.Equal(payloads[i], roundtrip(t, &buffers[i])),
+			"writer %d did not get its own data back", i)
+	}
+}
+
+// Each level keeps its own pool, so a configured Compressor cannot draw an
+// encoder that was built for another level. A wrong-level encoder still
+// produces a valid stream, which is why this compares the bytes against a
+// reference rather than only checking that the roundtrip succeeds.
+func TestLevelsDoNotShareEncoders(t *testing.T) {
+	payload := benchPayload(1 << 16)
+	levels := []zstd.EncoderLevel{zstd.SpeedFastest, zstd.SpeedBestCompression}
+
+	want := make(map[zstd.EncoderLevel][]byte, len(levels))
+	for _, level := range levels {
+		var out bytes.Buffer
+		encoder, err := zstd.NewWriter(&out, zstd.WithEncoderLevel(level))
+		require.NoError(t, err)
+		_, err = encoder.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, encoder.Close())
+		want[level] = out.Bytes()
+	}
+
+	// The first round fills each pool, the second draws from it.
+	for round := range 2 {
+		for _, level := range levels {
+			var out bytes.Buffer
+			writer := Compressor{Level: level}.NewWriter(&out)
+			_, err := writer.Write(payload)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
+			assert.True(t, bytes.Equal(want[level], out.Bytes()),
+				"round %d: level %s produced the output of another level", round, level)
+		}
+	}
+}
+
+func BenchmarkCompressor(b *testing.B) {
+	for _, size := range []int{1 << 20, 16 << 20} {
+		payload := benchPayload(size)
+		b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			for i := 0; i < b.N; i++ {
+				writer := Compressor{}.NewWriter(io.Discard)
+				if _, err := writer.Write(payload); err != nil {
+					b.Fatal(err)
+				}
+				if err := writer.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// After Close the encoder may already serve another writer, so a late Write or
+// Flush must fail with the encoder's own closed error instead of reaching it.
+func TestWriteAfterCloseDoesNotTouchNextStream(t *testing.T) {
+	var first bytes.Buffer
+	writer := Compressor{}.NewWriter(&first)
+	_, err := writer.Write([]byte("first"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	var second bytes.Buffer
+	next := Compressor{}.NewWriter(&second)
+	_, err = writer.Write([]byte("intruder"))
+	assert.ErrorIs(t, err, zstd.ErrEncoderClosed)
+	assert.ErrorIs(t, writer.Flush(), zstd.ErrEncoderClosed)
+
+	_, err = next.Write([]byte("second"))
+	require.NoError(t, err)
+	require.NoError(t, next.Close())
+	assert.Equal(t, "second", string(roundtrip(t, &second)))
+	assert.Equal(t, "first", string(roundtrip(t, &first)))
 }


### PR DESCRIPTION
### Database name
All databases (compression is database agnostic).

# Pull request description

### Describe what this PR fixes
Implements the encoder reuse asked for in #2462. Every tar part and WAL segment built a fresh zstd encoder, so the encoder's match tables and buffers were allocated once per uploaded member. Encoders now live in a sync.Pool per level and are Reset onto the next destination in NewWriter.

benchstat over 10 runs on my machine (i7-1355U, Windows), old vs new, one member per op:

```
                    sec/op (old)   sec/op (new)   vs base
Compressor/1MiB     12.875m ± 31%   4.784m ± 14%  -62.84% (p=0.000)
Compressor/16MiB     53.40m ± 61%   52.70m ± 27%        ~ (p=1.000)

                    B/op (old)     B/op (new)     vs base
Compressor/1MiB     18720.0Ki      937.2Ki        -94.99% (p=0.000)
Compressor/16MiB    18735.9Ki      954.0Ki        -94.91% (p=0.000)
```

To be upfront about what this does and does not do: it removes per-writer setup and allocation cost. It does not touch block encoding itself, so on a profile like the one in the issue, where blockEnc.encode dominates, elapsed time on large members stays within noise. The win is allocations and GC pressure, plus real time on small members. My laptop numbers are noisy; I would be glad to have this measured on your stand as offered in the issue.

On the memory precaution from #2429/#2430: sync.Pool is drained every GC cycle, so retained encoder state is bounded by the number of writers actually in flight, not by history. The wrapper also returns its encoder to the pool exactly once and refuses Write and Flush after Close with the encoder's own closed error; without that, a double Close through CascadeWriteCloser could hand one encoder to two writers and corrupt both streams. Encoders whose Close failed are dropped rather than recycled. Each of those guards has a test that fails when the guard is removed.

### Please provide steps to reproduce (if it's a bug)
Not a bug. To compare: `go test -run XXX -bench BenchmarkCompressor -benchtime 20x -count 10 ./internal/compression/zstd/` on master and on this branch, then benchstat the two outputs.

### Please add config and wal-g stdout/stderr logs for debug purpose
Not applicable (no behavior change; output remains a standard single-frame zstd stream). Covered by unit tests in internal/compression/zstd/compressor_test.go, including double close, write after close, concurrent writers under the race detector, and per-level pool separation.
