### PR TITLE
ci: drop leftovers from the pg_test image cache removal

### DIFF
--- a/.github/workflows/dockertests-par.yml
+++ b/.github/workflows/dockertests-par.yml
@@ -91,5 +91,4 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/dockertests.yml
     with:
-      pg-versions: ${{ needs.prepare.outputs.versions }}
       command-json-array: ${{ needs.prepare.outputs.commands }}

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -3,10 +3,6 @@ name: Docker tests
 on:
   workflow_call:
     inputs:
-      pg-versions:
-        description: 'Space-separated PostgreSQL majors whose test images to build and cache'
-        type: string
-        required: true
       command-json-array:
         required: true
         type: string
@@ -17,36 +13,25 @@ env:
   CACHE_FILE_UBUNTU_22_04: ~/docker-images-${{ github.sha }}/wal-g_ubuntu-22.04.tar
   CACHE_FILE_GOLANG: ~/docker-images-${{ github.sha }}/wal-g_golang.tar
   IMAGE_GOLANG: wal-g/golang
+  IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
 
 jobs:
-  # Build every image once here and cache it, so the test jobs below only load
-  # them instead of building their own. The cache is per commit.
+  # Build the shared base images once here and cache them for the test jobs.
+  # The PostgreSQL images are built in the test jobs themselves, see #2517.
   buildimages:
     name: Build images
     runs-on: ubuntu-latest
     steps:
-      # There is one image file per version, so the key must include the version
-      # list. A cache key is never overwritten, so an older key with fewer images
-      # would still be a hit and the missing images would be rebuilt every time.
-      - name: Resolve cache key
-        id: cachekey
-        env:
-          PG_VERSIONS: ${{ inputs.pg-versions }}
-        run: |
-          slug=$(echo "$PG_VERSIONS" | tr -s ' ' '-' | sed 's/^-//; s/-$//')
-          echo "key=docker-images-${{ github.sha }}-pg$slug" >>"$GITHUB_OUTPUT"
-
       #  use cache to pass docker images to the test jobs
       - name: Docker images caching
         id: cache-images
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CACHE_FOLDER }}/pg*_tests.tar
             ${{ env.CACHE_FILE_UBUNTU_18_04 }}
             ${{ env.CACHE_FILE_UBUNTU_22_04 }}
             ${{ env.CACHE_FILE_GOLANG }}
-          key: ${{ steps.cachekey.outputs.key }}
+          key: ${{ env.IMAGES_CACHE_KEY }}
 
       - name: Cleanup space on runner
         run: |
@@ -82,7 +67,7 @@ jobs:
       # build images
       - name: Build images
         if: steps.cache-images.outputs.cache-hit != 'true'
-        run: make PG_VERSIONS="${{ inputs.pg-versions }}" pg_save_image
+        run: make save_common_images
     env:
       USE_BROTLI: 1
       USE_LZO: 1
@@ -116,26 +101,16 @@ jobs:
           go-version-file: 'go.mod'
         id: go
 
-      # must be the same key as in buildimages, or no job will find the cache
-      - name: Resolve cache key
-        id: cachekey
-        env:
-          PG_VERSIONS: ${{ inputs.pg-versions }}
-        run: |
-          slug=$(echo "$PG_VERSIONS" | tr -s ' ' '-' | sed 's/^-//; s/-$//')
-          echo "key=docker-images-${{ github.sha }}-pg$slug" >>"$GITHUB_OUTPUT"
-
       # load docker images
       - name: Load docker images
         id: cache-images
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CACHE_FOLDER }}/pg*_tests.tar
             ${{ env.CACHE_FILE_UBUNTU_18_04 }}
             ${{ env.CACHE_FILE_UBUNTU_22_04 }}
             ${{ env.CACHE_FILE_GOLANG }}
-          key: ${{ steps.cachekey.outputs.key }}
+          key: ${{ env.IMAGES_CACHE_KEY }}
 
       - name: Fail if no cached images
         if: steps.cache-images.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,10 @@ pg_matrix_test:
 		$(MAKE) PG_MAJOR=$$v pg_integration_test || exit 1; \
 	done
 
-pg_save_image: install_and_build_pg pg10_build_image
+save_common_images: go_deps
 	mkdir -p ${CACHE_FOLDER}
 	sudo rm -rf ${CACHE_FOLDER}/*
+	docker compose build $(DOCKER_COMMON)
 	docker save wal-g/ubuntu:18.04 > ${CACHE_FILE_UBUNTU_18_04}
 	docker save wal-g/ubuntu:22.04 > ${CACHE_FILE_UBUNTU_22_04}
 	docker save ${IMAGE_GOLANG}    > ${CACHE_FILE_GOLANG}

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ save_common_images: go_deps
 	docker save ${IMAGE_GOLANG}    > ${CACHE_FILE_GOLANG}
 	ls -la ${CACHE_FOLDER}
 
-pg_integration_test: clean_compose install_and_build_pg
+pg_integration_test: clean_compose
 	if [ "$(PG_MAJOR)" = "10" ]; then\
 		make pg10_build_image;\
 	else\


### PR DESCRIPTION
### Database name
PostgreSQL

# Pull request description

A follow-up of #2517: it stopped caching the pg_test images, but the code around that cache was left in place.

