### PR TITLE
Handle cases where object VersionId is empty in S3 delete operations

### DIFF
--- a/pkg/storages/s3/folder.go
+++ b/pkg/storages/s3/folder.go
@@ -482,10 +482,14 @@ func (folder *Folder) DeleteObjects(ctx context.Context, objects []storage.Objec
 			Objects: []types.ObjectIdentifier{},
 		}}
 		for _, obj := range part {
-			input.Delete.Objects = append(input.Delete.Objects, types.ObjectIdentifier{
-				Key:       aws.String(folder.path + obj.GetName()),
-				VersionId: aws.String(obj.GetVersionID()),
-			})
+			versionID := obj.GetVersionID()
+			objectIdentifier := types.ObjectIdentifier{
+				Key: aws.String(folder.path + obj.GetName()),
+			}
+			if versionID != "" {
+				objectIdentifier.VersionId = aws.String(versionID)
+			}
+			input.Delete.Objects = append(input.Delete.Objects, objectIdentifier)
 		}
 		_, err := folder.s3API.DeleteObjects(ctx, input, withContentMD5)
 		if err != nil {


### PR DESCRIPTION
### Database name

Storage-layer fix and not database-specific. Affects every database that uses the S3 storage backend (PostgreSQL, MySQL, etc.).

# Pull request description

### Describe what this PR fixes

`Folder.DeleteObjects` (`pkg/storages/s3/folder.go`) always set `VersionId: aws.String(obj.GetVersionID())` on every `ObjectIdentifier`, even when the version ID was an empty string.

When a bucket does **not** have versioning enabled, objects have no version ID, so `GetVersionID()` returns `""`. Sending `VersionId: ""` to the S3 `DeleteObjects` batch API makes S3 reject that entry with a per-object `The specified version does not exist.` error.

That error is returned inside the API **response body** (`DeleteObjectsOutput.Errors`), not as a Go `error`. Line 494 (`_, err := folder.s3API.DeleteObjects(...)`) discards the response and only checks `err`, so the per-object failure is never surfaced. Result: wal-g reports the delete as successful while the objects are actually still there, e.g. `delete retain` / `delete before` silently keep old backups and WAL segments on non-versioned buckets.

Fix: only set `VersionId` when the object actually has a non-empty version ID. On non-versioned buckets the delete now goes through as a normal (unversioned) delete.

### Please provide steps to reproduce (if it's a bug)

1. Create an S3 bucket with versioning **disabled**.
2. Run any wal-g backup so objects exist under the prefix.
3. Run a delete, e.g. `wal-g delete everything FORCE` (or `delete retain 0`).
4. wal-g exits 0 and logs success.
5. `aws s3 ls --recursive s3://<bucket>/<prefix>` — objects are still present.

With the fix, step 4 actually removes the objects.
