### PR TITLE
Greenplum: extract AO storage into dedicated package

### DIFF
--- a/internal/databases/greenplum/ao/increment.go
+++ b/internal/databases/greenplum/ao/increment.go
@@ -1,4 +1,4 @@
-package greenplum
+package ao
 
 import (
 	"bytes"

--- a/internal/databases/greenplum/ao/increment_test.go
+++ b/internal/databases/greenplum/ao/increment_test.go
@@ -1,4 +1,4 @@
-package greenplum_test
+package ao_test
 
 import (
 	"bytes"
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wal-g/wal-g/internal/databases/greenplum"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/walparser/parsingutil"
 )
 
-const aoSegmentFileName = "../../../test/testdata/gp_ao_file.bin"
+const aoSegmentFileName = "../../../../test/testdata/gp_ao_file.bin"
 const aoSegmentFileSizeBytes = 192
 
 func TestReadIncrement(t *testing.T) {
@@ -29,10 +29,10 @@ func TestFailOnIncorrectOffset(t *testing.T) {
 		fmt.Print(err.Error())
 	}
 
-	_, err = greenplum.NewIncrementalPageReader(t.Context(), file, aoSegmentFileSizeBytes, aoSegmentFileSizeBytes)
+	_, err = ao.NewIncrementalPageReader(t.Context(), file, aoSegmentFileSizeBytes, aoSegmentFileSizeBytes)
 	assert.Error(t, err)
 
-	_, err = greenplum.NewIncrementalPageReader(t.Context(), file, 0, aoSegmentFileSizeBytes)
+	_, err = ao.NewIncrementalPageReader(t.Context(), file, 0, aoSegmentFileSizeBytes)
 	assert.Error(t, err)
 }
 
@@ -42,14 +42,14 @@ func gpReadIncrement(offset, eof int64, t *testing.T) {
 		fmt.Print(err.Error())
 	}
 
-	reader, err := greenplum.NewIncrementalPageReader(t.Context(), file, eof, offset)
+	reader, err := ao.NewIncrementalPageReader(t.Context(), file, eof, offset)
 	assert.NoError(t, err)
 
 	increment, err := io.ReadAll(reader)
 	assert.NoError(t, err)
 
 	incrementBuf := bytes.NewBuffer(increment)
-	err = greenplum.ReadIncrementFileHeader(incrementBuf)
+	err = ao.ReadIncrementFileHeader(incrementBuf)
 	assert.NoError(t, err)
 
 	var parsedEOF uint64

--- a/internal/databases/greenplum/ao/metadata.go
+++ b/internal/databases/greenplum/ao/metadata.go
@@ -1,17 +1,17 @@
-package greenplum
+package ao
 
 import (
 	"time"
 )
 
-const AOFilesMetadataName = "ao_files_metadata.json"
+const FilesMetadataName = "ao_files_metadata.json"
 
-// getAOFilesMetadataPath returns AO files metadata storage path.
-func getAOFilesMetadataPath(backupName string) string {
-	return backupName + "/" + AOFilesMetadataName
+// GetFilesMetadataPath returns AO files metadata storage path.
+func GetFilesMetadataPath(backupName string) string {
+	return backupName + "/" + FilesMetadataName
 }
 
-type BackupAOFileDesc struct {
+type BackupFileDesc struct {
 	StoragePath     string         `json:"StoragePath"`
 	IsSkipped       bool           `json:"IsSkipped"`
 	IsIncremented   bool           `json:"IsIncremented,omitempty"`
@@ -25,8 +25,8 @@ type BackupAOFileDesc struct {
 	Checksum        string         `json:"Checksum,omitempty"`
 }
 
-type AOFilesMetadataDTO struct {
-	Files BackupAOFiles
+type FilesMetadataDTO struct {
+	Files BackupFiles
 	// UploadedSharedSize is the volume this backup uploaded to the shared aosegments/ storage:
 	// Files smaller than WALG_GP_AOSEG_SIZE_THRESHOLD go into the regular tar balls and are not
 	// part of it.
@@ -36,15 +36,15 @@ type AOFilesMetadataDTO struct {
 	UploadedSharedSize int64 `json:",omitempty"`
 }
 
-type BackupAOFiles map[string]*BackupAOFileDesc
+type BackupFiles map[string]*BackupFileDesc
 
-func NewAOFilesMetadataDTO() *AOFilesMetadataDTO {
-	return &AOFilesMetadataDTO{Files: make(BackupAOFiles)}
+func NewFilesMetadataDTO() *FilesMetadataDTO {
+	return &FilesMetadataDTO{Files: make(BackupFiles)}
 }
 
-func (m *AOFilesMetadataDTO) addFile(key, storagePath string, mTime, initialUplTS time.Time, aoMeta AoRelFileMetadata,
+func (m *FilesMetadataDTO) addFile(key, storagePath string, mTime, initialUplTS time.Time, aoMeta RelFileMetadata,
 	fileMode int64, isSkipped, isIncremented bool, checksum string) {
-	m.Files[key] = &BackupAOFileDesc{
+	m.Files[key] = &BackupFileDesc{
 		StoragePath:     storagePath,
 		IsSkipped:       isSkipped,
 		IsIncremented:   isIncremented,

--- a/internal/databases/greenplum/ao/storage.go
+++ b/internal/databases/greenplum/ao/storage.go
@@ -1,4 +1,4 @@
-package greenplum
+package ao
 
 import (
 	"context"
@@ -12,32 +12,32 @@ import (
 )
 
 const (
-	AoStoragePath       = "aosegments"
-	AoSegSuffix         = "_aoseg"
-	AoSegDeltaDelimiter = "_D_"
+	StoragePath    = "aosegments"
+	KeySuffix      = "_aoseg"
+	DeltaDelimiter = "_D_"
 )
 
-func makeAoFileStorageKey(relNameMd5 string, modCount int64, location *walparser.BlockLocation, newAoSegFilesID string) string {
+func makeFileStorageKey(relNameMd5 string, modCount int64, location *walparser.BlockLocation, newAoSegFilesID string) string {
 	return fmt.Sprintf("%d_%d_%s_%d_%d_%d_%s%s",
 		location.RelationFileNode.SpcNode, location.RelationFileNode.DBNode,
 		relNameMd5,
 		location.RelationFileNode.RelNode, location.BlockNo,
-		modCount, newAoSegFilesID, AoSegSuffix)
+		modCount, newAoSegFilesID, KeySuffix)
 }
 
-func makeDeltaAoFileStorageKey(baseKey string, modCount int64) string {
-	trimmedKey := strings.TrimSuffix(baseKey, AoSegSuffix)
-	return fmt.Sprintf("%s%s%d%s", trimmedKey, AoSegDeltaDelimiter, modCount, AoSegSuffix)
+func makeDeltaFileStorageKey(baseKey string, modCount int64) string {
+	trimmedKey := strings.TrimSuffix(baseKey, KeySuffix)
+	return fmt.Sprintf("%s%s%d%s", trimmedKey, DeltaDelimiter, modCount, KeySuffix)
 }
 
-// LoadStorageAoFiles loads the list of the AO/AOCS segment files that are referenced from previous backups
-func LoadStorageAoFiles(ctx context.Context, baseBackupsFolder storage.Folder) (map[string]struct{}, error) {
+// LoadStorageAOFiles loads the list of the AO/AOCS segment files that are referenced from previous backups.
+func LoadStorageAOFiles(ctx context.Context, baseBackupsFolder storage.Folder) (map[string]struct{}, error) {
 	aoSegments := make(map[string]struct{}, 0)
 
-	iterateFunc := func(_ string, desc *BackupAOFileDesc) {
+	iterateFunc := func(_ string, desc *BackupFileDesc) {
 		aoSegments[desc.StoragePath] = struct{}{}
 	}
-	err := iterateStorageAoFilesWithFunc(ctx, baseBackupsFolder, iterateFunc)
+	err := iterateStorageFilesWithFunc(ctx, baseBackupsFolder, iterateFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +45,8 @@ func LoadStorageAoFiles(ctx context.Context, baseBackupsFolder storage.Folder) (
 	return aoSegments, nil
 }
 
-func iterateStorageAoFilesWithFunc(ctx context.Context,
-	baseBackupsFolder storage.Folder, iterateFunc func(string, *BackupAOFileDesc)) error {
+func iterateStorageFilesWithFunc(ctx context.Context,
+	baseBackupsFolder storage.Folder, iterateFunc func(string, *BackupFileDesc)) error {
 	backupObjects, _, err := baseBackupsFolder.ListFolder(ctx)
 	if err != nil {
 		return err
@@ -58,11 +58,12 @@ func iterateStorageAoFilesWithFunc(ctx context.Context,
 	}
 
 	for _, b := range backupTimes {
-		backup, err := NewSegBackup(ctx, baseBackupsFolder, b.BackupName, b.StorageName)
+		backup, err := internal.NewBackupInStorage(ctx, baseBackupsFolder, b.BackupName, b.StorageName)
 		if err != nil {
 			return err
 		}
-		aoMeta, err := backup.LoadAoFilesMetadata(ctx)
+		var aoMeta FilesMetadataDTO
+		err = internal.FetchDto(ctx, backup.Folder, &aoMeta, GetFilesMetadataPath(backup.Name))
 		if err != nil {
 			if _, ok := err.(storage.ObjectNotFoundError); ok {
 				tracelog.WarningLogger.Printf("No AO files metadata found for backup %s in folder %s, skipping",

--- a/internal/databases/greenplum/ao/storage_checksum_test.go
+++ b/internal/databases/greenplum/ao/storage_checksum_test.go
@@ -1,4 +1,4 @@
-package greenplum
+package ao
 
 import (
 	"encoding/hex"

--- a/internal/databases/greenplum/ao/storage_uploader.go
+++ b/internal/databases/greenplum/ao/storage_uploader.go
@@ -1,4 +1,4 @@
-package greenplum
+package ao
 
 import (
 	"context"
@@ -21,10 +21,10 @@ import (
 	"github.com/zeebo/xxh3"
 )
 
-type AoStorageUploader struct {
+type StorageUploader struct {
 	uploader      internal.Uploader
-	baseAoFiles   BackupAOFiles
-	meta          *AOFilesMetadataDTO
+	baseAoFiles   BackupFiles
+	meta          *FilesMetadataDTO
 	metaMutex     sync.Mutex
 	crypter       crypto.Crypter
 	bundleFiles   internal.BundleFiles
@@ -35,9 +35,9 @@ type AoStorageUploader struct {
 	newAoSegFilesID string
 }
 
-func NewAoStorageUploader(uploader internal.Uploader, baseAoFiles BackupAOFiles,
+func NewStorageUploader(uploader internal.Uploader, baseAoFiles BackupFiles,
 	crypter crypto.Crypter, files internal.BundleFiles, isIncremental bool, deduplicationAgeLimit time.Duration,
-	newAoSegFilesID string) *AoStorageUploader {
+	newAoSegFilesID string) *StorageUploader {
 	// Separate uploader for AO/AOCS relfiles, with a size counter of its own: cloning would share
 	// the counter of the backup uploader, and WAL-G does not count these files in the backup size.
 	//
@@ -45,10 +45,10 @@ func NewAoStorageUploader(uploader internal.Uploader, baseAoFiles BackupAOFiles,
 	// TODO: lookup the compression details for each relation and compress it when compression is turned off
 	aoSegUploader := internal.NewRegularUploader(nil, uploader.Folder())
 
-	return &AoStorageUploader{
+	return &StorageUploader{
 		uploader:            aoSegUploader,
 		baseAoFiles:         baseAoFiles,
-		meta:                NewAOFilesMetadataDTO(),
+		meta:                NewFilesMetadataDTO(),
 		crypter:             crypter,
 		bundleFiles:         files,
 		isIncremental:       isIncremental,
@@ -57,8 +57,8 @@ func NewAoStorageUploader(uploader internal.Uploader, baseAoFiles BackupAOFiles,
 	}
 }
 
-func (u *AoStorageUploader) AddFile(ctx context.Context,
-	cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error {
+func (u *StorageUploader) AddFile(ctx context.Context,
+	cfi *internal.ComposeFileInfo, aoMeta RelFileMetadata, location *walparser.BlockLocation) error {
 	err := u.addFile(ctx, cfi, aoMeta, location)
 	switch err.(type) {
 	case internal.FileNotExistError:
@@ -71,8 +71,8 @@ func (u *AoStorageUploader) AddFile(ctx context.Context,
 	return err
 }
 
-func (u *AoStorageUploader) addFile(ctx context.Context,
-	cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error {
+func (u *StorageUploader) addFile(ctx context.Context,
+	cfi *internal.ComposeFileInfo, aoMeta RelFileMetadata, location *walparser.BlockLocation) error {
 	remoteFile, ok := u.baseAoFiles[cfi.Header.Name]
 	if !ok {
 		tracelog.DebugLogger.Printf("%s: no base file in storage, will perform a regular upload", cfi.Header.Name)
@@ -157,8 +157,8 @@ func validateFileChecksum(ctx context.Context, path string, oldEOF int64, curEOF
 	return newChecksum, true, nil
 }
 
-func (u *AoStorageUploader) addAoFileMetadata(
-	cfi *internal.ComposeFileInfo, storageKey string, aoMeta AoRelFileMetadata, isSkipped, isIncremented bool,
+func (u *StorageUploader) addAoFileMetadata(
+	cfi *internal.ComposeFileInfo, storageKey string, aoMeta RelFileMetadata, isSkipped, isIncremented bool,
 	initialUplTS time.Time, checksum string) {
 	u.metaMutex.Lock()
 	u.meta.addFile(cfi.Header.Name, storageKey, cfi.FileInfo.ModTime(),
@@ -166,18 +166,18 @@ func (u *AoStorageUploader) addAoFileMetadata(
 	u.metaMutex.Unlock()
 }
 
-func (u *AoStorageUploader) GetFiles() *AOFilesMetadataDTO {
+func (u *StorageUploader) GetFiles() *FilesMetadataDTO {
 	return u.meta
 }
 
 // UploadedDataSize is the volume this backup pushed to the shared aosegments/ storage, as counted
 // by the uploader after compression and encryption. Files reused from an older backup via
 // deduplication never reach the uploader, so they are not counted.
-func (u *AoStorageUploader) UploadedDataSize() (int64, error) {
+func (u *StorageUploader) UploadedDataSize() (int64, error) {
 	return u.uploader.UploadedDataSize()
 }
 
-func (u *AoStorageUploader) skipAoUpload(cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, storageKey string,
+func (u *StorageUploader) skipAoUpload(cfi *internal.ComposeFileInfo, aoMeta RelFileMetadata, storageKey string,
 	initialUploadTS time.Time, isIncremented bool, checksum string) error {
 	u.addAoFileMetadata(cfi, storageKey, aoMeta, true, isIncremented, initialUploadTS, checksum)
 	u.bundleFiles.AddSkippedFile(cfi.Header, cfi.FileInfo)
@@ -204,9 +204,9 @@ func getCheckSum(ctx context.Context, filePath string, eof int64) (string, error
 	return checksum, nil
 }
 
-func (u *AoStorageUploader) regularAoUpload(ctx context.Context,
-	cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, location *walparser.BlockLocation) error {
-	storageKey := makeAoFileStorageKey(aoMeta.relNameMd5, aoMeta.modCount, location, u.newAoSegFilesID)
+func (u *StorageUploader) regularAoUpload(ctx context.Context,
+	cfi *internal.ComposeFileInfo, aoMeta RelFileMetadata, location *walparser.BlockLocation) error {
+	storageKey := makeFileStorageKey(aoMeta.relNameMd5, aoMeta.modCount, location, u.newAoSegFilesID)
 	tracelog.DebugLogger.Printf("Uploading %s AO relfile to %s", cfi.Path, storageKey)
 	fileReadCloser, err := internal.StartReadingFile(ctx, cfi.Header, cfi.FileInfo, cfi.Path)
 	if err != nil {
@@ -231,10 +231,10 @@ func (u *AoStorageUploader) regularAoUpload(ctx context.Context,
 	return nil
 }
 
-func (u *AoStorageUploader) incrementalAoUpload(ctx context.Context,
+func (u *StorageUploader) incrementalAoUpload(ctx context.Context,
 	baseFileStorageKey string,
-	cfi *internal.ComposeFileInfo, aoMeta AoRelFileMetadata, baseFileEOF int64, initialUploadTS time.Time, checksum string) error {
-	storageKey := makeDeltaAoFileStorageKey(baseFileStorageKey, aoMeta.modCount)
+	cfi *internal.ComposeFileInfo, aoMeta RelFileMetadata, baseFileEOF int64, initialUploadTS time.Time, checksum string) error {
+	storageKey := makeDeltaFileStorageKey(baseFileStorageKey, aoMeta.modCount)
 	tracelog.DebugLogger.Printf("Uploading %s AO relfile delta to %s", cfi.Path, storageKey)
 
 	file, err := internal.StartReadingFile(ctx, cfi.Header, cfi.FileInfo, cfi.Path)
@@ -258,8 +258,8 @@ func (u *AoStorageUploader) incrementalAoUpload(ctx context.Context,
 	return nil
 }
 
-func (u *AoStorageUploader) upload(ctx context.Context, reader io.Reader, storageKey string) error {
+func (u *StorageUploader) upload(ctx context.Context, reader io.Reader, storageKey string) error {
 	uploadContents := internal.CompressAndEncrypt(ctx, reader, u.uploader.Compression(), u.crypter)
-	uploadPath := path.Join(AoStoragePath, storageKey)
+	uploadPath := path.Join(StoragePath, storageKey)
 	return u.uploader.Upload(ctx, uploadPath, uploadContents)
 }

--- a/internal/databases/greenplum/ao/storage_uploader_test.go
+++ b/internal/databases/greenplum/ao/storage_uploader_test.go
@@ -1,4 +1,4 @@
-package greenplum_test
+package ao_test
 
 import (
 	"archive/tar"
@@ -14,7 +14,7 @@ import (
 
 	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/crypto/openpgp"
-	"github.com/wal-g/wal-g/internal/databases/greenplum"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/walparser"
 	"github.com/wal-g/wal-g/pkg/storages/memory"
 	"github.com/wal-g/wal-g/testtools"
@@ -23,7 +23,7 @@ import (
 
 type TestFileInfo struct {
 	internal.ComposeFileInfo
-	greenplum.AoRelFileMetadata
+	ao.RelFileMetadata
 	walparser.BlockLocation
 }
 
@@ -31,21 +31,21 @@ type ExpectedResult struct {
 	StoragePath   string
 	IsSkipped     bool
 	IsIncremented bool
-	StorageType   greenplum.RelStorageType
+	StorageType   ao.RelStorageType
 	EOF           int64
 	ModCount      int64
 }
 
 const deduplicationAgeLimit = 720 * time.Hour // 30 days
 const NewAoSegFilesID = "test"
-const PrivateKeyFilePath = "../../../test/testdata/waleGpgKey"
+const PrivateKeyFilePath = "../../../../test/testdata/waleGpgKey"
 
 func TestRegularAoUpload(t *testing.T) {
-	baseFiles := make(greenplum.BackupAOFiles)
+	baseFiles := make(ao.BackupFiles)
 	bundleFiles := &internal.RegularBundleFiles{}
 	testFiles := map[string]TestFileInfo{
 		"1663.1": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.ColumnOriented, 100, 3),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.ColumnOriented, 100, 3),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 1009,
@@ -56,7 +56,7 @@ func TestRegularAoUpload(t *testing.T) {
 			},
 		},
 		"1337.120": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.AppendOptimized, 60, 4),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.AppendOptimized, 60, 4),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 0,
@@ -67,7 +67,7 @@ func TestRegularAoUpload(t *testing.T) {
 			},
 		},
 		"1337.60": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.AppendOptimized, 77, 5),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.AppendOptimized, 77, 5),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 0,
@@ -83,7 +83,7 @@ func TestRegularAoUpload(t *testing.T) {
 			StoragePath:   "0_13_md5summock_1337_60_5_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.AppendOptimized,
+			StorageType:   ao.AppendOptimized,
 			EOF:           77,
 			ModCount:      5,
 		},
@@ -91,7 +91,7 @@ func TestRegularAoUpload(t *testing.T) {
 			StoragePath:   "1009_13_md5summock_1663_1_3_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.ColumnOriented,
+			StorageType:   ao.ColumnOriented,
 			EOF:           100,
 			ModCount:      3,
 		},
@@ -99,7 +99,7 @@ func TestRegularAoUpload(t *testing.T) {
 			StoragePath:   "0_13_md5summock_1337_120_4_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.AppendOptimized,
+			StorageType:   ao.AppendOptimized,
 			EOF:           60,
 			ModCount:      4,
 		},
@@ -109,13 +109,13 @@ func TestRegularAoUpload(t *testing.T) {
 
 func TestAoUpload_MaxAge(t *testing.T) {
 	initialUploadTS := time.Now().Add(-(deduplicationAgeLimit + 1*time.Minute)) // file should be reuploaded
-	baseFiles := greenplum.BackupAOFiles{
+	baseFiles := ao.BackupFiles{
 		"1663.1": {
 			StoragePath:     "1009_13_md5summock_1663_1_4_test_aoseg",
 			IsSkipped:       false,
 			IsIncremented:   false,
 			MTime:           initialUploadTS,
-			StorageType:     greenplum.ColumnOriented,
+			StorageType:     ao.ColumnOriented,
 			EOF:             70,
 			ModCount:        4,
 			Compressor:      "",
@@ -127,7 +127,7 @@ func TestAoUpload_MaxAge(t *testing.T) {
 			IsSkipped:       false,
 			IsIncremented:   true,
 			MTime:           initialUploadTS,
-			StorageType:     greenplum.AppendOptimized,
+			StorageType:     ao.AppendOptimized,
 			EOF:             60,
 			ModCount:        4,
 			Compressor:      "",
@@ -138,7 +138,7 @@ func TestAoUpload_MaxAge(t *testing.T) {
 	bundleFiles := &internal.RegularBundleFiles{}
 	testFiles := map[string]TestFileInfo{
 		"1663.1": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.ColumnOriented, 70, 4),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.ColumnOriented, 70, 4),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 1009,
@@ -149,7 +149,7 @@ func TestAoUpload_MaxAge(t *testing.T) {
 			},
 		},
 		"1337.120": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.AppendOptimized, 70, 5),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.AppendOptimized, 70, 5),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 0,
@@ -165,7 +165,7 @@ func TestAoUpload_MaxAge(t *testing.T) {
 			StoragePath:   "1009_13_md5summock_1663_1_4_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.ColumnOriented,
+			StorageType:   ao.ColumnOriented,
 			EOF:           70,
 			ModCount:      4,
 		},
@@ -173,7 +173,7 @@ func TestAoUpload_MaxAge(t *testing.T) {
 			StoragePath:   "0_13_md5summock_1337_120_5_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.AppendOptimized,
+			StorageType:   ao.AppendOptimized,
 			EOF:           70,
 			ModCount:      5,
 		},
@@ -186,13 +186,13 @@ func TestIncrementalAoUpload(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "1337.120")
 	require.NoError(t, os.WriteFile(path, []byte{1, 2, 3, 4, 5, 6, 7}, 0o600))
-	baseFiles := greenplum.BackupAOFiles{
+	baseFiles := ao.BackupFiles{
 		"1337.120": {
 			StoragePath:     "0_13_md5summock_1337_120_4_test_aoseg",
 			IsSkipped:       false,
 			IsIncremented:   false,
 			MTime:           time.Now(),
-			StorageType:     greenplum.AppendOptimized,
+			StorageType:     ao.AppendOptimized,
 			EOF:             60,
 			ModCount:        4,
 			Compressor:      "",
@@ -204,7 +204,7 @@ func TestIncrementalAoUpload(t *testing.T) {
 	bundleFiles := &internal.RegularBundleFiles{}
 	testFiles := map[string]TestFileInfo{
 		"1663.1": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.ColumnOriented, 100, 3),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.ColumnOriented, 100, 3),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 0,
@@ -215,7 +215,7 @@ func TestIncrementalAoUpload(t *testing.T) {
 			},
 		},
 		"1337.120": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.AppendOptimized, 70, 5),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.AppendOptimized, 70, 5),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 0,
@@ -226,7 +226,7 @@ func TestIncrementalAoUpload(t *testing.T) {
 			},
 		},
 		"1337.60": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.AppendOptimized, 77, 5),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.AppendOptimized, 77, 5),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 0,
@@ -242,7 +242,7 @@ func TestIncrementalAoUpload(t *testing.T) {
 			StoragePath:   "0_13_md5summock_1337_60_5_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.AppendOptimized,
+			StorageType:   ao.AppendOptimized,
 			EOF:           77,
 			ModCount:      5,
 		},
@@ -250,7 +250,7 @@ func TestIncrementalAoUpload(t *testing.T) {
 			StoragePath:   "0_13_md5summock_1663_1_3_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.ColumnOriented,
+			StorageType:   ao.ColumnOriented,
 			EOF:           100,
 			ModCount:      3,
 		},
@@ -258,7 +258,7 @@ func TestIncrementalAoUpload(t *testing.T) {
 			StoragePath:   "0_13_md5summock_1337_120_4_test_D_5_aoseg",
 			IsSkipped:     false,
 			IsIncremented: true,
-			StorageType:   greenplum.AppendOptimized,
+			StorageType:   ao.AppendOptimized,
 			EOF:           70,
 			ModCount:      5,
 		},
@@ -267,13 +267,13 @@ func TestIncrementalAoUpload(t *testing.T) {
 }
 
 func TestIncrementalAoUpload_EqualEOF_DifferentModCount(t *testing.T) {
-	baseFiles := greenplum.BackupAOFiles{
+	baseFiles := ao.BackupFiles{
 		"1663.1": {
 			StoragePath:     "1009_13_md5summock_1663_1_4_test_aoseg",
 			IsSkipped:       false,
 			IsIncremented:   false,
 			MTime:           time.Now(),
-			StorageType:     greenplum.ColumnOriented,
+			StorageType:     ao.ColumnOriented,
 			EOF:             100,
 			ModCount:        4,
 			Compressor:      "",
@@ -284,7 +284,7 @@ func TestIncrementalAoUpload_EqualEOF_DifferentModCount(t *testing.T) {
 	bundleFiles := &internal.RegularBundleFiles{}
 	testFiles := map[string]TestFileInfo{
 		"1663.1": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.ColumnOriented, 100, 5),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.ColumnOriented, 100, 5),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 1009,
@@ -300,7 +300,7 @@ func TestIncrementalAoUpload_EqualEOF_DifferentModCount(t *testing.T) {
 			StoragePath:   "1009_13_md5summock_1663_1_5_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.ColumnOriented,
+			StorageType:   ao.ColumnOriented,
 			EOF:           100,
 			ModCount:      5,
 		},
@@ -309,13 +309,13 @@ func TestIncrementalAoUpload_EqualEOF_DifferentModCount(t *testing.T) {
 }
 
 func TestIncrementalAoUpload_DifferentEOF_EqualModCount(t *testing.T) {
-	baseFiles := greenplum.BackupAOFiles{
+	baseFiles := ao.BackupFiles{
 		"1663.1": {
 			StoragePath:     "1009_13_md5summock_1663_1_4_test_aoseg",
 			IsSkipped:       false,
 			IsIncremented:   false,
 			MTime:           time.Now(),
-			StorageType:     greenplum.ColumnOriented,
+			StorageType:     ao.ColumnOriented,
 			EOF:             70,
 			ModCount:        4,
 			Compressor:      "",
@@ -326,7 +326,7 @@ func TestIncrementalAoUpload_DifferentEOF_EqualModCount(t *testing.T) {
 	bundleFiles := &internal.RegularBundleFiles{}
 	testFiles := map[string]TestFileInfo{
 		"1663.1": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.ColumnOriented, 100, 4),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.ColumnOriented, 100, 4),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 1009,
@@ -342,7 +342,7 @@ func TestIncrementalAoUpload_DifferentEOF_EqualModCount(t *testing.T) {
 			StoragePath:   "1009_13_md5summock_1663_1_4_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.ColumnOriented,
+			StorageType:   ao.ColumnOriented,
 			EOF:           100,
 			ModCount:      4,
 		},
@@ -351,13 +351,13 @@ func TestIncrementalAoUpload_DifferentEOF_EqualModCount(t *testing.T) {
 }
 
 func TestIncrementalAoUpload_FullAfterDelta(t *testing.T) {
-	baseFiles := greenplum.BackupAOFiles{
+	baseFiles := ao.BackupFiles{
 		"1663.1": {
 			StoragePath:     "1009_13_md5summock_1663_1_4_test_D_aoseg",
 			IsSkipped:       false,
 			IsIncremented:   true,
 			MTime:           time.Now(),
-			StorageType:     greenplum.ColumnOriented,
+			StorageType:     ao.ColumnOriented,
 			EOF:             70,
 			ModCount:        4,
 			Compressor:      "",
@@ -368,7 +368,7 @@ func TestIncrementalAoUpload_FullAfterDelta(t *testing.T) {
 	bundleFiles := &internal.RegularBundleFiles{}
 	testFiles := map[string]TestFileInfo{
 		"1663.1": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.ColumnOriented, 70, 4),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.ColumnOriented, 70, 4),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 1009,
@@ -384,7 +384,7 @@ func TestIncrementalAoUpload_FullAfterDelta(t *testing.T) {
 			StoragePath:   "1009_13_md5summock_1663_1_4_test_aoseg",
 			IsSkipped:     false,
 			IsIncremented: false,
-			StorageType:   greenplum.ColumnOriented,
+			StorageType:   ao.ColumnOriented,
 			EOF:           70,
 			ModCount:      4,
 		},
@@ -393,13 +393,13 @@ func TestIncrementalAoUpload_FullAfterDelta(t *testing.T) {
 }
 
 func TestAoUpload_SkippedFile(t *testing.T) {
-	baseFiles := greenplum.BackupAOFiles{
+	baseFiles := ao.BackupFiles{
 		"1663.1": {
 			StoragePath:     "1009_13_md5summock_1663_1_4_test_aoseg",
 			IsSkipped:       false,
 			IsIncremented:   false,
 			MTime:           time.Now(),
-			StorageType:     greenplum.ColumnOriented,
+			StorageType:     ao.ColumnOriented,
 			EOF:             70,
 			ModCount:        4,
 			Compressor:      "",
@@ -410,7 +410,7 @@ func TestAoUpload_SkippedFile(t *testing.T) {
 	bundleFiles := &internal.RegularBundleFiles{}
 	testFiles := map[string]TestFileInfo{
 		"1663.1": {
-			AoRelFileMetadata: greenplum.NewAoRelFileMetadata("md5summock", greenplum.ColumnOriented, 70, 4),
+			RelFileMetadata: ao.NewRelFileMetadata("md5summock", ao.ColumnOriented, 70, 4),
 			BlockLocation: walparser.BlockLocation{
 				RelationFileNode: walparser.RelFileNode{
 					SpcNode: 1009,
@@ -426,7 +426,7 @@ func TestAoUpload_SkippedFile(t *testing.T) {
 			StoragePath:   "1009_13_md5summock_1663_1_4_test_aoseg",
 			IsSkipped:     true,
 			IsIncremented: false,
-			StorageType:   greenplum.ColumnOriented,
+			StorageType:   ao.ColumnOriented,
 			EOF:           70,
 			ModCount:      4,
 		},
@@ -436,11 +436,11 @@ func TestAoUpload_SkippedFile(t *testing.T) {
 
 func TestAoUpload_NotExistFile(t *testing.T) {
 	name := "1663.1"
-	baseFiles := greenplum.BackupAOFiles{}
+	baseFiles := ao.BackupFiles{}
 	bundleFiles := &internal.RegularBundleFiles{}
 	deduplicationAgeLimit := 720 * time.Hour
-	uploader := newAoStorageUploader(baseFiles, bundleFiles, true, deduplicationAgeLimit)
-	meta := greenplum.NewAoRelFileMetadata("md5summock", greenplum.ColumnOriented, 70, 4)
+	uploader := newStorageUploader(baseFiles, bundleFiles, true, deduplicationAgeLimit)
+	meta := ao.NewRelFileMetadata("md5summock", ao.ColumnOriented, 70, 4)
 	location := walparser.BlockLocation{
 		RelationFileNode: walparser.RelFileNode{
 			SpcNode: 0,
@@ -475,16 +475,16 @@ func TestAoUpload_NotExistFile(t *testing.T) {
 	assert.Empty(t, uploader.GetFiles().Files)
 }
 
-func runSingleTest(t *testing.T, baseFiles greenplum.BackupAOFiles,
+func runSingleTest(t *testing.T, baseFiles ao.BackupFiles,
 	bundleFiles *internal.RegularBundleFiles, testFiles map[string]TestFileInfo, expectedResults map[string]ExpectedResult,
 	deduplicationAgeLimit time.Duration, isAploaderIncremental bool) {
-	uploader := newAoStorageUploader(baseFiles, bundleFiles, isAploaderIncremental, deduplicationAgeLimit)
+	uploader := newStorageUploader(baseFiles, bundleFiles, isAploaderIncremental, deduplicationAgeLimit)
 	testDir, testFiles := generateData("data", testFiles, t)
 	defer os.RemoveAll(testDir)
 
 	for _, testFile := range testFiles {
 		cfi := testFile.ComposeFileInfo
-		aoMeta := testFile.AoRelFileMetadata
+		aoMeta := testFile.RelFileMetadata
 		location := testFile.BlockLocation
 		err := uploader.AddFile(t.Context(), &cfi, aoMeta, &location)
 		assert.NoError(t, err)
@@ -513,16 +513,16 @@ func runSingleTest(t *testing.T, baseFiles greenplum.BackupAOFiles,
 	}
 }
 
-func newAoStorageUploader(
-	baseFiles greenplum.BackupAOFiles, bundleFiles internal.BundleFiles, isIncremental bool,
+func newStorageUploader(
+	baseFiles ao.BackupFiles, bundleFiles internal.BundleFiles, isIncremental bool,
 	deduplicationAgeLimit time.Duration,
-) *greenplum.AoStorageUploader {
+) *ao.StorageUploader {
 	storage := memory.NewKVS()
 	mockUploader := testtools.NewStoringMockUploader(storage)
 	crypter := openpgp.CrypterFromKeyPath(PrivateKeyFilePath, func() (string, bool) {
 		return "", false
 	})
-	return greenplum.NewAoStorageUploader(mockUploader, baseFiles, crypter, bundleFiles, isIncremental, deduplicationAgeLimit, NewAoSegFilesID)
+	return ao.NewStorageUploader(mockUploader, baseFiles, crypter, bundleFiles, isIncremental, deduplicationAgeLimit, NewAoSegFilesID)
 }
 
 func generateData(dirName string, testFiles map[string]TestFileInfo, t *testing.T) (string, map[string]TestFileInfo) {

--- a/internal/databases/greenplum/ao/types.go
+++ b/internal/databases/greenplum/ao/types.go
@@ -1,0 +1,57 @@
+package ao
+
+import (
+	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/postgres"
+	"github.com/wal-g/wal-g/internal/walparser"
+)
+
+type RelStorageType byte
+
+const (
+	AppendOptimized RelStorageType = 'a'
+	ColumnOriented  RelStorageType = 'c'
+)
+
+func NewRelFileMetadata(relNameMd5 string, storageType RelStorageType, eof, modCount int64) RelFileMetadata {
+	return RelFileMetadata{
+		relNameMd5:  relNameMd5,
+		storageType: storageType,
+		eof:         eof,
+		modCount:    modCount,
+	}
+}
+
+type RelFileMetadata struct {
+	relNameMd5  string
+	storageType RelStorageType
+	eof         int64
+	modCount    int64
+}
+
+// RelFileStorageMap indicates the storage type for the relfile.
+type RelFileStorageMap map[walparser.BlockLocation]RelFileMetadata
+
+func (storageMap RelFileStorageMap) Lookup(filePath string) (bool, RelFileMetadata, *walparser.BlockLocation) {
+	relFileNode, err := postgres.GetRelFileNodeFrom(filePath)
+	if err != nil {
+		// Looks like this is not a relfile at all.
+		return false, RelFileMetadata{}, nil
+	}
+	blockNo, err := postgres.GetRelFileIDFrom(filePath)
+	if err != nil {
+		tracelog.WarningLogger.Printf("Failed to parse blockNo for path %s: %v", filePath, err)
+		return false, RelFileMetadata{}, nil
+	}
+
+	location := walparser.NewBlockLocation(relFileNode.SpcNode, relFileNode.DBNode, relFileNode.RelNode, uint32(blockNo))
+	storageInfo, ok := storageMap[*location]
+	if !ok {
+		// Absence of the entry does not guarantee that the relfile is not append-optimized.
+		// It may have been created after the backup start. Currently, we do not need to
+		// detect an AO file with 100% precision, so it is OK.
+		return false, RelFileMetadata{}, nil
+	}
+
+	return true, storageInfo, location
+}

--- a/internal/databases/greenplum/ao_check_segment_length_handler.go
+++ b/internal/databases/greenplum/ao_check_segment_length_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
@@ -290,7 +291,7 @@ func (checker *AOLengthCheckSegmentHandler) getTableMetadataEOF(ctx context.Cont
 	return metaEOF, nil
 }
 
-func (checker *AOLengthCheckSegmentHandler) getAOMetadata(ctx context.Context, backupName string) (BackupAOFiles, error) {
+func (checker *AOLengthCheckSegmentHandler) getAOMetadata(ctx context.Context, backupName string) (ao.BackupFiles, error) {
 	rootFolder := checker.rootFolder
 
 	var backup internal.Backup
@@ -303,9 +304,9 @@ func (checker *AOLengthCheckSegmentHandler) getAOMetadata(ctx context.Context, b
 	}
 
 	tracelog.DebugLogger.Printf("backup %s", backup.Name)
-	files := NewAOFilesMetadataDTO()
+	files := ao.NewFilesMetadataDTO()
 
-	err = internal.FetchDto(ctx, backup.Folder, &files, fmt.Sprintf("%s/ao_files_metadata.json", backup.Name))
+	err = internal.FetchDto(ctx, backup.Folder, &files, ao.GetFilesMetadataPath(backup.Name))
 	if err != nil {
 		tracelog.ErrorLogger.Printf("failed to fetch file data")
 		return nil, err

--- a/internal/databases/greenplum/ao_relfile_storage_map.go
+++ b/internal/databases/greenplum/ao_relfile_storage_map.go
@@ -6,68 +6,17 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
-	"github.com/wal-g/wal-g/internal/walparser"
 )
 
-type RelStorageType byte
-
-const (
-	AppendOptimized RelStorageType = 'a'
-	ColumnOriented  RelStorageType = 'c'
-)
-
-func NewAoRelFileMetadata(relNameMd5 string, storageType RelStorageType, eof, modCount int64) AoRelFileMetadata {
-	return AoRelFileMetadata{
-		relNameMd5:  relNameMd5,
-		storageType: storageType,
-		eof:         eof,
-		modCount:    modCount,
-	}
-}
-
-type AoRelFileMetadata struct {
-	relNameMd5  string
-	storageType RelStorageType
-	eof         int64
-	modCount    int64
-}
-
-// AoRelFileStorageMap indicates the storage type for the relfile
-type AoRelFileStorageMap map[walparser.BlockLocation]AoRelFileMetadata
-
-func (storageMap *AoRelFileStorageMap) getAOStorageMetadata(filePath string) (bool, AoRelFileMetadata, *walparser.BlockLocation) {
-	relFileNode, err := postgres.GetRelFileNodeFrom(filePath)
-	if err != nil {
-		// looks like this is not the relfile at all => false
-		return false, AoRelFileMetadata{}, nil
-	}
-	blockNo, err := postgres.GetRelFileIDFrom(filePath)
-	if err != nil {
-		// same as above, but this is some unusual / unexpected error, better log it
-		tracelog.WarningLogger.Printf("Failed to parse blockNo for path %s: %v", filePath, err)
-		return false, AoRelFileMetadata{}, nil
-	}
-
-	location := walparser.NewBlockLocation(relFileNode.SpcNode, relFileNode.DBNode, relFileNode.RelNode, uint32(blockNo))
-	storageInfo, ok := (*storageMap)[*location]
-	if !ok {
-		// Absence of the entry does not guarantee that the relfile is not append-optimized.
-		// It may have been created after the backup start.
-		// Currently, we do not need to detect an AO file with 100% precision, so it is OK.
-		return false, AoRelFileMetadata{}, nil
-	}
-
-	return true, storageInfo, location
-}
-
-func NewAoRelFileStorageMap(ctx context.Context, queryRunner *GpQueryRunner) (AoRelFileStorageMap, error) {
+func NewAoRelFileStorageMap(ctx context.Context, queryRunner *GpQueryRunner) (ao.RelFileStorageMap, error) {
 	databases, err := queryRunner.GetDatabaseInfos(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get database names")
 	}
 
-	result := make(AoRelFileStorageMap)
+	result := make(ao.RelFileStorageMap)
 	// collect info for each relFileNode
 	for _, db := range databases {
 		dbName := db.Name

--- a/internal/databases/greenplum/incremental_tar_interpreter.go
+++ b/internal/databases/greenplum/incremental_tar_interpreter.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/spf13/viper"
 	conf "github.com/wal-g/wal-g/internal/config"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 )
 
 func NewIncrementalTarInterpreter(dbDataDirectory string, sentinel postgres.BackupSentinelDto, filesMetadata postgres.FilesMetadataDto,
-	aoFilesMetadata AOFilesMetadataDTO,
+	aoFilesMetadata ao.FilesMetadataDTO,
 	filesToUnwrap map[string]bool, createNewIncrementalFiles bool) *IncrementalTarInterpreter {
 	return &IncrementalTarInterpreter{
 		FileTarInterpreter: postgres.NewFileTarInterpreter(dbDataDirectory, sentinel, filesMetadata, filesToUnwrap, createNewIncrementalFiles),
@@ -23,7 +24,7 @@ func NewIncrementalTarInterpreter(dbDataDirectory string, sentinel postgres.Back
 type IncrementalTarInterpreter struct {
 	*postgres.FileTarInterpreter
 	fsync           bool
-	aoFilesMetadata AOFilesMetadataDTO
+	aoFilesMetadata ao.FilesMetadataDTO
 }
 
 func (i *IncrementalTarInterpreter) Interpret(reader io.Reader, header *tar.Header) error {
@@ -33,5 +34,5 @@ func (i *IncrementalTarInterpreter) Interpret(reader io.Reader, header *tar.Head
 	}
 
 	targetPath := path.Join(i.DBDataDirectory, header.Name)
-	return ApplyFileIncrement(targetPath, reader, i.fsync)
+	return ao.ApplyFileIncrement(targetPath, reader, i.fsync)
 }

--- a/internal/databases/greenplum/query_runner.go
+++ b/internal/databases/greenplum/query_runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/wal-g/tracelog"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/internal/walparser"
 )
@@ -25,7 +26,7 @@ type aoRelPgClassInfo struct {
 	relFileNodeID uint32
 	relNAtts      int16
 	spcNode       uint32
-	storage       RelStorageType
+	storage       ao.RelStorageType
 }
 
 // NewGpQueryRunner builds QueryRunner from available connection
@@ -313,7 +314,7 @@ func (queryRunner *GpQueryRunner) AbortBackup(ctx context.Context) (err error) {
 
 // FetchAOStorageMetadata queries the storage metadata for AO & AOCS tables (GreenplumDB)
 func (queryRunner *GpQueryRunner) FetchAOStorageMetadata(ctx context.Context,
-	dbInfo postgres.PgDatabaseInfo) (AoRelFileStorageMap, error) {
+	dbInfo postgres.PgDatabaseInfo) (ao.RelFileStorageMap, error) {
 	queryRunner.Mu.Lock()
 	defer queryRunner.Mu.Unlock()
 
@@ -337,7 +338,7 @@ func (queryRunner *GpQueryRunner) FetchAOStorageMetadata(ctx context.Context,
 		var aoSegTableFqn string
 		var relFileNodeID uint32
 		var spcNode uint32
-		var storage RelStorageType
+		var storage ao.RelStorageType
 		var relNAtts int16
 		if err := rows.Scan(&oid, &relNameMd5, &aoSegTableFqn, &relFileNodeID, &spcNode, &storage, &relNAtts); err != nil {
 			return nil, errors.Wrapf(err, "failed to parse query result")
@@ -356,12 +357,12 @@ func (queryRunner *GpQueryRunner) FetchAOStorageMetadata(ctx context.Context,
 		return nil, rows.Err()
 	}
 
-	relStorageMap := make(AoRelFileStorageMap)
+	relStorageMap := make(ao.RelFileStorageMap)
 
 	for aoSegTableFqn, row := range relPgClassInfo {
 		var queryFunc func() (pgx.Rows, error)
 		switch row.storage {
-		case AppendOptimized:
+		case ao.AppendOptimized:
 			queryFunc = func() (pgx.Rows, error) {
 				query, err := queryRunner.buildAOMetadataQuery(aoSegTableFqn)
 				if err != nil {
@@ -370,7 +371,7 @@ func (queryRunner *GpQueryRunner) FetchAOStorageMetadata(ctx context.Context,
 
 				return conn.Query(ctx, query)
 			}
-		case ColumnOriented:
+		case ao.ColumnOriented:
 			queryFunc = func() (pgx.Rows, error) {
 				query, err := queryRunner.buildAOCSMetadataQuery()
 				if err != nil {
@@ -394,7 +395,7 @@ func (queryRunner *GpQueryRunner) FetchAOStorageMetadata(ctx context.Context,
 	return relStorageMap, nil
 }
 
-func loadStorageMetadata(relStorageMap AoRelFileStorageMap, dbInfo postgres.PgDatabaseInfo,
+func loadStorageMetadata(relStorageMap ao.RelFileStorageMap, dbInfo postgres.PgDatabaseInfo,
 	queryFn func() (pgx.Rows, error), aoSegTableFqn string, relPgClassInfo map[string]aoRelPgClassInfo) error {
 	rows, err := queryFn()
 	if err != nil {
@@ -417,12 +418,7 @@ func loadStorageMetadata(relStorageMap AoRelFileStorageMap, dbInfo postgres.PgDa
 		if relFileLoc.RelationFileNode.SpcNode == walparser.Oid(0) {
 			relFileLoc.RelationFileNode.SpcNode = dbInfo.TblSpcOid
 		}
-		relStorageMap[*relFileLoc] = AoRelFileMetadata{
-			relNameMd5:  cInfo.relNameMd5,
-			storageType: cInfo.storage,
-			eof:         eof,
-			modCount:    modCount,
-		}
+		relStorageMap[*relFileLoc] = ao.NewRelFileMetadata(cInfo.relNameMd5, cInfo.storage, eof, modCount)
 	}
 	if rows.Err() != nil {
 		return rows.Err()

--- a/internal/databases/greenplum/segment_backup.go
+++ b/internal/databases/greenplum/segment_backup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/greenplum/pax"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -12,7 +13,7 @@ import (
 type SegBackup struct {
 	postgres.Backup
 
-	AoFilesMetadataDto  *AOFilesMetadataDTO
+	AoFilesMetadataDto  *ao.FilesMetadataDTO
 	PaxFilesMetadataDto *pax.FilesMetadataDTO
 }
 
@@ -32,13 +33,13 @@ func ToGpSegBackup(source postgres.Backup) (output SegBackup) {
 	}
 }
 
-func (backup *SegBackup) LoadAoFilesMetadata(ctx context.Context) (*AOFilesMetadataDTO, error) {
+func (backup *SegBackup) LoadAoFilesMetadata(ctx context.Context) (*ao.FilesMetadataDTO, error) {
 	if backup.AoFilesMetadataDto != nil {
 		return backup.AoFilesMetadataDto, nil
 	}
 
-	var meta AOFilesMetadataDTO
-	err := internal.FetchDto(ctx, backup.Folder, &meta, getAOFilesMetadataPath(backup.Name))
+	var meta ao.FilesMetadataDTO
+	err := internal.FetchDto(ctx, backup.Folder, &meta, ao.GetFilesMetadataPath(backup.Name))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/databases/greenplum/segment_delete_handler.go
+++ b/internal/databases/greenplum/segment_delete_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/greenplum/pax"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -74,7 +75,7 @@ func (h SegDeleteBeforeHandler) Delete(ctx context.Context, segBackup SegBackup)
 
 	filterFunc := func(object storage.Object) bool { return true }
 	folderFilter := func(folderPath string) bool {
-		aoSegFolderPrefix := path.Join(utility.BaseBackupPath, AoStoragePath)
+		aoSegFolderPrefix := path.Join(utility.BaseBackupPath, ao.StoragePath)
 		paxFolderPrefix := path.Join(utility.BaseBackupPath, pax.StoragePath)
 		return !strings.HasPrefix(folderPath, aoSegFolderPrefix) &&
 			!strings.HasPrefix(folderPath, paxFolderPrefix)
@@ -106,7 +107,7 @@ func (h SegDeleteTargetHandler) Delete(ctx context.Context, segBackup SegBackup)
 		segTarget.GetBackupName(), h.contentID)
 
 	folderFilter := func(folderPath string) bool {
-		return !strings.HasPrefix(folderPath, AoStoragePath) &&
+		return !strings.HasPrefix(folderPath, ao.StoragePath) &&
 			!strings.HasPrefix(folderPath, pax.StoragePath)
 	}
 	err = h.DeleteTarget(ctx, segTarget, h.args.Confirmed, h.args.FindFull, folderFilter)
@@ -126,8 +127,8 @@ func (h SegDeleteTargetHandler) Delete(ctx context.Context, segBackup SegBackup)
 
 // TODO: unit tests
 func cleanupAOSegments(ctx context.Context, target internal.BackupObject, segFolder storage.Folder, confirmed bool) error {
-	aoSegFolder := segFolder.GetSubFolder(utility.BaseBackupPath).GetSubFolder(AoStoragePath)
-	aoSegmentsToRetain, err := LoadStorageAoFiles(ctx, segFolder.GetSubFolder(utility.BaseBackupPath))
+	aoSegFolder := segFolder.GetSubFolder(utility.BaseBackupPath).GetSubFolder(ao.StoragePath)
+	aoSegmentsToRetain, err := ao.LoadStorageAOFiles(ctx, segFolder.GetSubFolder(utility.BaseBackupPath))
 	if err != nil {
 		return err
 	}
@@ -296,7 +297,7 @@ func findAoSegmentsToDelete(ctx context.Context, target internal.BackupObject,
 
 	aoSegmentsToDelete := make([]storage.Object, 0)
 	for _, obj := range aoObjects {
-		if !strings.HasSuffix(obj.GetName(), AoSegSuffix) && obj.GetLastModified().After(target.GetLastModified()) {
+		if !strings.HasSuffix(obj.GetName(), ao.KeySuffix) && obj.GetLastModified().After(target.GetLastModified()) {
 			tracelog.DebugLogger.Println(
 				"\tis not an AO segment file, will not delete (modify time is too recent): " + obj.GetName())
 			continue

--- a/internal/databases/greenplum/shared_size.go
+++ b/internal/databases/greenplum/shared_size.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/greenplum/pax"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/utility"
@@ -18,7 +19,7 @@ import (
 // It is stored under the same names the segments use, ao_files_metadata.json and
 // pax_files_metadata.json, one folder level up. The name is shared but the shape is not: the two
 // are told apart by the folder they are read from, and nothing reads the cluster-level one as
-// AOFilesMetadataDTO or vice versa (LoadStorageAoFiles and pax.LoadStoragePaxFiles are only ever
+// ao.FilesMetadataDTO or vice versa (ao.LoadStorageAOFiles and pax.LoadStoragePaxFiles are only ever
 // given a segment folder).
 type SharedSizeDTO struct {
 	// SharedSize is the volume, in bytes, the backup added to one of the shared storages. It is the
@@ -43,7 +44,7 @@ type sharedStorageKind struct {
 
 func sharedStorageKinds() []sharedStorageKind {
 	return []sharedStorageKind{
-		{name: "AO/AOCS", path: getAOFilesMetadataPath, readSegmentSize: readUploadedAOSize},
+		{name: "AO/AOCS", path: ao.GetFilesMetadataPath, readSegmentSize: readUploadedAOSize},
 		{name: "PAX", path: pax.GetFilesMetadataPath, readSegmentSize: readUploadedPaxSize},
 	}
 }
@@ -137,7 +138,7 @@ type paxUploadedSizeView struct {
 
 func readUploadedAOSize(ctx context.Context, baseBackupsFolder storage.Folder, backupName string) (int64, error) {
 	var meta aoUploadedSizeView
-	if err := internal.FetchDto(ctx, baseBackupsFolder, &meta, getAOFilesMetadataPath(backupName)); err != nil {
+	if err := internal.FetchDto(ctx, baseBackupsFolder, &meta, ao.GetFilesMetadataPath(backupName)); err != nil {
 		return 0, err
 	}
 	return meta.UploadedSharedSize, nil
@@ -157,7 +158,7 @@ func readUploadedPaxSize(ctx context.Context, baseBackupsFolder storage.Folder, 
 // rootFolder must be the cluster root. Given a segment folder this would read that segment's files
 // metadata, which has no SharedSize, and report a zero.
 func FetchAOSharedSize(ctx context.Context, rootFolder storage.Folder, backupName string) (int64, error) {
-	return fetchSharedSize(ctx, rootFolder, getAOFilesMetadataPath(backupName))
+	return fetchSharedSize(ctx, rootFolder, ao.GetFilesMetadataPath(backupName))
 }
 
 // FetchPaxSharedSize is the volume backupName added to the shared PAX storage cluster-wide.

--- a/internal/databases/greenplum/shared_size_test.go
+++ b/internal/databases/greenplum/shared_size_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wal-g/wal-g/internal/databases/greenplum"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/greenplum/pax"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
 	"github.com/wal-g/wal-g/testtools"
@@ -113,9 +114,9 @@ func putSegmentAOFilesMetadata(t *testing.T, root storage.Folder, contentID int,
 	t.Helper()
 
 	folder := root.GetSubFolder(greenplum.FormatSegmentStoragePrefix(contentID))
-	putDTO(t, folder, utility.BaseBackupPath+backupName+"/"+greenplum.AOFilesMetadataName,
-		greenplum.AOFilesMetadataDTO{
-			Files:              greenplum.BackupAOFiles{"1337.1": {StoragePath: "aosegments/1337.1", EOF: 4096}},
+	putDTO(t, folder, utility.BaseBackupPath+ao.GetFilesMetadataPath(backupName),
+		ao.FilesMetadataDTO{
+			Files:              ao.BackupFiles{"1337.1": {StoragePath: "aosegments/1337.1", EOF: 4096}},
 			UploadedSharedSize: aoSize,
 		})
 }

--- a/internal/databases/greenplum/tar_ball_composer.go
+++ b/internal/databases/greenplum/tar_ball_composer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/wal-g/wal-g/internal"
 	conf "github.com/wal-g/wal-g/internal/config"
 	"github.com/wal-g/wal-g/internal/crypto"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/greenplum/pax"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/internal/multistorage"
@@ -22,7 +23,7 @@ import (
 )
 
 type GpTarBallComposerMaker struct {
-	relStorageMap    AoRelFileStorageMap
+	relStorageMap    ao.RelFileStorageMap
 	paxRelStorageMap pax.RelFileStorageMap
 	bundleFiles      internal.BundleFiles
 	TarFileSets      internal.TarFileSets
@@ -30,7 +31,7 @@ type GpTarBallComposerMaker struct {
 	backupName       string
 }
 
-func NewGpTarBallComposerMaker(relStorageMap AoRelFileStorageMap, paxRelStorageMap pax.RelFileStorageMap,
+func NewGpTarBallComposerMaker(relStorageMap ao.RelFileStorageMap, paxRelStorageMap pax.RelFileStorageMap,
 	uploader internal.Uploader, backupName string,
 ) (*GpTarBallComposerMaker, error) {
 	return &GpTarBallComposerMaker{
@@ -61,7 +62,7 @@ func (maker *GpTarBallComposerMaker) Make(ctx context.Context, bundle *postgres.
 
 	now := time.Now().UnixNano()
 	newAoSegFilesID := strconv.FormatInt(now, 10)
-	aoStorageUploader := NewAoStorageUploader(
+	aoStorageUploader := ao.NewStorageUploader(
 		maker.uploader, baseFiles, bundle.Crypter, maker.bundleFiles, bundle.IncrementFromName != "", aoDedupAgeLimit, newAoSegFilesID)
 
 	basePaxFiles, err := maker.loadBasePaxFiles(ctx, bundle.IncrementFromName)
@@ -135,7 +136,7 @@ func (maker *GpTarBallComposerMaker) loadBasePaxFiles(ctx context.Context, incre
 	return baseFilesMetadata.Files, nil
 }
 
-func (maker *GpTarBallComposerMaker) loadBaseFiles(ctx context.Context, incrementFromName string) (files BackupAOFiles, err error) {
+func (maker *GpTarBallComposerMaker) loadBaseFiles(ctx context.Context, incrementFromName string) (files ao.BackupFiles, err error) {
 	var base SegBackup
 	// In case of delta backup, use the provided backup name as the base. Otherwise, use the latest backup.
 	if incrementFromName != "" {
@@ -153,7 +154,7 @@ func (maker *GpTarBallComposerMaker) loadBaseFiles(ctx context.Context, incremen
 		if err != nil {
 			if _, ok := err.(internal.NoBackupsFoundError); ok {
 				tracelog.InfoLogger.Println("Couldn't find previous backup, leaving the base files empty.")
-				return BackupAOFiles{}, nil
+				return ao.BackupFiles{}, nil
 			}
 
 			return nil, err
@@ -176,7 +177,7 @@ func (maker *GpTarBallComposerMaker) loadBaseFiles(ctx context.Context, incremen
 
 		tracelog.WarningLogger.Printf(
 			"AO files metadata was not found for backup %s, leaving the base files empty.", base.Name)
-		return BackupAOFiles{}, nil
+		return ao.BackupFiles{}, nil
 	}
 
 	return baseFilesMetadata.Files, nil
@@ -199,8 +200,8 @@ type GpTarBallComposer struct {
 	tarFileSets      internal.TarFileSets
 	tarFileSetsMutex sync.Mutex
 
-	relStorageMap        AoRelFileStorageMap
-	aoStorageUploader    *AoStorageUploader
+	relStorageMap        ao.RelFileStorageMap
+	aoStorageUploader    *ao.StorageUploader
 	aoSegSizeThreshold   int64
 	paxRelStorageMap     pax.RelFileStorageMap
 	paxStorageUploader   *pax.StorageUploader
@@ -209,9 +210,9 @@ type GpTarBallComposer struct {
 
 func NewGpTarBallComposer(
 	ctx context.Context,
-	tarBallQueue *internal.TarBallQueue, crypter crypto.Crypter, relStorageMap AoRelFileStorageMap,
+	tarBallQueue *internal.TarBallQueue, crypter crypto.Crypter, relStorageMap ao.RelFileStorageMap,
 	paxRelStorageMap pax.RelFileStorageMap,
-	bundleFiles internal.BundleFiles, packer *postgres.TarBallFilePackerImpl, aoStorageUploader *AoStorageUploader,
+	bundleFiles internal.BundleFiles, packer *postgres.TarBallFilePackerImpl, aoStorageUploader *ao.StorageUploader,
 	paxStorageUploader *pax.StorageUploader,
 	tarFileSets internal.TarFileSets, uploader internal.Uploader, backupName string,
 ) (*GpTarBallComposer, error) {
@@ -293,7 +294,7 @@ func (c *GpTarBallComposer) FinishComposing() (internal.TarFileSets, error) {
 		return nil, fmt.Errorf("failed to get the uploaded AO files size: %w", err)
 	}
 
-	err = internal.UploadDto(c.reqCtx, c.uploader.Folder(), aoMeta, getAOFilesMetadataPath(c.backupName))
+	err = internal.UploadDto(c.reqCtx, c.uploader.Folder(), aoMeta, ao.GetFilesMetadataPath(c.backupName))
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload AO files metadata: %v", err)
 	}
@@ -337,7 +338,7 @@ func (c *GpTarBallComposer) addFileWorker(tasks <-chan *internal.ComposeFileInfo
 
 func (c *GpTarBallComposer) addFile(cfi *internal.ComposeFileInfo) error {
 	// WAL-G uploads AO/AOCS relfiles to a different location
-	isAo, meta, location := c.relStorageMap.getAOStorageMetadata(cfi.Path)
+	isAo, meta, location := c.relStorageMap.Lookup(cfi.Path)
 	if isAo && cfi.FileInfo.Size() >= c.aoSegSizeThreshold {
 		tracelog.DebugLogger.Printf("%s is an AO/AOCS file, will process it through an AO storage manager",
 			cfi.Path)

--- a/internal/databases/greenplum/tars_to_extract_provider.go
+++ b/internal/databases/greenplum/tars_to_extract_provider.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wal-g/tracelog"
 	"github.com/wal-g/wal-g/internal"
+	"github.com/wal-g/wal-g/internal/databases/greenplum/ao"
 	"github.com/wal-g/wal-g/internal/databases/greenplum/pax"
 	"github.com/wal-g/wal-g/internal/databases/postgres"
 	"github.com/wal-g/wal-g/pkg/storages/storage"
@@ -39,7 +40,7 @@ func (t FilesToExtractProviderImpl) Get(ctx context.Context, backup SegBackup, f
 				tracelog.InfoLogger.Printf("Don't need to unwrap the %s AO segment file, skipping it...", extractPath)
 				continue
 			}
-			objPath := path.Join(AoStoragePath, meta.StoragePath)
+			objPath := path.Join(ao.StoragePath, meta.StoragePath)
 			readerMaker := internal.NewRegularFileStorageReaderMarker(backup.Folder, objPath, extractPath, meta.FileMode)
 			concurrentTarsToExtract = append(concurrentTarsToExtract, readerMaker)
 		}


### PR DESCRIPTION
Move AO metadata, storage, uploader, increment handling, and relfile types under internal/databases/greenplum/ao. Keep Greenplum-specific query and orchestration code in the parent package to avoid import cycles.
