### PR TITLE
fix(s3): list only the current version of each object unless --all-versions

### DIFF
--- a/cmd/common/st/remove.go
+++ b/cmd/common/st/remove.go
@@ -36,6 +36,11 @@ var removeCmd = &cobra.Command{
 			}
 
 			folder.SetVersioningEnabled(ctx, removeAllVersions)
+			if removeAllVersions {
+				// "remove all versions" must see every historical version and delete marker,
+				// not just the current version of each key.
+				storage.SetShowAllVersions(folder, true)
+			}
 			if glob {
 				return storagetools.HandleRemoveWithGlobPattern(ctx, args[0], folder)
 			}

--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -366,12 +366,19 @@ func (folder *Folder) collectVersions(allVersions *[]versionInfo, versions []typ
 }
 
 // buildObjectsFromVersions turns collected versions into storage objects for output and higher-level logic.
-// By default it filters out keys whose LATEST is a delete marker; `showAllVersions` disables that filter.
+// By default it returns a regular listing: the current version of each key, excluding keys whose LATEST
+// version is a delete marker. `showAllVersions` disables both filters, yielding every historical version.
 func (folder *Folder) buildObjectsFromVersions(allVersions []versionInfo, deletedKeys map[string]bool) []storage.Object {
 	objects := make([]storage.Object, 0, len(allVersions))
 	for _, v := range allVersions {
 		// Skip objects where the LATEST version is a delete marker (unless showing all versions)
 		if deletedKeys[v.relativePath] && !folder.config.showAllVersions {
+			continue
+		}
+		// Without showAllVersions, behave like a non-versioned listing and return only the current
+		// version of each key. Returning superseded versions here makes an overwritten object appear
+		// several times, which breaks callers that assume unique names (e.g. `st ls`, journal counting).
+		if !v.isLatest && !folder.config.showAllVersions {
 			continue
 		}
 		isLatest := ""

--- a/pkg/storages/s3/folder_list_versions_test.go
+++ b/pkg/storages/s3/folder_list_versions_test.go
@@ -141,7 +141,7 @@ func TestListFolder_VersioningEnabled_ExcludesDeletedObjects(t *testing.T) {
 	assert.NotContains(t, objectNames, "object2.txt", "Deleted object should not be in the list")
 }
 
-func TestListFolder_VersioningEnabled_IncludesAllVersionsOfNonDeletedObjects(t *testing.T) {
+func TestListFolder_VersioningEnabled_ReturnsOnlyCurrentVersionOfOverwrittenObject(t *testing.T) {
 	now := time.Now()
 
 	mockClient := &mockS3ClientVersioning{
@@ -174,8 +174,47 @@ func TestListFolder_VersioningEnabled_IncludesAllVersionsOfNonDeletedObjects(t *
 
 	require.NoError(t, err)
 
-	assert.Len(t, objects, 2)
+	// A regular listing (no --all-versions) returns one entry per key: the current version.
+	require.Len(t, objects, 1)
+	assert.Equal(t, "object1.txt", objects[0].GetName())
+	assert.Equal(t, "v1-latest", objects[0].GetVersionID())
+}
 
+func TestListFolder_VersioningEnabled_ShowAllVersionsIncludesSupersededVersions(t *testing.T) {
+	now := time.Now()
+
+	mockClient := &mockS3ClientVersioning{
+		versions: []types.ObjectVersion{
+			{
+				Key:          aws.String("object1.txt"),
+				VersionId:    aws.String("v1-latest"),
+				IsLatest:     aws.Bool(true),
+				LastModified: aws.Time(now),
+				Size:         aws.Int64(100),
+			},
+			{
+				Key:          aws.String("object1.txt"),
+				VersionId:    aws.String("v1-old"),
+				IsLatest:     aws.Bool(false),
+				LastModified: aws.Time(now.Add(-time.Hour)),
+				Size:         aws.Int64(90),
+			},
+		},
+		deleteMarkers: []types.DeleteMarkerEntry{},
+	}
+
+	config := &walgs3.Config{
+		Bucket:           "test-bucket",
+		EnableVersioning: "enabled",
+	}
+	folder := walgs3.NewFolder(mockClient, nil, "", config)
+	folder.SetShowAllVersions(true)
+
+	objects, _, err := folder.ListFolder(t.Context())
+
+	require.NoError(t, err)
+
+	assert.Len(t, objects, 2)
 	for _, obj := range objects {
 		assert.Equal(t, "object1.txt", obj.GetName())
 	}


### PR DESCRIPTION
### Database name
PostgreSQL / Greenplum (any database using an S3 storage with versioning enabled).

Closes #2525

## Problem

On a bucket with versioning enabled, `Folder.ListFolder` (the `listVersions` path) returned **every** non-deleted version of every key. An object that had been overwritten therefore appeared multiple times in the listing.

wal-g's journal feature rewrites the previous backup's `journal_<name>` file on each new backup (to record `SizeToNextBackup`). With versioning on, that file then has several versions, so:

```
wal-g st ls basebackups_005/ | grep journal_ | wc -l
```

reports more journals than exist, and `tests/journals_test.sh` fails with `test 2 -eq 3` (see the CI run linked in #2525). `wal-g st ls` also prints visible duplicates for any re-uploaded object.

### Steps to reproduce

1. Enable versioning on the S3 bucket.
2. `wal-g backup-push ... --count-journals` twice.
3. `wal-g st ls basebackups_005/ | grep journal_ | wc -l` → returns 3 instead of 2 (the first backup's journal was rewritten by the second and both versions are listed).

## Fix

`buildObjectsFromVersions` now returns only the **current** version of each key when `showAllVersions` is not set — a regular listing behaves the same on versioned and non-versioned buckets. This matches the documented behaviour: `docs/StorageTools.md` describes `st ls --all-versions` as the way to see full version history.

`st rm --all-versions` implicitly relied on the old behaviour to enumerate versions for deletion, so it now sets `SetShowAllVersions(true)` explicitly. As a side effect it also cleans up delete markers, which "remove all versions" arguably should.

`wal-g delete` already calls `SetShowAllVersions(true)` itself (`internal/delete_handler.go`), so it is unaffected.

## Tests

- Updated `TestListFolder_VersioningEnabled_IncludesAllVersionsOfNonDeletedObjects` → `...ReturnsOnlyCurrentVersionOfOverwrittenObject` to assert one entry per key.
- Added `TestListFolder_VersioningEnabled_ShowAllVersionsIncludesSupersededVersions` for the `--all-versions` path.
- `go test ./pkg/storages/s3/... ./internal/storagetools/... ./pkg/storages/storage/...` passes; `golangci-lint` / `go vet` / `gofmt` clean.

I could not run the full `journals_test.sh` locally (needs Postgres + a versioned object store), so please let CI exercise that path.