### PR TITLE
MongoDB: resume oplog replay after mongod crash

### DIFF
--- a/docs/MongoDB.md
+++ b/docs/MongoDB.md
@@ -237,6 +237,16 @@ SINCE is included and UNTIL is NOT.
 wal-g oplog-replay 1593554109.1 1593559109.1
 ```
 
+During replay, WAL-G runs `fsync` periodically and remembers the last durable oplog timestamp in memory. The interval is
+configured with `OPLOG_REPLAY_FSYNC_INTERVAL` and defaults to `10m`.
+
+When `binary-backup-fetch` replays PITR data using its temporary `mongod`, WAL-G restarts that process after an unexpected
+exit and resumes after the last durable timestamp. `OPLOG_REPLAY_MAX_MONGOD_RESTARTS` limits consecutive restarts without
+durable progress and defaults to `5`.
+
+Recovery has at-least-once semantics: MongoDB may have persisted some operations after the last completed `fsync`, so an
+automatic restart can apply those operations again.
+
 ### Common constraints:
 
 - SINCE: operation timestamp before full backup started.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,6 +149,8 @@ const (
 	OplogReplayOplogAlwaysUpsert        = "OPLOG_REPLAY_OPLOG_ALWAYS_UPSERT"
 	OplogReplayOplogApplicationMode     = "OPLOG_REPLAY_OPLOG_APPLICATION_MODE"
 	OplogReplayIgnoreErrorCodes         = "OPLOG_REPLAY_IGNORE_ERROR_CODES"
+	OplogReplayFsyncInterval            = "OPLOG_REPLAY_FSYNC_INTERVAL"
+	OplogReplayMaxMongodRestarts        = "OPLOG_REPLAY_MAX_MONGOD_RESTARTS"
 	OplogRecoverTimeout                 = "OPLOG_RECOVER_TIMEOUT"
 
 	MysqlDatasourceNameSetting     = "WALG_MYSQL_DATASOURCE_NAME"

--- a/internal/databases/mongo/binary/managed_mongod.go
+++ b/internal/databases/mongo/binary/managed_mongod.go
@@ -1,0 +1,96 @@
+package binary
+
+import (
+	"context"
+	"time"
+
+	"github.com/wal-g/tracelog"
+)
+
+type supervisedMongod interface {
+	URI() string
+	Done() <-chan struct{}
+	Wait() error
+	Connect(context.Context) error
+	Shutdown(context.Context) error
+	Stop()
+	Close()
+}
+
+type managedMongod struct {
+	process *MongodProcess
+	service *MongodService
+	done    chan struct{}
+	waitErr error
+}
+
+func startManagedMongod(
+	ctx context.Context,
+	minimalConfigPath string,
+	replayArgs ReplyOplogConfig,
+) (supervisedMongod, error) {
+	process := Mongod(minimalConfigPath)
+	if !replayArgs.WithCatchUpReconfig {
+		process.WithParams(DisableLogicalSessionCacheRefresh, TakeUnstableCheckpointOnShutdown)
+	}
+	if replayArgs.Partial {
+		process.WithRestore()
+	}
+	if _, err := process.Start(ctx); err != nil {
+		return nil, err
+	}
+
+	mongod := &managedMongod{process: process, done: make(chan struct{})}
+	go func() {
+		mongod.waitErr = process.Wait()
+		close(mongod.done)
+	}()
+	return mongod, nil
+}
+
+func (m *managedMongod) URI() string {
+	return m.process.GetURI()
+}
+
+func (m *managedMongod) Done() <-chan struct{} {
+	return m.done
+}
+
+func (m *managedMongod) Wait() error {
+	<-m.done
+	return m.waitErr
+}
+
+func (m *managedMongod) Connect(ctx context.Context) error {
+	service, err := CreateMongodService(ctx, "wal-g oplog replay", m.URI(), 10*time.Minute)
+	if err != nil {
+		return err
+	}
+	m.service = service
+	return nil
+}
+
+func (m *managedMongod) Shutdown(ctx context.Context) error {
+	return m.service.Shutdown(ctx)
+}
+
+func (m *managedMongod) Stop() {
+	select {
+	case <-m.done:
+	default:
+		m.process.Close()
+	}
+}
+
+func (m *managedMongod) Close() {
+	m.Stop()
+	_ = m.Wait()
+	if m.service == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), mongoDisconnectTimeout)
+	defer cancel()
+	if err := m.service.MongoClient.Disconnect(ctx); err != nil {
+		tracelog.WarningLogger.Printf("Unable to disconnect supervised mongod client: %v", err)
+	}
+}

--- a/internal/databases/mongo/binary/mongod.go
+++ b/internal/databases/mongo/binary/mongod.go
@@ -15,7 +15,6 @@ import (
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
-	"github.com/wal-g/wal-g/internal/databases/mongo/stages"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
@@ -477,8 +476,6 @@ type ReplyOplogConfig struct {
 
 	FsyncInterval     time.Duration
 	MaxMongodRestarts int
-	progress          *stages.ReplayProgress
-	resumeAfter       bool
 }
 
 type ShConfig struct {

--- a/internal/databases/mongo/binary/mongod.go
+++ b/internal/databases/mongo/binary/mongod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"github.com/wal-g/wal-g/internal/databases/mongo/stages"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
@@ -472,6 +474,11 @@ type ReplyOplogConfig struct {
 
 	Whitelist map[string]map[string]struct{}
 	Blacklist map[string]map[string]struct{}
+
+	FsyncInterval     time.Duration
+	MaxMongodRestarts int
+	progress          *stages.ReplayProgress
+	resumeAfter       bool
 }
 
 type ShConfig struct {
@@ -511,6 +518,20 @@ func NewReplyOplogConfig(
 	var roConfig ReplyOplogConfig
 	var err error
 	roConfig.HasPitr = true
+	roConfig.FsyncInterval, err = conf.GetDurationSettingDefault(conf.OplogReplayFsyncInterval, 10*time.Minute)
+	if err != nil {
+		return roConfig, err
+	}
+	if roConfig.FsyncInterval <= 0 {
+		return roConfig, fmt.Errorf("%s must be positive", conf.OplogReplayFsyncInterval)
+	}
+	roConfig.MaxMongodRestarts = 5
+	if value, ok := conf.GetSetting(conf.OplogReplayMaxMongodRestarts); ok {
+		roConfig.MaxMongodRestarts, err = strconv.Atoi(value)
+		if err != nil || roConfig.MaxMongodRestarts < 0 {
+			return roConfig, fmt.Errorf("%s must be a non-negative integer", conf.OplogReplayMaxMongodRestarts)
+		}
+	}
 
 	// resolve archiving settings
 	downloader, err := archive.NewStorageDownloader(ctx, archive.NewDefaultStorageSettings())

--- a/internal/databases/mongo/binary/oplog_replay_supervisor.go
+++ b/internal/databases/mongo/binary/oplog_replay_supervisor.go
@@ -111,7 +111,7 @@ func (e replayAttemptExecutor) run(
 ) replayAttemptResult {
 	mongod, err := e.startMongod(ctx, minimalConfigPath, replayArgs)
 	if err != nil {
-		return classifyAttemptError(ctx, replayAttemptFailed,
+		return classifyAttemptError(ctx,
 			errors.Wrap(err, "unable to start mongod in special mode"))
 	}
 	defer mongod.Close()
@@ -128,10 +128,10 @@ func (e replayAttemptExecutor) run(
 		return processExitResult(ctx, mongod.Wait())
 	case connectErr := <-connectC:
 		if connectErr != nil {
-			if processErr, exited := exitedProcess(mongod); exited {
+			if exited, processErr := exitedProcess(mongod); exited {
 				return processExitResult(ctx, processErr)
 			}
-			return classifyAttemptError(ctx, replayAttemptFailed,
+			return classifyAttemptError(ctx,
 				errors.Wrap(connectErr, "unable to create mongod service"))
 		}
 	}
@@ -150,17 +150,17 @@ func (e replayAttemptExecutor) run(
 		}
 	}
 
-	if processErr, exited := exitedProcess(mongod); exited {
+	if exited, processErr := exitedProcess(mongod); exited {
 		return processExitResult(ctx, processErr)
 	}
 	if err := mongod.Shutdown(ctx); err != nil {
-		if processErr, exited := exitedProcess(mongod); exited {
+		if exited, processErr := exitedProcess(mongod); exited {
 			return processExitResult(ctx, processErr)
 		}
-		return classifyAttemptError(ctx, replayAttemptFailed, err)
+		return classifyAttemptError(ctx, err)
 	}
 	if err := mongod.Wait(); err != nil {
-		return classifyAttemptError(ctx, replayAttemptFailed, err)
+		return classifyAttemptError(ctx, err)
 	}
 	return replayAttemptResult{kind: replayAttemptCompleted}
 }
@@ -170,10 +170,10 @@ func (e replayAttemptExecutor) classifyReplayError(
 	mongod supervisedMongod,
 	replayErr error,
 ) replayAttemptResult {
-	if result := classifyAttemptError(ctx, replayAttemptFailed, replayErr); result.kind == replayAttemptCanceled {
+	if result := classifyAttemptError(ctx, replayErr); result.kind == replayAttemptCanceled {
 		return result
 	}
-	if processErr, exited := exitedProcess(mongod); exited {
+	if exited, processErr := exitedProcess(mongod); exited {
 		return processExitResult(ctx, processErr)
 	}
 
@@ -189,20 +189,20 @@ func (e replayAttemptExecutor) classifyReplayError(
 	}
 }
 
-func exitedProcess(mongod supervisedMongod) (error, bool) {
+func exitedProcess(mongod supervisedMongod) (bool, error) {
 	select {
 	case <-mongod.Done():
-		return mongod.Wait(), true
+		return true, mongod.Wait()
 	default:
-		return nil, false
+		return false, nil
 	}
 }
 
-func classifyAttemptError(ctx context.Context, fallback replayAttemptKind, err error) replayAttemptResult {
+func classifyAttemptError(ctx context.Context, err error) replayAttemptResult {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return replayAttemptResult{kind: replayAttemptCanceled, err: ctxErr}
 	}
-	return replayAttemptResult{kind: fallback, err: err}
+	return replayAttemptResult{kind: replayAttemptFailed, err: err}
 }
 
 func processExitResult(ctx context.Context, err error) replayAttemptResult {

--- a/internal/databases/mongo/binary/oplog_replay_supervisor.go
+++ b/internal/databases/mongo/binary/oplog_replay_supervisor.go
@@ -1,0 +1,218 @@
+package binary
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/mongo/stages"
+)
+
+const mongodExitDetectionTimeout = time.Second
+
+type oplogReplayAttempt struct {
+	checkpoint  stages.ReplayCheckpoint
+	progress    *stages.ReplayProgress
+	resumeAfter bool
+}
+
+type replayAttemptKind uint8
+
+const (
+	replayAttemptCompleted replayAttemptKind = iota
+	replayAttemptMongodExited
+	replayAttemptFailed
+	replayAttemptCanceled
+)
+
+type replayAttemptResult struct {
+	kind replayAttemptKind
+	err  error
+}
+
+type replayAttemptExecutor struct {
+	startMongod        func(context.Context, string, ReplyOplogConfig) (supervisedMongod, error)
+	replay             func(context.Context, string, ReplyOplogConfig, oplogReplayAttempt) error
+	exitDetectionDelay time.Duration
+}
+
+func newReplayAttemptExecutor() replayAttemptExecutor {
+	return replayAttemptExecutor{
+		startMongod:        startManagedMongod,
+		replay:             runOplogReplay,
+		exitDetectionDelay: mongodExitDetectionTimeout,
+	}
+}
+
+func runSupervisedOplogReplay(ctx context.Context, replayArgs ReplyOplogConfig) error {
+	progress := stages.NewReplayProgress(replayArgs.Since)
+	executor := newReplayAttemptExecutor()
+	return superviseOplogReplay(ctx, replayArgs, progress, func(attempt oplogReplayAttempt) replayAttemptResult {
+		return executor.run(ctx, replayArgs, attempt, replayArgs.MinimalConfigPath)
+	})
+}
+
+func superviseOplogReplay(
+	ctx context.Context,
+	replayArgs ReplyOplogConfig,
+	progress *stages.ReplayProgress,
+	runAttempt func(oplogReplayAttempt) replayAttemptResult,
+) error {
+	consecutiveRestarts := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		checkpointBefore := progress.Snapshot()
+		result := runAttempt(oplogReplayAttempt{
+			checkpoint:  checkpointBefore,
+			progress:    progress,
+			resumeAfter: checkpointBefore.Generation > 0,
+		})
+
+		switch result.kind {
+		case replayAttemptCompleted:
+			return nil
+		case replayAttemptCanceled:
+			return result.err
+		case replayAttemptFailed:
+			return result.err
+		case replayAttemptMongodExited:
+		default:
+			return fmt.Errorf("unknown oplog replay attempt result: %d", result.kind)
+		}
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		checkpointAfter := progress.Snapshot()
+		if checkpointAfter.Generation > checkpointBefore.Generation {
+			consecutiveRestarts = 0
+		}
+		if consecutiveRestarts >= replayArgs.MaxMongodRestarts {
+			return errors.Wrapf(result.err,
+				"supervised mongod crashed after %d restarts, last durable oplog timestamp is %s",
+				consecutiveRestarts, checkpointAfter.OpTime.TS)
+		}
+		consecutiveRestarts++
+		tracelog.WarningLogger.Printf(
+			"supervised mongod crashed, restarting oplog replay after %s, attempt %d/%d",
+			checkpointAfter.OpTime.TS, consecutiveRestarts, replayArgs.MaxMongodRestarts)
+	}
+}
+
+func (e replayAttemptExecutor) run(
+	ctx context.Context,
+	replayArgs ReplyOplogConfig,
+	attempt oplogReplayAttempt,
+	minimalConfigPath string,
+) replayAttemptResult {
+	mongod, err := e.startMongod(ctx, minimalConfigPath, replayArgs)
+	if err != nil {
+		return classifyAttemptError(ctx, replayAttemptFailed,
+			errors.Wrap(err, "unable to start mongod in special mode"))
+	}
+	defer mongod.Close()
+
+	attemptCtx, cancelAttempt := context.WithCancel(ctx)
+	defer cancelAttempt()
+
+	connectC := make(chan error, 1)
+	go func() { connectC <- mongod.Connect(attemptCtx) }()
+	select {
+	case <-mongod.Done():
+		cancelAttempt()
+		<-connectC
+		return processExitResult(ctx, mongod.Wait())
+	case connectErr := <-connectC:
+		if connectErr != nil {
+			if processErr, exited := exitedProcess(mongod); exited {
+				return processExitResult(ctx, processErr)
+			}
+			return classifyAttemptError(ctx, replayAttemptFailed,
+				errors.Wrap(connectErr, "unable to create mongod service"))
+		}
+	}
+
+	replayC := make(chan error, 1)
+	go func() { replayC <- e.replay(attemptCtx, mongod.URI(), replayArgs, attempt) }()
+
+	select {
+	case <-mongod.Done():
+		cancelAttempt()
+		<-replayC
+		return processExitResult(ctx, mongod.Wait())
+	case replayErr := <-replayC:
+		if replayErr != nil {
+			return e.classifyReplayError(ctx, mongod, replayErr)
+		}
+	}
+
+	if processErr, exited := exitedProcess(mongod); exited {
+		return processExitResult(ctx, processErr)
+	}
+	if err := mongod.Shutdown(ctx); err != nil {
+		if processErr, exited := exitedProcess(mongod); exited {
+			return processExitResult(ctx, processErr)
+		}
+		return classifyAttemptError(ctx, replayAttemptFailed, err)
+	}
+	if err := mongod.Wait(); err != nil {
+		return classifyAttemptError(ctx, replayAttemptFailed, err)
+	}
+	return replayAttemptResult{kind: replayAttemptCompleted}
+}
+
+func (e replayAttemptExecutor) classifyReplayError(
+	ctx context.Context,
+	mongod supervisedMongod,
+	replayErr error,
+) replayAttemptResult {
+	if result := classifyAttemptError(ctx, replayAttemptFailed, replayErr); result.kind == replayAttemptCanceled {
+		return result
+	}
+	if processErr, exited := exitedProcess(mongod); exited {
+		return processExitResult(ctx, processErr)
+	}
+
+	timer := time.NewTimer(e.exitDetectionDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return replayAttemptResult{kind: replayAttemptCanceled, err: ctx.Err()}
+	case <-mongod.Done():
+		return processExitResult(ctx, mongod.Wait())
+	case <-timer.C:
+		return replayAttemptResult{kind: replayAttemptFailed, err: replayErr}
+	}
+}
+
+func exitedProcess(mongod supervisedMongod) (error, bool) {
+	select {
+	case <-mongod.Done():
+		return mongod.Wait(), true
+	default:
+		return nil, false
+	}
+}
+
+func classifyAttemptError(ctx context.Context, fallback replayAttemptKind, err error) replayAttemptResult {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return replayAttemptResult{kind: replayAttemptCanceled, err: ctxErr}
+	}
+	return replayAttemptResult{kind: fallback, err: err}
+}
+
+func processExitResult(ctx context.Context, err error) replayAttemptResult {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return replayAttemptResult{kind: replayAttemptCanceled, err: ctxErr}
+	}
+	if err == nil {
+		err = fmt.Errorf("supervised mongod exited unexpectedly during oplog replay")
+	} else {
+		err = errors.Wrap(err, "supervised mongod exited during oplog replay")
+	}
+	return replayAttemptResult{kind: replayAttemptMongodExited, err: err}
+}

--- a/internal/databases/mongo/binary/oplog_replay_supervisor_test.go
+++ b/internal/databases/mongo/binary/oplog_replay_supervisor_test.go
@@ -1,0 +1,138 @@
+package binary
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"github.com/wal-g/wal-g/internal/databases/mongo/stages"
+)
+
+func TestSuperviseOplogReplayCarriesDurableOpTimeIntoNextAttempt(t *testing.T) {
+	progress := stages.NewReplayProgress(models.Timestamp{TS: 100, Inc: 1})
+	durable := models.OpTime{TS: models.Timestamp{TS: 101, Inc: 2}, Term: 7}
+	attempts := 0
+
+	err := superviseOplogReplay(t.Context(), ReplyOplogConfig{MaxMongodRestarts: 1}, progress,
+		func(attempt oplogReplayAttempt) replayAttemptResult {
+			attempts++
+			if attempts == 1 {
+				require.False(t, attempt.resumeAfter)
+				progress.MarkDurable(durable)
+				return replayAttemptResult{kind: replayAttemptMongodExited, err: errors.New("crash")}
+			}
+			require.True(t, attempt.resumeAfter)
+			require.Equal(t, durable, attempt.checkpoint.OpTime)
+			return replayAttemptResult{kind: replayAttemptCompleted}
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+}
+
+func TestSuperviseOplogReplayStopsAfterConsecutiveCrashes(t *testing.T) {
+	progress := stages.NewReplayProgress(models.Timestamp{TS: 100, Inc: 1})
+	attempts := 0
+
+	err := superviseOplogReplay(t.Context(), ReplyOplogConfig{MaxMongodRestarts: 2}, progress,
+		func(oplogReplayAttempt) replayAttemptResult {
+			attempts++
+			return replayAttemptResult{kind: replayAttemptMongodExited, err: errors.New("crash")}
+		})
+
+	require.ErrorContains(t, err, "crashed after 2 restarts")
+	require.Equal(t, 3, attempts)
+}
+
+func TestSuperviseOplogReplayStopsOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	progress := stages.NewReplayProgress(models.Timestamp{TS: 100, Inc: 1})
+	attempts := 0
+
+	err := superviseOplogReplay(ctx, ReplyOplogConfig{MaxMongodRestarts: 5}, progress,
+		func(oplogReplayAttempt) replayAttemptResult {
+			attempts++
+			cancel()
+			return replayAttemptResult{kind: replayAttemptMongodExited, err: errors.New("killed")}
+		})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, attempts)
+}
+
+func TestReplayAttemptExecutorClassifiesStartupCrash(t *testing.T) {
+	processErr := errors.New("process crashed")
+	mongod := newFakeSupervisedMongod(processErr)
+	mongod.connectErr = errors.New("connect failed")
+	mongod.exit()
+	executor := replayAttemptExecutor{
+		startMongod: func(context.Context, string, ReplyOplogConfig) (supervisedMongod, error) {
+			return mongod, nil
+		},
+		replay: func(context.Context, string, ReplyOplogConfig, oplogReplayAttempt) error {
+			t.Fatal("replay must not start after a startup crash")
+			return nil
+		},
+		exitDetectionDelay: time.Millisecond,
+	}
+
+	result := executor.run(t.Context(), ReplyOplogConfig{}, oplogReplayAttempt{}, "config")
+
+	require.Equal(t, replayAttemptMongodExited, result.kind)
+	require.ErrorIs(t, result.err, processErr)
+}
+
+type fakeSupervisedMongod struct {
+	mu         sync.Mutex
+	done       chan struct{}
+	waitErr    error
+	connectErr error
+}
+
+func newFakeSupervisedMongod(waitErr error) *fakeSupervisedMongod {
+	return &fakeSupervisedMongod{done: make(chan struct{}), waitErr: waitErr}
+}
+
+func (m *fakeSupervisedMongod) URI() string {
+	return "mongodb://localhost:27017"
+}
+
+func (m *fakeSupervisedMongod) Done() <-chan struct{} {
+	return m.done
+}
+
+func (m *fakeSupervisedMongod) Wait() error {
+	<-m.done
+	return m.waitErr
+}
+
+func (m *fakeSupervisedMongod) Connect(context.Context) error {
+	return m.connectErr
+}
+
+func (m *fakeSupervisedMongod) Shutdown(context.Context) error {
+	m.exit()
+	return nil
+}
+
+func (m *fakeSupervisedMongod) Stop() {
+	m.exit()
+}
+
+func (m *fakeSupervisedMongod) Close() {
+	m.exit()
+}
+
+func (m *fakeSupervisedMongod) exit() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	select {
+	case <-m.done:
+	default:
+		close(m.done)
+	}
+}

--- a/internal/databases/mongo/binary/oplog_reply.go
+++ b/internal/databases/mongo/binary/oplog_reply.go
@@ -148,8 +148,10 @@ func runInlineOplogReplayAttempt(
 	replayArgs ReplyOplogConfig,
 	minimalConfigPath string,
 ) (bool, error) {
-	mongodProcess := Mongod(minimalConfigPath).
-		WithParams(DisableLogicalSessionCacheRefresh, TakeUnstableCheckpointOnShutdown)
+	mongodProcess := Mongod(minimalConfigPath)
+	if !replayArgs.WithCatchUpReconfig {
+		mongodProcess.WithParams(DisableLogicalSessionCacheRefresh, TakeUnstableCheckpointOnShutdown)
+	}
 	if replayArgs.Partial {
 		mongodProcess.WithRestore()
 	}
@@ -162,11 +164,32 @@ func runInlineOplogReplayAttempt(
 	attemptCtx, cancelAttempt := context.WithCancel(ctx)
 	defer cancelAttempt()
 
-	mongodService, err := CreateMongodService(attemptCtx, "wal-g oplog replay", mongodProcess.GetURI(), 10*time.Minute)
-	if err != nil {
-		mongodProcess.Close()
-		<-waitC
-		return false, errors.Wrap(err, "unable to create mongod service")
+	serviceC := make(chan struct {
+		service *MongodService
+		err     error
+	}, 1)
+	go func() {
+		service, err := CreateMongodService(
+			attemptCtx, "wal-g oplog replay", mongodProcess.GetURI(), 10*time.Minute)
+		serviceC <- struct {
+			service *MongodService
+			err     error
+		}{service: service, err: err}
+	}()
+
+	var mongodService *MongodService
+	select {
+	case processErr := <-waitC:
+		cancelAttempt()
+		<-serviceC
+		return true, unexpectedMongodExit(processErr)
+	case result := <-serviceC:
+		if result.err != nil {
+			mongodProcess.Close()
+			<-waitC
+			return false, errors.Wrap(result.err, "unable to create mongod service")
+		}
+		mongodService = result.service
 	}
 
 	replayC := make(chan error, 1)
@@ -191,7 +214,7 @@ func runInlineOplogReplayAttempt(
 			}
 		}
 
-		if err = mongodService.Shutdown(ctx); err != nil {
+		if err := mongodService.Shutdown(ctx); err != nil {
 			mongodProcess.Close()
 			<-waitC
 			return false, err

--- a/internal/databases/mongo/binary/oplog_reply.go
+++ b/internal/databases/mongo/binary/oplog_reply.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/client"
@@ -15,18 +14,25 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const (
-	mongodExitDetectionTimeout = time.Second
-)
+const mongoDisconnectTimeout = 30 * time.Second
 
 func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplogConfig) error {
 	if replayArgs.MinimalConfigPath != "" {
 		return runSupervisedOplogReplay(ctx, replayArgs)
 	}
-	return runOplogReplay(ctx, mongodbURL, replayArgs)
+	progress := stages.NewReplayProgress(replayArgs.Since)
+	return runOplogReplay(ctx, mongodbURL, replayArgs, oplogReplayAttempt{
+		checkpoint: progress.Snapshot(),
+		progress:   progress,
+	})
 }
 
-func runOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplogConfig) error {
+func runOplogReplay(
+	ctx context.Context,
+	mongodbURL string,
+	replayArgs ReplyOplogConfig,
+	attempt oplogReplayAttempt,
+) (err error) {
 	// set up mongodb client and oplog applier
 	var mongoClientArgs []client.Option
 	if replayArgs.OplogAlwaysUpsert != nil {
@@ -42,23 +48,27 @@ func runOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 	if err != nil {
 		return err
 	}
+	defer func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), mongoDisconnectTimeout)
+		defer cancel()
+		if closeErr := mongoClient.Close(closeCtx, false); err == nil && closeErr != nil {
+			err = fmt.Errorf("can not close mongodb client: %w", closeErr)
+		}
+	}()
 
+	since := attempt.checkpoint.OpTime.TS
 	var emptyTS models.Timestamp
-	if replayArgs.Since == emptyTS {
+	if since == emptyTS {
 		if replayArgs.WithCatchUpReconfig {
-			replayArgs.Since, err = mongoClient.CatchUpStartTS(ctx)
+			since, err = mongoClient.CatchUpStartTS(ctx)
 		} else {
-			replayArgs.Since, err = mongoClient.LastOplogTS(ctx)
+			since, err = mongoClient.LastOplogTS(ctx)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	if replayArgs.progress == nil {
-		replayArgs.progress = stages.NewReplayProgress(replayArgs.Since)
-	} else {
-		replayArgs.progress.Initialize(replayArgs.Since)
-	}
+	attempt.progress.Initialize(since)
 
 	if err = mongoClient.EnsureIsMaster(ctx); err != nil {
 		return err
@@ -70,7 +80,6 @@ func runOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 		// the replica can rejoin replSet without NamespaceNotFound on master's UUIDs
 		PreserveUUID:   replayArgs.WithCatchUpReconfig,
 		Partial:        replayArgs.Partial,
-		InitMongo:      false,
 		Reconfig:       replayArgs.WithCatchUpReconfig,
 		IgnoreErrCodes: replayArgs.IgnoreErrCodes,
 	})
@@ -78,7 +87,7 @@ func runOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 		mongoClient,
 		dbApplier,
 		replayArgs.FsyncInterval,
-		replayArgs.progress,
+		attempt.progress,
 	)
 
 	// set up storage downloader client
@@ -87,144 +96,41 @@ func runOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 		return err
 	}
 
-	path, err := resolveOplogReplaySequence(ctx, downloader, replayArgs.Since, replayArgs.Until)
+	path, err := resolveOplogReplaySequence(ctx, downloader, since, replayArgs.Until)
 	if err != nil {
 		return err
 	}
 
 	// setup storage fetcher
 	oplogFetcher := stages.NewStorageFetcher(downloader, path)
-	if replayArgs.resumeAfter {
+	if attempt.resumeAfter {
 		oplogFetcher.WithResumeAfter()
 	}
 
 	// run worker cycle
-	return HandleOplogReplay(ctx, replayArgs.Since, replayArgs.Until, oplogFetcher, oplogApplier)
-}
-
-func runSupervisedOplogReplay(ctx context.Context, replayArgs ReplyOplogConfig) error {
-	progress := stages.NewReplayProgress(replayArgs.Since)
-	consecutiveRestarts := 0
-
-	for {
-		durableTS, generationBefore := progress.Snapshot()
-
-		replayAttemptConfig := replayArgs
-		replayAttemptConfig.MinimalConfigPath = ""
-		replayAttemptConfig.Since = durableTS
-		replayAttemptConfig.progress = progress
-		replayAttemptConfig.resumeAfter = generationBefore > 0
-
-		mongodExited, err := runSupervisedOplogReplayAttempt(
-			ctx, replayAttemptConfig, replayArgs.MinimalConfigPath)
-		if err == nil {
-			return nil
-		}
-		if !mongodExited {
-			return err
-		}
-
-		durableTS, generationAfter := progress.Snapshot()
-		if generationAfter > generationBefore {
-			consecutiveRestarts = 0
-		}
-		if consecutiveRestarts >= replayArgs.MaxMongodRestarts {
-			return errors.Wrapf(err,
-				"supervised mongod crashed after %d restarts, last durable oplog timestamp is %s",
-				consecutiveRestarts, durableTS)
-		}
-		consecutiveRestarts++
-		tracelog.WarningLogger.Printf(
-			"supervised mongod crashed, restarting oplog replay after %s, attempt %d/%d",
-			durableTS, consecutiveRestarts, replayArgs.MaxMongodRestarts)
+	if err = HandleOplogReplay(ctx, since, replayArgs.Until, oplogFetcher, oplogApplier); err != nil {
+		return err
 	}
+	if err = finalizeCatchUp(ctx, replayArgs, mongoClient, attempt.progress); err != nil {
+		return err
+	}
+	return nil
 }
 
-func runSupervisedOplogReplayAttempt(
+func finalizeCatchUp(
 	ctx context.Context,
 	replayArgs ReplyOplogConfig,
-	minimalConfigPath string,
-) (bool, error) {
-	mongodProcess := Mongod(minimalConfigPath)
+	db client.MongoDriver,
+	progress *stages.ReplayProgress,
+) error {
 	if !replayArgs.WithCatchUpReconfig {
-		mongodProcess.WithParams(DisableLogicalSessionCacheRefresh, TakeUnstableCheckpointOnShutdown)
+		return nil
 	}
-	if replayArgs.Partial {
-		mongodProcess.WithRestore()
+	checkpoint := progress.Snapshot()
+	if checkpoint.Generation == 0 {
+		return nil
 	}
-	if _, err := mongodProcess.Start(ctx); err != nil {
-		return false, errors.Wrap(err, "unable to start mongod in special mode")
-	}
-
-	waitC := make(chan error, 1)
-	go func() { waitC <- mongodProcess.Wait() }()
-	attemptCtx, cancelAttempt := context.WithCancel(ctx)
-	defer cancelAttempt()
-
-	serviceC := make(chan struct {
-		service *MongodService
-		err     error
-	}, 1)
-	go func() {
-		service, err := CreateMongodService(
-			attemptCtx, "wal-g oplog replay", mongodProcess.GetURI(), 10*time.Minute)
-		serviceC <- struct {
-			service *MongodService
-			err     error
-		}{service: service, err: err}
-	}()
-
-	var mongodService *MongodService
-	select {
-	case processErr := <-waitC:
-		cancelAttempt()
-		<-serviceC
-		return true, unexpectedMongodExit(processErr)
-	case result := <-serviceC:
-		if result.err != nil {
-			mongodProcess.Close()
-			<-waitC
-			return false, errors.Wrap(result.err, "unable to create mongod service")
-		}
-		mongodService = result.service
-	}
-
-	replayC := make(chan error, 1)
-	go func() { replayC <- runOplogReplay(attemptCtx, mongodProcess.GetURI(), replayArgs) }()
-
-	select {
-	case processErr := <-waitC:
-		cancelAttempt()
-		<-replayC
-		return true, unexpectedMongodExit(processErr)
-
-	case replayErr := <-replayC:
-		if replayErr != nil {
-			select {
-			case processErr := <-waitC:
-				return true, unexpectedMongodExit(processErr)
-			// The driver may report a broken connection just before cmd.Wait publishes the process exit.
-			case <-time.After(mongodExitDetectionTimeout):
-				mongodProcess.Close()
-				<-waitC
-				return false, replayErr
-			}
-		}
-
-		if err := mongodService.Shutdown(ctx); err != nil {
-			mongodProcess.Close()
-			<-waitC
-			return false, err
-		}
-		return false, <-waitC
-	}
-}
-
-func unexpectedMongodExit(err error) error {
-	if err == nil {
-		return fmt.Errorf("supervised mongod exited unexpectedly during oplog replay")
-	}
-	return errors.Wrap(err, "supervised mongod exited during oplog replay")
+	return db.ChangeOplogLastTimestamp(ctx, checkpoint.OpTime)
 }
 
 func resolveOplogReplaySequence(

--- a/internal/databases/mongo/binary/oplog_reply.go
+++ b/internal/databases/mongo/binary/oplog_reply.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	"github.com/wal-g/wal-g/internal/databases/mongo/client"
@@ -15,15 +16,20 @@ import (
 )
 
 const (
-	inlineMongodShutdownTimeout = 30 * time.Second
-	mongodExitDetectionTimeout  = time.Second
+	mongodExitDetectionTimeout = time.Second
 )
 
 func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplogConfig) error {
 	if replayArgs.FsyncInterval <= 0 {
 		replayArgs.FsyncInterval = 10 * time.Minute
 	}
+	if replayArgs.MinimalConfigPath != "" {
+		return runInlineOplogReplay(ctx, replayArgs)
+	}
+	return runOplogReplay(ctx, mongodbURL, replayArgs)
+}
 
+func runOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplogConfig) error {
 	// set up mongodb client and oplog applier
 	var mongoClientArgs []client.Option
 	if replayArgs.OplogAlwaysUpsert != nil {
@@ -33,35 +39,6 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 	if replayArgs.OplogApplicationMode != nil {
 		mongoClientArgs = append(mongoClientArgs,
 			client.OplogApplicationMode(client.OplogAppMode(*replayArgs.OplogApplicationMode)))
-	}
-
-	initMongo := replayArgs.MinimalConfigPath != ""
-	if initMongo {
-		mongodProcess, err := Mongod(replayArgs.MinimalConfigPath).Start(ctx)
-		if err != nil {
-			return err
-		}
-		// Wait for inline mongod to actually exit before unwind: applier.Close
-		// issues graceful `shutdown` admin command on happy path (db.Close with
-		// initMongo=true), but Close() alone only SIGKILLs and races WiredTiger
-		// checkpoint, leaving mongod.lock that breaks subsequent restart (e.g.
-		// chown + supervisorctl in catch_up_stale_replica.feature). SIGKILL
-		// fallback covers early-error paths where shutdown is never sent.
-		defer func() {
-			done := make(chan struct{})
-			go func() {
-				_ = mongodProcess.Wait()
-				close(done)
-			}()
-			select {
-			case <-done:
-			case <-time.After(inlineMongodShutdownTimeout):
-				tracelog.WarningLogger.Printf("inline mongod did not exit gracefully within %s, killing", inlineMongodShutdownTimeout)
-				mongodProcess.Close()
-				<-done
-			}
-		}()
-		mongodbURL = mongodProcess.GetURI()
 	}
 
 	mongoClient, err := client.NewMongoClient(ctx, mongodbURL, mongoClientArgs...)
@@ -82,6 +59,8 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 	}
 	if replayArgs.progress == nil {
 		replayArgs.progress = stages.NewReplayProgress(replayArgs.Since)
+	} else {
+		replayArgs.progress.Initialize(replayArgs.Since)
 	}
 
 	if err = mongoClient.EnsureIsMaster(ctx); err != nil {
@@ -94,7 +73,7 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 		// the replica can rejoin replSet without NamespaceNotFound on master's UUIDs
 		PreserveUUID:   replayArgs.WithCatchUpReconfig,
 		Partial:        replayArgs.Partial,
-		InitMongo:      initMongo,
+		InitMongo:      false,
 		Reconfig:       replayArgs.WithCatchUpReconfig,
 		IgnoreErrCodes: replayArgs.IgnoreErrCodes,
 	})
@@ -124,6 +103,108 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 
 	// run worker cycle
 	return HandleOplogReplay(ctx, replayArgs.Since, replayArgs.Until, oplogFetcher, oplogApplier)
+}
+
+func runInlineOplogReplay(ctx context.Context, replayArgs ReplyOplogConfig) error {
+	progress := stages.NewReplayProgress(replayArgs.Since)
+	consecutiveRestarts := 0
+
+	for {
+		_, durableTS, generationBefore := progress.Snapshot()
+		progress.ResetAttempt()
+
+		attemptConfig := replayArgs
+		attemptConfig.MinimalConfigPath = ""
+		attemptConfig.Since = durableTS
+		attemptConfig.progress = progress
+		attemptConfig.resumeAfter = generationBefore > 0
+
+		mongodCrashed, err := runInlineOplogReplayAttempt(ctx, attemptConfig, replayArgs.MinimalConfigPath)
+		if err == nil {
+			return nil
+		}
+		if !mongodCrashed {
+			return err
+		}
+
+		_, durableTS, generationAfter := progress.Snapshot()
+		if generationAfter > generationBefore {
+			consecutiveRestarts = 0
+		}
+		if consecutiveRestarts >= replayArgs.MaxMongodRestarts {
+			return errors.Wrapf(err,
+				"inline mongod crashed after %d restarts, last durable oplog timestamp is %s",
+				consecutiveRestarts, durableTS)
+		}
+		consecutiveRestarts++
+		tracelog.WarningLogger.Printf(
+			"inline mongod crashed, restarting oplog replay after %s, attempt %d/%d",
+			durableTS, consecutiveRestarts, replayArgs.MaxMongodRestarts)
+	}
+}
+
+func runInlineOplogReplayAttempt(
+	ctx context.Context,
+	replayArgs ReplyOplogConfig,
+	minimalConfigPath string,
+) (bool, error) {
+	mongodProcess := Mongod(minimalConfigPath).
+		WithParams(DisableLogicalSessionCacheRefresh, TakeUnstableCheckpointOnShutdown)
+	if replayArgs.Partial {
+		mongodProcess.WithRestore()
+	}
+	if _, err := mongodProcess.Start(ctx); err != nil {
+		return false, errors.Wrap(err, "unable to start mongod in special mode")
+	}
+
+	waitC := make(chan error, 1)
+	go func() { waitC <- mongodProcess.Wait() }()
+	attemptCtx, cancelAttempt := context.WithCancel(ctx)
+	defer cancelAttempt()
+
+	mongodService, err := CreateMongodService(attemptCtx, "wal-g oplog replay", mongodProcess.GetURI(), 10*time.Minute)
+	if err != nil {
+		mongodProcess.Close()
+		<-waitC
+		return false, errors.Wrap(err, "unable to create mongod service")
+	}
+
+	replayC := make(chan error, 1)
+	go func() { replayC <- runOplogReplay(attemptCtx, mongodProcess.GetURI(), replayArgs) }()
+
+	select {
+	case processErr := <-waitC:
+		cancelAttempt()
+		<-replayC
+		return true, unexpectedMongodExit(processErr)
+
+	case replayErr := <-replayC:
+		if replayErr != nil {
+			select {
+			case processErr := <-waitC:
+				return true, unexpectedMongodExit(processErr)
+			// The driver may report a broken connection just before cmd.Wait publishes the process exit.
+			case <-time.After(mongodExitDetectionTimeout):
+				mongodProcess.Close()
+				<-waitC
+				return false, replayErr
+			}
+		}
+
+		if err = mongodService.Shutdown(ctx); err != nil {
+			mongodProcess.Close()
+			<-waitC
+			return false, err
+		}
+		return false, <-waitC
+	}
+}
+
+func unexpectedMongodExit(err error) error {
+	if err == nil {
+		return fmt.Errorf("inline mongod exited unexpectedly during oplog replay")
+	}
+	return errors.Wrap(err, "inline mongod exited during oplog replay")
 }
 
 func resolveOplogReplaySequence(

--- a/internal/databases/mongo/binary/oplog_reply.go
+++ b/internal/databases/mongo/binary/oplog_reply.go
@@ -14,9 +14,16 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const inlineMongodShutdownTimeout = 30 * time.Second
+const (
+	inlineMongodShutdownTimeout = 30 * time.Second
+	mongodExitDetectionTimeout  = time.Second
+)
 
 func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplogConfig) error {
+	if replayArgs.FsyncInterval <= 0 {
+		replayArgs.FsyncInterval = 10 * time.Minute
+	}
+
 	// set up mongodb client and oplog applier
 	var mongoClientArgs []client.Option
 	if replayArgs.OplogAlwaysUpsert != nil {
@@ -73,6 +80,9 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 			return err
 		}
 	}
+	if replayArgs.progress == nil {
+		replayArgs.progress = stages.NewReplayProgress(replayArgs.Since)
+	}
 
 	if err = mongoClient.EnsureIsMaster(ctx); err != nil {
 		return err
@@ -88,7 +98,12 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 		Reconfig:       replayArgs.WithCatchUpReconfig,
 		IgnoreErrCodes: replayArgs.IgnoreErrCodes,
 	})
-	oplogApplier := stages.NewGenericApplier(dbApplier)
+	oplogApplier := stages.NewCheckpointingApplier(
+		mongoClient,
+		dbApplier,
+		replayArgs.FsyncInterval,
+		replayArgs.progress,
+	)
 
 	// set up storage downloader client
 	downloader, err := archive.NewStorageDownloader(ctx, archive.NewDefaultStorageSettings())
@@ -103,6 +118,9 @@ func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 
 	// setup storage fetcher
 	oplogFetcher := stages.NewStorageFetcher(downloader, path)
+	if replayArgs.resumeAfter {
+		oplogFetcher.WithResumeAfter()
+	}
 
 	// run worker cycle
 	return HandleOplogReplay(ctx, replayArgs.Since, replayArgs.Until, oplogFetcher, oplogApplier)

--- a/internal/databases/mongo/binary/oplog_reply.go
+++ b/internal/databases/mongo/binary/oplog_reply.go
@@ -20,11 +20,8 @@ const (
 )
 
 func RunOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplogConfig) error {
-	if replayArgs.FsyncInterval <= 0 {
-		replayArgs.FsyncInterval = 10 * time.Minute
-	}
 	if replayArgs.MinimalConfigPath != "" {
-		return runInlineOplogReplay(ctx, replayArgs)
+		return runSupervisedOplogReplay(ctx, replayArgs)
 	}
 	return runOplogReplay(ctx, mongodbURL, replayArgs)
 }
@@ -105,45 +102,45 @@ func runOplogReplay(ctx context.Context, mongodbURL string, replayArgs ReplyOplo
 	return HandleOplogReplay(ctx, replayArgs.Since, replayArgs.Until, oplogFetcher, oplogApplier)
 }
 
-func runInlineOplogReplay(ctx context.Context, replayArgs ReplyOplogConfig) error {
+func runSupervisedOplogReplay(ctx context.Context, replayArgs ReplyOplogConfig) error {
 	progress := stages.NewReplayProgress(replayArgs.Since)
 	consecutiveRestarts := 0
 
 	for {
-		_, durableTS, generationBefore := progress.Snapshot()
-		progress.ResetAttempt()
+		durableTS, generationBefore := progress.Snapshot()
 
-		attemptConfig := replayArgs
-		attemptConfig.MinimalConfigPath = ""
-		attemptConfig.Since = durableTS
-		attemptConfig.progress = progress
-		attemptConfig.resumeAfter = generationBefore > 0
+		replayAttemptConfig := replayArgs
+		replayAttemptConfig.MinimalConfigPath = ""
+		replayAttemptConfig.Since = durableTS
+		replayAttemptConfig.progress = progress
+		replayAttemptConfig.resumeAfter = generationBefore > 0
 
-		mongodCrashed, err := runInlineOplogReplayAttempt(ctx, attemptConfig, replayArgs.MinimalConfigPath)
+		mongodExited, err := runSupervisedOplogReplayAttempt(
+			ctx, replayAttemptConfig, replayArgs.MinimalConfigPath)
 		if err == nil {
 			return nil
 		}
-		if !mongodCrashed {
+		if !mongodExited {
 			return err
 		}
 
-		_, durableTS, generationAfter := progress.Snapshot()
+		durableTS, generationAfter := progress.Snapshot()
 		if generationAfter > generationBefore {
 			consecutiveRestarts = 0
 		}
 		if consecutiveRestarts >= replayArgs.MaxMongodRestarts {
 			return errors.Wrapf(err,
-				"inline mongod crashed after %d restarts, last durable oplog timestamp is %s",
+				"supervised mongod crashed after %d restarts, last durable oplog timestamp is %s",
 				consecutiveRestarts, durableTS)
 		}
 		consecutiveRestarts++
 		tracelog.WarningLogger.Printf(
-			"inline mongod crashed, restarting oplog replay after %s, attempt %d/%d",
+			"supervised mongod crashed, restarting oplog replay after %s, attempt %d/%d",
 			durableTS, consecutiveRestarts, replayArgs.MaxMongodRestarts)
 	}
 }
 
-func runInlineOplogReplayAttempt(
+func runSupervisedOplogReplayAttempt(
 	ctx context.Context,
 	replayArgs ReplyOplogConfig,
 	minimalConfigPath string,
@@ -225,9 +222,9 @@ func runInlineOplogReplayAttempt(
 
 func unexpectedMongodExit(err error) error {
 	if err == nil {
-		return fmt.Errorf("inline mongod exited unexpectedly during oplog replay")
+		return fmt.Errorf("supervised mongod exited unexpectedly during oplog replay")
 	}
-	return errors.Wrap(err, "inline mongod exited during oplog replay")
+	return errors.Wrap(err, "supervised mongod exited during oplog replay")
 }
 
 func resolveOplogReplaySequence(

--- a/internal/databases/mongo/binary/oplog_reply_test.go
+++ b/internal/databases/mongo/binary/oplog_reply_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 	archivepkg "github.com/wal-g/wal-g/internal/databases/mongo/archive"
 	archivemocks "github.com/wal-g/wal-g/internal/databases/mongo/archive/mocks"
+	clientmocks "github.com/wal-g/wal-g/internal/databases/mongo/client/mocks"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"github.com/wal-g/wal-g/internal/databases/mongo/stages"
 )
 
 func TestResolveOplogReplaySequenceFallsBackToFullList(t *testing.T) {
@@ -53,4 +55,23 @@ func mustArchive(t *testing.T, start, end models.Timestamp) models.Archive {
 	arch, err := models.NewArchive(start, end, "lz4", models.ArchiveTypeOplog)
 	require.NoError(t, err)
 	return arch
+}
+
+func TestFinalizeCatchUpUsesDurableOpTime(t *testing.T) {
+	db := clientmocks.NewMongoDriver(t)
+	opTime := models.OpTime{TS: models.Timestamp{TS: 101, Inc: 2}, Term: 7}
+	db.On("ChangeOplogLastTimestamp", testifymock.Anything, opTime).Return(nil).Once()
+	progress := stages.NewReplayProgress(models.Timestamp{TS: 100, Inc: 1})
+	progress.MarkDurable(opTime)
+
+	err := finalizeCatchUp(t.Context(), ReplyOplogConfig{WithCatchUpReconfig: true}, db, progress)
+	require.NoError(t, err)
+}
+
+func TestFinalizeCatchUpSkipsEmptyReplay(t *testing.T) {
+	db := clientmocks.NewMongoDriver(t)
+	progress := stages.NewReplayProgress(models.Timestamp{TS: 100, Inc: 1})
+
+	err := finalizeCatchUp(t.Context(), ReplyOplogConfig{WithCatchUpReconfig: true}, db, progress)
+	require.NoError(t, err)
 }

--- a/internal/databases/mongo/binary/restore.go
+++ b/internal/databases/mongo/binary/restore.go
@@ -2,6 +2,7 @@ package binary
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -10,6 +11,7 @@ import (
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo/common"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"github.com/wal-g/wal-g/internal/databases/mongo/stages"
 )
 
 var (
@@ -235,6 +237,50 @@ func (restoreService *RestoreService) recoverFromOplogAsStandalone(ctx context.C
 
 func (restoreService *RestoreService) oplogReply(ctx context.Context,
 	replayOplogConfig ReplyOplogConfig, partial bool) error {
+	if replayOplogConfig.FsyncInterval <= 0 {
+		replayOplogConfig.FsyncInterval = 10 * time.Minute
+	}
+	progress := stages.NewReplayProgress(replayOplogConfig.Since)
+	consecutiveRestarts := 0
+
+	for {
+		_, durableTS, generationBefore := progress.Snapshot()
+		progress.ResetAttempt()
+
+		attemptConfig := replayOplogConfig
+		attemptConfig.Since = durableTS
+		attemptConfig.progress = progress
+		attemptConfig.resumeAfter = generationBefore > 0
+
+		mongodCrashed, err := restoreService.runOplogReplayAttempt(ctx, attemptConfig, partial)
+		if err == nil {
+			return nil
+		}
+		if !mongodCrashed {
+			return err
+		}
+
+		_, durableTS, generationAfter := progress.Snapshot()
+		if generationAfter > generationBefore {
+			consecutiveRestarts = 0
+		}
+		if consecutiveRestarts >= replayOplogConfig.MaxMongodRestarts {
+			return errors.Wrapf(err,
+				"inline mongod crashed after %d restarts, last durable oplog timestamp is %s",
+				consecutiveRestarts, durableTS)
+		}
+		consecutiveRestarts++
+		tracelog.WarningLogger.Printf(
+			"inline mongod crashed, restarting oplog replay after %s, attempt %d/%d",
+			durableTS, consecutiveRestarts, replayOplogConfig.MaxMongodRestarts)
+	}
+}
+
+func (restoreService *RestoreService) runOplogReplayAttempt(
+	ctx context.Context,
+	replayOplogConfig ReplyOplogConfig,
+	partial bool,
+) (bool, error) {
 	mongodProcess := Mongod(restoreService.minimalConfigPath).
 		WithParams(DisableLogicalSessionCacheRefresh, TakeUnstableCheckpointOnShutdown)
 
@@ -243,30 +289,61 @@ func (restoreService *RestoreService) oplogReply(ctx context.Context,
 	}
 
 	if _, err := mongodProcess.Start(ctx); err != nil {
-		return errors.Wrap(err, "unable to start mongod in special mode")
+		return false, errors.Wrap(err, "unable to start mongod in special mode")
 	}
-
-	defer mongodProcess.Close()
+	waitC := make(chan error, 1)
+	go func() { waitC <- mongodProcess.Wait() }()
+	attemptCtx, cancelAttempt := context.WithCancel(ctx)
+	defer cancelAttempt()
 
 	mongodService, err := CreateMongodService(
-		ctx,
+		attemptCtx,
 		"wal-g restore",
 		mongodProcess.GetURI(),
 		10*time.Minute,
 	)
 	if err != nil {
-		return errors.Wrap(err, "unable to create mongod service")
+		mongodProcess.Close()
+		<-waitC
+		return false, errors.Wrap(err, "unable to create mongod service")
 	}
 
-	err = RunOplogReplay(ctx, mongodProcess.GetURI(), replayOplogConfig)
-	if err != nil {
-		return err
-	}
+	replayC := make(chan error, 1)
+	go func() {
+		replayC <- RunOplogReplay(attemptCtx, mongodProcess.GetURI(), replayOplogConfig)
+	}()
 
-	err = mongodService.Shutdown(ctx)
-	if err != nil {
-		return err
-	}
+	select {
+	case processErr := <-waitC:
+		cancelAttempt()
+		<-replayC
+		return true, unexpectedMongodExit(processErr)
 
-	return mongodProcess.Wait()
+	case replayErr := <-replayC:
+		if replayErr != nil {
+			select {
+			case processErr := <-waitC:
+				return true, unexpectedMongodExit(processErr)
+			// The driver may report a broken connection just before cmd.Wait publishes the process exit.
+			case <-time.After(mongodExitDetectionTimeout):
+				mongodProcess.Close()
+				<-waitC
+				return false, replayErr
+			}
+		}
+
+		if err = mongodService.Shutdown(ctx); err != nil {
+			mongodProcess.Close()
+			<-waitC
+			return false, err
+		}
+		return false, <-waitC
+	}
+}
+
+func unexpectedMongodExit(err error) error {
+	if err == nil {
+		return fmt.Errorf("inline mongod exited unexpectedly during oplog replay")
+	}
+	return errors.Wrap(err, "inline mongod exited during oplog replay")
 }

--- a/internal/databases/mongo/binary/restore.go
+++ b/internal/databases/mongo/binary/restore.go
@@ -2,7 +2,6 @@ package binary
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -11,7 +10,6 @@ import (
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/databases/mongo/common"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
-	"github.com/wal-g/wal-g/internal/databases/mongo/stages"
 )
 
 var (
@@ -237,113 +235,7 @@ func (restoreService *RestoreService) recoverFromOplogAsStandalone(ctx context.C
 
 func (restoreService *RestoreService) oplogReply(ctx context.Context,
 	replayOplogConfig ReplyOplogConfig, partial bool) error {
-	if replayOplogConfig.FsyncInterval <= 0 {
-		replayOplogConfig.FsyncInterval = 10 * time.Minute
-	}
-	progress := stages.NewReplayProgress(replayOplogConfig.Since)
-	consecutiveRestarts := 0
-
-	for {
-		_, durableTS, generationBefore := progress.Snapshot()
-		progress.ResetAttempt()
-
-		attemptConfig := replayOplogConfig
-		attemptConfig.Since = durableTS
-		attemptConfig.progress = progress
-		attemptConfig.resumeAfter = generationBefore > 0
-
-		mongodCrashed, err := restoreService.runOplogReplayAttempt(ctx, attemptConfig, partial)
-		if err == nil {
-			return nil
-		}
-		if !mongodCrashed {
-			return err
-		}
-
-		_, durableTS, generationAfter := progress.Snapshot()
-		if generationAfter > generationBefore {
-			consecutiveRestarts = 0
-		}
-		if consecutiveRestarts >= replayOplogConfig.MaxMongodRestarts {
-			return errors.Wrapf(err,
-				"inline mongod crashed after %d restarts, last durable oplog timestamp is %s",
-				consecutiveRestarts, durableTS)
-		}
-		consecutiveRestarts++
-		tracelog.WarningLogger.Printf(
-			"inline mongod crashed, restarting oplog replay after %s, attempt %d/%d",
-			durableTS, consecutiveRestarts, replayOplogConfig.MaxMongodRestarts)
-	}
-}
-
-func (restoreService *RestoreService) runOplogReplayAttempt(
-	ctx context.Context,
-	replayOplogConfig ReplyOplogConfig,
-	partial bool,
-) (bool, error) {
-	mongodProcess := Mongod(restoreService.minimalConfigPath).
-		WithParams(DisableLogicalSessionCacheRefresh, TakeUnstableCheckpointOnShutdown)
-
-	if partial {
-		mongodProcess.WithRestore()
-	}
-
-	if _, err := mongodProcess.Start(ctx); err != nil {
-		return false, errors.Wrap(err, "unable to start mongod in special mode")
-	}
-	waitC := make(chan error, 1)
-	go func() { waitC <- mongodProcess.Wait() }()
-	attemptCtx, cancelAttempt := context.WithCancel(ctx)
-	defer cancelAttempt()
-
-	mongodService, err := CreateMongodService(
-		attemptCtx,
-		"wal-g restore",
-		mongodProcess.GetURI(),
-		10*time.Minute,
-	)
-	if err != nil {
-		mongodProcess.Close()
-		<-waitC
-		return false, errors.Wrap(err, "unable to create mongod service")
-	}
-
-	replayC := make(chan error, 1)
-	go func() {
-		replayC <- RunOplogReplay(attemptCtx, mongodProcess.GetURI(), replayOplogConfig)
-	}()
-
-	select {
-	case processErr := <-waitC:
-		cancelAttempt()
-		<-replayC
-		return true, unexpectedMongodExit(processErr)
-
-	case replayErr := <-replayC:
-		if replayErr != nil {
-			select {
-			case processErr := <-waitC:
-				return true, unexpectedMongodExit(processErr)
-			// The driver may report a broken connection just before cmd.Wait publishes the process exit.
-			case <-time.After(mongodExitDetectionTimeout):
-				mongodProcess.Close()
-				<-waitC
-				return false, replayErr
-			}
-		}
-
-		if err = mongodService.Shutdown(ctx); err != nil {
-			mongodProcess.Close()
-			<-waitC
-			return false, err
-		}
-		return false, <-waitC
-	}
-}
-
-func unexpectedMongodExit(err error) error {
-	if err == nil {
-		return fmt.Errorf("inline mongod exited unexpectedly during oplog replay")
-	}
-	return errors.Wrap(err, "inline mongod exited during oplog replay")
+	replayOplogConfig.Partial = partial
+	replayOplogConfig.MinimalConfigPath = restoreService.minimalConfigPath
+	return RunOplogReplay(ctx, "", replayOplogConfig)
 }

--- a/internal/databases/mongo/client/client.go
+++ b/internal/databases/mongo/client/client.go
@@ -79,6 +79,7 @@ type MongoDriver interface {
 	LastWriteTS(ctx context.Context) (lastTS, lastMajTS models.Timestamp, err error)
 	TailOplogFrom(ctx context.Context, from models.Timestamp) (OplogCursor, error)
 	ApplyOp(ctx context.Context, op *db.Oplog) error
+	Fsync(ctx context.Context) error
 	Close(ctx context.Context, shutdown bool) error
 	ChangeOplogLastTimestamp(ctx context.Context, opTime models.OpTime) error
 	LastOplogTS(ctx context.Context) (lastTS models.Timestamp, err error)
@@ -519,7 +520,7 @@ func (mc *MongoClient) ChangeOplogLastTimestamp(ctx context.Context, opTime mode
 		return err
 	}
 
-	return mc.fsync(ctx)
+	return mc.Fsync(ctx)
 }
 
 func (mc *MongoClient) changeMinValueTimestamp(ctx context.Context, opTime models.OpTime) error {
@@ -602,7 +603,7 @@ func (mc *MongoClient) addNoopToOplog(ctx context.Context, opTime models.OpTime)
 	return err
 }
 
-func (mc *MongoClient) fsync(ctx context.Context) error {
+func (mc *MongoClient) Fsync(ctx context.Context) error {
 	res := mc.c.Database("admin").RunCommand(ctx, bson.D{
 		{Key: "fsync", Value: 1},
 		{Key: "lock", Value: false},

--- a/internal/databases/mongo/client/mocks/MongoDriver.go
+++ b/internal/databases/mongo/client/mocks/MongoDriver.go
@@ -107,6 +107,24 @@ func (_m *MongoDriver) DropIndexes(ctx context.Context, dbName string, rawComman
 	return r0
 }
 
+// Fsync provides a mock function with given fields: ctx
+func (_m *MongoDriver) Fsync(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Fsync")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // EnsureIsMaster provides a mock function with given fields: ctx
 func (_m *MongoDriver) EnsureIsMaster(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/internal/databases/mongo/oplog/applier.go
+++ b/internal/databases/mongo/oplog/applier.go
@@ -113,8 +113,7 @@ func (ap *DBApplier) IsPartial() bool {
 }
 
 func (ap *DBApplier) HasPendingTransactions() bool {
-	oldest := ap.txnBuffer.OldestOpTime()
-	return oldest.Timestamp.T != 0 || oldest.Timestamp.I != 0
+	return !db.OpTimeIsEmpty(ap.txnBuffer.OldestOpTime())
 }
 
 func (ap *DBApplier) Apply(ctx context.Context, opr models.Oplog) error {

--- a/internal/databases/mongo/oplog/applier.go
+++ b/internal/databases/mongo/oplog/applier.go
@@ -112,6 +112,11 @@ func (ap *DBApplier) IsPartial() bool {
 	return ap.partial
 }
 
+func (ap *DBApplier) HasPendingTransactions() bool {
+	oldest := ap.txnBuffer.OldestOpTime()
+	return oldest.Timestamp.T != 0 || oldest.Timestamp.I != 0
+}
+
 func (ap *DBApplier) Apply(ctx context.Context, opr models.Oplog) error {
 	op := db.Oplog{}
 	if err := bson.Unmarshal(opr.Data, &op); err != nil {
@@ -149,6 +154,8 @@ func (ap *DBApplier) Apply(ctx context.Context, opr models.Oplog) error {
 }
 
 func (ap *DBApplier) Close(ctx context.Context) error {
+	defer ap.txnBuffer.Stop()
+
 	if ap.catchUp {
 		if err := ap.db.ChangeOplogLastTimestamp(ctx, ap.lastOpTime); err != nil {
 			return err
@@ -158,8 +165,6 @@ func (ap *DBApplier) Close(ctx context.Context) error {
 	if err := ap.db.Close(ctx, ap.initMongo); err != nil {
 		return err
 	}
-
-	ap.txnBuffer.Stop()
 
 	return nil
 }

--- a/internal/databases/mongo/oplog/applier.go
+++ b/internal/databases/mongo/oplog/applier.go
@@ -83,15 +83,14 @@ type DBApplier struct {
 	partial               bool
 	applyIgnoreErrorCodes map[string][]int32
 	lastOpTime            models.OpTime
+	hasAppliedOp          bool
 	catchUp               bool
-	initMongo             bool
 }
 
 type DBApplierArgs struct {
 	PreserveUUID   bool
 	Partial        bool
 	Reconfig       bool
-	InitMongo      bool
 	IgnoreErrCodes map[string][]int32
 }
 
@@ -104,7 +103,6 @@ func NewDBApplier(m client.MongoDriver, args DBApplierArgs) *DBApplier {
 		partial:               args.Partial,
 		catchUp:               args.Reconfig,
 		applyIgnoreErrorCodes: args.IgnoreErrCodes,
-		initMongo:             args.InitMongo,
 	}
 }
 
@@ -114,6 +112,10 @@ func (ap *DBApplier) IsPartial() bool {
 
 func (ap *DBApplier) HasPendingTransactions() bool {
 	return !db.OpTimeIsEmpty(ap.txnBuffer.OldestOpTime())
+}
+
+func (ap *DBApplier) LastAppliedOpTime() (models.OpTime, bool) {
+	return ap.lastOpTime, ap.hasAppliedOp
 }
 
 func (ap *DBApplier) Apply(ctx context.Context, opr models.Oplog) error {
@@ -148,23 +150,13 @@ func (ap *DBApplier) Apply(ctx context.Context, opr models.Oplog) error {
 		term = *op.Term
 	}
 	ap.lastOpTime = models.OpTime{TS: models.TimestampFromBson(op.Timestamp), Term: term}
+	ap.hasAppliedOp = true
 
 	return nil
 }
 
-func (ap *DBApplier) Close(ctx context.Context) error {
-	defer ap.txnBuffer.Stop()
-
-	if ap.catchUp {
-		if err := ap.db.ChangeOplogLastTimestamp(ctx, ap.lastOpTime); err != nil {
-			return err
-		}
-	}
-
-	if err := ap.db.Close(ctx, ap.initMongo); err != nil {
-		return err
-	}
-
+func (ap *DBApplier) Close(context.Context) error {
+	ap.txnBuffer.Stop()
 	return nil
 }
 

--- a/internal/databases/mongo/stages/fetcher.go
+++ b/internal/databases/mongo/stages/fetcher.go
@@ -157,13 +157,19 @@ func (w *CloserPipeWriter) RealClose() error {
 
 // StorageFetcher implements BetweenFetcher interface for storage.
 type StorageFetcher struct {
-	downloader archive.Downloader
-	path       archive.Sequence
+	downloader  archive.Downloader
+	path        archive.Sequence
+	resumeAfter bool
 }
 
 // NewStorageFetcher builds StorageFetcher instance
 func NewStorageFetcher(downloader archive.Downloader, path archive.Sequence) *StorageFetcher {
 	return &StorageFetcher{downloader: downloader, path: path}
+}
+
+func (sf *StorageFetcher) WithResumeAfter() *StorageFetcher {
+	sf.resumeAfter = true
+	return sf
 }
 
 // FetchBetween returns channel of oplog records, channel is filled in background.
@@ -228,7 +234,8 @@ func (sf *StorageFetcher) FetchBetween(ctx context.Context,
 			}
 
 			if !firstFound {
-				if models.LessTS(op.TS, from) {
+				if models.LessTS(op.TS, from) || sf.resumeAfter && models.Equal(op.TS, from) {
+					models.PutOplogEntry(op)
 					continue
 				}
 				firstFound = true

--- a/internal/databases/mongo/stages/fetcher.go
+++ b/internal/databases/mongo/stages/fetcher.go
@@ -234,7 +234,7 @@ func (sf *StorageFetcher) FetchBetween(ctx context.Context,
 			}
 
 			if !firstFound {
-				if models.LessTS(op.TS, from) || sf.resumeAfter && models.Equal(op.TS, from) {
+				if sf.isBeforeStart(op.TS, from) {
 					models.PutOplogEntry(op)
 					continue
 				}
@@ -258,4 +258,8 @@ func (sf *StorageFetcher) FetchBetween(ctx context.Context,
 	}()
 
 	return data, errc, nil
+}
+
+func (sf *StorageFetcher) isBeforeStart(ts, from models.Timestamp) bool {
+	return models.LessTS(ts, from) || sf.resumeAfter && models.Equal(ts, from)
 }

--- a/internal/databases/mongo/stages/fetcher_test.go
+++ b/internal/databases/mongo/stages/fetcher_test.go
@@ -137,12 +137,13 @@ func TestStorageFetcher_OplogBetween(t *testing.T) {
 		until models.Timestamp
 	}
 	tests := []struct {
-		name     string
-		fields   DownloaderFields
-		args     args
-		wantOps  []*models.Oplog
-		wantErr  error
-		wantErrc error
+		name        string
+		fields      DownloaderFields
+		args        args
+		wantOps     []*models.Oplog
+		wantErr     error
+		wantErrc    error
+		resumeAfter bool
 	}{
 		{
 			name:   "from_first_until_last,_one_archive",
@@ -178,6 +179,17 @@ func TestStorageFetcher_OplogBetween(t *testing.T) {
 			wantErrc: nil,
 		},
 		{
+			name:        "resume_after_excludes_checkpoint_operation",
+			fields:      SetupDownloaderMocks(ops),
+			resumeAfter: true,
+			args: args{
+				ctx:   t.Context(),
+				from:  ops[1].TS,
+				until: ops[len(ops)-1].TS,
+			},
+			wantOps: ops[2 : len(ops)-1],
+		},
+		{
 			name:   "error:_first_>_until",
 			fields: SetupDownloaderMocks(ops[0:2], ops[2:3], ops[3:]),
 			args: args{
@@ -204,8 +216,9 @@ func TestStorageFetcher_OplogBetween(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sf := &StorageFetcher{
-				downloader: tt.fields.downloader,
-				path:       tt.fields.path,
+				downloader:  tt.fields.downloader,
+				path:        tt.fields.path,
+				resumeAfter: tt.resumeAfter,
 			}
 
 			outc, errc, err := sf.FetchBetween(tt.args.ctx, tt.args.from, tt.args.until)

--- a/internal/databases/mongo/stages/replay_applier.go
+++ b/internal/databases/mongo/stages/replay_applier.go
@@ -13,56 +13,32 @@ import (
 
 type ReplayProgress struct {
 	mu                   sync.RWMutex
-	lastHandledTS        models.Timestamp
 	lastDurableTS        models.Timestamp
 	checkpointGeneration uint64
-	dirty                bool
 }
 
 func NewReplayProgress(since models.Timestamp) *ReplayProgress {
-	return &ReplayProgress{lastHandledTS: since, lastDurableTS: since}
+	return &ReplayProgress{lastDurableTS: since}
 }
 
-func (p *ReplayProgress) Snapshot() (models.Timestamp, models.Timestamp, uint64) {
+func (p *ReplayProgress) Snapshot() (models.Timestamp, uint64) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.lastHandledTS, p.lastDurableTS, p.checkpointGeneration
-}
-
-func (p *ReplayProgress) ResetAttempt() {
-	p.mu.Lock()
-	p.lastHandledTS = p.lastDurableTS
-	p.dirty = false
-	p.mu.Unlock()
+	return p.lastDurableTS, p.checkpointGeneration
 }
 
 func (p *ReplayProgress) Initialize(ts models.Timestamp) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.checkpointGeneration == 0 && !p.dirty {
-		p.lastHandledTS = ts
+	if p.checkpointGeneration == 0 {
 		p.lastDurableTS = ts
 	}
-}
-
-func (p *ReplayProgress) NeedsCheckpoint() bool {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.dirty
-}
-
-func (p *ReplayProgress) setHandled(ts models.Timestamp) {
-	p.mu.Lock()
-	p.lastHandledTS = ts
-	p.dirty = true
-	p.mu.Unlock()
 }
 
 func (p *ReplayProgress) setDurable(ts models.Timestamp) {
 	p.mu.Lock()
 	p.lastDurableTS = ts
 	p.checkpointGeneration++
-	p.dirty = false
 	p.mu.Unlock()
 }
 
@@ -72,6 +48,8 @@ type CheckpointingApplier struct {
 	interval      time.Duration
 	progress      *ReplayProgress
 	checkpointDue bool
+	lastAppliedTS models.Timestamp
+	dirty         bool
 }
 
 type replayDBApplier interface {
@@ -144,7 +122,8 @@ func (a *CheckpointingApplier) applyOperation(
 	if err := a.applier.Apply(ctx, *op); err != nil {
 		return fmt.Errorf("can not handle op: %w", err)
 	}
-	a.progress.setHandled(op.TS)
+	a.lastAppliedTS = op.TS
+	a.dirty = true
 	if !a.checkpointDue || a.applier.HasPendingTransactions() {
 		return nil
 	}
@@ -168,14 +147,14 @@ func (a *CheckpointingApplier) finish(ctx context.Context) error {
 }
 
 func (a *CheckpointingApplier) makeDurable(ctx context.Context) error {
-	handled, _, _ := a.progress.Snapshot()
-	if !a.progress.NeedsCheckpoint() {
+	if !a.dirty {
 		return nil
 	}
 	if err := a.db.Fsync(ctx); err != nil {
-		return fmt.Errorf("can not fsync oplog replay at %s: %w", handled, err)
+		return fmt.Errorf("can not fsync oplog replay at %s: %w", a.lastAppliedTS, err)
 	}
-	a.progress.setDurable(handled)
-	tracelog.InfoLogger.Printf("Oplog replay progress is durable through %s", handled)
+	a.progress.setDurable(a.lastAppliedTS)
+	a.dirty = false
+	tracelog.InfoLogger.Printf("Oplog replay progress is durable through %s", a.lastAppliedTS)
 	return nil
 }

--- a/internal/databases/mongo/stages/replay_applier.go
+++ b/internal/databases/mongo/stages/replay_applier.go
@@ -36,6 +36,15 @@ func (p *ReplayProgress) ResetAttempt() {
 	p.mu.Unlock()
 }
 
+func (p *ReplayProgress) Initialize(ts models.Timestamp) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.checkpointGeneration == 0 && !p.dirty {
+		p.lastHandledTS = ts
+		p.lastDurableTS = ts
+	}
+}
+
 func (p *ReplayProgress) NeedsCheckpoint() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()

--- a/internal/databases/mongo/stages/replay_applier.go
+++ b/internal/databases/mongo/stages/replay_applier.go
@@ -93,66 +93,78 @@ func (a *CheckpointingApplier) Apply(ctx context.Context, ch chan *models.Oplog)
 	errC := make(chan error, 1)
 	go func() {
 		defer close(errC)
-		defer func() {
-			if err := a.applier.Close(ctx); err != nil {
-				select {
-				case errC <- fmt.Errorf("can not close applier: %w", err):
-				default:
-				}
-			}
-		}()
-
-		timer := time.NewTimer(a.interval)
-		defer timer.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				errC <- ctx.Err()
-				return
-
-			case <-timer.C:
-				a.checkpointDue = true
-				if !a.applier.HasPendingTransactions() {
-					if err := a.makeDurable(ctx); err != nil {
-						errC <- err
-						return
-					}
-					a.checkpointDue = false
-					timer.Reset(a.interval)
-				}
-
-			case op, ok := <-ch:
-				if !ok {
-					if a.applier.HasPendingTransactions() {
-						errC <- fmt.Errorf("oplog stream ended with an incomplete transaction")
-						return
-					}
-					if err := a.makeDurable(ctx); err != nil {
-						errC <- err
-					}
-					return
-				}
-
-				if err := a.applier.Apply(ctx, *op); err != nil {
-					errC <- fmt.Errorf("can not handle op: %w", err)
-					return
-				}
-				a.progress.setHandled(op.TS)
-
-				if a.checkpointDue && !a.applier.HasPendingTransactions() {
-					if err := a.makeDurable(ctx); err != nil {
-						errC <- err
-						return
-					}
-					a.checkpointDue = false
-					timer.Reset(a.interval)
-				}
-			}
+		err := a.run(ctx, ch)
+		if closeErr := a.applier.Close(ctx); err == nil && closeErr != nil {
+			err = fmt.Errorf("can not close applier: %w", closeErr)
+		}
+		if err != nil {
+			errC <- err
 		}
 	}()
 
 	return errC, nil
+}
+
+func (a *CheckpointingApplier) run(ctx context.Context, ch chan *models.Oplog) error {
+	timer := time.NewTimer(a.interval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			if err := a.checkpointWhenPossible(ctx, timer); err != nil {
+				return err
+			}
+		case op, ok := <-ch:
+			if !ok {
+				return a.finish(ctx)
+			}
+			if err := a.applyOperation(ctx, op, timer); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (a *CheckpointingApplier) checkpointWhenPossible(ctx context.Context, timer *time.Timer) error {
+	a.checkpointDue = true
+	if a.applier.HasPendingTransactions() {
+		return nil
+	}
+	return a.checkpoint(ctx, timer)
+}
+
+func (a *CheckpointingApplier) applyOperation(
+	ctx context.Context,
+	op *models.Oplog,
+	timer *time.Timer,
+) error {
+	if err := a.applier.Apply(ctx, *op); err != nil {
+		return fmt.Errorf("can not handle op: %w", err)
+	}
+	a.progress.setHandled(op.TS)
+	if !a.checkpointDue || a.applier.HasPendingTransactions() {
+		return nil
+	}
+	return a.checkpoint(ctx, timer)
+}
+
+func (a *CheckpointingApplier) checkpoint(ctx context.Context, timer *time.Timer) error {
+	if err := a.makeDurable(ctx); err != nil {
+		return err
+	}
+	a.checkpointDue = false
+	timer.Reset(a.interval)
+	return nil
+}
+
+func (a *CheckpointingApplier) finish(ctx context.Context) error {
+	if a.applier.HasPendingTransactions() {
+		return fmt.Errorf("oplog stream ended with an incomplete transaction")
+	}
+	return a.makeDurable(ctx)
 }
 
 func (a *CheckpointingApplier) makeDurable(ctx context.Context) error {

--- a/internal/databases/mongo/stages/replay_applier.go
+++ b/internal/databases/mongo/stages/replay_applier.go
@@ -12,33 +12,37 @@ import (
 )
 
 type ReplayProgress struct {
-	mu                   sync.RWMutex
-	lastDurableTS        models.Timestamp
-	checkpointGeneration uint64
+	mu         sync.RWMutex
+	checkpoint ReplayCheckpoint
+}
+
+type ReplayCheckpoint struct {
+	OpTime     models.OpTime
+	Generation uint64
 }
 
 func NewReplayProgress(since models.Timestamp) *ReplayProgress {
-	return &ReplayProgress{lastDurableTS: since}
+	return &ReplayProgress{checkpoint: ReplayCheckpoint{OpTime: models.OpTime{TS: since}}}
 }
 
-func (p *ReplayProgress) Snapshot() (models.Timestamp, uint64) {
+func (p *ReplayProgress) Snapshot() ReplayCheckpoint {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.lastDurableTS, p.checkpointGeneration
+	return p.checkpoint
 }
 
 func (p *ReplayProgress) Initialize(ts models.Timestamp) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.checkpointGeneration == 0 {
-		p.lastDurableTS = ts
+	if p.checkpoint.Generation == 0 {
+		p.checkpoint.OpTime = models.OpTime{TS: ts}
 	}
 }
 
-func (p *ReplayProgress) setDurable(ts models.Timestamp) {
+func (p *ReplayProgress) MarkDurable(opTime models.OpTime) {
 	p.mu.Lock()
-	p.lastDurableTS = ts
-	p.checkpointGeneration++
+	p.checkpoint.OpTime = opTime
+	p.checkpoint.Generation++
 	p.mu.Unlock()
 }
 
@@ -56,6 +60,7 @@ type replayDBApplier interface {
 	Apply(context.Context, models.Oplog) error
 	Close(context.Context) error
 	HasPendingTransactions() bool
+	LastAppliedOpTime() (models.OpTime, bool)
 }
 
 func NewCheckpointingApplier(
@@ -153,7 +158,11 @@ func (a *CheckpointingApplier) makeDurable(ctx context.Context) error {
 	if err := a.db.Fsync(ctx); err != nil {
 		return fmt.Errorf("can not fsync oplog replay at %s: %w", a.lastAppliedTS, err)
 	}
-	a.progress.setDurable(a.lastAppliedTS)
+	opTime, ok := a.applier.LastAppliedOpTime()
+	if !ok || !models.Equal(opTime.TS, a.lastAppliedTS) {
+		opTime = models.OpTime{TS: a.lastAppliedTS}
+	}
+	a.progress.MarkDurable(opTime)
 	a.dirty = false
 	tracelog.InfoLogger.Printf("Oplog replay progress is durable through %s", a.lastAppliedTS)
 	return nil

--- a/internal/databases/mongo/stages/replay_applier.go
+++ b/internal/databases/mongo/stages/replay_applier.go
@@ -1,0 +1,160 @@
+package stages
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/mongo/client"
+	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+)
+
+type ReplayProgress struct {
+	mu                   sync.RWMutex
+	lastHandledTS        models.Timestamp
+	lastDurableTS        models.Timestamp
+	checkpointGeneration uint64
+	dirty                bool
+}
+
+func NewReplayProgress(since models.Timestamp) *ReplayProgress {
+	return &ReplayProgress{lastHandledTS: since, lastDurableTS: since}
+}
+
+func (p *ReplayProgress) Snapshot() (models.Timestamp, models.Timestamp, uint64) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.lastHandledTS, p.lastDurableTS, p.checkpointGeneration
+}
+
+func (p *ReplayProgress) ResetAttempt() {
+	p.mu.Lock()
+	p.lastHandledTS = p.lastDurableTS
+	p.dirty = false
+	p.mu.Unlock()
+}
+
+func (p *ReplayProgress) NeedsCheckpoint() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.dirty
+}
+
+func (p *ReplayProgress) setHandled(ts models.Timestamp) {
+	p.mu.Lock()
+	p.lastHandledTS = ts
+	p.dirty = true
+	p.mu.Unlock()
+}
+
+func (p *ReplayProgress) setDurable(ts models.Timestamp) {
+	p.mu.Lock()
+	p.lastDurableTS = ts
+	p.checkpointGeneration++
+	p.dirty = false
+	p.mu.Unlock()
+}
+
+type CheckpointingApplier struct {
+	db            client.MongoDriver
+	applier       replayDBApplier
+	interval      time.Duration
+	progress      *ReplayProgress
+	checkpointDue bool
+}
+
+type replayDBApplier interface {
+	Apply(context.Context, models.Oplog) error
+	Close(context.Context) error
+	HasPendingTransactions() bool
+}
+
+func NewCheckpointingApplier(
+	db client.MongoDriver,
+	applier replayDBApplier,
+	interval time.Duration,
+	progress *ReplayProgress,
+) *CheckpointingApplier {
+	return &CheckpointingApplier{db: db, applier: applier, interval: interval, progress: progress}
+}
+
+func (a *CheckpointingApplier) Apply(ctx context.Context, ch chan *models.Oplog) (chan error, error) {
+	errC := make(chan error, 1)
+	go func() {
+		defer close(errC)
+		defer func() {
+			if err := a.applier.Close(ctx); err != nil {
+				select {
+				case errC <- fmt.Errorf("can not close applier: %w", err):
+				default:
+				}
+			}
+		}()
+
+		timer := time.NewTimer(a.interval)
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				errC <- ctx.Err()
+				return
+
+			case <-timer.C:
+				a.checkpointDue = true
+				if !a.applier.HasPendingTransactions() {
+					if err := a.makeDurable(ctx); err != nil {
+						errC <- err
+						return
+					}
+					a.checkpointDue = false
+					timer.Reset(a.interval)
+				}
+
+			case op, ok := <-ch:
+				if !ok {
+					if a.applier.HasPendingTransactions() {
+						errC <- fmt.Errorf("oplog stream ended with an incomplete transaction")
+						return
+					}
+					if err := a.makeDurable(ctx); err != nil {
+						errC <- err
+					}
+					return
+				}
+
+				if err := a.applier.Apply(ctx, *op); err != nil {
+					errC <- fmt.Errorf("can not handle op: %w", err)
+					return
+				}
+				a.progress.setHandled(op.TS)
+
+				if a.checkpointDue && !a.applier.HasPendingTransactions() {
+					if err := a.makeDurable(ctx); err != nil {
+						errC <- err
+						return
+					}
+					a.checkpointDue = false
+					timer.Reset(a.interval)
+				}
+			}
+		}
+	}()
+
+	return errC, nil
+}
+
+func (a *CheckpointingApplier) makeDurable(ctx context.Context) error {
+	handled, _, _ := a.progress.Snapshot()
+	if !a.progress.NeedsCheckpoint() {
+		return nil
+	}
+	if err := a.db.Fsync(ctx); err != nil {
+		return fmt.Errorf("can not fsync oplog replay at %s: %w", handled, err)
+	}
+	a.progress.setDurable(handled)
+	tracelog.InfoLogger.Printf("Oplog replay progress is durable through %s", handled)
+	return nil
+}

--- a/internal/databases/mongo/stages/replay_applier_test.go
+++ b/internal/databases/mongo/stages/replay_applier_test.go
@@ -13,16 +13,29 @@ import (
 )
 
 type replayApplierStub struct {
-	mu      sync.RWMutex
-	pending bool
+	mu             sync.RWMutex
+	pending        bool
+	lastApplied    models.OpTime
+	lastAppliedSet bool
 }
 
-func (a *replayApplierStub) Apply(context.Context, models.Oplog) error { return nil }
-func (a *replayApplierStub) Close(context.Context) error               { return nil }
+func (a *replayApplierStub) Apply(_ context.Context, op models.Oplog) error {
+	a.mu.Lock()
+	a.lastApplied = models.OpTime{TS: op.TS, Term: 7}
+	a.lastAppliedSet = true
+	a.mu.Unlock()
+	return nil
+}
+func (a *replayApplierStub) Close(context.Context) error { return nil }
 func (a *replayApplierStub) HasPendingTransactions() bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.pending
+}
+func (a *replayApplierStub) LastAppliedOpTime() (models.OpTime, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.lastApplied, a.lastAppliedSet
 }
 func (a *replayApplierStub) setPending(pending bool) {
 	a.mu.Lock()
@@ -52,9 +65,9 @@ func TestCheckpointingApplierMakesHandledTimestampDurable(t *testing.T) {
 	close(ops)
 	require.NoError(t, <-errC)
 
-	durable, generation := progress.Snapshot()
-	require.Equal(t, applied, durable)
-	require.Equal(t, uint64(1), generation)
+	checkpoint := progress.Snapshot()
+	require.Equal(t, models.OpTime{TS: applied, Term: 7}, checkpoint.OpTime)
+	require.Equal(t, uint64(1), checkpoint.Generation)
 }
 
 func TestCheckpointingApplierWaitsForTransactionBoundary(t *testing.T) {
@@ -71,8 +84,8 @@ func TestCheckpointingApplierWaitsForTransactionBoundary(t *testing.T) {
 	ops <- &models.Oplog{TS: models.Timestamp{TS: 101}}
 	time.Sleep(30 * time.Millisecond)
 
-	durable, _ := progress.Snapshot()
-	require.Equal(t, models.Timestamp{TS: 100}, durable)
+	checkpoint := progress.Snapshot()
+	require.Equal(t, models.Timestamp{TS: 100}, checkpoint.OpTime.TS)
 
 	stub.setPending(false)
 	ops <- &models.Oplog{TS: models.Timestamp{TS: 102}}

--- a/internal/databases/mongo/stages/replay_applier_test.go
+++ b/internal/databases/mongo/stages/replay_applier_test.go
@@ -1,0 +1,87 @@
+package stages
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	clientmocks "github.com/wal-g/wal-g/internal/databases/mongo/client/mocks"
+	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+)
+
+type replayApplierStub struct {
+	mu      sync.RWMutex
+	pending bool
+}
+
+func (a *replayApplierStub) Apply(context.Context, models.Oplog) error { return nil }
+func (a *replayApplierStub) Close(context.Context) error               { return nil }
+func (a *replayApplierStub) HasPendingTransactions() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.pending
+}
+func (a *replayApplierStub) setPending(pending bool) {
+	a.mu.Lock()
+	a.pending = pending
+	a.mu.Unlock()
+}
+
+func TestCheckpointingApplierMakesHandledTimestampDurable(t *testing.T) {
+	db := clientmocks.NewMongoDriver(t)
+	fsynced := make(chan struct{})
+	db.On("Fsync", mock.Anything).Run(func(mock.Arguments) { close(fsynced) }).Return(nil).Once()
+
+	since := models.Timestamp{TS: 100, Inc: 1}
+	applied := models.Timestamp{TS: 101, Inc: 2}
+	progress := NewReplayProgress(since)
+	applier := NewCheckpointingApplier(db, &replayApplierStub{}, 10*time.Millisecond, progress)
+	ops := make(chan *models.Oplog)
+	errC, err := applier.Apply(t.Context(), ops)
+	require.NoError(t, err)
+	ops <- &models.Oplog{TS: applied}
+
+	select {
+	case <-fsynced:
+	case <-time.After(time.Second):
+		t.Fatal("fsync was not called")
+	}
+	close(ops)
+	require.NoError(t, <-errC)
+
+	handled, durable, generation := progress.Snapshot()
+	require.Equal(t, applied, handled)
+	require.Equal(t, applied, durable)
+	require.Equal(t, uint64(1), generation)
+}
+
+func TestCheckpointingApplierWaitsForTransactionBoundary(t *testing.T) {
+	db := clientmocks.NewMongoDriver(t)
+	fsynced := make(chan struct{})
+	db.On("Fsync", mock.Anything).Run(func(mock.Arguments) { close(fsynced) }).Return(nil).Once()
+
+	stub := &replayApplierStub{pending: true}
+	progress := NewReplayProgress(models.Timestamp{TS: 100})
+	applier := NewCheckpointingApplier(db, stub, 10*time.Millisecond, progress)
+	ops := make(chan *models.Oplog)
+	errC, err := applier.Apply(t.Context(), ops)
+	require.NoError(t, err)
+	ops <- &models.Oplog{TS: models.Timestamp{TS: 101}}
+	time.Sleep(30 * time.Millisecond)
+
+	_, durable, _ := progress.Snapshot()
+	require.Equal(t, models.Timestamp{TS: 100}, durable)
+
+	stub.setPending(false)
+	ops <- &models.Oplog{TS: models.Timestamp{TS: 102}}
+	select {
+	case <-fsynced:
+	case <-time.After(time.Second):
+		t.Fatal("fsync was not called after transaction boundary")
+	}
+	close(ops)
+	require.NoError(t, <-errC)
+}

--- a/internal/databases/mongo/stages/replay_applier_test.go
+++ b/internal/databases/mongo/stages/replay_applier_test.go
@@ -52,8 +52,7 @@ func TestCheckpointingApplierMakesHandledTimestampDurable(t *testing.T) {
 	close(ops)
 	require.NoError(t, <-errC)
 
-	handled, durable, generation := progress.Snapshot()
-	require.Equal(t, applied, handled)
+	durable, generation := progress.Snapshot()
 	require.Equal(t, applied, durable)
 	require.Equal(t, uint64(1), generation)
 }
@@ -72,7 +71,7 @@ func TestCheckpointingApplierWaitsForTransactionBoundary(t *testing.T) {
 	ops <- &models.Oplog{TS: models.Timestamp{TS: 101}}
 	time.Sleep(30 * time.Millisecond)
 
-	_, durable, _ := progress.Snapshot()
+	durable, _ := progress.Snapshot()
 	require.Equal(t, models.Timestamp{TS: 100}, durable)
 
 	stub.setPending(false)

--- a/tests_func/features/mongodb/binary_backup_with_pitr.feature
+++ b/tests_func/features/mongodb/binary_backup_with_pitr.feature
@@ -83,3 +83,21 @@ Feature: MongoDB binary backups with PITR
     And we restore from #1 backup to "after fourth load" timestamp to mongodb02
     And we save mongodb02 data "restore to after fourth load from second backup"
     Then we have same data in "after fourth load" and "restore to after fourth load from second backup"
+
+  Scenario: Binary PITR resumes after replay mongod crashes
+    Given mongodb01 has test mongodb data test1
+    And mongodb01 has 5000 replay transaction documents
+    And we create binary mongo-backup on mongodb01
+    And mongodb01 has 250 transactions with 20 documents each
+    And mongodb01 has been loaded with "load1"
+    And mongodb01 has been loaded with "load2"
+    And mongodb01 has been loaded with "load3"
+    And mongodb01 has been loaded with "load4"
+    And we save last oplog timestamp on mongodb01 to "after interrupted replay load"
+    And we save mongodb01 data "before interrupted replay restore"
+
+    Given mongodb02 has no data
+    And mongodb initialized on mongodb02
+    When we restore binary mongo-backup #0 to "after interrupted replay load" timestamp on mongodb02 and crash replay mongod
+    And we save mongodb02 data "after interrupted replay restore"
+    Then we have same data in "before interrupted replay restore" and "after interrupted replay restore"

--- a/tests_func/helpers/mongo.go
+++ b/tests_func/helpers/mongo.go
@@ -259,6 +259,46 @@ func (mc *MongoCtl) WriteTestData(mark string, dbCount, tablesCount, docsCount i
 	return nil
 }
 
+func (mc *MongoCtl) WriteTransactions(transactionCount, documentsPerTransaction int) error {
+	conn, err := mc.AdminConnect()
+	if err != nil {
+		return err
+	}
+	collection := conn.Database("replay_restart").Collection("transactions")
+
+	for transactionID := 0; transactionID < transactionCount; transactionID++ {
+		session, err := conn.StartSession()
+		if err != nil {
+			return err
+		}
+		_, err = session.WithTransaction(mc.ctx, func(ctx context.Context) (interface{}, error) {
+			firstDocumentID := transactionID * documentsPerTransaction
+			_, err := collection.UpdateMany(ctx, bson.M{
+				"_id": bson.M{"$gte": firstDocumentID, "$lt": firstDocumentID + documentsPerTransaction},
+			}, bson.M{"$set": bson.M{"updated": true, "transactionID": transactionID}})
+			return nil, err
+		})
+		session.EndSession(context.Background())
+		if err != nil {
+			return fmt.Errorf("transaction %d failed: %w", transactionID, err)
+		}
+	}
+	return nil
+}
+
+func (mc *MongoCtl) PrepareTransactionDocuments(documentCount int) error {
+	conn, err := mc.AdminConnect()
+	if err != nil {
+		return err
+	}
+	documents := make([]interface{}, documentCount)
+	for documentID := 0; documentID < documentCount; documentID++ {
+		documents[documentID] = bson.M{"_id": documentID, "updated": false}
+	}
+	_, err = conn.Database("replay_restart").Collection("transactions").InsertMany(mc.ctx, documents)
+	return err
+}
+
 func (mc *MongoCtl) Snapshot() ([]NsSnapshot, error) {
 	var snapshot []NsSnapshot
 

--- a/tests_func/helpers/walg.go
+++ b/tests_func/helpers/walg.go
@@ -109,6 +109,8 @@ type WalgUtil struct {
 	dbMajorVersion string
 }
 
+const interruptedReplayLogPath = "/tmp/walg-interrupted-replay.log"
+
 func NewWalgUtil(ctx context.Context, host, cliPath, confPath, dbMajorVersion string) *WalgUtil {
 	return &WalgUtil{ctx, host, cliPath, confPath, dbMajorVersion}
 }
@@ -203,7 +205,7 @@ func (w *WalgUtil) FetchBinaryBackup(
 func (w *WalgUtil) FetchBinaryBackupWithPITR(
 	backup, mongodConfigPath, mongodbVersion, since, until string,
 ) (ExecResult, error) {
-	command := []string{
+	walgCommand := []string{
 		"env",
 		"OPLOG_REPLAY_FSYNC_INTERVAL=1ms",
 		"OPLOG_REPLAY_MAX_MONGOD_RESTARTS=5",
@@ -212,7 +214,38 @@ func (w *WalgUtil) FetchBinaryBackupWithPITR(
 		"--pitr-since", since,
 		"--pitr-until", until,
 	}
-	return RunCommandStrict(w.ctx, w.host, command)
+	command := []string{"bash", "-c", `
+log_path="$1"
+shift
+: > "$log_path"
+exec "$@" > "$log_path" 2>&1
+`, "--", interruptedReplayLogPath}
+	command = append(command, walgCommand...)
+	_, restoreErr := RunCommandStrict(w.ctx, w.host, command)
+	logResult, logErr := RunCommand(w.ctx, w.host, []string{"bash", "-c", `
+while IFS= read -r line; do
+    printf '%s\n' "$line"
+done < "$1"
+`, "--", interruptedReplayLogPath})
+	if restoreErr != nil {
+		return logResult, restoreErr
+	}
+	return logResult, logErr
+}
+
+func (w *WalgUtil) InterruptedReplayCheckpointLogged() (bool, error) {
+	result, err := RunCommand(w.ctx, w.host, []string{"bash", "-c", `
+while IFS= read -r line; do
+    case "$line" in
+        *"Oplog replay progress is durable through"*) exit 0 ;;
+    esac
+done < "$1" 2>/dev/null
+exit 1
+`, "--", interruptedReplayLogPath})
+	if err != nil {
+		return false, err
+	}
+	return result.ExitCode == 0, nil
 }
 
 func (w *WalgUtil) BackupMeta(backupNum int) (Sentinel, error) {

--- a/tests_func/helpers/walg.go
+++ b/tests_func/helpers/walg.go
@@ -200,6 +200,21 @@ func (w *WalgUtil) FetchBinaryBackup(
 	return err
 }
 
+func (w *WalgUtil) FetchBinaryBackupWithPITR(
+	backup, mongodConfigPath, mongodbVersion, since, until string,
+) (ExecResult, error) {
+	command := []string{
+		"env",
+		"OPLOG_REPLAY_FSYNC_INTERVAL=1ms",
+		"OPLOG_REPLAY_MAX_MONGOD_RESTARTS=5",
+		w.cliPath, "--config", w.confPath,
+		"binary-backup-fetch", backup, mongodConfigPath, mongodbVersion,
+		"--pitr-since", since,
+		"--pitr-until", until,
+	}
+	return RunCommandStrict(w.ctx, w.host, command)
+}
+
 func (w *WalgUtil) BackupMeta(backupNum int) (Sentinel, error) {
 	backups, err := w.Backups()
 	if err != nil {

--- a/tests_func/mongo_binary_backup_steps.go
+++ b/tests_func/mongo_binary_backup_steps.go
@@ -114,7 +114,7 @@ func (tctx *TestContext) restoreMongoBinaryBackupWithInterruptedPITR(
 
 	output := result.Combined()
 	checkpointPosition := strings.Index(output, "Oplog replay progress is durable through")
-	restartPosition := strings.Index(output, "inline mongod crashed, restarting oplog replay")
+	restartPosition := strings.Index(output, "supervised mongod crashed, restarting oplog replay")
 	if checkpointPosition < 0 || restartPosition < 0 || checkpointPosition > restartPosition {
 		return fmt.Errorf("expected a durable checkpoint before mongod restart, output:\n%s", output)
 	}

--- a/tests_func/mongo_binary_backup_steps.go
+++ b/tests_func/mongo_binary_backup_steps.go
@@ -100,7 +100,7 @@ func (tctx *TestContext) restoreMongoBinaryBackupWithInterruptedPITR(
 
 	killC := make(chan error, 1)
 	go func() {
-		killC <- tctx.crashReplayMongod(container)
+		killC <- tctx.crashReplayMongod(walg, container)
 	}()
 	result, restoreErr := walg.FetchBinaryBackupWithPITR(
 		backup, configPath, mongodbVersion, since.String(), until.String())
@@ -128,10 +128,19 @@ func (tctx *TestContext) restoreMongoBinaryBackupWithInterruptedPITR(
 	return tctx.initiateReplSet(container)
 }
 
-func (tctx *TestContext) crashReplayMongod(container string) error {
+func (tctx *TestContext) crashReplayMongod(walg *helpers.WalgUtil, container string) error {
 	host := tctx.ContainerFQDN(container)
 	deadline := time.Now().Add(time.Minute)
 	for time.Now().Before(deadline) {
+		checkpointLogged, err := walg.InterruptedReplayCheckpointLogged()
+		if err != nil {
+			return err
+		}
+		if !checkpointLogged {
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+
 		result, err := helpers.RunCommand(tctx.Context, host, []string{"bash", "-c", `
 for proc in /proc/[0-9]*; do
     while IFS= read -r -d '' arg; do
@@ -154,15 +163,14 @@ exit 1
 			if err != nil {
 				return err
 			}
-			time.Sleep(2 * time.Second)
 			_, err = helpers.RunCommandStrict(tctx.Context, host, []string{
 				"bash", "-c", `kill -ABRT "$1"`, "--", strconv.Itoa(pid),
 			})
 			return err
 		}
-		time.Sleep(50 * time.Millisecond)
+		return fmt.Errorf("replay mongod exited before it could be interrupted")
 	}
-	return fmt.Errorf("replay mongod was not started within one minute")
+	return fmt.Errorf("durable replay checkpoint was not reached within one minute")
 }
 
 func (tctx *TestContext) createMongoBinaryBackup(container string) error {

--- a/tests_func/mongo_binary_backup_steps.go
+++ b/tests_func/mongo_binary_backup_steps.go
@@ -15,7 +15,7 @@ import (
 func SetupMongodbBinaryBackupSteps(ctx *godog.ScenarioContext, tctx *TestContext) {
 	ctx.Step(`^we create binary mongo-backup on ([^\s]*)$`, tctx.createMongoBinaryBackup)
 	ctx.Step(`^we create binary mongo-backup on ([^\s]*) with metadata$`, tctx.createMongoBinaryBackupWithMetadata)
-	ctx.Step(`^we restore binary mongo-backup #(\d+) to ([^\s]+)`, tctx.restoreMongoBinaryBackupAsNonInitialized)
+	ctx.Step(`^we restore binary mongo-backup #(\d+) to ([^\s]+)$`, tctx.restoreMongoBinaryBackupAsNonInitialized)
 	ctx.Step(`^we restore initialized binary mongo-backup #(\d+) to ([^\s]+)`,
 		tctx.restoreMongoBinaryBackupAsInitialized)
 	ctx.Step(`^we restore mongo-backup #(\d+) to ([^\s]+) with whitelist "([^"]*)"$`,

--- a/tests_func/mongo_binary_backup_steps.go
+++ b/tests_func/mongo_binary_backup_steps.go
@@ -2,7 +2,11 @@ package functests
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/cucumber/godog"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/tests_func/helpers"
@@ -24,6 +28,129 @@ func SetupMongodbBinaryBackupSteps(ctx *godog.ScenarioContext, tctx *TestContext
 		tctx.restoreMongoBinaryBackupWithWhitelistAsNonInitialized)
 	ctx.Step(`^journal info count is #(\d+)$`,
 		tctx.checkJournals)
+	ctx.Step(`^([^\s]+) has (\d+) transactions with (\d+) documents each$`, tctx.addMongoTransactions)
+	ctx.Step(`^([^\s]+) has (\d+) replay transaction documents$`, tctx.prepareMongoTransactionDocuments)
+	ctx.Step(`^we restore binary mongo-backup #(\d+) to "([^"]*)" timestamp on ([^\s]+) and crash replay mongod$`,
+		tctx.restoreMongoBinaryBackupWithInterruptedPITR)
+}
+
+func (tctx *TestContext) addMongoTransactions(container string, transactionCount, documentsPerTransaction int) error {
+	mc, err := MongoCtlFromTestContext(tctx, container)
+	if err != nil {
+		return err
+	}
+	return mc.WriteTransactions(transactionCount, documentsPerTransaction)
+}
+
+func (tctx *TestContext) prepareMongoTransactionDocuments(container string, documentCount int) error {
+	mc, err := MongoCtlFromTestContext(tctx, container)
+	if err != nil {
+		return err
+	}
+	return mc.PrepareTransactionDocuments(documentCount)
+}
+
+func (tctx *TestContext) restoreMongoBinaryBackupWithInterruptedPITR(
+	backupNumber int,
+	timestampID,
+	container string,
+) error {
+	walg := WalgUtilFromTestContext(tctx, container)
+	backup, err := walg.GetBackupByNumber(backupNumber)
+	if err != nil {
+		return err
+	}
+	backupMeta, err := walg.BackupMeta(backupNumber)
+	if err != nil {
+		return err
+	}
+	since := backupMeta.MongoMeta.GetBackupLastTS()
+	until := tctx.AuxData.Timestamps[timestampID]
+	until.Inc++
+
+	s3 := S3StorageFromTestContext(tctx, tctx.S3Host())
+	if _, err = backoff.Retry(tctx.Context, func() (struct{}, error) {
+		exists, err := s3.ArchTsExists(until)
+		if err != nil {
+			return struct{}{}, err
+		}
+		if !exists {
+			return struct{}{}, fmt.Errorf("timestamp %s is not archived yet", until.String())
+		}
+		return struct{}{}, nil
+	}, backoff.WithMaxTries(30)); err != nil {
+		return err
+	}
+
+	mc, err := MongoCtlFromTestContext(tctx, container)
+	if err != nil {
+		return err
+	}
+	mongodbVersion, err := mc.GetVersion()
+	if err != nil {
+		return err
+	}
+	configPath, err := mc.GetConfigPath()
+	if err != nil {
+		return err
+	}
+	if err = mc.StopMongod(); err != nil {
+		return err
+	}
+
+	killC := make(chan error, 1)
+	go func() {
+		killC <- tctx.crashReplayMongod(container)
+	}()
+	result, restoreErr := walg.FetchBinaryBackupWithPITR(
+		backup, configPath, mongodbVersion, since.String(), until.String())
+	killErr := <-killC
+	if killErr != nil {
+		return killErr
+	}
+	if restoreErr != nil {
+		return restoreErr
+	}
+
+	output := result.Combined()
+	checkpointPosition := strings.Index(output, "Oplog replay progress is durable through")
+	restartPosition := strings.Index(output, "inline mongod crashed, restarting oplog replay")
+	if checkpointPosition < 0 || restartPosition < 0 || checkpointPosition > restartPosition {
+		return fmt.Errorf("expected a durable checkpoint before mongod restart, output:\n%s", output)
+	}
+
+	if err = mc.ChownDBPath(); err != nil {
+		return err
+	}
+	if err = mc.StartMongod(); err != nil {
+		return err
+	}
+	return tctx.initiateReplSet(container)
+}
+
+func (tctx *TestContext) crashReplayMongod(container string) error {
+	host := tctx.ContainerFQDN(container)
+	deadline := time.Now().Add(time.Minute)
+	for time.Now().Before(deadline) {
+		result, err := helpers.RunCommand(tctx.Context, host,
+			[]string{"pgrep", "-f", "[t]akeUnstableCheckpointOnShutdown=true"})
+		if err == nil && result.ExitCode == 0 {
+			pidFields := strings.Fields(result.Stdout())
+			if len(pidFields) == 0 {
+				continue
+			}
+			pid, err := strconv.Atoi(pidFields[0])
+			if err != nil {
+				return err
+			}
+			time.Sleep(2 * time.Second)
+			_, err = helpers.RunCommandStrict(tctx.Context, host,
+				[]string{"kill", "-ABRT", strconv.Itoa(pid)})
+			return err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("replay mongod was not started within one minute")
 }
 
 func (tctx *TestContext) createMongoBinaryBackup(container string) error {

--- a/tests_func/mongo_binary_backup_steps.go
+++ b/tests_func/mongo_binary_backup_steps.go
@@ -132,8 +132,19 @@ func (tctx *TestContext) crashReplayMongod(container string) error {
 	host := tctx.ContainerFQDN(container)
 	deadline := time.Now().Add(time.Minute)
 	for time.Now().Before(deadline) {
-		result, err := helpers.RunCommand(tctx.Context, host,
-			[]string{"pgrep", "-f", "[t]akeUnstableCheckpointOnShutdown=true"})
+		result, err := helpers.RunCommand(tctx.Context, host, []string{"bash", "-c", `
+for proc in /proc/[0-9]*; do
+    while IFS= read -r -d '' arg; do
+        case "$arg" in
+            *takeUnstableCheckpointOnShutdown=true*)
+                printf '%s\n' "${proc##*/}"
+                exit 0
+                ;;
+        esac
+    done < "$proc/cmdline" 2>/dev/null
+done
+exit 1
+`})
 		if err == nil && result.ExitCode == 0 {
 			pidFields := strings.Fields(result.Stdout())
 			if len(pidFields) == 0 {
@@ -144,8 +155,9 @@ func (tctx *TestContext) crashReplayMongod(container string) error {
 				return err
 			}
 			time.Sleep(2 * time.Second)
-			_, err = helpers.RunCommandStrict(tctx.Context, host,
-				[]string{"kill", "-ABRT", strconv.Itoa(pid)})
+			_, err = helpers.RunCommandStrict(tctx.Context, host, []string{
+				"bash", "-c", `kill -ABRT "$1"`, "--", strconv.Itoa(pid),
+			})
 			return err
 		}
 		time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
### Database name
Wal-g provides support for many databases, please write down name of database you uses.

# Pull request description

### Describe what this PR fixes
// problem is ...

### Please provide steps to reproduce (if it's a bug)
// it can really help

### Please add config and wal-g stdout/stderr logs for debug purpose

also you can use WALG_LOG_LEVEL=DEVEL for logs collecting
<details><summary>If you can, provide logs</summary>
<p>
```bash
any logs here
```
</p>
</details>
