### PR TITLE
MongoDB: avoid deadlock on metadata collection errors

### DIFF
--- a/internal/databases/mongo/binary/backup.go
+++ b/internal/databases/mongo/binary/backup.go
@@ -229,8 +229,7 @@ func (backupService *BackupService) DoBackup(ctx context.Context, args DoBackupA
 	}
 
 	if !args.SkipMetadata {
-		metadataCollector.TarsChan <- tarFileSets
-		if err = <-metadataCollector.ErrsChan; err != nil {
+		if err = metadataCollector.Complete(ctx, tarFileSets); err != nil {
 			return err
 		}
 		backupService.Sentinel.Top100Namespaces = *metadataCollector.top100Ns

--- a/internal/databases/mongo/binary/metadata_collector.go
+++ b/internal/databases/mongo/binary/metadata_collector.go
@@ -2,6 +2,7 @@ package binary
 
 import (
 	"container/heap"
+	"context"
 
 	"github.com/mongodb/mongo-tools/common/util"
 	"github.com/wal-g/wal-g/internal"
@@ -35,13 +36,34 @@ func NewStorageMetadataCollector(
 		pmc:           NewPartialMetadataCollector(),
 		heap:          h,
 		TarsChan:      make(chan internal.TarFileSets),
-		ErrsChan:      make(chan error),
+		ErrsChan:      make(chan error, 1),
 		onComplete:    onComplete,
 		systemDbs:     common.SystemDBs(),
 	}
 }
 
 func (smc *StorageMetadataCollector) GetStats() {
+	smc.ErrsChan <- smc.getStats()
+}
+
+func (smc *StorageMetadataCollector) Complete(ctx context.Context, tarFileSets internal.TarFileSets) error {
+	select {
+	case smc.TarsChan <- tarFileSets:
+	case err := <-smc.ErrsChan:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case err := <-smc.ErrsChan:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (smc *StorageMetadataCollector) getStats() error {
 	pipeline := mongo.Pipeline{
 		{{Key: "$_internalAllCollectionStats", Value: bson.D{
 			{Key: "stats", Value: bson.D{
@@ -52,16 +74,14 @@ func (smc *StorageMetadataCollector) GetStats() {
 
 	cursor, err := smc.mongodService.MongoClient.Database(adminDB).Aggregate(smc.mongodService.Context, pipeline)
 	if err != nil {
-		smc.ErrsChan <- err
-		return
+		return err
 	}
 	defer cursor.Close(smc.mongodService.Context)
 
 	for cursor.TryNext(smc.mongodService.Context) {
 		var nsInfo models.NsInfo
 		if err = cursor.Decode(&nsInfo); err != nil {
-			smc.ErrsChan <- err
-			return
+			return err
 		}
 
 		smc.handleTop100Info(&nsInfo)
@@ -69,8 +89,7 @@ func (smc *StorageMetadataCollector) GetStats() {
 	}
 
 	if err := cursor.Err(); err != nil {
-		smc.ErrsChan <- err
-		return
+		return err
 	}
 
 	top100Ns := make([]string, smc.heap.Len())
@@ -80,13 +99,17 @@ func (smc *StorageMetadataCollector) GetStats() {
 
 	smc.top100Ns = &top100Ns
 
-	tarsFileSet := <-smc.TarsChan
+	var tarsFileSet internal.TarFileSets
+	select {
+	case tarsFileSet = <-smc.TarsChan:
+	case <-smc.mongodService.Context.Done():
+		return smc.mongodService.Context.Err()
+	}
 	if err := smc.pmc.EnrichWithTarPaths(tarsFileSet.Get()); err != nil {
-		smc.ErrsChan <- err
-		return
+		return err
 	}
 
-	smc.ErrsChan <- smc.onComplete(smc.pmc.GetRoutes())
+	return smc.onComplete(smc.pmc.GetRoutes())
 }
 
 func (smc *StorageMetadataCollector) handleTop100Info(nsInfo *models.NsInfo) {

--- a/internal/databases/mongo/binary/metadata_collector_test.go
+++ b/internal/databases/mongo/binary/metadata_collector_test.go
@@ -2,14 +2,103 @@ package binary
 
 import (
 	"container/heap"
+	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wal-g/wal-g/internal"
 	"github.com/wal-g/wal-g/internal/databases/mongo/common"
 	"github.com/wal-g/wal-g/internal/databases/mongo/models"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
+
+func TestStorageMetadataCollector_EarlyError(t *testing.T) {
+	client, err := mongo.Connect()
+	require.NoError(t, err)
+	require.NoError(t, client.Disconnect(t.Context()))
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		collector := NewStorageMetadataCollector(&MongodService{
+			Context:     ctx,
+			MongoClient: client,
+		}, func(*models.BackupRoutesInfo) error {
+			t.Error("metadata must not be uploaded after a collection error")
+			return nil
+		})
+
+		done := make(chan struct{})
+		go func() {
+			collector.GetStats()
+			close(done)
+		}()
+
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Error("collector must finish even when its result has no consumer yet")
+		}
+
+		err := collector.Complete(ctx, internal.NewRegularTarFileSets())
+		require.ErrorIs(t, err, mongo.ErrClientDisconnected)
+	})
+}
+
+func TestStorageMetadataCollector_Complete(t *testing.T) {
+	for _, result := range []error{nil, errors.New("metadata upload failed")} {
+		t.Run(fmt.Sprint(result), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+				defer cancel()
+				collector := NewStorageMetadataCollector(&MongodService{Context: ctx}, nil)
+				tarFileSets := internal.NewRegularTarFileSets()
+				go func() {
+					select {
+					case received := <-collector.TarsChan:
+						assert.Same(t, tarFileSets, received)
+						collector.ErrsChan <- result
+					case <-ctx.Done():
+						t.Error("collector did not receive tar files")
+					}
+				}()
+
+				err := collector.Complete(ctx, tarFileSets)
+				require.ErrorIs(t, err, result)
+			})
+		})
+	}
+}
+
+func TestStorageMetadataCollector_CompleteCanceled(t *testing.T) {
+	for _, receiveTars := range []bool{false, true} {
+		t.Run(fmt.Sprintf("tar_files_received=%t", receiveTars), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				collector := NewStorageMetadataCollector(&MongodService{Context: ctx}, nil)
+				done := make(chan error, 1)
+				go func() {
+					done <- collector.Complete(ctx, internal.NewRegularTarFileSets())
+				}()
+
+				if receiveTars {
+					<-collector.TarsChan
+				}
+				synctest.Wait()
+				cancel()
+				require.ErrorIs(t, <-done, context.Canceled)
+			})
+		})
+	}
+}
 
 func TestNewStorageMetadataCollector_Initialization(t *testing.T) {
 	svc := &MongodService{Context: t.Context()}


### PR DESCRIPTION
### Database name

MongoDB

### Describe what this PR fixes

An error while collecting binary backup metadata can leave `binary-backup-push` blocked indefinitely. The collector sends the error to the unbuffered `ErrsChan` before receiving `TarsChan`, while `DoBackup` sends the tar file sets before reading the error. Both goroutines then wait on channel sends.

Allow metadata completion to receive an early error while attempting to hand off tar file sets. Buffer the single collection result so the collector can exit without a waiting consumer, and respect context cancellation while waiting for tar file sets or the result.

### Please provide steps to reproduce (if it's a bug)

1. Let the metadata aggregation, cursor iteration, or document decoding fail before the collector receives the tar file sets.
2. Let the main backup flow finish uploading and attempt to send those file sets.
3. Both goroutines block instead of returning the collection error.

The regression test uses a disconnected MongoDB client to trigger an aggregation error without a running server. Restoring the original unbuffered channels and sequential handoff through a temporary Go overlay reproduces `panic: deadlock: all goroutines in bubble are blocked`. With the fix, the test returns `mongo.ErrClientDisconnected`.

### Validation

- Tests cover early collection failure, successful completion, a final metadata error, and cancellation before and after the tar file handoff.
- Passed: `go test -mod=readonly -race ./internal/databases/mongo/... -count=1 -timeout=180s`.
- Passed: `git diff --check`.

`-mod=readonly` was used because the local vendor directory is out of sync with `go.mod`.
